### PR TITLE
use GOVUK_STATSD_PREFIX environment variable to set statsd prefix

### DIFF
--- a/config/initializers/statsd.rb
+++ b/config/initializers/statsd.rb
@@ -5,4 +5,4 @@
 # block your application. You do not need to have a statsd process
 # running locally on your development environment.
 STATSD_HOST = "localhost"
-STATSD_PREFIX = "govuk.app.signon"
+STATSD_PREFIX = ENV['GOVUK_STATSD_PREFIX']


### PR DESCRIPTION
After alphagov/puppet@5bec09fd02820 we now specify an environment variable GOVUK_STATSD_PREFIX which apps can use to specify a statsd prefix which will be unique for each app/machine combination. This pull request gets signon to use this environment variable.

Obviously, after merging this we need to be careful not to deploy signon to an environment which hasn't had alphagov/puppet@5bec09fd02820 deployed to it already. (Therefore please give this a little time before merging, will probably talk to @jamiecobbett directly and get him to merge.)

This should free up alphagov/signonotron2#23 to be pulled in too.
