### PR TITLE
Don't repeat class name in SSOPushError message.

### DIFF
--- a/lib/propagator.rb
+++ b/lib/propagator.rb
@@ -25,7 +25,7 @@ class Propagator
         end
         results[:failures] << { application: application, message: message, technical: "HTTP status code was: #{e.code}" }
       rescue GdsApi::BaseError, StandardError => e
-        results[:failures] << { application: application, message: e.message }
+        results[:failures] << { application: application, message: "#{e.class.name}: #{e.message}" }
       end
     end
     results

--- a/lib/sso_push_error.rb
+++ b/lib/sso_push_error.rb
@@ -4,7 +4,7 @@ class SSOPushError < StandardError
   end
 
   def message
-    message = %Q(#{to_s}: Error pushing to #{@application.name} for user with uid #{@uid})
+    message = "Error pushing to #{@application.name} for user with uid #{@uid}"
     message += ", got response #{@details[:response_code]}" if @details[:response_code]
     message += ". #{@details[:message]}" if @details[:message]
     message

--- a/test/unit/sso_push_error_test.rb
+++ b/test/unit/sso_push_error_test.rb
@@ -15,7 +15,7 @@ class SSOPushErrorTest < ActiveSupport::TestCase
     should "add application name, user uid and response error code to exception message" do
       ex = GdsApi::HTTPErrorResponse.new(504)
       SSOPushClient.any_instance.stubs(:post_json!).raises(ex)
-      @error_message_template = "SSOPushError: Error pushing to %s for user with uid %s, got response %d"
+      @error_message_template = "Error pushing to %s for user with uid %s, got response %d"
 
       exception = assert_raise(SSOPushError) do
         SSOPushClient.new(@application).reauth_user(@user.uid)
@@ -28,7 +28,7 @@ class SSOPushErrorTest < ActiveSupport::TestCase
     should "add application name, user uid and error message to exception message" do
       ex = GdsApi::TimedOutException.new()
       SSOPushClient.any_instance.stubs(:post_json!).raises(ex)
-      @error_message_template = "SSOPushError: Error pushing to %s for user with uid %s. %s"
+      @error_message_template = "Error pushing to %s for user with uid %s. %s"
 
       exception = assert_raise(SSOPushError) do
         SSOPushClient.new(@application).reauth_user(@user.uid)
@@ -42,7 +42,7 @@ class SSOPushErrorTest < ActiveSupport::TestCase
     should "add application name, user uid and message to exception message" do
       ex = StandardError.new()
       SSOPushClient.any_instance.stubs(:post_json!).raises(ex)
-      @error_message_template = "SSOPushError: Error pushing to %s for user with uid %s. StandardError"
+      @error_message_template = "Error pushing to %s for user with uid %s. StandardError"
 
       exception = assert_raise(SSOPushError) do
         SSOPushClient.new(@application).reauth_user(@user.uid)


### PR DESCRIPTION
This causes duplication in error reporting in errbit and other places.
