### PR TITLE
Make comma use in HTML/text emails consistent

### DIFF
--- a/app/views/devise/mailer/confirmation_instructions.text.erb
+++ b/app/views/devise/mailer/confirmation_instructions.text.erb
@@ -1,5 +1,4 @@
-Hello <%= @resource.name %>
-=============================
+Hello <%= @resource.name %>,
 
 You can confirm your email change by copying-and-pasting the link below into your browser's URL bar:
 

--- a/app/views/devise/mailer/invitation_instructions.text.erb
+++ b/app/views/devise/mailer/invitation_instructions.text.erb
@@ -1,5 +1,4 @@
-Hello <%= @resource.name %>
-============================
+Hello <%= @resource.name %>,
 
 Someone has invited you to GOV.UK Signon, you can accept it copying-and-pasting the link below into your browser's URL bar:
 

--- a/app/views/devise/mailer/reset_password_instructions.text.erb
+++ b/app/views/devise/mailer/reset_password_instructions.text.erb
@@ -1,5 +1,4 @@
-Hello <%= @resource.name %>
-=============================
+Hello <%= @resource.name %>,
 
 Someone has requested a link to change your passphrase, and you can do this copying-and-pasting the link below into your browser's URL bar:
 

--- a/app/views/devise/mailer/unlock_instructions.text.erb
+++ b/app/views/devise/mailer/unlock_instructions.text.erb
@@ -1,5 +1,4 @@
-Hello <%= @resource.name %>
-=============================
+Hello <%= @resource.name %>,
 
 Your account has been locked due to an excessive amount of unsuccessful sign in attempts.
 


### PR DESCRIPTION
Also remove the rows of equals signs below the greeting in the text emails.
