### PR TITLE
Remove gendered pronouns from test names

### DIFF
--- a/test/functional/admin/invitations_controller_test.rb
+++ b/test/functional/admin/invitations_controller_test.rb
@@ -17,7 +17,7 @@ class Admin::InvitationsControllerTest < ActionController::TestCase
 
   context "GET new" do
     context "organisation admin" do
-      should "can select only organisations under him" do
+      should "can select only organisations under them" do
         admin = create(:organisation_admin)
         sub_organisation = create(:organisation, parent: admin.organisation)
         outside_organisation = create(:organisation)
@@ -71,7 +71,7 @@ class Admin::InvitationsControllerTest < ActionController::TestCase
     end
 
     context "organisation admin" do
-      should "not assign organisations not under him" do
+      should "not assign organisations not under them" do
         admin = create(:organisation_admin)
         outside_organisation = create(:organisation)
         sign_in admin
@@ -81,7 +81,7 @@ class Admin::InvitationsControllerTest < ActionController::TestCase
         assert_redirected_to root_path
       end
 
-      should "assign only organisations under him" do
+      should "assign only organisations under them" do
         admin = create(:organisation_admin)
         sub_organisation = create(:organisation, parent: admin.organisation)
         sign_in admin

--- a/test/functional/admin/suspensions_controller_test.rb
+++ b/test/functional/admin/suspensions_controller_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class Admin::SuspensionsControllerTest < ActionController::TestCase
 
   context "organisation admin" do
-    should "be unable to control suspension of a user outside his organisation" do
+    should "be unable to control suspension of a user outside their organisation" do
       user = create(:suspended_user, reason_for_suspension: "Negligence")
       admin = create(:organisation_admin)
       sign_in admin
@@ -13,7 +13,7 @@ class Admin::SuspensionsControllerTest < ActionController::TestCase
       assert_true user.reload.suspended?
     end
 
-    should "be able to control suspension of a user within his organisation" do
+    should "be able to control suspension of a user within their organisation" do
       admin = create(:organisation_admin)
       sign_in admin
       user = create(:suspended_user, reason_for_suspension: "Negligence", organisation: admin.organisation)

--- a/test/functional/admin/users_controller_test.rb
+++ b/test/functional/admin/users_controller_test.rb
@@ -74,7 +74,7 @@ class Admin::UsersControllerTest < ActionController::TestCase
     end
 
     context "organisation admin" do
-      should "not be able to assign organisations outside his organisation subtree" do
+      should "not be able to assign organisations outside their organisation subtree" do
         admin = create(:organisation_admin)
         outside_organisation = create(:organisation)
         sign_in admin
@@ -89,7 +89,7 @@ class Admin::UsersControllerTest < ActionController::TestCase
         end
       end
 
-      should "be able to assign organisations within his organisation subtree" do
+      should "be able to assign organisations within their organisation subtree" do
         admin = create(:organisation_admin)
         sub_organisation = create(:organisation, parent: admin.organisation)
         sign_in admin
@@ -134,7 +134,7 @@ class Admin::UsersControllerTest < ActionController::TestCase
     end
 
     context "organisation admin" do
-      should "be able to assign organisations under his organisation subtree" do
+      should "be able to assign organisations under their organisation subtree" do
         admin = create(:organisation_admin)
         sub_organisation = create(:organisation, parent: admin.organisation)
         sign_in admin
@@ -146,7 +146,7 @@ class Admin::UsersControllerTest < ActionController::TestCase
         assert_equal admin.organisation.id, user.reload.organisation.id
       end
 
-      should "not be able to assign organisations outside his organisation subtree" do
+      should "not be able to assign organisations outside their organisation subtree" do
         admin = create(:organisation_admin)
         outside_organisation = create(:organisation)
         sign_in admin


### PR DESCRIPTION
As recommended by, among other things, the [GOV.UK style guide](https://www.gov.uk/design-principles/style-guide#writing-gender-neutral-text).

Note: I left some instances of ‘his’ in `config/initializers/devise.rb`, as this was automatically generated from Devise, so I decided it was better to leave that, in case we need to merge it with a future version of Devise.
