### PR TITLE
Notify airbrake on suspension reminder email failure.

### DIFF
--- a/lib/inactive_users_suspension_reminder.rb
+++ b/lib/inactive_users_suspension_reminder.rb
@@ -14,9 +14,11 @@ class InactiveUsersSuspensionReminder
 
           Rails.logger.warn "#{self.class}: Failed to send suspension reminder email to #{user.email}."
           ExceptionNotifier.notify_exception e, data: { receiver_email: user.email }
+          Airbrake.notify_or_ignore e, :parameters => { :receiver_email => user.email }
         rescue AWS::SES::ResponseError => e
           Rails.logger.warn "#{self.class}: #{e.response.error.message} while sending email to #{user.email}."
           ExceptionNotifier.notify_exception e, data: { receiver_email: user.email }
+          Airbrake.notify_or_ignore e, :parameters => { :receiver_email => user.email }
         end
       end
     end

--- a/test/unit/inactive_users_suspension_reminder_test.rb
+++ b/test/unit/inactive_users_suspension_reminder_test.rb
@@ -76,6 +76,7 @@ class InactiveUsersSuspensionReminderTest < ActiveSupport::TestCase
 
     should "send an exception notification if retries fail" do
       ExceptionNotifier.expects(:notify_exception).once
+      Airbrake.expects(:notify_or_ignore).once
       UserMailer.expects(:suspension_reminder).returns(@mailer).times(3)
 
       InactiveUsersSuspensionReminder.new.send_reminders


### PR DESCRIPTION
See https://github.com/airbrake/airbrake/wiki/Using-Airbrake-with-plain-Ruby for details.
