### PR TITLE
Refactor User.to_sensible_json to a presenter

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,7 +6,8 @@ class UsersController < ApplicationController
     relevant_permission.synced! if relevant_permission
     respond_to do |format|
       format.json do
-        render json: current_resource_owner.to_sensible_json(application_making_request)
+        presenter = UserOAuthPresenter.new(current_resource_owner, application_making_request)
+        render json: presenter.as_hash.to_json
       end
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -46,11 +46,6 @@ class User < ActiveRecord::Base
     self.uid = UUID.generate
   end
 
-  def to_sensible_json(for_application)
-    permission = self.permissions.where(application_id: for_application.id).first
-    { user: { uid: uid, name: name, email: email, permissions: permission.nil? ? [] : permission.permissions } }.to_json
-  end
-
   def invited_but_not_accepted
     !invitation_sent_at.nil? && invitation_accepted_at.nil?
   end

--- a/app/presenters/user_o_auth_presenter.rb
+++ b/app/presenters/user_o_auth_presenter.rb
@@ -1,0 +1,20 @@
+# Generates a hash suitable for exposing to an application integrating with
+# signon for SSO over OAuth. Also used when pushing user updates, which isn't
+# part of OAuth.
+class UserOAuthPresenter < Struct.new(:user, :application)
+  def as_hash
+    {
+      user: {
+        uid: user.uid,
+        name: user.name,
+        email: user.email,
+        permissions: permissions_strings
+      }
+    }
+  end
+
+  def permissions_strings
+    permission = user.permissions.where(application_id: application.id).first
+    permission.nil? ? [] : permission.permissions
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,7 +20,10 @@ module Signonotron2
     # -- all .rb files in that directory are automatically loaded.
 
     # Custom directories with classes and modules you want to be autoloadable.
-    config.autoload_paths += %W(#{config.root}/lib)
+    config.autoload_paths += %W(
+      #{config.root}/lib
+      #{config.root}/app/presenters
+    )
 
     # Only load the plugins named here, in the order given (default is alphabetical).
     # :all can be used as a placeholder for all plugins not explicitly named.

--- a/lib/permission_updater.rb
+++ b/lib/permission_updater.rb
@@ -15,7 +15,8 @@ class PermissionUpdater
   def self.updater
     Proc.new do |user, application|
       api = SSOPushClient.new(application)
-      api.update_user(user.uid, JSON.parse(user.to_sensible_json(application)))
+      presenter = UserOAuthPresenter.new(user, application)
+      api.update_user(user.uid, presenter.as_hash)
     end
   end
 

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -132,7 +132,8 @@ class UsersControllerTest < ActionController::TestCase
       get :show, {:format => :json}
 
       assert_equal "200", response.code
-      assert_equal user.to_sensible_json(application), response.body
+      presenter = UserOAuthPresenter.new(user, application)
+      assert_equal presenter.as_hash.to_json, response.body
     end
 
     should "fetching json profile with an invalid oauth token should not succeed" do

--- a/test/unit/permission_updater_test.rb
+++ b/test/unit/permission_updater_test.rb
@@ -20,7 +20,7 @@ class PermissionUpdaterTest < ActiveSupport::TestCase
   end
 
   should "send a PUT to the related app with the user.json as in the OAuth exchange" do
-    expected_body = @user.to_sensible_json(@application)
+    expected_body = UserOAuthPresenter.new(@user, @application).as_hash.to_json
     request = stub_request(:put, url_for_app(@application)).with(body: expected_body)
     PermissionUpdater.new(@user, @user.permissions.map(&:application)).attempt
     assert_requested request
@@ -71,7 +71,7 @@ class PermissionUpdaterTest < ActiveSupport::TestCase
 
   context "successful update" do
     should "record the last_synced_at timestamp on the permission" do
-      expected_body = @user.to_sensible_json(@application)
+      expected_body = UserOAuthPresenter.new(@user, @application).as_hash.to_json
 
       stub_request(:put, url_for_app(@application)).with(body: expected_body)
       PermissionUpdater.new(@user, @user.permissions.map(&:application)).attempt
@@ -81,7 +81,7 @@ class PermissionUpdaterTest < ActiveSupport::TestCase
 
   context "failed update" do
     should "not record the last_synced_at timestamp on the permission" do
-      expected_body = @user.to_sensible_json(@application)
+      expected_body = UserOAuthPresenter.new(@user, @application).as_hash.to_json
 
       stub_request(:put, url_for_app(@application)).to_timeout
       PermissionUpdater.new(@user, @user.permissions.map(&:application)).attempt

--- a/test/unit/user_o_auth_presenter_test.rb
+++ b/test/unit/user_o_auth_presenter_test.rb
@@ -1,0 +1,35 @@
+require 'test_helper'
+
+class UserOAuthPresenterTest < ActiveSupport::TestCase
+  setup do
+    @user = FactoryGirl.create(:user)
+  end
+
+  should "generate JSON" do
+    app = FactoryGirl.create(:application)
+    FactoryGirl.create(:permission, application: app, user: @user, permissions: ["signin", "coughing"])
+    expected = {
+      user: {
+        email:  @user.email,
+        name: @user.name,
+        uid: @user.uid,
+        permissions: ["signin", "coughing"]
+      }
+    }
+    presenter = UserOAuthPresenter.new(@user, app)
+    assert_equal(expected, presenter.as_hash)
+  end
+
+  should "handle the user having nil permissions value for the app" do
+    app = FactoryGirl.create(:application)
+    FactoryGirl.create(:permission, application: app, user: @user, permissions: nil)
+    presenter = UserOAuthPresenter.new(@user, app)
+    assert_equal([], presenter.as_hash[:user][:permissions])
+  end
+
+  should "handle the user having no permissions record for the app" do
+    app = FactoryGirl.create(:application)
+    presenter = UserOAuthPresenter.new(@user, app)
+    assert_equal([], presenter.as_hash[:user][:permissions])
+  end
+end

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -12,22 +12,6 @@ class UserTest < ActiveSupport::TestCase
     assert_equal "needs to be confirmed within 14 days, please request a new one", @user.errors[:email][0]
   end
 
-  # JSON Output
-
-  test "sensible json output" do
-    app1 = FactoryGirl.create(:application, name: "app1")
-    FactoryGirl.create(:permission, application: app1, user: @user, permissions: ["signin", "coughing"])
-    expected = {
-      "user" => {
-        "email" =>  @user.email,
-        "name" => @user.name,
-        "uid" => @user.uid,
-        "permissions" => ["signin", "coughing"]
-      }
-    }
-    assert_equal(expected, JSON.parse(@user.to_sensible_json(app1)) )
-  end
-
   # Attribute protection
 
   test "the role has to be specifically assigned" do


### PR DESCRIPTION
This didn't belong in the model, and we're about to add organisations to this code so it seems helpful to tidy it up first.

It also means we don't generate a JSON string to then parse it back to a Ruby structure in PermissionUpdater.
