### PR TITLE
Fix title on user edit page

### DIFF
--- a/app/views/admin/suspensions/edit.html.erb
+++ b/app/views/admin/suspensions/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "Suspend \"#{@user.name}\"" %>
+<% content_for :title, "Suspend [#{@user.name}]" %>
 
 <ol class="breadcrumb">
   <li><%= link_to @user.name, admin_user_path(@user) %></li>

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "Edit \"#{@user.name}\"" %>
+<% content_for :title, "Edit [#{@user.name}]" %>
 
 <h1>Edit &ldquo;<%= @user.name %>&rdquo;</h1>
 


### PR DESCRIPTION
Without this, the page title is:

``` html
<title>Edit &amp;quot;<name>&amp;quot; | GOV.UK Signon</title>
```

![image](https://cloud.githubusercontent.com/assets/23801/3688369/8c0f80ec-1335-11e4-9bfb-ef72c5fd65f0.png)
