### PR TITLE
Switch to using released airbrake gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,8 +9,7 @@ gem 'aws-ses', require: 'aws/ses'
 gem 'jquery-rails'
 gem 'exception_notification', '4.0.1'
 
-# Using our branch until https://github.com/airbrake/airbrake/pull/268 is merged
-gem 'airbrake', '3.1.15', :git => "https://github.com/alphagov/airbrake", :branch => "disable_unless_configured"
+gem 'airbrake', '3.1.15'
 gem 'plek', '1.4.0'
 gem 'json', '1.7.7'
 gem 'whenever', '0.7.3', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,4 @@
 GIT
-  remote: https://github.com/alphagov/airbrake
-  revision: 49fb7d1a3004970e2830f4e7b5b6b95f1bcb70fc
-  branch: disable_unless_configured
-  specs:
-    airbrake (3.1.15)
-      builder
-      multi_json
-
-GIT
   remote: https://github.com/alphagov/devise_security_extension.git
   revision: 4d14ed4c9ae8f23da0e9d5de2b6b69d9b53cd73d
   branch: graceful_return_to_behaviour
@@ -48,6 +39,9 @@ GEM
       i18n (~> 0.6, >= 0.6.4)
       multi_json (~> 1.0)
     addressable (2.3.2)
+    airbrake (3.1.15)
+      builder
+      multi_json
     alphabetical_paginate (2.1.0)
     ancestry (2.0.0)
       activerecord (>= 3.0.0)
@@ -238,7 +232,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  airbrake (= 3.1.15)!
+  airbrake (= 3.1.15)
   alphabetical_paginate (= 2.1.0)
   ancestry (= 2.0.0)
   aws-ses

--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -1,3 +1,7 @@
 # This file is overwritten on deploy
 #
-# Nothing to configure in dev
+Airbrake.configure do |config|
+  # Adding production to the development environments causes Airbrake not
+  # to attempt to send notifications.
+  config.development_environments << "production"
+end


### PR DESCRIPTION
It looks like https://github.com/airbrake/airbrake/pull/268 isn't going to be merged anytime soon, so I found another way to disable notifications until the config is overwritten (on deploy).
