### PR TITLE
Introduce an 'Editor' permission for Whitehall.

### DIFF
--- a/db/migrate/20120917131351_create_whitehall_editor_supported_permission.rb
+++ b/db/migrate/20120917131351_create_whitehall_editor_supported_permission.rb
@@ -1,0 +1,23 @@
+class CreateWhitehallEditorSupportedPermission < ActiveRecord::Migration
+  class SupportedPermission < ActiveRecord::Base
+    belongs_to :application, class_name: 'Doorkeeper::Application'
+  end
+
+  class Permission < ActiveRecord::Base
+    serialize :permissions, Array
+  end
+
+  def up
+    whitehall = ::Doorkeeper::Application.find_by_name("Whitehall")
+    if whitehall
+      permission_name = "Editor"
+      permission = SupportedPermission.create!(application: whitehall, name: permission_name)
+      Permission.where(application_id: whitehall.id).each do |permission|
+        if permission.permissions.include?("signin")
+          permission.permissions << permission_name
+          permission.save!
+        end
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20120828162043) do
+ActiveRecord::Schema.define(:version => 20120917131351) do
 
   create_table "oauth_access_grants", :force => true do |t|
     t.integer  "resource_owner_id", :null => false


### PR DESCRIPTION
Currently each user on whitehall has a 'departmental_editor' flag,
but we intend to remove that in favour of this role.  All our
current users are editors, hence the migration to set this role on
all our users.
