### PR TITLE
more concise app and permission test definitions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,7 @@ gem 'logstasher', '0.2.8'
 group :test do
   gem 'cucumber-rails', '1.3.0', require: false
   gem 'database_cleaner', '0.7.2'
-  gem 'factory_girl_rails', '3.1.0'
+  gem 'factory_girl_rails', '4.3.0'
   gem 'mocha', '0.13.3', require: false
   gem 'shoulda', '3.0.1'
   gem 'webmock', '1.8.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,10 +102,10 @@ GEM
     erubis (2.7.0)
     exception_notification (2.6.1)
       actionmailer (>= 3.0.4)
-    factory_girl (3.1.1)
+    factory_girl (4.3.0)
       activesupport (>= 3.0.0)
-    factory_girl_rails (3.1.0)
-      factory_girl (~> 3.1.0)
+    factory_girl_rails (4.3.0)
+      factory_girl (~> 4.3.0)
       railties (>= 3.0.0)
     ffi (1.1.5)
     gds-api-adapters (7.11.0)
@@ -250,7 +250,7 @@ DEPENDENCIES
   devise_security_extension (= 0.7.2)!
   doorkeeper (= 0.6.7)
   exception_notification
-  factory_girl_rails (= 3.1.0)
+  factory_girl_rails (= 4.3.0)
   gds-api-adapters (= 7.11.0)
   jquery-rails
   json (= 1.7.7)

--- a/test/factories/oauth_applications.rb
+++ b/test/factories/oauth_applications.rb
@@ -1,8 +1,23 @@
 FactoryGirl.define do
   factory :application, :class => Doorkeeper::Application do
+    ignore do
+      with_supported_permissions []
+      with_delegatable_supported_permissions []
+    end
+
     sequence(:name) { |n| "Application #{n}" }
     redirect_uri "https://app.com/callback"
     home_uri "https://app.com/"
     description "Important information about this app"
+
+    after(:create) do |app, evaluator|
+      evaluator.with_supported_permissions.each do |permission_name|
+        create(:supported_permission, application_id: app.id, name: permission_name)
+      end
+
+      evaluator.with_delegatable_supported_permissions.each do |permission_name|
+        create(:delegatable_supported_permission, application_id: app.id, name: permission_name)
+      end
+    end
   end
 end

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -1,9 +1,34 @@
 FactoryGirl.define do
   factory :user do
+    ignore do
+      with_permissions {}
+      with_signin_permissions_for []
+    end
+
     sequence(:email) { |n| "user#{n}@example.com" }
     password "this 1s 4 v3333ry s3cur3 p4ssw0rd.!Z"
     confirmed_at 1.day.ago
     name { "A name is now required" }
+
+    after(:create) do |user, evaluator|
+      evaluator.with_permissions.each do |app_or_name, permission_names|
+        app = if app_or_name.is_a?(String)
+                Doorkeeper::Application.where(name: app_or_name).first!
+              else
+                app_or_name
+              end
+        create(:permission, application: app, user: user, permissions: permission_names)
+      end if evaluator.with_permissions
+
+      evaluator.with_signin_permissions_for.each do |app_or_name|
+        app = if app_or_name.is_a?(String)
+                Doorkeeper::Application.where(name: app_or_name).first!
+              else
+                app_or_name
+              end
+        create(:permission, application: app, user: user)
+      end
+    end
   end
 
   factory :user_with_pending_email_change, parent: :user do

--- a/test/functional/admin/invitations_controller_test.rb
+++ b/test/functional/admin/invitations_controller_test.rb
@@ -35,22 +35,17 @@ class Admin::InvitationsControllerTest < ActionController::TestCase
 
     context "organisation admin" do
       should "can give permissions to only applications where signin is delegatable and they have access to" do
-        admin = create(:organisation_admin)
-        delegatable_application = create(:application)
-        delegatable_permission = create(:supported_permission, name: 'signin', delegatable: true, application: delegatable_application)
-        create(:permission, application: delegatable_application, user: admin, permissions: ['signin'])
-
-        non_delegatable_application = create(:application)
-        non_delegatable_permission = create(:supported_permission, name: 'signin', delegatable: false, application: non_delegatable_application)
-        create(:permission, application: non_delegatable_application, user: admin, permissions: ['signin'])
+        delegatable_app = create(:application, with_delegatable_supported_permissions: ["signin"])
+        non_delegatable_app = create(:application, with_supported_permissions: ["signin"])
+        admin = create(:organisation_admin, with_signin_permissions_for: [ delegatable_app, non_delegatable_app ] )
 
         sign_in admin
 
         get :new
 
         assert_select ".container" do
