### PR TITLE
Switch off autocomplete

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,9 +1,9 @@
 <h1>Sign in</h1>
 
-<%= form_for(resource, as: resource_name, url: session_path(resource_name), html: { class: 'well' }) do |f| %>
+<%= form_for(resource, as: resource_name, url: session_path(resource_name), html: { class: 'well', autocomplete: 'off' }) do |f| %>
 
   <%= f.label :email %>
-  <%= f.email_field :email, class: 'span6' %>
+  <%= f.email_field :email, class: 'span6', autocomplete: 'off' %>
 
   <%= f.label :password, "Passphrase" %>
   <%= f.password_field :password, class: 'span6' %>


### PR DESCRIPTION
Add autocomplete=off to sign in form

To avoid browsers automatically completing a user's email address, thereby leaving a trail when users have signed in on public computers. Many browsers implemented this as a custom attribute on input elements, HTML5 makes it a supported attribute on the form element. This implements both to be sure.
