### PR TITLE
Rename organisation to organisation_slug

### DIFF
--- a/app/presenters/user_o_auth_presenter.rb
+++ b/app/presenters/user_o_auth_presenter.rb
@@ -9,7 +9,7 @@ class UserOAuthPresenter < Struct.new(:user, :application)
         name: user.name,
         email: user.email,
         permissions: permissions_strings,
-        organisation: organisation_slug,
+        organisation_slug: organisation_slug,
       }
     }
   end

--- a/test/unit/user_o_auth_presenter_test.rb
+++ b/test/unit/user_o_auth_presenter_test.rb
@@ -17,7 +17,7 @@ class UserOAuthPresenterTest < ActiveSupport::TestCase
         name: @user.name,
         uid: @user.uid,
         permissions: ["signin", "coughing"],
-        organisation: "justice-league",
+        organisation_slug: "justice-league",
       }
     }
     presenter = UserOAuthPresenter.new(@user, app)


### PR DESCRIPTION
When it came to making use of this data in an application, it quickly became
clear that it was going to be common for people doing the same task to want a
method on their user called 'organisation' which would clash directly with this
field name.

We are still in a position where we can change the field name to reflect what
it really is and to make integration for apps cleaner and simpler, without breaking anything.

If we were ever to change how we passed around organisation references (eg to a
full URL) then we would need to put it in a different field name anyway.
