### PR TITLE
Remove "Edit" links from the user list

### DIFF
--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -53,7 +53,7 @@
           <td><%= user.sign_in_count %></td>
           <td><%= time_ago_in_words(user.created_at) %> ago</td>
           <td><%= user.suspended? ? "Yes" : "No" %></td>
-          <td><%= link_to "Edit", edit_admin_user_path(user) %>
+          <td>
             <% if user.invited_but_not_accepted %>
               <%= form_tag resend_user_invitation_path(user) do %>
                 <%= submit_tag "Resend signup email", :class => 'btn btn-primary' %>


### PR DESCRIPTION
The user's name and email act as a link through to the edit page anyway, and the edit links don't fit together well with the buttons to resend the signup email and unlock a user.

There don't appear to be any tests that cover this functionality.
