### PR TITLE
Rescue SMTP errors when sending suspension mailers

### DIFF
--- a/lib/inactive_users_suspension_reminder.rb
+++ b/lib/inactive_users_suspension_reminder.rb
@@ -1,5 +1,12 @@
 class InactiveUsersSuspensionReminder
 
+  ERRORS_TO_RETRY_ON = [TimeoutError,
+                        SocketError,
+                        Net::SMTPServerBusy,
+                        Errno::ETIMEDOUT,
+                        Errno::EHOSTUNREACH,
+                        Errno::ECONNREFUSED]
+
   def initialize(users, days_to_suspension)
     @users, @days_to_suspension = users, days_to_suspension
   end
@@ -11,23 +18,23 @@ class InactiveUsersSuspensionReminder
         Rails.logger.info "#{self.class}: Sending email to #{user.email}."
         UserMailer.suspension_reminder(user, @days_to_suspension).deliver
         Rails.logger.info "#{self.class}: Successfully sent email to #{user.email}."
-      rescue *network_errors => e
-        Rails.logger.debug "#{self.class}: #{e.class} - #{e.message} while sending email to #{user.email} during attempt (#{(tries..3).count}/3)."
-        retry if (tries -= 1) > 0
+      rescue *ERRORS_TO_RETRY_ON => e
+        Rails.logger.debug "#{self.class}: #{e.class} - #{e.message} while sending email to #{user.email} during attempt (#{(tries..3).count}/3)."        
+        sleep(3) and retry if (tries -= 1) > 0
 
         Rails.logger.warn "#{self.class}: Failed to send suspension reminder email to #{user.email}."
-        Airbrake.notify_or_ignore e, :parameters => { :receiver_email => user.email }
-      rescue AWS::SES::ResponseError => e
+        notify_airbrake(e, user)
+      rescue => e
         Rails.logger.warn "#{self.class}: #{e.response.error.message} while sending email to #{user.email}."
-        Airbrake.notify_or_ignore e, :parameters => { :receiver_email => user.email }
+        notify_airbrake(e, user)
       end
     end
   end
 
 private
 
-  def network_errors
-    [SocketError, Timeout::Error, Errno::ECONNREFUSED, Errno::EHOSTDOWN, Errno::EHOSTUNREACH, Errno::ETIMEDOUT]
+  def notify_airbrake(e, user)
+    Airbrake.notify_or_ignore e, :parameters => { :receiver_email => user.email }
   end
 
 end


### PR DESCRIPTION
also, ensuring we retry only on errors where
it makes sense to retry: like timeouts and
server busy errors.

related reading:

http://robots.thoughtbot.com/i-accidentally-the-whole-smtp-exception
http://ruby-doc.org/stdlib-2.0/libdoc/net/smtp/rdoc/Net/SMTP.html#method-c-start-label-Errors
