### PR TITLE
Ensure user name is not nullable

### DIFF
--- a/db/migrate/20121206142526_ensure_user_name_is_not_nullable.rb
+++ b/db/migrate/20121206142526_ensure_user_name_is_not_nullable.rb
@@ -1,0 +1,5 @@
+class EnsureUserNameIsNotNullable < ActiveRecord::Migration
+  def up
+    change_column_null(:users, :name, false)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20121204162009) do
+ActiveRecord::Schema.define(:version => 20121206142526) do
 
   create_table "oauth_access_grants", :force => true do |t|
     t.integer  "resource_owner_id", :null => false


### PR DESCRIPTION
User names haven't been nullable for some time. Let's ensure that the 
databases are consistent.

The production, staging and preview databases all have user name set
to not nullable, but if you migrate a database from scratch it is the
reverse.

This isn't generally a problem as we clone from production, but it would
be nice if it was consistent. It has caused some occasional mismatches
when a dev has built a database from migrations, and then the schema.rb
has changed the nullability of the user name.

This migration shouldn't change anything in production, but will ensure
that it is not nullable everywhere, rather than because we happen to build
our databases in a certain way.
