### PR TITLE
Grant signin permissions to an app when creating user

### DIFF
--- a/lib/unsupported_permission_error.rb
+++ b/lib/unsupported_permission_error.rb
@@ -1,0 +1,2 @@
+class UnsupportedPermissionError < StandardError
+end


### PR DESCRIPTION
The user creation rake task predates the introduction of granular
permissions. It doesn't make much sense to create a user without a
signin permission to any app at all.

This change adds the ability to specify an application name as an
argument to the rake task. The user will be granted signing permission
to that app when they are created.

You can also specify multiple apps as a comma separated list.
