### PR TITLE
Silence the asset pipeline in dev

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ gem 'unicorn', '4.3.1'
 
 group :development do
   gem 'sqlite3'
+  gem 'quiet_assets'
 end
 
 gem 'lograge', '0.1.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,6 +137,8 @@ GEM
     orm_adapter (0.4.0)
     plek (1.3.1)
     polyglot (0.3.3)
+    quiet_assets (1.0.1)
+      railties (~> 3.1)
     rack (1.4.5)
     rack-cache (1.2)
       rack (>= 0.4)
@@ -234,6 +236,7 @@ DEPENDENCIES
   paginate_alphabetically (= 0.4.0)!
   passphrase_entropy!
   plek (= 1.3.1)
+  quiet_assets
   rails (= 3.2.12)
   rake (= 0.9.2)
   shoulda (= 3.0.1)


### PR DESCRIPTION
The asset pipeline logging is very noisy, this makes it quiet. I can't think of when the asset log has ever been useful for debugging asset pipeline issues. I'd suggest using this gem across all of our Rails apps.
