### PR TITLE
Avoid erroneous IP spoofing error

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -56,6 +56,13 @@ module Signonotron2
 
     #config.middleware.insert_before Warden::Manager, Slimmer::App, config.slimmer.to_hash
 
+    # Prevent ActionDispatch::RemoteIp::IpSpoofAttackError when the client set a Client-IP
+    # header and the request IP was interrogated.
+    #
+    # In our infrastructure, the protection this would give is provided by nginx, so
+    # disabling it solves the above problem and doesn't give us additional risk.
+    config.action_dispatch.ip_spoofing_check = false
+
     config.to_prepare do
       Doorkeeper::ApplicationController.layout "application"
     end

--- a/features/sign_in.feature
+++ b/features/sign_in.feature
@@ -8,3 +8,9 @@ Feature: Signing in
     Given a user exists with email "email@example.com" and passphrase "some passphrase with various $ymb0l$"
     When I try to sign in with email "email@example.com" and passphrase "some incorrect passphrase $ymb0l$"
     Then I should see "Invalid email or passphrase"
+
+  Scenario: My proxy sets the Client-IP HTTP Header
+    Given a user exists with email "email@example.com" and passphrase "some passphrase with various $ymb0l$"
+    And my requests include a Client-IP HTTP Header
+    When I try to sign in with email "email@example.com" and passphrase "some passphrase with various $ymb0l$"
+    Then I should see "Signed in successfully."

--- a/features/step_definitions/authentication_steps.rb
+++ b/features/step_definitions/authentication_steps.rb
@@ -59,3 +59,7 @@ end
 Then /^I should not see "([^"]*)"$/ do |content|
   assert ! page.has_content?(content)
 end
+
+Given /^my requests include a Client-IP HTTP Header$/ do
+  page.driver.browser.header("Client-IP", "127.0.0.1")
+end


### PR DESCRIPTION
Do this by disabling the check. The alternative was to strip the Client-IP
header in middleware. There is an intention to remove this header from all
requests at nginx, but this should get us a solution faster.
