### PR TITLE
Moved schedule.rb to alphagov-deployment

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,11 +1,2 @@
-# default cron env is "/usr/bin:/bin" which is not sufficient as govuk_env is in /usr/local/bin
-env :PATH, '/usr/local/bin:/usr/bin:/bin'
-
-set :output, {:error => 'log/cron.error.log', :standard => 'log/cron.log'}
-
-# We need Rake to use our own environment
-job_type :rake, "cd :path && govuk_setenv signon bundle exec rake :task :output"
-
-every :day, at: '3am' do
-  rake "organisations:fetch"
-end
+# This file is here only for reference.
+# Tasks are configured from alphagov-deployment.


### PR DESCRIPTION
We want to have the ability to configure tasks
per deployment environment f.ex. suspension
reminder emails to be sent only from preview
and production.

merge alphagov-deployment PR first - https://github.gds/gds/alphagov-deployment/pull/412

/cc @jakebenilov @alextomlins 
