### PR TITLE
Add the signin permission to the SSO Push User

### DIFF
--- a/lib/sso_push_credential.rb
+++ b/lib/sso_push_credential.rb
@@ -1,6 +1,7 @@
 class SSOPushCredential
 
   PERMISSIONS = [
+    "signin",
     "user_update_permission"
   ]
 

--- a/test/unit/sso_push_credential_test.rb
+++ b/test/unit/sso_push_credential_test.rb
@@ -37,18 +37,29 @@ class SSOPushCredentialTest < ActiveSupport::TestCase
         SSOPushCredential.credentials(@application)
 
         assert_equal 1, @user.permissions.count
-        assert_equal ["user_update_permission"], @user.permissions.first.permissions
+        assert_equal ["signin", "user_update_permission"], @user.permissions.first.permissions
         assert_equal @application.id, @user.permissions.first.application_id
       end
 
-      should "not create a new permission if one already exists" do
+      should "not create a new permission if both already exist" do
+        @user.grant_permissions(@application, ["user_update_permission", "signin"])
+
+        assert_equal 1, @user.permissions.count
+        SSOPushCredential.credentials(@application)
+
+        assert_equal 1, @user.permissions.count
+        assert_equal ["user_update_permission", "signin"], @user.permissions.first.permissions
+        assert_equal @application.id, @user.permissions.first.application_id
+      end
+
+      should "update the existing permission if it does not include all the require permissions" do
         @user.grant_permission(@application, "user_update_permission")
 
         assert_equal 1, @user.permissions.count
         SSOPushCredential.credentials(@application)
 
         assert_equal 1, @user.permissions.count
-        assert_equal ["user_update_permission"], @user.permissions.first.permissions
+        assert_equal ["user_update_permission", "signin"], @user.permissions.first.permissions
         assert_equal @application.id, @user.permissions.first.application_id
       end
     end


### PR DESCRIPTION
Currently the SSO Push User only has the `user_update_permission` permission, however due to GDS::SSO not skipping the requirement for the `signin` permission explicitly for the push requests, there is inconsistent behaviour with each app depending on whether the `signin` permission is required in the `ApplicationController`.

The easiest way to fix this right now is to give the SSO User the `signin` permission too. We may want to make a change to the SSO gem in the future to not require this.
