### PR TITLE
Fix test that was spuriously passing with sqlite3

### DIFF
--- a/features/login_timeout.feature
+++ b/features/login_timeout.feature
@@ -11,7 +11,7 @@ Feature: Restrictions around signin
     Given a user exists with email "email@example.com" and passphrase "some passphrase with various $ymb0l$"
       And they have been locked out
       And a signed-in admin user
-    When I go to the list of users
+    When I go to the list of users beginning with E
     Then I should see a button to unlock account
 
     When I press the unlock button

--- a/features/step_definitions/authentication_steps.rb
+++ b/features/step_definitions/authentication_steps.rb
@@ -1,7 +1,7 @@
 require 'factory_girl'
 
 Given /^a user exists with email "([^"]*)" and passphrase "([^"]*)"$/ do |email, passphrase|
-  @user = FactoryGirl.create(:user, email: email, password: passphrase, password_confirmation: passphrase, name: email.split('@').first)
+  @user = FactoryGirl.create(:user, email: email, password: passphrase, password_confirmation: passphrase, name: email.split('@').first.titleize)
 end
 
 Given /^a signed\-in user exists with email "([^"]*)" and passphrase "([^"]*)"$/ do |email, passphrase|

--- a/features/step_definitions/timeout_steps.rb
+++ b/features/step_definitions/timeout_steps.rb
@@ -6,6 +6,10 @@ When /^I go to the list of users$/ do
   visit admin_users_path
 end
 
+When /^I go to the list of users beginning with (.)$/ do |letter|
+  visit admin_users_path(:letter => letter)
+end
+
 Then /^I should see a button to unlock account$/ do
   assert page.find_button('Unlock'), "Can't find unlock button"
 end


### PR DESCRIPTION
sqlite3 does case-sensitive sorting, which means that "email" was sorting before "A name is now...", and therefore when no letter was specified, the users index was defaulting to 'E'.  With the switch to mysql, this broke the test because it was now defaulting to 'A'.

See https://github.com/edendevelopment/paginate_alphabetically/blob/master/lib/paginate_alphabetically/active_record.rb#L16-L20 for the code that does this.
