### PR TITLE
Change “in X days' time” to “in X days” in emails.

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -13,7 +13,7 @@ private
     if @days == 1
       "tomorrow"
     else
-      "in #{@days} days' time"
+      "in #{@days} days"
     end
   end
 


### PR DESCRIPTION
It says the same thing, just with fewer words.
