### PR TITLE
Fixing password reset for existing users

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -57,16 +57,6 @@ class User < ActiveRecord::Base
     :admin
   end
 
-  def accept_invitation!
-    # We want to "confirm" an account when a user accepts an invitation,
-    # otherwise confirmable won't let them log in.
-    # Unfortunately, this is also (for some reason) called when a password 
-    # is reset via email so, as a workaround, don't attempt confirmation 
-    # if already confirmed
-    self.confirmed_at = Time.now.utc unless confirmed_at.present?
-    super
-  end
-
   # Override Devise so that, when a user has been invited with one address
   # and then it is changed, we can send a new invitation email, rather than
   # a confirmation email (and hence they'll be in the correct flow re setting

--- a/db/migrate/20121203213600_fix_password_reset_for_existing_users.rb
+++ b/db/migrate/20121203213600_fix_password_reset_for_existing_users.rb
@@ -1,0 +1,14 @@
+class FixPasswordResetForExistingUsers < ActiveRecord::Migration
+  def up
+    # devise_invitable #invite! calls #skip_confirmation!, which in turn sets confirmed_at to Time.now.utc.
+    # That means that when the user accepts the invitation, they are already "confirmed", and everything works.
+    #
+    # However, because we didn't have confirmable enabled (nor the columns on the user table), that had no effect.
+    # Now that we've added confirmable (and the columns on the user table), the behaviour of things like
+    # password resets for those existing users breaks because Devise assumes confirmed_at (or confirmation_sent_at)
+    # is set.
+    #
+    # So to make the old users look like users created now, those users need to have confirmed_at set.
+    User.update_all("confirmed_at = created_at", "confirmed_at is NULL")
+  end
+end


### PR DESCRIPTION
devise_invitable #invite! calls #skip_confirmation!, which in turn sets confirmed_at to Time.now.utc.
That means that when the user accepts the invitation, they are already "confirmed", and everything works.

However, because we didn't have confirmable enabled (nor the columns on the user table), that had no effect.
Now that we've added confirmable (and the columns on the user table), the behaviour of things like
password resets for those existing users breaks because Devise assumes confirmed_at (or confirmation_sent_at)
is set.

So to make the old users look like users created now, those users need to have confirmed_at set.

Removing the hack in the User model because, whilst that addressed some problems, it was based upon a false understanding.
