### PR TITLE
Rewrite the user create rake task

### DIFF
--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -1,26 +1,13 @@
 namespace :users do
   desc "Create a new user (specify name, email and optional password in environment)"
   task :create => :environment do
-    require 'securerandom'
     raise "Requires name and email specified in environment" unless ENV['name'] && ENV['email']
-    default_password = ENV['password'].to_s.strip
-    default_password = SecureRandom.urlsafe_base64 if default_password == ''
-    user_params = {
-      :name => ENV['name'],
-      :email => ENV['email'],
-      # :github => (ENV['github'] || nil),
-      # :twitter => (ENV['twitter'] || nil),
-      :password => "#{default_password}",
-      :password_confirmation => "#{default_password}",
-      :uid => SecureRandom.urlsafe_base64
-    }
 
-    params = Hash[user_params.reject { |k, v| v.nil? }.collect { |k, v| [k, v.dup] }]
-    user = User.create!(params)
-    user.send_reset_password_instructions
+    user = User.invite!(name: ENV['name'].dup, email: ENV['email'].dup)
+    invitation_url = "#{Plek.current.find("signon")}/users/invitation/accept?invitation_token=#{user.invitation_token}"
     puts "User created: user.name <#{user.name}>"
     puts "              user.email <#{user.email}>"
-    puts "              user.password <#{default_password}>" if ENV['password']
+    puts "              follow this link to set a password: #{invitation_url}"
   end
 
   desc "Suspend a user's access to the site (specify email in environment)"


### PR DESCRIPTION
The old code was written when it was the only mechanism for creating
users. It now reuses the code that is used in the controllers for
creating users.
