### PR TITLE
Disallow managing roles with greater privileges

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -56,7 +56,12 @@ private
 
   def filter_users
     @users = @users.filter(params[:filter]) if params[:filter].present?
-    @users = @users.with_role(params[:role]) if params[:role].present?
+    @users = @users.with_role(params[:role]) if can_filter_role?
+  end
+
+  def can_filter_role?
+    params[:role].present? &&
+    current_user.manageable_roles.include?(params[:role])
   end
 
   def paginate_users

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -28,7 +28,7 @@ module UsersHelper
   end
 
   def user_role_list_items
-    list_items = User.roles.map do |role_name|
+    list_items = filtered_user_roles.map do |role_name|
       content_tag(:li,
         link_to(role_name.humanize, current_path_with_role_filter(role_name)),
         class: params[:role] == role_name ? 'active' : '')
@@ -39,5 +39,9 @@ module UsersHelper
 
   def edit_user_path_by_user_type(user)
     user.api_user? ? edit_superadmin_api_user_path(user) : edit_admin_user_path(user)
+  end
+
+  def filtered_user_roles
+    current_user.manageable_roles
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -124,6 +124,10 @@ class User < ActiveRecord::Base
     "active"
   end
 
+  def manageable_roles
+    "Roles::#{role.camelize}".constantize.manageable_roles
+  end
+
 private
 
   # Override devise_security_extension for updating expired passwords

--- a/app/views/admin/users/_form_fields.html.erb
+++ b/app/views/admin/users/_form_fields.html.erb
@@ -30,7 +30,7 @@
 <% if can? :assign_role, User %>
   <p class="form-group">
     <%= f.label :role %><br />
-    <%= f.select :role, options_for_select(User.roles.map(&:humanize).zip(User.roles), f.object.role), {}, class: "chosen-select form-control", 'data-module' => 'chosen' %>
+    <%= f.select :role, options_for_select(filtered_user_roles.map(&:humanize).zip(User.roles), f.object.role), {}, class: "chosen-select form-control", 'data-module' => 'chosen' %>
     <span class="help-block">
       <strong>Admins</strong> can create and edit normal users.<br />
       <strong>Superadmins</strong> can create and edit all user types and edit applications.

--- a/lib/abilities/admin.rb
+++ b/lib/abilities/admin.rb
@@ -9,7 +9,11 @@ module Abilities
       can [:read, :create], BatchInvitation
       can :delegate_all_permissions, ::Doorkeeper::Application
       can [:read, :create, :update, :unlock, :invite!, :suspend, :unsuspend,
-            :perform_admin_tasks, :resend_email_change, :cancel_email_change], User, api_user: false
+            :perform_admin_tasks, :resend_email_change, :cancel_email_change, :assign_role],
+          User,
+          { api_user: false,
+            role: Roles::Admin.manageable_roles }
+
       can [:read], EventLog
 
       cannot :manage, [ApiUser, Doorkeeper::AccessToken]

--- a/lib/abilities/organisation_admin.rb
+++ b/lib/abilities/organisation_admin.rb
@@ -8,8 +8,12 @@ module Abilities
       can :read, Organisation, id: user.organisation.subtree.map(&:id)
       can [:read, :create], BatchInvitation, organisation: { id: user.organisation.subtree.map(&:id) }
       can [:read, :create, :update, :unlock, :invite!, :suspend, :unsuspend,
-            :perform_admin_tasks, :resend_email_change, :cancel_email_change],
-              User, { organisation: { id: user.organisation.subtree.map(&:id) }, api_user: false }
+           :perform_admin_tasks, :resend_email_change, :cancel_email_change],
+          User,
+          { organisation: { id: user.organisation.subtree.map(&:id) },
+            api_user: false,
+            role: Roles::OrganisationAdmin.manageable_roles
+          }
 
       cannot :manage, [ApiUser, Doorkeeper::AccessToken]
       cannot :delegate_all_permissions, ::Doorkeeper::Application

--- a/lib/roles/admin.rb
+++ b/lib/roles/admin.rb
@@ -11,5 +11,9 @@ module Roles
     end
 
     def self.level; 1; end
+
+    def self.manageable_roles
+      %w{normal organisation_admin admin}
+    end
   end
 end

--- a/lib/roles/normal.rb
+++ b/lib/roles/normal.rb
@@ -10,5 +10,9 @@ module Roles
     end
 
     def self.level; 3; end
+
+    def self.manageable_roles
+      []
+    end
   end
 end

--- a/lib/roles/organisation_admin.rb
+++ b/lib/roles/organisation_admin.rb
@@ -11,5 +11,9 @@ module Roles
     end
 
     def self.level; 2; end
+
+    def self.manageable_roles
+      ['normal']
+    end
   end
 end

--- a/lib/roles/superadmin.rb
+++ b/lib/roles/superadmin.rb
@@ -12,5 +12,9 @@ module Roles
     end
 
     def self.level; 0; end
+
+    def self.manageable_roles
+      User.roles
+    end
   end
 end

--- a/test/integration/admin_user_index_test.rb
+++ b/test/integration/admin_user_index_test.rb
@@ -83,13 +83,7 @@ class AdminUserIndexTest < ActionDispatch::IntegrationTest
     should "filter users by role" do
       visit "/admin/users"
 
-      select_role("Admin")
-
-      assert_equal 1, page.all('table tbody tr').count
-      assert page.has_content?("Admin User <admin@example.com>")
-      User.with_role(:normal).each do |normal_user|
-        assert ! page.has_content?(normal_user.email)
-      end
+      assert_role_not_present("Superadmin")
 
       select_role("Normal")
 
@@ -110,6 +104,13 @@ class AdminUserIndexTest < ActionDispatch::IntegrationTest
       click_on "filter-by-role-menu"
       within ".dropdown-menu" do
         click_on role_name
+      end
+    end
+
+    def assert_role_not_present(role_name)
+      click_on "filter-by-role-menu"
+      within ".dropdown-menu" do
+        assert page.has_no_content? role_name
       end
     end
   end

--- a/test/integration/granting_permissions_test.rb
+++ b/test/integration/granting_permissions_test.rb
@@ -1,8 +1,8 @@
 require 'test_helper'
- 
+
 class GrantingPermissionsTest < ActionDispatch::IntegrationTest
   setup do
-    @admin = create(:user, role: "admin")
+    @admin = create(:superadmin_user)
     @user = create(:user)
 
     visit root_path


### PR DESCRIPTION
www.agileplannerapp.com/boards/173808/cards/5254
- Only allow superadmins to view and manage other superadmins
- 'Filter by Role' only shows roles that current user can manage
