### PR TITLE
Remove overridden doorkeeper controller

### DIFF
--- a/app/controllers/doorkeeper/application_controller.rb
+++ b/app/controllers/doorkeeper/application_controller.rb
@@ -1,9 +1,0 @@
-# Need to load because in development mode this file gets re-evaluated on every request and a require
-# would only load the parent app controller on the first request.
-load Doorkeeper::Engine.config.root.join 'app', 'controllers', 'doorkeeper', 'application_controller.rb'
-
-Doorkeeper::ApplicationController.class_eval do
-  before_filter do
-    headers['X-Slimmer-Template'] = 'admin'
-  end
-end


### PR DESCRIPTION
We were only doing this for slimmer integration but we no longer use slimmer.
