### PR TITLE
Corrected variable name in rake task

### DIFF
--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -31,7 +31,7 @@ namespace :users do
       suspension_reminder_mailing_list = InactiveUsersSuspensionReminderMailingList.new(User::SUSPENSION_THRESHOLD_PERIOD).generate
       suspension_reminder_mailing_list.each do |days_to_suspension, users|
         InactiveUsersSuspensionReminder.new(users, days_to_suspension).send_reminders
-        puts "InactiveUsersSuspensionReminder: #{users_to_remind.count} users were reminded about their account getting suspended in #{days_to_suspension} days"
+        puts "InactiveUsersSuspensionReminder: Sent emails to #{users.count} users to remind them that their account will be suspended in #{days_to_suspension} days"
       end
     end
   end


### PR DESCRIPTION
www.agileplannerapp.com/boards/173808/cards/3407

the rake task was using an undefined variable, `users_to_remind`. also, corrected the output to make it simpler.
