### PR TITLE
Update rake to latest

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,10 +2,6 @@ source 'https://rubygems.org'
 
 gem 'rails', '3.2.16'
 
-group :passenger_compatibility do
-  gem 'rake', '0.9.2'
-end
-
 gem 'kaminari', '0.14.1'
 gem 'alphabetical_paginate', '2.1.0'
 gem 'mysql2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -167,7 +167,7 @@ GEM
       rdoc (~> 3.4)
       thor (>= 0.14.6, < 2.0)
     raindrops (0.10.0)
-    rake (0.9.2)
+    rake (10.1.1)
     rdoc (3.12.2)
       json (~> 1.4)
     redis (3.0.6)
@@ -258,7 +258,6 @@ DEPENDENCIES
   plek (= 1.4.0)
   quiet_assets
   rails (= 3.2.16)
-  rake (= 0.9.2)
   redis (= 3.0.6)
   shoulda (= 3.0.1)
   sidekiq (= 2.17.2)


### PR DESCRIPTION
Passenger is no longer used, so no need to pin rake to an old version.
