### PR TITLE
make lograge output more useful

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,8 @@ group :development do
   gem 'quiet_assets'
 end
 
-gem 'lograge', '0.1.2'
+gem 'lograge', '0.2.2'
+gem 'logstash-event', '1.2.02'
 
 group :test do
   gem 'cucumber-rails', '1.3.0', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,9 +129,11 @@ GEM
     kgio (2.7.4)
     libwebsocket (0.1.5)
       addressable
-    lograge (0.1.2)
-      actionpack
-      activesupport
+    lograge (0.2.2)
+      actionpack (>= 3)
+      activesupport (>= 3)
+      railties (>= 3)
+    logstash-event (1.2.02)
     lrucache (0.1.4)
       PriorityQueue (~> 0.1.2)
     macaddr (1.6.1)
@@ -144,7 +146,7 @@ GEM
     mime-types (1.21)
     mocha (0.13.3)
       metaclass (~> 0.0.1)
-    multi_json (1.7.8)
+    multi_json (1.8.0)
     mysql2 (0.3.11)
     nokogiri (1.5.5)
     null_logger (0.0.1)
@@ -247,7 +249,8 @@ DEPENDENCIES
   jquery-rails
   json (= 1.7.7)
   kaminari (= 0.14.1)
-  lograge (= 0.1.2)
+  lograge (= 0.2.2)
+  logstash-event (= 1.2.02)
   mocha (= 0.13.3)
   mysql2
   paginate_alphabetically (= 0.4.0)!

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -60,6 +60,7 @@ Signonotron2::Application.configure do
 
   # Enable lograge
   config.lograge.enabled = true
+  config.lograge.formatter = Lograge::Formatters::Logstash.new
 
   # Send deprecation notices to registered listeners
   config.active_support.deprecation = :notify


### PR DESCRIPTION
currently, the production lograge output doesn't even include the timestamp.
This change changes the logs to logstash format, which includes the timestamp.

**NOTE**: This is an alternative to #87; if one of these is merged, the other should be thrown away.
