### PR TITLE
Do not accept current password as new password

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,7 +15,8 @@ class User < ActiveRecord::Base
          :zxcvbnable,
          :encryptable,
          :confirmable,
-         :password_expirable
+         :password_expirable,
+         :password_archivable
 
   attr_readonly :uid
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -273,10 +273,10 @@ Devise.setup do |config|
   # config.password_regex = /(?=.*\d)(?=.*[a-z])(?=.*[A-Z])/
 
   # How many passwords to keep in archive
-  # config.password_archiving_count = 5
+  config.password_archiving_count = 2
 
   # Deny old password (true, false, count)
-  # config.deny_old_passwords = true
+  config.deny_old_passwords = true
 
   # enable email validation for :secure_validatable. (true, false, validation_options)
   # dependency: need an email validator like rails_email_validator

--- a/db/migrate/20140409170000_enable_devise_security_extension.rb
+++ b/db/migrate/20140409170000_enable_devise_security_extension.rb
@@ -1,0 +1,19 @@
+class EnableDeviseSecurityExtension < ActiveRecord::Migration
+  def self.up
+    create_table :old_passwords do |t|
+      t.string   :encrypted_password, :null => false
+      t.string   :password_salt
+      t.integer  :password_archivable_id, :null => false
+      t.string   :password_archivable_type, :null => false
+      t.datetime :created_at
+    end
+
+    add_index :old_passwords,
+              [:password_archivable_type, :password_archivable_id],
+              :name => :index_password_archivable
+  end
+
+  def self.down
+    drop_table :old_passwords
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20140320162328) do
+ActiveRecord::Schema.define(:version => 20140409170000) do
 
   create_table "batch_invitation_users", :force => true do |t|
     t.integer  "batch_invitation_id"
@@ -77,6 +77,16 @@ ActiveRecord::Schema.define(:version => 20140320162328) do
 
   add_index "oauth_applications", ["name"], :name => "unique_application_name", :unique => true
   add_index "oauth_applications", ["uid"], :name => "index_oauth_applications_on_uid", :unique => true
+
+  create_table "old_passwords", :force => true do |t|
+    t.string   "encrypted_password",       :null => false
+    t.string   "password_salt"
+    t.integer  "password_archivable_id",   :null => false
+    t.string   "password_archivable_type", :null => false
+    t.datetime "created_at"
+  end
+
+  add_index "old_passwords", ["password_archivable_type", "password_archivable_id"], :name => "index_password_archivable"
 
   create_table "organisations", :force => true do |t|
     t.string   "slug",              :null => false

--- a/test/integration/passphrase_change_test.rb
+++ b/test/integration/passphrase_change_test.rb
@@ -97,6 +97,12 @@ class PassphraseChangeTest < ActionDispatch::IntegrationTest
     assert_response_contains("Your passphrase was changed successfully")
   end
 
+  should "not accept a recently used password as the new password" do
+    change_password_to(@original_password)
+
+    assert_response_contains "Passphrase was already taken in the past"
+  end
+
   private
   def change_password_to(new_password)
     change_password(old: @user.password,


### PR DESCRIPTION
Ensure from now on that people using Signon don't try to set their current password to be the same as a password they have used recently.

https://www.pivotaltracker.com/story/show/69168314
