### PR TITLE
Don't show user_update_permission in user form

### DIFF
--- a/app/models/enhancements/application.rb
+++ b/app/models/enhancements/application.rb
@@ -7,11 +7,13 @@ class ::Doorkeeper::Application < ActiveRecord::Base
   attr_accessible :name, :description, :uid, :secret, :redirect_uri, :home_uri
 
   def self.default_permission_strings
+    # Excludes user_update_permission which is granted automatically when needed
+    # to the special SSO Push User
     ["signin"]
   end
 
   def supported_permission_strings
-    ["user_update_permission"] + self.class.default_permission_strings + supported_permissions.order(:name).map(&:name)
+    self.class.default_permission_strings + supported_permissions.order(:name).map(&:name)
   end
 
   def url_without_path

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -65,11 +65,6 @@ class User < ActiveRecord::Base
   end
 
   def grant_permissions(application, permissions)
-    unsupported_permissions = permissions - application.supported_permission_strings
-    if unsupported_permissions.any?
-      raise UnsupportedPermissionError, "Cannot grant '#{unsupported_permissions.join("', '")}' permission(s), they are not supported by the '#{application.name}' application"
-    end
-
     permission_record = self.permissions.find_by_application_id(application.id) || self.permissions.build(application_id: application.id)
     new_permissions = Set.new(permission_record.permissions || [])
     new_permissions += permissions

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -9,6 +9,10 @@ namespace :users do
 
     user = User.invite!(name: ENV['name'].dup, email: ENV['email'].dup)
     applications.each do |application|
+      unsupported_permissions = permissions - application.supported_permission_strings
+      if unsupported_permissions.any?
+        raise UnsupportedPermissionError, "Cannot grant '#{unsupported_permissions.join("', '")}' permission(s), they are not supported by the '#{application.name}' application"
+      end
       user.grant_permission(application, 'signin')
     end
 

--- a/test/unit/doorkeeper_application_test.rb
+++ b/test/unit/doorkeeper_application_test.rb
@@ -5,7 +5,7 @@ class ::Doorkeeper::ApplicationTest < ActiveSupport::TestCase
     should "return a list of string permissions, merging in the defaults" do
       app = FactoryGirl.create(:application)
       FactoryGirl.create(:supported_permission, name: "write", application: app)
-      assert_equal ["user_update_permission", "signin", "write"], app.supported_permission_strings
+      assert_equal ["signin", "write"], app.supported_permission_strings
     end
   end
 end

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -103,16 +103,6 @@ class UserTest < ActiveSupport::TestCase
     assert_user_has_permissions ['Create publications'], app, user
   end
 
-  test "granting an unsupported permission raises an error" do
-    app = FactoryGirl.create(:application, name: "my_app")
-    app.supported_permissions.create!(name: 'signin')
-    user = FactoryGirl.create(:user)
-
-    assert_raises UnsupportedPermissionError do
-      user.grant_permission(app, "Unsupported")
-    end
-  end
-
   test "granting an already granted permission doesn't cause duplicates" do
     app = FactoryGirl.create(:application, name: "my_app")
     user = FactoryGirl.create(:user)


### PR DESCRIPTION
Remove it from the supported_permission_strings list so that it doesn't appear
in the GUI. This was introduced in: 505a51a93cbb4d60ccc857a8e21b5b00ccb43242

We moved the check for unsupported permissions to the rake task so that
SSOPushCredential could still use grant_permissions to add the (supposedly)
unsupported permission.

This was easier than trying to make the supported permissions list vary based
on whether or not the user is the SSOPushUser.
