### PR TITLE
bump api-adapters and pin plek

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'mysql2'
 gem 'aws-ses', require: 'aws/ses'
 gem 'jquery-rails'
 gem 'exception_notification'
-gem 'plek'
+gem 'plek', '0.5.0'
 
 gem 'uuid'
 
@@ -24,7 +24,7 @@ gem 'passphrase_entropy', git: 'https://github.com/alphagov/passphrase_entropy.g
 
 gem 'doorkeeper', '0.3.1'
 
-gem 'gds-api-adapters', '0.2.1'
+gem 'gds-api-adapters', '4.1.3'
 gem 'statsd-ruby', '1.0.0'
 gem 'unicorn', '4.3.1'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,7 +96,7 @@ GEM
       factory_girl (~> 3.1.0)
       railties (>= 3.0.0)
     ffi (1.1.5)
-    gds-api-adapters (0.2.1)
+    gds-api-adapters (4.1.3)
       lrucache (~> 0.1.1)
       null_logger
       plek
@@ -118,7 +118,7 @@ GEM
     lograge (0.0.6)
       actionpack
       activesupport
-    lrucache (0.1.3)
+    lrucache (0.1.4)
       PriorityQueue (~> 0.1.2)
     macaddr (1.6.1)
       systemu (~> 2.5.0)
@@ -135,7 +135,7 @@ GEM
     nokogiri (1.5.5)
     null_logger (0.0.1)
     orm_adapter (0.4.0)
-    plek (0.3.0)
+    plek (0.5.0)
       builder
     polyglot (0.3.3)
     rack (1.4.1)
@@ -224,7 +224,7 @@ DEPENDENCIES
   doorkeeper (= 0.3.1)
   exception_notification
   factory_girl_rails (= 3.1.0)
-  gds-api-adapters (= 0.2.1)
+  gds-api-adapters (= 4.1.3)
   jquery-rails
   kaminari (= 0.14.1)
   lograge
@@ -232,7 +232,7 @@ DEPENDENCIES
   mysql2
   paginate_alphabetically (= 0.4.0)!
   passphrase_entropy!
-  plek
+  plek (= 0.5.0)
   rails (= 3.2.7)
   rake (= 0.9.2)
   shoulda (= 3.0.1)

--- a/lib/sso_push_client.rb
+++ b/lib/sso_push_client.rb
@@ -2,8 +2,7 @@ require 'gds_api/base'
 
 class SSOPushClient < GdsApi::Base
   def initialize(application)
-    options = { endpoint_url: application.url_without_path }.merge(GDS_API_CREDENTIALS)
-    super(nil, options)
+    super(application.url_without_path, GDS_API_CREDENTIALS)
   end
 
   def update_user(uid, user)

--- a/test/unit/permission_updater_test.rb
+++ b/test/unit/permission_updater_test.rb
@@ -46,7 +46,7 @@ class PermissionUpdaterTest < ActiveSupport::TestCase
     expected_failures = [
       { 
         application: user_not_in_database, 
-        message: "", 
+        message: "GdsApi::HTTPNotFound",
         technical: "HTTP status code was: 404" 
       }, 
       { 

--- a/test/unit/suspension_updater_test.rb
+++ b/test/unit/suspension_updater_test.rb
@@ -31,7 +31,7 @@ class SuspensionUpdaterTest < ActiveSupport::TestCase
     expected_failures = [
       { 
         application: user_not_in_database, 
-        message: "", 
+        message: "GdsApi::HTTPNotFound",
         technical: "HTTP status code was: 404" 
       }, 
       { 


### PR DESCRIPTION
Bumping gds-api-adapters to 4.1.3 to prepare for plek 1.0.0. This resulted in some code
and test changes to work with the newer version of the dependencies.

Also explicitly declaring the version of plek in the Gemfile rather than pulling it in
transitively (and in doing so, upgrading from 0.3.0 to 0.5.0).
