### PR TITLE
Redirect user to sign_in page after sign_out

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,10 @@ class ApplicationController < ActionController::Base
     headers['X-Frame-Options'] = 'SAMEORIGIN'
   end
 
+  def after_sign_out_path_for(resource_or_scope)
+    new_user_session_path
+  end
+
   def current_resource_owner
     User.find(doorkeeper_token.resource_owner_id) if doorkeeper_token
   end


### PR DESCRIPTION
Before this change user was redirected to index page which requires
authentication. This caused a 'Signed out successfully' message to be
overriden with 'You need to sign in' message. It was quite confusing
for a user to see 'You need to sign in' message right after signing
out.
