### PR TITLE
Add 'last sign-in' column to user accounts table

### DIFF
--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -36,6 +36,7 @@
         <th scope="col">Name and email</th>
         <th scope="col">Role</th>
         <th scope="col">Sign-in count</th>
+        <th scope="col">Last sign-in</th>
         <th scope="col">Created</th>
         <th scope="col">Suspended?</th>
         <th scope="col">Actions</th>
@@ -51,6 +52,13 @@
           </td>
           <td class="role"><%= user.role.humanize %></td>
           <td><%= user.sign_in_count %></td>
+          <td class="last-sign-in">
+            <% if user.current_sign_in_at %>
+              <%= time_ago_in_words(user.current_sign_in_at) %> ago
+            <% else %>
+              never signed in
+            <% end %>
+          </td>
           <td><%= time_ago_in_words(user.created_at) %> ago</td>
           <td><%= user.suspended? ? "Yes" : "No" %></td>
           <td>

--- a/test/integration/admin_user_index_test.rb
+++ b/test/integration/admin_user_index_test.rb
@@ -4,17 +4,33 @@ class AdminUserIndexTest < ActionDispatch::IntegrationTest
 
   context "logged in as an admin" do
     setup do
+      current_time = Time.zone.now
+      Timecop.freeze(current_time)
+
       @admin = create(:admin_user, :name => "Admin User", :email => "admin@example.com")
       visit new_user_session_path
       signin(@admin)
 
-      create(:user, :name => "Aardvark", :email => "aardvark@example.com")
+      create(:user, :name => "Aardvark", :email => "aardvark@example.com", :current_sign_in_at => current_time - 5.minutes)
       create(:user, :name => "Abbey", :email => "abbey@example.com")
       create(:user, :name => "Abbot", :email => "mr_ab@example.com")
       create(:user, :name => "Bert", :email => "bbbert@example.com")
       create(:user, :name => "Ed", :email => "ed@example.com")
       create(:user, :name => "Eddie", :email => "eddie_bb@example.com")
       create(:user, :name => "Ernie", :email => "ernie@example.com")
+    end
+
+    teardown do
+      Timecop.return
+    end
+
+    should "see when the user last logged in" do
+      visit "/admin/users"
+
+      assert page.has_content?("Last sign-in")
+
+      actual_last_sign_in_strings = page.all('table tr td.last-sign-in').map(&:text).map(&:strip)[0..1]
+      assert_equal ["5 minutes ago", "never signed in"], actual_last_sign_in_strings
     end
 
     should "see list of users paginated alphabetically" do


### PR DESCRIPTION
This allows an administrator to see when a user last managed to successfully
log into their Signon account, and is useful when checking whether someone
has managed to resolve their log-in/password difficulties, or whether they're
an active user or not.
