### PR TITLE
Split suspension reminder logic

### DIFF
--- a/lib/inactive_users_suspension_reminder.rb
+++ b/lib/inactive_users_suspension_reminder.rb
@@ -1,37 +1,27 @@
 class InactiveUsersSuspensionReminder
-  def send_reminders
-    mailing_list = users_by_days_to_suspension
-    mailing_list.each do |days, users|
-      users.each do |user|
-        tries = 3
-        begin
-          Rails.logger.info "#{self.class}: Sending email to #{user.email}."
-          UserMailer.suspension_reminder(user, days).deliver
-          Rails.logger.info "#{self.class}: Successfully sent email to #{user.email}."
-        rescue *network_errors => e
-          Rails.logger.debug "#{self.class}: #{e.class} - #{e.message} while sending email to #{user.email} during attempt (#{(tries..3).count}/3)."
-          retry if (tries -= 1) > 0
 
-          Rails.logger.warn "#{self.class}: Failed to send suspension reminder email to #{user.email}."
-          Airbrake.notify_or_ignore e, :parameters => { :receiver_email => user.email }
-        rescue AWS::SES::ResponseError => e
-          Rails.logger.warn "#{self.class}: #{e.response.error.message} while sending email to #{user.email}."
-          Airbrake.notify_or_ignore e, :parameters => { :receiver_email => user.email }
-        end
-      end
-    end
-    mailing_list.values.flatten.uniq.count
+  def initialize(users, days_to_suspension)
+    @users, @days_to_suspension = users, days_to_suspension
   end
 
-  def users_by_days_to_suspension
-    suspension_threshold_exceeded = User::SUSPENSION_THRESHOLD_PERIOD + 1.day
+  def send_reminders
+    @users.each do |user|
+      tries = 3
+      begin
+        Rails.logger.info "#{self.class}: Sending email to #{user.email}."
+        UserMailer.suspension_reminder(user, @days_to_suspension).deliver
+        Rails.logger.info "#{self.class}: Successfully sent email to #{user.email}."
+      rescue *network_errors => e
+        Rails.logger.debug "#{self.class}: #{e.class} - #{e.message} while sending email to #{user.email} during attempt (#{(tries..3).count}/3)."
+        retry if (tries -= 1) > 0
 
-    users_by_days_to_suspension = [14, 7, 3, 1].inject({}) do |result, days_to_suspension|
-      result[days_to_suspension] = User.last_signed_in_on((suspension_threshold_exceeded - days_to_suspension.days).ago)
-      result
+        Rails.logger.warn "#{self.class}: Failed to send suspension reminder email to #{user.email}."
+        Airbrake.notify_or_ignore e, :parameters => { :receiver_email => user.email }
+      rescue AWS::SES::ResponseError => e
+        Rails.logger.warn "#{self.class}: #{e.response.error.message} while sending email to #{user.email}."
+        Airbrake.notify_or_ignore e, :parameters => { :receiver_email => user.email }
+      end
     end
-    users_by_days_to_suspension[1] += User.last_signed_in_before(suspension_threshold_exceeded.ago).to_a
-    users_by_days_to_suspension
   end
 
 private

--- a/lib/inactive_users_suspension_reminder_mailing_list.rb
+++ b/lib/inactive_users_suspension_reminder_mailing_list.rb
@@ -1,0 +1,20 @@
+class InactiveUsersSuspensionReminderMailingList
+
+  DAYS_TO_SUSPENSION = [14, 7, 3, 1]
+
+  def initialize(suspension_threshold_period)
+    @suspension_threshold_period = suspension_threshold_period
+  end
+
+  def generate
+    suspension_threshold_exceeded = @suspension_threshold_period + 1.day
+
+    suspension_reminder_mailing_list = DAYS_TO_SUSPENSION.inject({}) do |result, days_to_suspension|
+      result[days_to_suspension] = User.last_signed_in_on((suspension_threshold_exceeded - days_to_suspension.days).ago)
+      result
+    end
+    suspension_reminder_mailing_list[1] += User.last_signed_in_before(suspension_threshold_exceeded.ago).to_a
+    suspension_reminder_mailing_list
+  end
+
+end

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -28,8 +28,11 @@ namespace :users do
   desc "Remind users that their account will get suspended"
   task :send_suspension_reminders => :environment do
     with_lock('signon:users:send_suspension_reminders') do
