### PR TITLE
Expose organisations in the user.json

### DIFF
--- a/app/presenters/user_o_auth_presenter.rb
+++ b/app/presenters/user_o_auth_presenter.rb
@@ -8,7 +8,8 @@ class UserOAuthPresenter < Struct.new(:user, :application)
         uid: user.uid,
         name: user.name,
         email: user.email,
-        permissions: permissions_strings
+        permissions: permissions_strings,
+        organisations: organisations_strings,
       }
     }
   end
@@ -16,5 +17,9 @@ class UserOAuthPresenter < Struct.new(:user, :application)
   def permissions_strings
     permission = user.permissions.where(application_id: application.id).first
     permission.nil? ? [] : permission.permissions
+  end
+
+  def organisations_strings
+    user.organisations.pluck(:slug)
   end
 end

--- a/test/unit/user_o_auth_presenter_test.rb
+++ b/test/unit/user_o_auth_presenter_test.rb
@@ -8,12 +8,16 @@ class UserOAuthPresenterTest < ActiveSupport::TestCase
   should "generate JSON" do
     app = FactoryGirl.create(:application)
     FactoryGirl.create(:permission, application: app, user: @user, permissions: ["signin", "coughing"])
+    justice_league = FactoryGirl.create(:organisation, slug: "justice-league")
+    @user.organisations << justice_league
+
     expected = {
       user: {
         email:  @user.email,
         name: @user.name,
         uid: @user.uid,
-        permissions: ["signin", "coughing"]
+        permissions: ["signin", "coughing"],
+        organisations: ["justice-league"],
       }
     }
     presenter = UserOAuthPresenter.new(@user, app)


### PR DESCRIPTION
This will enable apps to know what organisations a user is a member of.

The slugs will be sourced from the Whitehall Organisations API: http://whitehall-admin.dev.gov.uk/api/organisations

I have successfully tested for forwards and backwards compatibility with apps.

We will test integration with apps that don't use gds-sso (eg Performance Platform) on preview.
