### PR TITLE
Rake task to delete expired oauth access grants

### DIFF
--- a/lib/tasks/oauth_access_grants.rake
+++ b/lib/tasks/oauth_access_grants.rake
@@ -1,0 +1,10 @@
+namespace :oauth_access_grants do
+  desc "Delete expired OAuth access grants"
+  task :delete_expired => :environment do
+    count = Doorkeeper::AccessGrant
+              .where('expires_in is not null AND DATE_ADD(created_at, INTERVAL expires_in second) < ?', Time.zone.now)
+              .delete_all
+
+    puts "Done. Deleted #{count} expired OAuth access grants."
+  end
+end


### PR DESCRIPTION
This task is configured in [cron](https://github.gds/gds/alphagov-deployment/pull/445) at alphagov-deployment. please merge that as well.
