### PR TITLE
Lower-case blog post link in suspension emails

### DIFF
--- a/app/views/user_mailer/suspension_notification.html.erb
+++ b/app/views/user_mailer/suspension_notification.html.erb
@@ -6,4 +6,4 @@
 
 <p>You'll need to request for your account to be unsuspended.</p>
 
-<p>Read our blog post about <%= link_to 'Suspending unused GOV.UK accounts', 'https://insidegovuk.blog.gov.uk/2014/08/21/suspending-unused-gov-uk-accounts' %>.</p>
+<p>Read our blog post about <%= link_to 'suspending unused GOV.UK accounts', 'https://insidegovuk.blog.gov.uk/2014/08/21/suspending-unused-gov-uk-accounts' %>.</p>

--- a/app/views/user_mailer/suspension_notification.text.erb
+++ b/app/views/user_mailer/suspension_notification.text.erb
@@ -6,6 +6,6 @@ Your <%= account_name %> has now been suspended and you will not be able to acce
 
 You'll need to request for your account to be unsuspended.
 
-Read our blog post about Suspending unused GOV.UK accounts:
+Read our blog post about suspending unused GOV.UK accounts:
 
 https://insidegovuk.blog.gov.uk/2014/08/21/suspending-unused-gov-uk-accounts

--- a/app/views/user_mailer/suspension_reminder.html.erb
+++ b/app/views/user_mailer/suspension_reminder.html.erb
@@ -8,4 +8,4 @@
 
 <p>If you’re unable to sign in to your account because you’ve forgotten your passphrase, you can request a new one on the sign in screen.</p>
 
-<p>Read our blog post about <%= link_to 'Suspending unused GOV.UK accounts', 'https://insidegovuk.blog.gov.uk/2014/08/21/suspending-unused-gov-uk-accounts' %>.</p>
+<p>Read our blog post about <%= link_to 'suspending unused GOV.UK accounts', 'https://insidegovuk.blog.gov.uk/2014/08/21/suspending-unused-gov-uk-accounts' %>.</p>

--- a/app/views/user_mailer/suspension_reminder.text.erb
+++ b/app/views/user_mailer/suspension_reminder.text.erb
@@ -10,6 +10,6 @@ You’ll need to sign in to your account to stop it being suspended.
 
 If you’re unable to sign in to your account because you’ve forgotten your passphrase, you can request a new one on the sign in screen.
 
-Read our blog post about Suspending unused GOV.UK accounts:
+Read our blog post about suspending unused GOV.UK accounts:
 
 https://insidegovuk.blog.gov.uk/2014/08/21/suspending-unused-gov-uk-accounts


### PR DESCRIPTION
@fatbusinessman suggested this edit, because the blog post title "looks really out of place in the plain-text version, and moderately out of place in the HTML version."

confirmed this edit with Natalie Shaw.
