### PR TITLE
Remove homepage column from organisations index

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -14,18 +14,4 @@ class Organisation < ActiveRecord::Base
       name
     end
   end
-
-  def web_url
-    root_url + '/government/organisations/' + slug
-  end
-
-private
-
-  def root_url
-    if Rails.env.development?
-      Plek.current.find('whitehall-admin')
-    else
-      Plek.current.find('www')
-    end
-  end
 end

--- a/app/views/admin/organisations/index.html.erb
+++ b/app/views/admin/organisations/index.html.erb
@@ -8,7 +8,6 @@
           <th>Name</th>
           <th>Abbreviation</th>
           <th>Organisation Type</th>
-          <th>Homepage</th>
         </tr>
       </thead>
       <tbody>
@@ -17,7 +16,6 @@
             <td><%= organisation.name %></td>
             <td><%= organisation.abbreviation %></td>
             <td><%= organisation.organisation_type %></td>
-            <td><%= link_to organisation.web_url, organisation.web_url %></td>
           </tr>
         <% end %>
       </tbody>


### PR DESCRIPTION
This was using the wrong hostname in production, doesn't provide any
additional useful information, and removing it leaves more horizontal
space to display long names and organisation types.
