### PR TITLE
Show user status on admin edit page

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -110,6 +110,20 @@ class User < ActiveRecord::Base
     super
   end
 
+  def status
+    if suspended?
+      "suspended"
+    elsif invited_but_not_yet_accepted?
+      "invited"
+    elsif need_change_password?
+      "passphrase expired"
+    elsif access_locked?
+      "locked"
+    else
+      "active"
+    end
+  end
+
 private
 
   # Override devise_security_extension for updating expired passwords

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -1,7 +1,7 @@
 <h1>Edit user &ldquo;<%= @user.name %>&rdquo;</h1>
 
 <p class="suspenders">
-  User <strong><%= @user.suspended? ? "suspended" : "active" %></strong> &bull;
+  User <strong><%= @user.status %></strong> &bull;
   <%= link_to "Account access log", admin_user_event_logs_path(@user) %> &bull;
   <%= link_to "#{@user.suspended? ? "Uns" : "S"}uspend user", edit_admin_suspension_path(@user) %>
 </p>

--- a/test/integration/user_status_test.rb
+++ b/test/integration/user_status_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+require 'helpers/passphrase_support'
+
+class UserStatusTest < ActionDispatch::IntegrationTest
+  include PassPhraseSupport
+
+  setup do
+    @admin = create(:admin_user)
+    @user = create(:user, password_changed_at: 91.days.ago)
+  end
+
+  test "User status appears on the edit user page" do
+    visit root_path
+    signin @admin
+    visit admin_user_path(@user)
+
+    assert page.has_content?("User passphrase expired")
+  end
+end

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -208,6 +208,36 @@ class UserTest < ActiveSupport::TestCase
     assert_false user.persisted?
   end
 
+  context "User status" do
+    setup do
+      @user = create(:user)
+    end
+
+    should "return suspended" do
+      @user.suspend("because grumble")
+      assert_equal "suspended", @user.status
+    end
+
+    should "return invited" do
+      user = User.invite!(name: "Oberyn Martell", email: "redviper@dorne.com")
+      assert_equal "invited", user.status
+    end
+
+    should "return passphrase expired" do
+      user = create(:user, password_changed_at: 91.days.ago)
+      assert_equal "passphrase expired", user.status
+    end
+
+    should "return locked" do
+      @user.lock_access!
+      assert_equal "locked", @user.status
+    end
+
+    should "return active" do
+      assert_equal "active", @user.status
+    end
+  end
+
   context "authorised applications" do
     setup do
       @user = create(:user)


### PR DESCRIPTION
There are more user states than `active` and `suspended`: show all possible user states on the Signon user edit page.

https://www.agileplannerapp.com/boards/173808/cards/4283
