### PR TITLE
Remove exception_notification

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,6 @@ gem 'alphabetical_paginate', '2.1.0'
 gem 'mysql2'
 gem 'aws-ses', require: 'aws/ses'
 gem 'jquery-rails'
-gem 'exception_notification', '4.0.1'
 
 gem 'airbrake', '3.1.15'
 gem 'plek', '1.4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,9 +99,6 @@ GEM
     doorkeeper (0.6.7)
       railties (~> 3.1)
     erubis (2.7.0)
-    exception_notification (4.0.1)
-      actionmailer (>= 3.0.4)
-      activesupport (>= 3.0.4)
     factory_girl (4.3.0)
       activesupport (>= 3.0.0)
     factory_girl_rails (4.3.0)
@@ -259,7 +256,6 @@ DEPENDENCIES
   devise_security_extension (= 0.7.2)!
   devise_zxcvbn (= 1.1.0)
   doorkeeper (= 0.6.7)
-  exception_notification (= 4.0.1)
   factory_girl_rails (= 4.3.0)
   gds-api-adapters (= 7.11.0)
   jquery-rails

--- a/config/initializers/exception_notification.rb
+++ b/config/initializers/exception_notification.rb
@@ -1,2 +1,0 @@
-# This file is here only for reference.
-# ExceptionNotification is configured from alphagov-deployment.

--- a/lib/inactive_users_suspension_reminder.rb
+++ b/lib/inactive_users_suspension_reminder.rb
@@ -13,11 +13,9 @@ class InactiveUsersSuspensionReminder
           retry if (tries -= 1) > 0
 
           Rails.logger.warn "#{self.class}: Failed to send suspension reminder email to #{user.email}."
-          ExceptionNotifier.notify_exception e, data: { receiver_email: user.email }
           Airbrake.notify_or_ignore e, :parameters => { :receiver_email => user.email }
         rescue AWS::SES::ResponseError => e
           Rails.logger.warn "#{self.class}: #{e.response.error.message} while sending email to #{user.email}."
-          ExceptionNotifier.notify_exception e, data: { receiver_email: user.email }
           Airbrake.notify_or_ignore e, :parameters => { :receiver_email => user.email }
         end
       end

--- a/test/unit/inactive_users_suspension_reminder_test.rb
+++ b/test/unit/inactive_users_suspension_reminder_test.rb
@@ -75,7 +75,6 @@ class InactiveUsersSuspensionReminderTest < ActiveSupport::TestCase
     end
 
     should "send an exception notification if retries fail" do
-      ExceptionNotifier.expects(:notify_exception).once
       Airbrake.expects(:notify_or_ignore).once
       UserMailer.expects(:suspension_reminder).returns(@mailer).times(3)
 


### PR DESCRIPTION
This is using errbit for exception handling now.

This depends on https://github.gds/gds/alphagov-deployment/pull/440
