### PR TITLE
No longer need flag to toggle membership editing

### DIFF
--- a/app/views/admin/users/_form_fields.html.erb
+++ b/app/views/admin/users/_form_fields.html.erb
@@ -37,14 +37,12 @@
   </p>
 <% end %>
 
-<% unless DISABLE_MEMBERSHIP_EDITING %>
-  <p>
-    <%= f.label :organisation_id, "Organisation" %>
-    <%= f.select :organisation_id, options_from_collection_for_select(Organisation.accessible_by(current_ability), :id, :name_with_abbreviation, selected: f.object.organisation_id),
-      { include_blank: current_user.role == 'organisation_admin' ? false : 'None' },
-      { class: "chzn-select" } %>
-  </p>
-<% end %>
+<p>
+  <%= f.label :organisation_id, "Organisation" %>
+  <%= f.select :organisation_id, options_from_collection_for_select(Organisation.accessible_by(current_ability), :id, :name_with_abbreviation, selected: f.object.organisation_id),
+    { include_blank: current_user.role == 'organisation_admin' ? false : 'None' },
+    { class: "chzn-select" } %>
+</p>
 
 <h2>Permissions</h2>
 

--- a/config/initializers/membership_editing.rb
+++ b/config/initializers/membership_editing.rb
@@ -1,3 +1,0 @@
-# A feature flag to turn off editing of a user's membership of an organisation
-
-DISABLE_MEMBERSHIP_EDITING = false

--- a/test/functional/admin/invitations_controller_test.rb
+++ b/test/functional/admin/invitations_controller_test.rb
@@ -23,14 +23,12 @@ class Admin::InvitationsControllerTest < ActionController::TestCase
         outside_organisation = create(:organisation)
         sign_in admin
 
-        with_const_override(:DISABLE_MEMBERSHIP_EDITING, false) do
-          get :new
+        get :new
 
-          assert_select ".container" do
-            assert_select "option", count: 0, text: outside_organisation.name_with_abbreviation
-            assert_select "option", count: 1, text: admin.organisation.name_with_abbreviation
-            assert_select "option", count: 1, text: sub_organisation.name_with_abbreviation
-          end
+        assert_select ".container" do
+          assert_select "option", count: 0, text: outside_organisation.name_with_abbreviation
+          assert_select "option", count: 1, text: admin.organisation.name_with_abbreviation
+          assert_select "option", count: 1, text: sub_organisation.name_with_abbreviation
         end
       end
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -31,14 +31,3 @@ end
 class ActionController::TestCase
   include Devise::TestHelpers
 end
-
-def with_const_override(const_sym, value)
-  old_value = Object.send :remove_const, const_sym
-  begin
-    Object.send :const_set, const_sym, value
-    yield
-  ensure
-    Object.send :remove_const, const_sym
-    Object.send :const_set, const_sym, old_value
-  end
-end


### PR DESCRIPTION
ProTip™: add w=1 to the url to view an equivalent of git diff -w

https://github.com/alphagov/signonotron2/compare/master...removing-membership-editing-feature-flag?w=1
