### PR TITLE
Fix error in authentication + changing passphrase

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'uuid'
 gem 'devise', '2.2.3'
 gem 'devise_invitable', '1.1.5'
 gem 'devise-encryptable', '0.1.1'
-gem 'devise_security_extension', '0.7.2'
+gem 'devise_security_extension', '0.7.2', git: "https://github.com/alphagov/devise_security_extension.git", branch: "graceful_return_to_behaviour"
 gem 'passphrase_entropy', git: 'https://github.com/alphagov/passphrase_entropy.git'
 
 gem 'doorkeeper', '0.6.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,13 @@
 GIT
+  remote: https://github.com/alphagov/devise_security_extension.git
+  revision: 4d14ed4c9ae8f23da0e9d5de2b6b69d9b53cd73d
+  branch: graceful_return_to_behaviour
+  specs:
+    devise_security_extension (0.7.2)
+      devise (>= 2.0.0)
+      rails (>= 3.1.1)
+
+GIT
   remote: https://github.com/alphagov/passphrase_entropy.git
   revision: 70c37daeb0c85afe9832ad4231cc5c548efb3184
   specs:
@@ -89,9 +98,6 @@ GEM
       actionmailer (~> 3.0)
       devise (>= 2.1.1)
       railties (~> 3.0)
-    devise_security_extension (0.7.2)
-      devise (>= 2.0.0)
-      rails (>= 3.1.1)
     diff-lcs (1.1.3)
     doorkeeper (0.6.7)
       railties (~> 3.1)
@@ -233,7 +239,7 @@ DEPENDENCIES
   devise (= 2.2.3)
   devise-encryptable (= 0.1.1)
   devise_invitable (= 1.1.5)
-  devise_security_extension (= 0.7.2)
+  devise_security_extension (= 0.7.2)!
   doorkeeper (= 0.6.7)
   exception_notification
   factory_girl_rails (= 3.1.0)

--- a/features/passphrase_expiry.feature
+++ b/features/passphrase_expiry.feature
@@ -11,6 +11,15 @@ Feature: Passphrase expiry
     Then I should see "Your new passphrase is saved"
       And I should be on the dashboard
 
+  Scenario: Returning to the exact path I wanted after changing passphrase
+    Given I am a user with email "email@example.com" and passphrase "some v3ry s3cure passphrase"
+    And I last changed my passphrase 91 days ago
+    And I visit "/user/edit?arbitrary=1"
+    When I sign in
+    And I fill in the form with existing passphrase "some v3ry s3cure passphrase" and new passphrase "some 3v3n more s3cure passphrase"
+    Then I should see "Your new passphrase is saved"
+    And I should be on "/user/edit?arbitrary=1"
+
   Scenario: Making a mistake when choosing a new passphrase
     Given I am being prompted for a new passphrase
     When I make a mistake entering my existing passphrase

--- a/features/step_definitions/passphrase_expiry_steps.rb
+++ b/features/step_definitions/passphrase_expiry_steps.rb
@@ -33,6 +33,16 @@ When /^I fill in the form with existing passphrase "(.*?)" and new passphrase "(
   reset_expired_passphrase(old_passphrase, new_passphrase, new_passphrase)
 end
 
+Given /^I visit "(.*?)"$/ do |fullpath|
+  visit fullpath
+end
+
+Then /^I should be on "(.*?)"$/ do |fullpath|
+  current_path_including_querystring = current_url.gsub(current_host, "")
+  assert_equal fullpath, current_path_including_querystring
+end
+
+
 Then /^I should be on the dashboard$/ do
   assert_equal root_url, current_url
 end


### PR DESCRIPTION
The problem flow was:
  Visit Client app (e.g. publisher).
  Redirected to signon
  Login to signon
  Password change required
  Change password
  Error message saying "The authoprization server does not support this response type."

The underlying cause was that devise_security_extension was returning you to
the request.path, which excluded the querystring, which the OAuth flow needed.
The fix was to change the gem to return you to the fullpath.

Open PR on the gem:
https://github.com/phatworx/devise_security_extension/pull/53
