### PR TITLE
Adding and removing link_to references to GOV.UK

### DIFF
--- a/app/views/user_mailer/suspension_notification.html.erb
+++ b/app/views/user_mailer/suspension_notification.html.erb
@@ -5,7 +5,7 @@
 <p>Your <%= link_to 'GOV.UK', "https://www.gov.uk" %> Signon <%= account_name %>, for <%= @user.email %>, has now been suspended and you won't be able to access any <%= link_to 'GOV.UK', "https://www.gov.uk" %> <%= account_name %> applications, eg Whitehall Publisher or Licensing.</p>
 
 <% if instance_name.present? %>
-<p><%= account_name.humanize %> suspensions do not suspend production accounts or remove access to GOV.UK production applications.</p>
+<p><%= account_name.humanize %> suspensions do not suspend production accounts or remove access to <%= link_to 'GOV.UK', "https://www.gov.uk" %> production applications.</p>
 <% end %>
 
 <p>If you don't need the account you can ignore this email.</p>

--- a/app/views/user_mailer/suspension_notification.text.erb
+++ b/app/views/user_mailer/suspension_notification.text.erb
@@ -18,5 +18,5 @@ https://insidegovuk.blog.gov.uk/2014/08/21/suspending-unused-gov-uk-accounts
 
 All the best,
 
-<%= link_to 'GOV.UK', "https://www.gov.uk" %> team
+GOV.UK team
 Government Digital Service

--- a/app/views/user_mailer/suspension_reminder.html.erb
+++ b/app/views/user_mailer/suspension_reminder.html.erb
@@ -5,7 +5,7 @@
 <p>Your <%= link_to 'GOV.UK', "https://www.gov.uk" %> Signon <%= account_name %>, for <%= @user.email %>, will be suspended <%= suspension_time %>. After suspension you won't be able to access any <%= link_to 'GOV.UK', "https://www.gov.uk" %> <%= account_name %> applications, eg Whitehall Publisher or Licensing.</p>
 
 <% if instance_name.present? %>
-<p><%= account_name.humanize %> suspensions do not suspend production accounts or remove access to GOV.UK production applications.</p>
+<p><%= account_name.humanize %> suspensions do not suspend production accounts or remove access to <%= link_to 'GOV.UK', "https://www.gov.uk" %> production applications.</p>
 <% end %>
 
 <p>If you don't need the account you can ignore these emails.</p>


### PR DESCRIPTION
Adding link_to references to www.gov.uk in HTML emails and removing
from text only emails.
