### PR TITLE
Fix User creation rake task

### DIFF
--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -8,6 +8,8 @@ namespace :users do
     end
 
     user = User.invite!(name: ENV['name'].dup, email: ENV['email'].dup)
+    permissions = ENV.fetch('permissions', '').split(',').uniq
+
     applications.each do |application|
       unsupported_permissions = permissions - application.supported_permission_strings
       if unsupported_permissions.any?


### PR DESCRIPTION
`permissions` variable is undefined in this context (https://github.com/alphagov/signonotron2/blob/master/lib/tasks/users.rake#L4-L12). Permissions should be passed using environment variable.

Looks like the issue was introduced in https://github.com/alphagov/signonotron2/commit/4474af0b02b8d41c1bc0bd86435b98a983f0958f
