### PR TITLE
Refer to GOV.UK Signon consistently

### DIFF
--- a/app/mailers/noisy_batch_invitation.rb
+++ b/app/mailers/noisy_batch_invitation.rb
@@ -1,5 +1,5 @@
 class NoisyBatchInvitation < ActionMailer::Base
-  default from: "GOV.UK Sign On <noreply-signon@digital.cabinet-office.gov.uk>"
+  default from: "GOV.UK Signon <noreply-signon@digital.cabinet-office.gov.uk>"
   default to: "signon-alerts@digital.cabinet-office.gov.uk"
 
   def make_noise(batch_invitation)

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,7 +1,7 @@
 class UserMailer < ActionMailer::Base
   helper_method :suspension_time, :account_name
 
-  default from: "GOV.UK Sign On <noreply-signon@digital.cabinet-office.gov.uk>"
+  default from: "GOV.UK Signon <noreply-signon@digital.cabinet-office.gov.uk>"
 
   def suspension_reminder(user, days)
     @user, @days = user, days

--- a/app/views/superadmin/applications/index.html.erb
+++ b/app/views/superadmin/applications/index.html.erb
@@ -1,6 +1,6 @@
-<% content_for :title, "Single sign on applications" %>
+<% content_for :title, "Single Signon applications" %>
 <div class="page-title">
-  <h1>Single Sign On Applications</h1>
+  <h1>Single Signon Applications</h1>
 </div>
 <table class="table table-striped table-bordered">
   <thead>

--- a/app/views/superadmin/supported_permissions/new.html.erb
+++ b/app/views/superadmin/supported_permissions/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "Single sign on application permissions" %>
+<% content_for :title, "Single Signon application permissions" %>
 
 <ol class="breadcrumb">
   <li><%= link_to 'Applications', superadmin_applications_path %></li>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -6,7 +6,7 @@ Devise.setup do |config|
   # ==> Mailer Configuration
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class with default "from" parameter.
-  config.mailer_sender = "GOV.UK Sign On <noreply-signon@digital.cabinet-office.gov.uk>"
+  config.mailer_sender = "GOV.UK Signon <noreply-signon@digital.cabinet-office.gov.uk>"
 
   # Configure the class responsible to send e-mails.
   # config.mailer = "Devise::Mailer"


### PR DESCRIPTION
When referring to GOV.UK Signon, we should be consistent and use Signon, not Sign On.
