### PR TITLE
Add a manage keyword permission for Panopticon

### DIFF
--- a/db/migrate/20121204162009_add_manage_keyword_permission.rb
+++ b/db/migrate/20121204162009_add_manage_keyword_permission.rb
@@ -1,0 +1,17 @@
+class AddManageKeywordPermission < ActiveRecord::Migration
+  def up
+    unless panopticon.nil?
+      SupportedPermission.create(application: panopticon, name: "manage_keywords")
+    end
+  end
+
+  def down
+    unless panopticon.nil?
+      SupportedPermission.where(application_id: panopticon.id, name: "manage_keywords").delete_all
+    end
+  end
+
+  def panopticon
+    @panopticon ||= Doorkeeper::Application.find_by_name("Panopticon")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20121203213600) do
+ActiveRecord::Schema.define(:version => 20121204162009) do
 
   create_table "oauth_access_grants", :force => true do |t|
     t.integer  "resource_owner_id", :null => false


### PR DESCRIPTION
This will support a forthcoming UI in Panopticon for managing
an Artefact's keywords, that will only be accessible to some
Panopticon users.