-      count = InactiveUsersSuspensionReminder.new.send_reminders
-      puts "InactiveUsersSuspensionReminder: #{count} users were reminded about account suspension"
+      suspension_reminder_mailing_list = InactiveUsersSuspensionReminderMailingList.new(User::SUSPENSION_THRESHOLD_PERIOD).generate
+      suspension_reminder_mailing_list.each do |days_to_suspension, users|
+        InactiveUsersSuspensionReminder.new(users, days_to_suspension).send_reminders
+        puts "InactiveUsersSuspensionReminder: #{users_to_remind.count} users were reminded about their account getting suspended in #{days_to_suspension} days"
+      end
     end
   end
 

--- a/test/unit/inactive_users_suspension_reminder_mailing_list_test.rb
+++ b/test/unit/inactive_users_suspension_reminder_mailing_list_test.rb
@@ -1,0 +1,38 @@
+require 'test_helper'
+
+class InactiveUsersSuspensionReminderMailingListTest < ActiveSupport::TestCase
+
+  context "generating suspension mailing list" do
+    setup do
+      @in_1  = create(:user, current_sign_in_at: User::SUSPENSION_THRESHOLD_PERIOD.ago)
+      @in_3  = create(:user, current_sign_in_at: (User::SUSPENSION_THRESHOLD_PERIOD - 2.days).ago)
+      @in_7  = create(:user, current_sign_in_at: (User::SUSPENSION_THRESHOLD_PERIOD - 6.days).ago)
+      @in_14 = create(:user, current_sign_in_at: (User::SUSPENSION_THRESHOLD_PERIOD - 13.days).ago)
+    end
+
+    def suspension_reminder_mailing_list
+      InactiveUsersSuspensionReminderMailingList.new(User::SUSPENSION_THRESHOLD_PERIOD).generate
+    end
+
+    should "select users whose accounts will get suspended in 1 day" do
+      assert_equal [@in_1], suspension_reminder_mailing_list[1]
+    end
+
+    should "select users whose accounts will get suspended in 3 days" do
+      assert_equal [@in_3], suspension_reminder_mailing_list[3]
+    end
+
+    should "select users whose accounts will get suspended in 7 days" do
+      assert_equal [@in_7], suspension_reminder_mailing_list[7]
+    end
+
+    should "select users whose accounts will get suspended in 14 days" do
+      assert_equal [@in_14], suspension_reminder_mailing_list[14]
+    end
+
+    should "select users who signed-in more than suspension threshold days ago" do
+      signed_in_48_days_ago = create(:user, current_sign_in_at: 48.days.ago)
+      assert_include suspension_reminder_mailing_list[1], signed_in_48_days_ago
+    end
+  end
+end

--- a/test/unit/inactive_users_suspension_reminder_test.rb
+++ b/test/unit/inactive_users_suspension_reminder_test.rb
@@ -2,83 +2,38 @@ require 'test_helper'
 
 class InactiveUsersSuspensionReminderTest < ActiveSupport::TestCase
 
