### PR TITLE
Allowing account to be unlocked from the edit page

### DIFF
--- a/app/assets/stylesheets/signon.css.erb
+++ b/app/assets/stylesheets/signon.css.erb
@@ -106,3 +106,7 @@ hr.grey {
 .js-enabled #parts-of-email {
   display: none;
 }
+
+.unlock-account-form {
+  margin-bottom: 5px;
+}

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -35,7 +35,7 @@ class Admin::UsersController < ApplicationController
     EventLog.record_event(@user, EventLog::MANUAL_ACCOUNT_UNLOCK)
     @user.unlock_access!
     flash[:notice] = "Unlocked #{@user.email}"
-    redirect_to admin_users_path
+    redirect_to :back
   end
 
   def resend_email_change

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -6,6 +6,16 @@
   <%= link_to "#{@user.suspended? ? "Uns" : "S"}uspend user", edit_admin_suspension_path(@user) %>
 </p>
 
+<% if @user.access_locked? %>
+  <div class="alert">
+    <strong>Account has been locked after too many unsuccessful login attempts.</strong><br/>
+    Locked accounts are automatically unlocked after 1 hour.
+    <%= form_tag unlock_admin_user_path(@user), class: 'unlock-account-form' do %>
+      <%= submit_tag "Unlock account", :class => 'btn top-buffer' %>
+    <% end %>
+  </div>
+<% end %>
+
 <% if @user.suspended? and @user.reason_for_suspension.present? %>
   <p class="alert">
     <strong>User suspended:</strong> <em><%= @user.reason_for_suspension %></em>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -69,7 +69,7 @@
             <% end %>
             <% if user.access_locked? %>
               <%= form_tag unlock_admin_user_path(user) do %>
-                <%= submit_tag "Unlock", :class => 'btn btn-danger' %>
+                <%= submit_tag "Unlock account", :class => 'btn' %>
               <% end %>
             <% end %>
           </td>

--- a/test/integration/user_locking_test.rb
+++ b/test/integration/user_locking_test.rb
@@ -22,7 +22,22 @@ class UserLockingTest < ActionDispatch::IntegrationTest
     signin(admin)
     first_letter_of_name = user.name[0]
     visit admin_users_path(letter: first_letter_of_name)
-    click_button 'Unlock'
+    click_button 'Unlock account'
+
+    user.reload
+    assert ! user.access_locked?
+  end
+
+  should "be reversible from the user edit page" do
+    admin = create(:user, role: "admin")
+    user = create(:user)
+    user.lock_access!
+
+    visit root_path
+    signin(admin)
+    visit edit_admin_user_path(user)
+
+    click_button 'Unlock account'
 
     user.reload
     assert ! user.access_locked?


### PR DESCRIPTION
https://www.agileplannerapp.com/boards/173808/cards/4276

the users listing was the only place from where
the account could be unlocked. trying to bring
more user related admin actions on the edit page.

i've also unified the look and feel of Unlock buttons
based on inputs from @fofr.

![screen shot 2014-06-20 at 15 47 35](https://cloud.githubusercontent.com/assets/230074/3339011/4cf051d4-f864-11e3-8598-c1c65db254ad.png)
