### PR TITLE
Upgrade Plek to 1.7.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'aws-ses', require: 'aws/ses'
 gem 'jquery-rails'
 
 gem 'airbrake', '3.1.15'
-gem 'plek', '1.4.0'
+gem 'plek', '1.7.0'
 gem 'json', '1.7.7'
 gem 'whenever', '0.7.3', require: false
 
@@ -56,4 +56,3 @@ group :test do
   gem 'ci_reporter', '1.7.0'
   gem 'timecop', '0.7.1'
 end
-

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,7 +132,7 @@ GEM
       mini_portile (~> 0.5.0)
     null_logger (0.0.1)
     orm_adapter (0.5.0)
-    plek (1.4.0)
+    plek (1.7.0)
     poltergeist (1.5.0)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
@@ -257,7 +257,7 @@ DEPENDENCIES
   logstasher (= 0.4.1)
   mocha (= 0.13.3)
   mysql2
-  plek (= 1.4.0)
+  plek (= 1.7.0)
   poltergeist (= 1.5.0)
   quiet_assets
   rails (= 3.2.16)


### PR DESCRIPTION
Was fiddling with the organisations syncing functionality but noticed I couldn't fudge the Plek URL. We were 0.3 versions behind so I upgraded it.
