### PR TITLE
Friendlier error message

### DIFF
--- a/config/locales/devise.security_extension.en.yml
+++ b/config/locales/devise.security_extension.en.yml
@@ -1,7 +1,7 @@
 en:
   errors:
     messages:
-      taken_in_past: "was already taken in the past!"
+      taken_in_past: "was used previously. Please choose a different one."
       equal_to_current_password: "must be different to the current passphrase!"
   devise:
     invalid_captcha: "The captcha input is not valid!"

--- a/test/integration/passphrase_change_test.rb
+++ b/test/integration/passphrase_change_test.rb
@@ -100,7 +100,7 @@ class PassphraseChangeTest < ActionDispatch::IntegrationTest
   should "not accept a recently used password as the new password" do
     change_password_to(@original_password)
 
-    assert_response_contains "Passphrase was already taken in the past"
+    assert_response_contains "Passphrase was used previously. Please choose a different one."
   end
 
   private


### PR DESCRIPTION
Rather than 'Passphrase was already taken in the past!'.
