### PR TITLE
Allow API clients with the 'signin' permission.

### DIFF
--- a/lib/tasks/api_clients.rake
+++ b/lib/tasks/api_clients.rake
@@ -17,7 +17,9 @@ namespace :api_clients do
   task :create, [:name, :email, :application_name, :permission] => :environment do |t, args|
     # make sure we have all the pieces
     application = Doorkeeper::Application.find_by_name!(args[:application_name])
-    permission = application.supported_permissions.find_by_name!(args[:permission])
+    unless application.supported_permission_strings.include? args[:permission]
+      raise ArgumentError, "Unsupported permission '#{args[:permission]}'"
+    end
 
     # create as user
     default_password = SecureRandom.urlsafe_base64
@@ -29,7 +31,7 @@ namespace :api_clients do
     )
 
     # Grant authorisation and permissions
-    user.permissions.create!(application: application, permissions: [permission.name])
+    user.permissions.create!(application: application, permissions: [args[:permission]])
 
     # The application attribute is attr_protected, hence this form of setting it.
     authorisation = user.authorisations.build(expires_in: 10.years.to_i)


### PR DESCRIPTION
Apps all implicitly support this permission, even if they don't have a
`SupportedPermission` object to say so. By changing the Rake task to use
the `supported_permission_strings` method, we can use this permission
when creating API clients.
