### PR TITLE
Validate users before inviting

### DIFF
--- a/app/models/permission.rb
+++ b/app/models/permission.rb
@@ -1,10 +1,10 @@
 class Permission < ActiveRecord::Base
-  belongs_to :user
+  belongs_to :user, inverse_of: :permissions
   belongs_to :application, class_name: 'Doorkeeper::Application'
   serialize :permissions, Array
 
-  validates_presence_of :application_id
-  validates_presence_of :user_id
+  validates_presence_of :application
+  validates_presence_of :user
 
   def synced!
     update_attributes(last_synced_at: Time.zone.now)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -33,7 +33,7 @@ class User < ActiveRecord::Base
   validates :role, inclusion: { in: ROLES }
 
   has_many :authorisations, :class_name => 'Doorkeeper::AccessToken', :foreign_key => :resource_owner_id
-  has_many :permissions
+  has_many :permissions, inverse_of: :user
   has_many :batch_invitations
   belongs_to :organisation
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -91,22 +91,22 @@ Devise.setup do |config|
   # this period, the invited resource won't be able to accept the invitation.
   # When invite_for is 0 (the default), the invitation won't expire.
   config.invite_for = 2.weeks
-  
+
   # Number of invitations users can send.
   # If invitation_limit is nil, users can send unlimited invitations.
   # If invitation_limit is 0, users can't send invitations.
   # If invitation_limit n > 0, users can send n invitations.
   # Default: nil
   config.invitation_limit = nil
-  
+
   # The key to be used to check existing users when sending an invitation
   # and the regexp used to test it when validate_on_invite is not set.
   # config.invite_key = {:email => /A[^@]+@[^@]+z/}
   # config.invite_key = {:email => /A[^@]+@[^@]+z/, :username => nil}
-  
-  # Flag that force a record to be valid before being actually invited 
+
+  # Flag that force a record to be valid before being actually invited
   # Default: false
-  # config.validate_on_invite = true
+  config.validate_on_invite = true
 
   # ==> Configuration for :confirmable
   # A period that the user is allowed to access the website even without

--- a/lib/user_permissions_controller_methods.rb
+++ b/lib/user_permissions_controller_methods.rb
@@ -2,7 +2,7 @@ module UserPermissionsControllerMethods
   private
     def applications_and_permissions(user)
       ::Doorkeeper::Application.order(:name).all.map do |application|
-        permission_for_application = user.permissions.find_or_create_by_application_id(application.id)
+        permission_for_application = Permission.where(application_id: application.id, user_id: user.id).first_or_initialize
         [application, permission_for_application]
       end
     end

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -107,6 +107,13 @@ class UserTest < ActiveSupport::TestCase
     assert_not_nil user.confirmed_at
   end
 
+  test "performs validations before inviting" do
+    user = User.invite!(name: nil, email: "j@1.com")
+
+    assert_not_empty user.errors
+    assert_false user.persisted?
+  end
+
   def assert_user_has_permissions(expected_permissions, application, user)
     permissions_for_my_app = user.permissions.reload.find_by_application_id(application.id)
     assert_equal expected_permissions, permissions_for_my_app.permissions


### PR DESCRIPTION
the addition of an organisation admin role requires
a validation that the organisation can't be blank for
an organisation admin (obviously !). this requires
us to turn-on [devise validate_on_invite](https://github.com/scambra/devise_invitable#model-configuration).

the existing code assumed that permissions coming
in as nested attributes of users won't be validated 
during invite. which needed to be fixed.

the use of [`inverse_of`](http://api.rubyonrails.org/classes/ActiveRecord/Associations/ClassMethods.html#label-Bi-directional+associations) makes sure Rails understands
that permissions can be validated only once a user gets
saved, till then it can validate against an in memory user.
