### PR TITLE
Remove db/seeds.rb

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,0 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rake db:seed (or created alongside the db with db:setup).
-#
-# Examples:
-#
-#   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
-#   Mayor.create(name: 'Emanuel', city: cities.first)


### PR DESCRIPTION
This file isn't used. It's the default file generated by Rails.

Its existence confused me when getting signonotron set up initially because I assumed there would be some basic database content once I'd run `rake db:setup`.