-  context "users by days to suspension" do
-    setup do
-      @in_1  = create(:user, current_sign_in_at: User::SUSPENSION_THRESHOLD_PERIOD.ago)
-      @in_3  = create(:user, current_sign_in_at: (User::SUSPENSION_THRESHOLD_PERIOD - 2.days).ago)
-      @in_7  = create(:user, current_sign_in_at: (User::SUSPENSION_THRESHOLD_PERIOD - 6.days).ago)
-      @in_14 = create(:user, current_sign_in_at: (User::SUSPENSION_THRESHOLD_PERIOD - 13.days).ago)
-    end
-
-    def users_by_days_to_suspension
-      InactiveUsersSuspensionReminder.new.users_by_days_to_suspension
-    end
-
-    should "select users whose accounts will get suspended in 1 day" do
-      assert_equal [@in_1], users_by_days_to_suspension[1]
-    end
-
-    should "select users whose accounts will get suspended in 3 days" do
-      assert_equal [@in_3], users_by_days_to_suspension[3]
-    end
-
-    should "select users whose accounts will get suspended in 7 days" do
-      assert_equal [@in_7], users_by_days_to_suspension[7]
-    end
-
-    should "select users whose accounts will get suspended in 14 days" do
-      assert_equal [@in_14], users_by_days_to_suspension[14]
-    end
-
-    should "select users who signed-in more than suspension threshold days ago" do
-      signed_in_48_days_ago = create(:user, current_sign_in_at: 48.days.ago)
-      assert_include users_by_days_to_suspension[1], signed_in_48_days_ago
-    end
-  end
-
-  context "sucessfully sending mails" do
-    setup do
-      @in_1  = create(:user, current_sign_in_at: User::SUSPENSION_THRESHOLD_PERIOD.ago)
-      @in_3  = create(:user, current_sign_in_at: (User::SUSPENSION_THRESHOLD_PERIOD - 2.days).ago)
-      @in_7  = create(:user, current_sign_in_at: (User::SUSPENSION_THRESHOLD_PERIOD - 6.days).ago)
-      @in_14 = create(:user, current_sign_in_at: (User::SUSPENSION_THRESHOLD_PERIOD - 13.days).ago)
-    end
-
-    should "send mails to users to remind" do
+  context "sending reminder emails" do
+    should "send reminder emails to users with the correct number of days from suspension" do
+      suspends_in_3_days = create(:user, current_sign_in_at: (User::SUSPENSION_THRESHOLD_PERIOD - 2.days).ago)
+      
       mailer = mock()
-      mailer.expects(:deliver).returns(true).times(4)
-      UserMailer.expects(:suspension_reminder).with(@in_1, 1).returns(mailer)
-      UserMailer.expects(:suspension_reminder).with(@in_3, 3).returns(mailer)
-      UserMailer.expects(:suspension_reminder).with(@in_7, 7).returns(mailer)
-      UserMailer.expects(:suspension_reminder).with(@in_14, 14).returns(mailer)
+      mailer.expects(:deliver).returns(true)
+      UserMailer.expects(:suspension_reminder).with(suspends_in_3_days, 3).returns(mailer)
 
-      InactiveUsersSuspensionReminder.new.send_reminders
-    end
-
-    should "return number of reminders sent" do
-      signed_in_48_days_ago = create(:user, current_sign_in_at: 48.days.ago)
-
-      assert_equal 5, InactiveUsersSuspensionReminder.new.send_reminders
+      users_to_remind = User.last_signed_in_on((User::SUSPENSION_THRESHOLD_PERIOD - 2.days).ago)
+      InactiveUsersSuspensionReminder.new(users_to_remind, 3).send_reminders
     end
   end
 
   context "failing to send emails with SES down" do
     setup do
       create(:user, current_sign_in_at: User::SUSPENSION_THRESHOLD_PERIOD.ago)
+      @users_to_remind = User.last_signed_in_on(User::SUSPENSION_THRESHOLD_PERIOD.ago)
+
       @mailer = mock()
       @mailer.expects(:deliver).raises(Errno::ETIMEDOUT).times(3)
     end
 
     should "retry twice if there are errors connecting to SES" do
       UserMailer.expects(:suspension_reminder).returns(@mailer).times(3)
-      InactiveUsersSuspensionReminder.new.send_reminders
+      InactiveUsersSuspensionReminder.new(@users_to_remind, 1).send_reminders
     end
 
     should "send an exception notification if retries fail" do
       Airbrake.expects(:notify_or_ignore).once
       UserMailer.expects(:suspension_reminder).returns(@mailer).times(3)
 
-      InactiveUsersSuspensionReminder.new.send_reminders
+      InactiveUsersSuspensionReminder.new(@users_to_remind, 1).send_reminders
     end
   end
 


### PR DESCRIPTION
https://www.agileplannerapp.com/boards/173808/cards/3407

for better separation of concerns, and so that
we can run the suspension reminder logic manually
from production console to notify arbitrary set of
users. this is necessary to gradually roll-out the
auto-suspension feature.

related discussion:
https://www.agileplannerapp.com/boards/173808/discussions/411

script to be manually executed from production console:
https://gist.github.com/vinayvinay/579dea8babcfa7f4cc77
