### PR TITLE
Remove unnecessary negation from suspension logic

### DIFF
--- a/lib/devise/models/suspendable.rb
+++ b/lib/devise/models/suspendable.rb
@@ -12,14 +12,14 @@ module Devise
 
       def active_for_authentication?
         if super
-          return true if !suspended?
+          return true unless suspended?
           EventLog.record_event(self, EventLog::SUSPENDED_ACCOUNT_AUTHENTICATED_LOGIN)
         end
         false
       end
 
       def inactive_message
-        !suspended? ? super : :suspended
+        suspended? ? :suspended : super
       end
 
       # Suspends the user in the database.


### PR DESCRIPTION
Use `unless` and flip ternary operators to avoid having to think through too much negation in conditionals; hopefully this makes the logic a bit clearer.
