### PR TITLE
Bump admin gem to fix precompile error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'kaminari', '0.16.1'
 gem 'bootstrap-kaminari-views', '0.0.3'
 gem 'alphabetical_paginate', git: 'https://github.com/fofr/alphabetical_paginate.git', branch: 'bootstrap3-fix'
 gem 'mysql2'
-gem 'govuk_admin_template', '1.0.3'
+gem 'govuk_admin_template', '1.0.4'
 
 gem 'airbrake', '3.1.15'
 gem 'plek', '1.7.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,7 +106,7 @@ GEM
       null_logger
       plek
       rest-client (~> 1.6.3)
-    govuk_admin_template (1.0.3)
+    govuk_admin_template (1.0.4)
       bootstrap-sass (= 3.1.0)
       jquery-rails (= 3.0.4)
       rails (>= 3.2.0)
@@ -267,7 +267,7 @@ DEPENDENCIES
   doorkeeper (= 0.6.7)
   factory_girl_rails (= 4.3.0)
   gds-api-adapters (= 7.11.0)
-  govuk_admin_template (= 1.0.3)
+  govuk_admin_template (= 1.0.4)
   json (= 1.7.7)
   kaminari (= 0.16.1)
   logstasher (= 0.4.8)


### PR DESCRIPTION
- Precompile IE7 to a CSS file, not SCSS: See https://github.com/alphagov/govuk_admin_template/pull/31
- The precompile list needs to list the output filenames, not the source filenames.