-          assert_select "td", { count: 1, text: delegatable_application.name }
-          assert_select "td", { count: 0, text: non_delegatable_application.name }
+          assert_select "td", { count: 1, text: delegatable_app.name }
+          assert_select "td", { count: 0, text: non_delegatable_app.name }
         end
       end
     end

--- a/test/functional/root_controller_test.rb
+++ b/test/functional/root_controller_test.rb
@@ -27,9 +27,7 @@ class RootControllerTest < ActionController::TestCase
   test "Your Applications should include apps you have permission to signin to" do
     exclusive_app = create(:application, name: "Exclusive app")
     everybody_app = create(:application, name: "Everybody app")
-    user = create(:user)
-    create(:permission, user: user, application: exclusive_app, permissions: [])
-    create(:permission, user: user, application: everybody_app, permissions: ["signin"])
+    user = create(:user, with_permissions: { exclusive_app => [], everybody_app => ["signin"] })
 
     sign_in user
 

--- a/test/functional/superadmin/supported_permissions_controller_test.rb
+++ b/test/functional/superadmin/supported_permissions_controller_test.rb
@@ -9,8 +9,7 @@ class Superadmin::SupportedPermissionsControllerTest < ActionController::TestCas
 
   context "GET index" do
     should "render the permissions list" do
-      app = create(:application, name: "My first app")
-      perm = create(:supported_permission, application_id: app.id, name: "permission1", delegatable: true)
+      app = create(:application, name: "My first app", with_delegatable_supported_permissions: ["permission1"])
 
       get :index, application_id: app.id
 
@@ -24,8 +23,7 @@ class Superadmin::SupportedPermissionsControllerTest < ActionController::TestCas
 
   context "GET new" do
     should "render the form" do
-      app = create(:application, name: "My first app")
-      perm = create(:supported_permission, application_id: app.id, name: "permission1")
+      app = create(:application, name: "My first app", with_supported_permissions: ["permission1"])
       get :new, application_id: app.id
       assert_select "h1", /My first app/
       assert_select "input[name='supported_permission[name]']", true

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -153,9 +153,8 @@ class UsersControllerTest < ActionController::TestCase
     end
 
     should "fetching json profile should include permissions" do
-      user = create(:user)
       application = create(:application)
-      permission = create(:permission, user_id: user.id, application_id: application.id)
+      user = create(:user, with_signin_permissions_for: [ application ])
       token = create(:access_token, :application => application, :resource_owner_id => user.id)
 
       @request.env['HTTP_AUTHORIZATION'] = "Bearer #{token.token}"
@@ -165,11 +164,9 @@ class UsersControllerTest < ActionController::TestCase
     end
 
     should "fetching json profile should include only permissions for the relevant app" do
-      user = create(:user)
-      application = create(:application)
-      other_application = create(:application)
-      permission = create(:permission, user_id: user.id, application_id: application.id)
-      other_permission = create(:permission, user_id: user.id, application_id: other_application.id)
+      application, other_application = create_pair(:application)
+      user = create(:user, with_signin_permissions_for: [ application, other_application ])
+
       token = create(:access_token, :application => application, :resource_owner_id => user.id)
 
       @request.env['HTTP_AUTHORIZATION'] = "Bearer #{token.token}"

--- a/test/unit/doorkeeper_application_test.rb
+++ b/test/unit/doorkeeper_application_test.rb
@@ -6,18 +6,14 @@ class ::Doorkeeper::ApplicationTest < ActiveSupport::TestCase
 
     should "return a list of string permissions, merging in the defaults" do
       user = create(:user)
-      app = create(:application, supported_permissions: [create(:supported_permission, name: "write")])
+      app = create(:application, with_supported_permissions: ["write"])
 
       assert_equal ["signin", "write"], app.supported_permission_strings(user)
     end
 
     should "only show permissions that organisation admins themselves have" do
-      user = create(:organisation_admin)
-      app = create(:application, supported_permissions: [
-        create(:delegatable_supported_permission, name: "write"),
-        create(:delegatable_supported_permission, name: "approve")
-      ])
-      create(:permission, user: user, application: app, permissions: ['write'])
+      app = create(:application, with_delegatable_supported_permissions: ["write", "approve"])
+      user = create(:organisation_admin, with_permissions: { app => ["write"] })
 
       assert_equal ["write"], app.supported_permission_strings(user)
     end


### PR DESCRIPTION
This app's tests commonly need to create applications with certain
supported permissions, and users with certain permissions.

This change adds logic to the FactoryGirl factories to allow more
compact definitions of the common cases. A bump in the FactoryGirl gem
is needed to pick up the necessary syntax.
