### PR TITLE
Set a sender name for sign-on emails

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -6,7 +6,7 @@ Devise.setup do |config|
   # ==> Mailer Configuration
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class with default "from" parameter.
-  config.mailer_sender = "winston@alphagov.co.uk"
+  config.mailer_sender = "GOV.UK Sign On <winston@alphagov.co.uk>"
 
   # Configure the class responsible to send e-mails.
   # config.mailer = "Devise::Mailer"


### PR DESCRIPTION
I chose "GOV.UK Sign On" for now.
