### PR TITLE
Hurray, abilities control access to api_users

### DIFF
--- a/lib/abilities/admin.rb
+++ b/lib/abilities/admin.rb
@@ -9,7 +9,7 @@ module Abilities
       can [:read, :create], BatchInvitation
       can :delegate_all_permissions, ::Doorkeeper::Application
       can [:read, :create, :update, :unlock, :invite!, :suspend, :unsuspend,
-            :perform_admin_tasks, :resend_email_change, :cancel_email_change], User
+            :perform_admin_tasks, :resend_email_change, :cancel_email_change], User, api_user: false
     end
   end
 end

--- a/lib/abilities/normal.rb
+++ b/lib/abilities/normal.rb
@@ -3,7 +3,7 @@ module Abilities
     include CanCan::Ability
 
     def initialize(user)
-      can [:read, :update], User, id: user.id
+      can [:read, :update], User, { id: user.id, api_user: false }
       cannot [:index, :invite!], User
     end
   end

--- a/lib/abilities/organisation_admin.rb
+++ b/lib/abilities/organisation_admin.rb
@@ -9,7 +9,7 @@ module Abilities
       can [:read, :create], BatchInvitation, organisation: { id: user.organisation.subtree.map(&:id) }
       can [:read, :create, :update, :unlock, :invite!, :suspend, :unsuspend,
             :perform_admin_tasks, :resend_email_change, :cancel_email_change],
-              User, organisation: { id: user.organisation.subtree.map(&:id) }
+              User, { organisation: { id: user.organisation.subtree.map(&:id) }, api_user: false }
 
       cannot :delegate_all_permissions, ::Doorkeeper::Application
     end

--- a/lib/abilities/superadmin.rb
+++ b/lib/abilities/superadmin.rb
@@ -9,8 +9,9 @@ module Abilities
       can [:read, :create], BatchInvitation
       can [:read, :update, :delegate_all_permissions], Doorkeeper::Application
       can [:read, :create, :update], SupportedPermission
-      can [:read, :create, :update, :assign_role, :unlock, :invite!,
-            :perform_admin_tasks, :suspend, :unsuspend, :resend_email_change, :cancel_email_change], User
+      can [:read, :create, :update, :assign_role, :unlock,
+            :invite!, :perform_admin_tasks, :suspend, :unsuspend,
+            :resend_email_change, :cancel_email_change], User, api_user: false
     end
   end
 end

--- a/test/functional/admin/invitations_controller_test.rb
+++ b/test/functional/admin/invitations_controller_test.rb
@@ -52,6 +52,12 @@ class Admin::InvitationsControllerTest < ActionController::TestCase
   end
 
   context "POST create" do
+    should "not allow creation of api users" do
+      post :create, user: { name: 'Testing APIs', email: 'api@example.com', api_user: true }
+
+      assert_empty User.where(api_user: true)
+    end
+
     context "SES has blacklisted the address" do
       should "show the user a helpful message" do
         Devise::Mailer.any_instance.expects(:mail).with(anything)
@@ -65,7 +71,7 @@ class Admin::InvitationsControllerTest < ActionController::TestCase
     end
 
     context "organisation admin" do
-      should "cannot assign only organisations not under him" do
+      should "not assign organisations not under him" do
         admin = create(:organisation_admin)
         outside_organisation = create(:organisation)
         sign_in admin
@@ -75,7 +81,7 @@ class Admin::InvitationsControllerTest < ActionController::TestCase
         assert_redirected_to root_path
       end
 
-      should "can assign only organisations under him" do
+      should "assign only organisations under him" do
         admin = create(:organisation_admin)
         sub_organisation = create(:organisation, parent: admin.organisation)
         sign_in admin

--- a/test/functional/admin/users_controller_test.rb
+++ b/test/functional/admin/users_controller_test.rb
@@ -14,6 +14,12 @@ class Admin::UsersControllerTest < ActionController::TestCase
       assert_select "td.email", /another_user@email.com/
     end
 
+    should "not list api users" do
+      create(:api_user, email: "api_user@email.com")
+      get :index
+      assert_select "td.email", count: 0, text: /api_user@email.com/
+    end
+
     should "show user roles" do
       create(:admin_user, email: "another_user@email.com")
       get :index
@@ -109,6 +115,14 @@ class Admin::UsersControllerTest < ActionController::TestCase
       assert_equal "New Name", another_user.reload.name
       assert_equal 200, response.status
       assert_equal "Updated user #{another_user.email} successfully", flash[:notice]
+    end
+
+    should "not update an api user" do
+      api_user = create(:api_user)
+      put :update, id: api_user.id, user: { api_user: false }
+
+      assert_redirected_to root_path
+      assert_equal 'You do not have permission to perform this action.', flash[:alert]
     end
 
     should "update the user's organisation" do


### PR DESCRIPTION
Updating abilities to control set of api_users and
tests to assert that admins cannot create, list,
or edit api_users.
