### PR TITLE
Fixed flaky test for EventLog

### DIFF
--- a/test/integration/event_log_test.rb
+++ b/test/integration/event_log_test.rb
@@ -40,7 +40,8 @@ class EventLogTest < ActionDispatch::IntegrationTest
                     new: new_password,
                     new_confirmation: new_password)
 
-    assert_equal EventLog::SUCCESSFUL_PASSPHRASE_CHANGE, EventLog.for(@user).last.event
+    # multiple events are registered with the same time, order changes.
+    assert_include EventLog.for(@user).map(&:event), EventLog::SUCCESSFUL_PASSPHRASE_CHANGE
   end
 
   test "record unsuccessful passphrase change" do


### PR DESCRIPTION
there are multiple events logged at the same time
hence the order in which events are retrieved is
not predictable.

fix for one-off failures like these:
https://ci-new.alphagov.co.uk/job/govuk_signonotron2_branches/217/console
