### PR TITLE
An app can request a user's details even if they don't have permissions in that app

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,7 +3,7 @@ class UsersController < ApplicationController
   doorkeeper_for :show
 
   def show
-    relevant_permission.synced!
+    relevant_permission.synced! if relevant_permission
     respond_to do |format|
       format.json do
         render json: current_resource_owner.to_sensible_json(application_making_request)

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -98,6 +98,17 @@ class UsersControllerTest < ActionController::TestCase
     assert_not_nil permission.reload.last_synced_at
   end
 
+  test "fetching json profile should succeed even if no permission for relevant app" do
+    user = FactoryGirl.create(:user)
+    application = FactoryGirl.create(:application)
+    token = FactoryGirl.create(:access_token, :application => application, :resource_owner_id => user.id)
+
+    @request.env['HTTP_AUTHORIZATION'] = "Bearer #{token.token}"
+    get :show, {:format => :json}
+
+    assert_response :ok
+  end
+
   private
 
   def change_user_password(user_factory, new_password)


### PR DESCRIPTION
Previously if a user tried to sign in to an app they don't have any permissions in an exception would be raised when that app tried to store the last updated time of their permissions. We will now return a response without any permission details and trust the app's to behave accordingly.
