### PR TITLE
Set autofocus on input field

### DIFF
--- a/app/views/superadmin/supported_permissions/_form.html.erb
+++ b/app/views/superadmin/supported_permissions/_form.html.erb
@@ -15,7 +15,7 @@
         <% if f.object.name.try(:downcase) == 'signin' %>
           <%= f.object.name %>
         <% else %>
-          <%= f.text_field :name, placeholder: t('supported_permissions.form.placeholder.name'), class: 'form-control input-md-4' %>
+          <%= f.text_field :name, placeholder: t('supported_permissions.form.placeholder.name'), class: 'form-control input-md-4', autofocus: 'autofocus' %>
         <% end %>
     </div>
     <hr />


### PR DESCRIPTION
As a superadmin
When I am adding a new permission
I would like the focus to be on the input field
So that I can start to type without tabbing or clicking
