### PR TITLE
Fix the api_clients:create rake task.

### DIFF
--- a/lib/tasks/api_clients.rake
+++ b/lib/tasks/api_clients.rake
@@ -30,7 +30,11 @@ namespace :api_clients do
 
     # Grant authorisation and permissions
     user.permissions.create!(application: application, permissions: [permission.name])
-    authorisation = user.authorisations.create!(application: application, expires_in: 10.years.to_i)
+
+    # The application attribute is attr_protected, hence this form of setting it.
+    authorisation = user.authorisations.build(expires_in: 10.years.to_i)
+    authorisation.application = application
+    authorisation.save!
     
     puts "User created: user.name <#{user.name}>"
     puts "              user.email <#{user.email}>"


### PR DESCRIPTION
The recent Doorkeeper upgrade has made the application attribute on
DoorKeeper::AccessToken attr_protected causing this rake task to fail at
that step.
