### PR TITLE
Fix for organisations:fetch parallel runs

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,6 +4,9 @@
 
 require File.expand_path('../config/application', __FILE__)
 
+require_relative 'lib/volatile_lock'
+include VolatileLock::DSL
+
 Signonotron2::Application.load_tasks
 
 task :default => [:test, :check_for_bad_time_handling]

--- a/lib/tasks/organisations.rake
+++ b/lib/tasks/organisations.rake
@@ -1,6 +1,8 @@
 namespace :organisations do
   desc "Fetch organisations from Whitehall"
   task :fetch => :environment do
-    OrganisationsFetcher.new.call
+    with_lock('signon:organisations:fetch') do
+      OrganisationsFetcher.new.call
+    end
   end
 end

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -27,25 +27,17 @@ namespace :users do
 
   desc "Remind users that their account will get suspended"
   task :send_suspension_reminders => :environment do
-    require_relative '../volatile_lock'
-
-    if VolatileLock.new('signon:send_suspension_reminders').obtained?
+    with_lock('signon:users:send_suspension_reminders') do
       count = InactiveUsersSuspensionReminder.new.send_reminders
       puts "InactiveUsersSuspensionReminder: #{count} users were reminded about account suspension"
-    else
-      puts "InactiveUsersSuspensionReminder: skipping, couldn't obtain lock"
     end
   end
 
   desc "Suspend users who have not signed-in for 45 days"
   task :suspend_inactive => :environment do
-    require_relative '../volatile_lock'
-
-    if VolatileLock.new('signon:suspend_inactive').obtained?
+    with_lock('signon:users:suspend_inactive') do
       count = InactiveUsersSuspender.new.suspend
       puts "#{count} users were suspended because they had not logged in since #{User::SUSPENSION_THRESHOLD_PERIOD.inspect}"
-    else
-      puts "InactiveUsersSuspender: skipping, couldn't obtain lock"
     end
   end
 

--- a/lib/volatile_lock.rb
+++ b/lib/volatile_lock.rb
@@ -3,6 +3,17 @@ require 'redis_client'
 class VolatileLock
   class FailedToSetExpiration < StandardError; end
 
+  module DSL
+    def with_lock(key)
+      # lock for next 10.minutes
+      if VolatileLock.new(key).obtained?
+        yield
+      else
+        puts "Skipping task on #{Socket.gethostname}, couldn't obtain lock: #{key}"
+      end
+    end
+  end
+
   # expiration_time takes care of time-drifts on our
   # servers. defaults to 10.minutes assuming our servers
   # won't realistically have a greater time-drift.


### PR DESCRIPTION
Errbit [reported](https://errbit.preview.alphagov.co.uk/apps/52e678360da1158195000002/problems/52fc354f0da1151c9c00017c) duplicates being inserted
into the Signon organisations table.

Given that organisation slugs are unique
the only possible reason why this is happening
is because the task is running from all backend
machines where cron is configured with this task.

This change ensures we obtain a lock, that expires
in 10 minutes, before running this task, so that
only one task fetches organisation info, and the
rest skip because they didn't obtain a lock.
