### PR TITLE
Remove aws-ses gem and replace AWS::SES exceptions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ gem 'rails', '3.2.18'
 gem 'kaminari', '0.14.1'
 gem 'alphabetical_paginate', '2.1.0'
 gem 'mysql2'
-gem 'aws-ses', require: 'aws/ses'
 gem 'jquery-rails'
 
 gem 'airbrake', '3.1.15'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,11 +46,6 @@ GEM
     ancestry (2.0.0)
       activerecord (>= 3.0.0)
     arel (3.0.3)
-    aws-ses (0.4.4)
-      builder
-      mail (> 2.2.5)
-      mime-types
-      xml-simple
     bcrypt-ruby (3.1.2)
     builder (3.0.4)
     cancan (1.6.10)
@@ -227,7 +222,6 @@ GEM
     whenever (0.7.3)
       activesupport (>= 2.3.4)
       chronic (~> 0.6.3)
-    xml-simple (1.1.1)
     xpath (2.0.0)
       nokogiri (~> 1.3)
     zxcvbn-ruby (0.0.2)
@@ -239,7 +233,6 @@ DEPENDENCIES
   airbrake (= 3.1.15)
   alphabetical_paginate (= 2.1.0)
   ancestry (= 2.0.0)
-  aws-ses
   cancan (= 1.6.10)
   capybara (= 2.2.1)
   ci_reporter (= 1.7.0)

--- a/app/controllers/admin/invitations_controller.rb
+++ b/app/controllers/admin/invitations_controller.rb
@@ -6,7 +6,7 @@ class Admin::InvitationsController < Devise::InvitationsController
 
   helper_method :applications_and_permissions
 
-  rescue_from AWS::SES::ResponseError do |exception|
+  rescue_from Net::SMTPFatalError do |exception|
     if exception.message =~ /Address blacklisted/i
       @exception = exception
       render "shared/address_blacklisted", status: 500

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -19,7 +19,7 @@ class PasswordsController < Devise::PasswordsController
   def create
     begin
       self.resource = resource_class.send_reset_password_instructions(resource_params)
-    rescue AWS::SES::ResponseError => exception
+    rescue Net::SMTPFatalError => exception
       if exception.message =~ /Address blacklisted/i
         self.resource = user_from_params
       else

--- a/test/functional/admin/invitations_controller_test.rb
+++ b/test/functional/admin/invitations_controller_test.rb
@@ -61,7 +61,7 @@ class Admin::InvitationsControllerTest < ActionController::TestCase
     context "SES has blacklisted the address" do
       should "show the user a helpful message" do
         Devise::Mailer.any_instance.expects(:mail).with(anything)
-            .raises(AWS::SES::ResponseError, OpenStruct.new(error: { 'Code' => "MessageRejected", 'Message' => "Address blacklisted." }))
+            .raises(Net::SMTPFatalError, OpenStruct.new(error: { 'Code' => "MessageRejected", 'Message' => "Address blacklisted." }))
 
         post :create, user: { name: "John Smith", email: "jsmith@restrictivemailserver.com" }
 

--- a/test/helpers/passphrase_support.rb
+++ b/test/helpers/passphrase_support.rb
@@ -31,6 +31,6 @@ module PassPhraseSupport
 
   def given_email_is_on_ses_blacklist
     Devise::Mailer.any_instance.expects(:mail).with(anything)
-    .raises(AWS::SES::ResponseError, OpenStruct.new(error: { 'Code' => "MessageRejected", 'Message' => "Address blacklisted." }))
+    .raises(Net::SMTPFatalError, OpenStruct.new(error: { 'Code' => "MessageRejected", 'Message' => "Address blacklisted." }))
   end
 end


### PR DESCRIPTION
https://www.agileplannerapp.com/boards/173808/cards/4274

we've switched to sending emails through SMTP
instead of the SES HTTP API.

note about exceptions: if the recipient of an
email is blacklisted by SES, an SMTP 554 error
is returned. the corresponding exception raised
in ruby code is: [Net::SMTPFatalError](http://ruby-doc.org/stdlib-1.9.3/libdoc/net/smtp/rdoc/Net/SMTPFatalError.html)
