### PR TITLE
Validate client_id in /user.json endpoint

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,7 @@
 class UsersController < ApplicationController
   before_filter :authenticate_user!, :except => :show
   doorkeeper_for :show
+  before_filter :validate_token_matches_client_id, :only => :show
 
   # it's okay for current_user to modify own attributes
   skip_authorization_check
@@ -67,4 +68,14 @@ class UsersController < ApplicationController
     def application_making_request
       ::Doorkeeper::Application.find(doorkeeper_token.application_id)
     end
+
+  def validate_token_matches_client_id
+    # FIXME: Once gds-sso is updated everywhere, this should always validate
+    # the client_id param.  It should 401 if no client_id is given.
+    if params[:client_id].present?
+      if params[:client_id] != doorkeeper_token.application.uid
+        head :unauthorized
+      end
+    end
+  end
 end

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -122,78 +122,103 @@ class UsersControllerTest < ActionController::TestCase
   end
 
   context "GET show (as OAuth client application)" do
+    setup do
+      @application = create(:application)
+    end
+
     should "fetching json profile with a valid oauth token should succeed" do
       user = create(:user)
-      application = create(:application)
-      permission = create(:permission, user_id: user.id, application_id: application.id)
-      token = create(:access_token, :application => application, :resource_owner_id => user.id)
+      permission = create(:permission, user_id: user.id, application_id: @application.id)
+      token = create(:access_token, :application => @application, :resource_owner_id => user.id)
+
+      @request.env['HTTP_AUTHORIZATION'] = "Bearer #{token.token}"
+      get :show, {:client_id => @application.uid, :format => :json}
+
+      assert_equal "200", response.code
+      presenter = UserOAuthPresenter.new(user, @application)
+      assert_equal presenter.as_hash.to_json, response.body
+    end
+
+    should "fetching json profile with a valid oauth token, but no client_id should succeed" do
+      # For now.  Once gds-sso is updated everywhere, this will 401.
+
+      user = create(:user)
+      permission = create(:permission, user_id: user.id, application_id: @application.id)
+      token = create(:access_token, :application => @application, :resource_owner_id => user.id)
 
       @request.env['HTTP_AUTHORIZATION'] = "Bearer #{token.token}"
       get :show, {:format => :json}
 
       assert_equal "200", response.code
-      presenter = UserOAuthPresenter.new(user, application)
+      presenter = UserOAuthPresenter.new(user, @application)
       assert_equal presenter.as_hash.to_json, response.body
     end
 
     should "fetching json profile with an invalid oauth token should not succeed" do
       user = create(:user)
-      application = create(:application)
-      token = create(:access_token, :application => application, :resource_owner_id => user.id)
+      token = create(:access_token, :application => @application, :resource_owner_id => user.id)
 
       @request.env['HTTP_AUTHORIZATION'] = "Bearer #{token.token.sub(/[0-9]/, 'x')}"
-      get :show, {:format => :json}
+      get :show, {:client_id => @application.uid, :format => :json}
+
+      assert_equal "401", response.code
+    end
+
+    should "fetching json profile with a token for another app should not succeed" do
+      other_application = create(:application)
+      user = create(:user)
+      token = create(:access_token, :application => other_application, :resource_owner_id => user.id)
+
+      @request.env['HTTP_AUTHORIZATION'] = "Bearer #{token.token.sub(/[0-9]/, 'x')}"
+      get :show, {:client_id => @application.uid, :format => :json}
 
       assert_equal "401", response.code
     end
 
     should "fetching json profile without any bearer header should not succeed" do
-      get :show, {:format => :json}
+      get :show, {:client_id => @application.uid, :format => :json}
       assert_equal "401", response.code
     end
 
     should "fetching json profile should include permissions" do
-      application = create(:application)
-      user = create(:user, with_signin_permissions_for: [ application ])
-      token = create(:access_token, :application => application, :resource_owner_id => user.id)
+      user = create(:user, with_signin_permissions_for: [ @application ])
+      token = create(:access_token, :application => @application, :resource_owner_id => user.id)
 
       @request.env['HTTP_AUTHORIZATION'] = "Bearer #{token.token}"
-      get :show, {:format => :json}
+      get :show, {:client_id => @application.uid, :format => :json}
       json = JSON.parse(response.body)
       assert_equal(["signin"], json['user']['permissions'])
     end
 
     should "fetching json profile should include only permissions for the relevant app" do
-      application, other_application = create_pair(:application)
-      user = create(:user, with_signin_permissions_for: [ application, other_application ])
+      other_application = create(:application)
+      user = create(:user, with_signin_permissions_for: [ @application, other_application ])
 
-      token = create(:access_token, :application => application, :resource_owner_id => user.id)
+      token = create(:access_token, :application => @application, :resource_owner_id => user.id)
 
       @request.env['HTTP_AUTHORIZATION'] = "Bearer #{token.token}"
-      get :show, {:format => :json}
+      get :show, {:client_id => @application.uid, :format => :json}
       json = JSON.parse(response.body)
       assert_equal(["signin"], json['user']['permissions'])
     end
 
     should "fetching json profile should update last_synced_at for the relevant app" do
       user = create(:user)
-      application = create(:application)
-      permission = create(:permission, user_id: user.id, application_id: application.id)
-      token = create(:access_token, :application => application, :resource_owner_id => user.id)
+      permission = create(:permission, user_id: user.id, application_id: @application.id)
+      token = create(:access_token, :application => @application, :resource_owner_id => user.id)
 
       @request.env['HTTP_AUTHORIZATION'] = "Bearer #{token.token}"
-      get :show, {:format => :json}
+      get :show, {:client_id => @application.uid, :format => :json}
 
       assert_not_nil permission.reload.last_synced_at
     end
 
     should "fetching json profile should succeed even if no permission for relevant app" do
       user = create(:user)
-      application = create(:application)
-      token = create(:access_token, :application => application, :resource_owner_id => user.id)
+      token = create(:access_token, :application => @application, :resource_owner_id => user.id)
 
       @request.env['HTTP_AUTHORIZATION'] = "Bearer #{token.token}"
-      get :show, {:format => :json}
+      get :show, {:client_id => @application.uid, :format => :json}
 
       assert_response :ok
     end


### PR DESCRIPTION
Previously, there was no way for this endpoint to ensure that the client
application requesting the user information was the same app that the
token had been issued for.  For normal user tokens, this isn't really an
issue because they are unlikely to ever be different.  For API users,
this becomes a significant issue, because the tokens are both
long-lived, and also exposed to users.  This means that an API token
issued for one app could be used to gain access to a different app.

This change adds a client_id param to the /user.json endpoint to hold
the oauth_id of the requesting app.  If given, this will be validated
against the token used to ensure that they match.  Once we have updated
all the client applications to send this param, it will be made
mandatory.
