### PR TITLE
Only process unprocessed BatchInvitationUsers

### DIFF
--- a/app/models/batch_invitation.rb
+++ b/app/models/batch_invitation.rb
@@ -24,7 +24,7 @@ class BatchInvitation < ActiveRecord::Base
   end
 
   def perform(options = {})
-    self.batch_invitation_users.each do |bi_user|
+    self.batch_invitation_users.unprocessed.each do |bi_user|
       bi_user.invite(self.user, self.applications_and_permissions)
     end
     self.outcome = "success"

--- a/app/models/batch_invitation_user.rb
+++ b/app/models/batch_invitation_user.rb
@@ -4,6 +4,7 @@ class BatchInvitationUser < ActiveRecord::Base
   validates :outcome, inclusion: { :in => [nil, "success", "failed", "skipped"] }
 
   scope :processed, where("outcome IS NOT NULL")
+  scope :unprocessed, where("outcome IS NULL")
   scope :failed, where(outcome: "failed")
 
   def invite(inviting_user, applications_and_permissions)

--- a/test/unit/batch_invitation_test.rb
+++ b/test/unit/batch_invitation_test.rb
@@ -122,5 +122,19 @@ class BatchInvitationTest < ActiveSupport::TestCase
         assert_not_nil User.find_by_email("b@m.com")
       end
     end
+
+    context "idempotence" do
+      should "not re-invite users that have already been processed" do
+        create(:user, :email => @user_a.email)
+        @user_a.update_column(:outcome, "success")
+
+        @bi.perform
+        assert_equal 1, ActionMailer::Base.deliveries.size
+
+        # Assert user_a status hasn't been set to skipped.
+        @user_a.reload
+        assert_equal "success", @user_a.outcome
+      end
+    end
   end
 end


### PR DESCRIPTION
This is to handle the case where the job is interrupted, and restarted.
