### PR TITLE
Use alphabetical_paginate gem with merged fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem 'rails', '3.2.18'
 
 gem 'kaminari', '0.16.1'
 gem 'bootstrap-kaminari-views', '0.0.3'
-gem 'alphabetical_paginate', git: 'https://github.com/fofr/alphabetical_paginate.git', branch: 'bootstrap3-fix'
+gem 'alphabetical_paginate', '2.2.3'
 gem 'mysql2'
 gem 'govuk_admin_template', '1.0.4'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,13 +7,6 @@ GIT
       devise (>= 2.0.0)
       rails (>= 3.1.1)
 
-GIT
-  remote: https://github.com/fofr/alphabetical_paginate.git
-  revision: 35b41fbcfe00b1a7b3a6d94b94c9624e33fbe6ed
-  branch: bootstrap3-fix
-  specs:
-    alphabetical_paginate (2.2.2)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -49,6 +42,7 @@ GEM
     airbrake (3.1.15)
       builder
       multi_json
+    alphabetical_paginate (2.2.3)
     ancestry (2.0.0)
       activerecord (>= 3.0.0)
     arel (3.0.3)
@@ -251,7 +245,7 @@ PLATFORMS
 
 DEPENDENCIES
   airbrake (= 3.1.15)
-  alphabetical_paginate!
+  alphabetical_paginate (= 2.2.3)
   ancestry (= 2.0.0)
   bootstrap-kaminari-views (= 0.0.3)
   cancan (= 1.6.10)


### PR DESCRIPTION
- PR https://github.com/lingz/alphabetical_paginate/pull/23 now merged,
  fixed HTML markup when using Bootstrap 3 theme
- Switch back from using a forked version of gem
