### PR TITLE
Ensure latest changes to sidekiq-statsd get used

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ gem 'gds-api-adapters', '7.11.0'
 gem 'statsd-ruby', '1.0.0'
 gem 'unicorn', '4.3.1'
 gem 'sidekiq', '2.17.2'
-gem 'sidekiq-statsd', git: "https://github.com/alphagov/sidekiq-statsd.git", branch: "more-metrics"
+gem 'sidekiq-statsd', git: "https://github.com/alphagov/sidekiq-statsd.git", branch: "more-metrics", ref: "866e2b5"
 
 gem 'redis', '3.0.6'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,8 @@ GIT
 
 GIT
   remote: https://github.com/alphagov/sidekiq-statsd.git
-  revision: 0b94f81b402fc6eb1e07871dd631e5b8dd086c04
+  revision: 866e2b5941d3ce276834a9221acd6bfd008609ed
+  ref: 866e2b5
   branch: more-metrics
   specs:
     sidekiq-statsd (0.1.1)


### PR DESCRIPTION
Pinning to a particular ref, so that bundle checks
out the latest code from more-metrics branch.
