### PR TITLE
Remove cron to send suspension reminders

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -9,7 +9,3 @@ job_type :rake, "cd :path && govuk_setenv signon bundle exec rake :task :output"
 every :day, at: '3am' do
   rake "organisations:fetch"
 end
-
-every :day, at: '2am' do
-  rake "users:send_suspension_reminders"
-end


### PR DESCRIPTION
we'll revert this change when we have
approved the change to actually suspend
user accounts. both these changes need
to go hand-in-hand.
