### PR TITLE
Conceal that an account exists after SES blacklist error

### DIFF
--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -1,6 +1,27 @@
 class PasswordsController < Devise::PasswordsController
   before_filter :record_password_reset_request, only: :create
 
+  # Copied from https://github.com/plataformatec/devise/blob/v2.1.2/app/controllers/devise/passwords_controller.rb#L12
+  # So that we can rescue from SES blacklist errors and behave normally 
+  # (i.e. not giving away whether or not an account exists for the email)
+  def create
+    begin
+      self.resource = resource_class.send_reset_password_instructions(resource_params)
+    rescue AWS::SES::ResponseError => exception
+      if exception.message =~ /Address blacklisted/i
+        self.resource = User.find_by_email(params[:user][:email])
+      else
+        raise
+      end
+    end
+
+    if successfully_sent?(resource)
+      respond_with({}, :location => after_sending_reset_password_instructions_path_for(resource_name))
+    else
+      respond_with(resource)
+    end
+  end
+
   private
     def record_password_reset_request
       Statsd.new(::STATSD_HOST).increment(

--- a/features/passphrase_reset.feature
+++ b/features/passphrase_reset.feature
@@ -3,6 +3,14 @@ Feature: Passphrase reset
     Given no user exists with email "email@example.com"
     When I request a new passphrase for "email@example.com"
     Then I should not see "Email not found"
+    Then I should see "If your e-mail exists on our database, you will receive a passphrase recovery link on your e-mail"
+
+  Scenario: Not showing too much information after an SES blacklist error occurs
+    Given a user exists with email "email@example.com" and passphrase "some v3ry s3cure passphrase"
+    And SES will raise a blacklist error
+    When I request a new passphrase for "email@example.com"
+    Then I should not see "Email not found"
+    Then I should see "If your e-mail exists on our database, you will receive a passphrase recovery link on your e-mail"
 
   Scenario: Successfully request a passphrase reset
     Given a user exists with email "email@example.com" and passphrase "some v3ry s3cure passphrase"

--- a/features/step_definitions/passphrase_steps.rb
+++ b/features/step_definitions/passphrase_steps.rb
@@ -1,3 +1,8 @@
+Given /^SES will raise a blacklist error$/ do
+  Devise::Mailer.any_instance.expects(:mail).with(anything)
+      .raises(AWS::SES::ResponseError, OpenStruct.new(error: { 'Code' => "MessageRejected", 'Message' => "Address blacklisted." }))
+end
+
 When /^I request a new passphrase for "([^"]*)"$/ do |email|
   visit new_user_password_path
   fill_in "Email", with: email


### PR DESCRIPTION
Currently, if an email is blacklisted by SES, then a password reset
request for that account will trigger a 500 error, which is different
from the normal flow which deliberately indicates that the request
was valid, but doesn't indicate whether or not an account exists for
the email.
