### PR TITLE
[Do Not Merge] Reduce Signon Administrator privileges

### DIFF
--- a/app/views/admin/users/_form_fields.html.erb
+++ b/app/views/admin/users/_form_fields.html.erb
@@ -30,7 +30,7 @@
 <% if can? :assign_role, User %>
   <p class="form-group">
     <%= f.label :role %><br />
-    <%= f.select :role, options_for_select(User.roles.map(&:humanize).zip(User.roles), f.object.role), {}, class: "chosen-select form-control", 'data-module' => 'chosen' %>
+    <%= f.select :role, options_for_select(filtered_user_roles.map(&:humanize).zip(User.roles), f.object.role), {}, class: "chosen-select form-control", 'data-module' => 'chosen' %>
     <span class="help-block">
       <strong>Admins</strong> can create and edit normal users.<br />
       <strong>Superadmins</strong> can create and edit all user types and edit applications.

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -80,36 +80,38 @@
     </thead>
     <tbody>
       <% @users.each do |user| %>
-        <tr>
-          <td class="email">
-            <%= user.suspended? ? "<del>".html_safe : "" %>
-              <%= link_to "#{user.name} <#{user.email}>", edit_admin_user_path(user) %>
-            <%= user.suspended? ? "</del>".html_safe : "" %>
-          </td>
-          <td class="role"><%= user.role.humanize %></td>
-          <td><%= user.sign_in_count %></td>
-          <td class="last-sign-in">
-            <% if user.current_sign_in_at %>
-              <%= time_ago_in_words(user.current_sign_in_at) %> ago
-            <% else %>
-              never signed in
-            <% end %>
-          </td>
-          <td><%= time_ago_in_words(user.created_at) %> ago</td>
-          <td><%= user.suspended? ? "Yes" : "No" %></td>
-          <td>
-            <% if user.invited_but_not_accepted %>
-              <%= form_tag resend_user_invitation_path(user) do %>
-                <%= submit_tag "Resend signup email", :class => 'btn btn-sm btn-default' %>
+        <% if current_role_allows_managing_user?(current_user.role, user.role) %>
+          <tr>
+            <td class="email">
+              <%= user.suspended? ? "<del>".html_safe : "" %>
+                <%= link_to "#{user.name} <#{user.email}>", edit_admin_user_path(user) %>
+              <%= user.suspended? ? "</del>".html_safe : "" %>
+            </td>
+            <td class="role"><%= user.role.humanize %></td>
+            <td><%= user.sign_in_count %></td>
+            <td class="last-sign-in">
+              <% if user.current_sign_in_at %>
+                <%= time_ago_in_words(user.current_sign_in_at) %> ago
+              <% else %>
+                never signed in
               <% end %>
-            <% end %>
-            <% if user.access_locked? %>
-              <%= form_tag unlock_admin_user_path(user) do %>
-                <%= submit_tag "Unlock account", :class => 'btn btn-default' %>
+            </td>
+            <td><%= time_ago_in_words(user.created_at) %> ago</td>
+            <td><%= user.suspended? ? "Yes" : "No" %></td>
+            <td>
+              <% if user.invited_but_not_accepted %>
+                <%= form_tag resend_user_invitation_path(user) do %>
+                  <%= submit_tag "Resend signup email", :class => 'btn btn-sm btn-default' %>
+                <% end %>
               <% end %>
-            <% end %>
-          </td>
-        </tr>
+              <% if user.access_locked? %>
+                <%= form_tag unlock_admin_user_path(user) do %>
+                  <%= submit_tag "Unlock account", :class => 'btn btn-default' %>
+                <% end %>
+              <% end %>
+            </td>
+          </tr>
+        <% end %>
       <% end %>
     </tbody>
   </table>

--- a/lib/abilities/admin.rb
+++ b/lib/abilities/admin.rb
@@ -7,9 +7,13 @@ module Abilities
 
       can :read, Organisation
       can [:read, :create], BatchInvitation
-      can :delegate_all_permissions, ::Doorkeeper::Application
+      cannot :delegate_all_permissions, ::Doorkeeper::Application
       can [:read, :create, :update, :unlock, :invite!, :suspend, :unsuspend,
-            :perform_admin_tasks, :resend_email_change, :cancel_email_change], User, api_user: false
+            :perform_admin_tasks, :resend_email_change, :cancel_email_change, :assign_role],
+          User,
+          { api_user: false,
+            role: %w(normal organisation_admin) }
+
       can [:read], EventLog
 
       cannot :manage, [ApiUser, Doorkeeper::AccessToken]

--- a/lib/abilities/organisation_admin.rb
+++ b/lib/abilities/organisation_admin.rb
@@ -8,8 +8,12 @@ module Abilities
       can :read, Organisation, id: user.organisation.subtree.map(&:id)
       can [:read, :create], BatchInvitation, organisation: { id: user.organisation.subtree.map(&:id) }
       can [:read, :create, :update, :unlock, :invite!, :suspend, :unsuspend,
-            :perform_admin_tasks, :resend_email_change, :cancel_email_change],
-              User, { organisation: { id: user.organisation.subtree.map(&:id) }, api_user: false }
+           :perform_admin_tasks, :resend_email_change, :cancel_email_change],
+          User,
+          { organisation: { id: user.organisation.subtree.map(&:id) },
+            api_user: false,
+            role: %w(normal)
+          }
 
       cannot :manage, [ApiUser, Doorkeeper::AccessToken]
       cannot :delegate_all_permissions, ::Doorkeeper::Application

--- a/lib/user_permissions_controller_methods.rb
+++ b/lib/user_permissions_controller_methods.rb
@@ -7,7 +7,7 @@ module UserPermissionsControllerMethods
       elsif can? :delegate_all_permissions, ::Doorkeeper::Application
         applications = ::Doorkeeper::Application
       else
-        applications = ::Doorkeeper::Application.can_signin(current_user).with_signin_delegatable
+        applications = ::Doorkeeper::Application.can_signin(current_user)
       end
       zip_permissions(applications.includes(:supported_permissions), user)
     end


### PR DESCRIPTION
https://www.agileplannerapp.com/boards/173808/cards/5255
https://www.agileplannerapp.com/boards/173808/cards/5254

Initial attempt (test fixes still to come) to simplify and restrict what users are able to do on Signon.
- 'Filter by Role' shows roles that are appropriate for the current user
- Only be able to administer users lower in the permission hierarchy
- Restrict the abilities of Admin and Organisation Admin users
- Can only grant users permissions for apps that the admin user can access.
