### PR TITLE
Add SupportedPermission support to rake applications:create

### DIFF
--- a/lib/tasks/applications.rake
+++ b/lib/tasks/applications.rake
@@ -2,12 +2,19 @@ namespace :applications do
 
   desc "Creates an application(OAuth client)"
   task :create => :environment do 
+    # Create client app
     a = Doorkeeper::Application.create!(
       name: ENV['name'],
       redirect_uri: ENV['redirect_uri'],
       description: ENV['description'],
       home_uri: ENV['home_uri']
     )
+    # Optionally set up supported permissions
+    permissions = (ENV['supported_permissions'] || '').split(',')
+    permissions.each do |permission|
+      SupportedPermission.create(:application_id => a.id, :name => permission)
+    end
+    # Done
     puts "Application '#{a.name}' created."
     puts 
     puts "config.oauth_id     = '#{a.uid}'"


### PR DESCRIPTION
SupportedPermission objects are required for the api client create task, but the applications:create task doesn't create any, and neither does db:migrate. So, I've added the ability to create them as part of the applications:create rake task:

```
rake application:create name=publisher ... supported_permissions=signin
```
