### PR TITLE
Pre-empt GMail auto-linking GOV.UK

### DIFF
--- a/app/views/user_mailer/suspension_notification.html.erb
+++ b/app/views/user_mailer/suspension_notification.html.erb
@@ -1,8 +1,8 @@
 <p>Hello <%= @user.name %>,
 
-<p>GOV.UK Signon accounts are suspended after <%= User::SUSPENSION_THRESHOLD_PERIOD.inspect %> of inactivity.</p>
+<p><%= link_to 'GOV.UK', "https://www.gov.uk" %> Signon accounts are suspended after <%= User::SUSPENSION_THRESHOLD_PERIOD.inspect %> of inactivity.</p>
 
-<p>Your <%= account_name %> has now been suspended and you won’t be able to access any GOV.UK applications.</p>
+<p>Your <%= account_name %> has now been suspended and you won’t be able to access any <%= link_to 'GOV.UK', "https://www.gov.uk" %> applications.</p>
 
 <p>You must ask for your account to be unsuspended.</p>
 

--- a/app/views/user_mailer/suspension_reminder.html.erb
+++ b/app/views/user_mailer/suspension_reminder.html.erb
@@ -1,8 +1,8 @@
 <p>Hello <%= @user.name %>,
 
-<p>GOV.UK Signon accounts are suspended after <%= User::SUSPENSION_THRESHOLD_PERIOD.inspect %> of inactivity.</p>
+<p><%= link_to 'GOV.UK', "https://www.gov.uk" %> Signon accounts are suspended after <%= User::SUSPENSION_THRESHOLD_PERIOD.inspect %> of inactivity.</p>
 
-<p>Your <%= account_name %> will be suspended <%= suspension_time %> and you won’t be able to access any GOV.UK applications.</p>
+<p>Your <%= account_name %> will be suspended <%= suspension_time %> and you won’t be able to access any <%= link_to 'GOV.UK', "https://www.gov.uk" %> applications.</p>
 
 <p><%= link_to 'Sign in', new_user_session_url(protocol: 'https') %> to your account to stop it being suspended.</p>
 


### PR DESCRIPTION
GMail is being helpful by converting GOV.UK to a link, but it should link to www.gov.uk instead.
