### PR TITLE
Prevent errors from inviting a user twice

### DIFF
--- a/app/controllers/admin/invitations_controller.rb
+++ b/app/controllers/admin/invitations_controller.rb
@@ -7,11 +7,9 @@ class Admin::InvitationsController < Devise::InvitationsController
   before_filter :must_be_admin, only: [:new, :create]
 
   def create
+    # Prevent an error when devise_invitable invites/updates an existing user,
+    # and accepts_nested_attributes_for tries to create duplicate permissions.
     if self.resource = User.find_by_email(params[:user][:email])
-      # The admin user has tried to invite an existing user.
-      # This would trigger an error when accepts_nested_attributes tries to create
-      # duplicate permissions.
-      # Therefore, let's catch it, rather than erroring.
       flash[:alert] = "User already invited. If you want to, you can click 'Resend signup email'."
       respond_with resource, :location => after_invite_path_for(resource)
     else


### PR DESCRIPTION
This fix catches the scenario where you are attempting to invite an existing user and it fails ungracefully because it attempts to create duplicate permissions.

Unfortunately, accepts_nested_attributes doesn't pick up on existing records unless it is given their IDs, so it was trying to create duplicate permissions when updating an existing user.

The changes could resend the invitation email, but I imagine the admin is probably unaware they exist, so it's probably better not to confuse the new user with multiple emails.

Problem is very similar/related to that fixed by: 98a119665aedb16efa6613b0625a95c063ddcc2d
