### PR TITLE
Clean up logged-out change email form

### DIFF
--- a/app/views/devise/confirmations/show.html.erb
+++ b/app/views/devise/confirmations/show.html.erb
@@ -1,26 +1,26 @@
 <% content_for :title, "Confirm account email changes" %>
 
-<h1>Confirm a change to your account email</h1>
+<h1>Confirm account email changes</h1>
+
+<div class="alert alert-info">
+  For security, we need you to enter your passphrase before your account email can be changed.
+</div>
 
 <%= form_for resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :put, class: 'well'} do |f| %>
   <%= hidden_field_tag :confirmation_token, params[:confirmation_token] %>
 
-  <div class="alert alert-info">
-    For security, we need you to enter your passphrase before your account email can be changed.
-  </div>
-
   <p>
     <%= f.label :email, "Current email" %>
-    <%= f.text_field :email, disabled: "disabled", readonly: "readonly" %>
+    <%= f.text_field :email, disabled: "disabled", readonly: "readonly", class: 'form-control input-md-5' %>
   </p>
   <p>
     <%= f.label :unconfirmed_email, "New email" %>
-    <%= f.text_field :unconfirmed_email, disabled: "disabled", readonly: "readonly" %>
+    <%= f.text_field :unconfirmed_email, disabled: "disabled", readonly: "readonly", class: 'form-control input-md-5' %>
   </p>
-  <label>
+  <p>
     <%= f.label :password, "Passphrase" %>
-    <%= f.password_field :password, required: "required" %>
-  </label>
+    <%= f.password_field :password, required: "required", class: 'form-control input-md-5' %>
+  </p>
 
   <hr>
 

--- a/test/helpers/user_account_operations.rb
+++ b/test/helpers/user_account_operations.rb
@@ -18,7 +18,7 @@ module UserAccountOperations
 
     signout
     visit user_confirmation_path(confirmation_token: options[:confirmation_token])
-    assert_response_contains("Confirm a change to your account email")
+    assert_response_contains("Confirm account email changes")
     fill_in "Passphrase", with: options[:password]
     click_button "Confirm email change"
   end


### PR DESCRIPTION
Change email form was missing default Bootstrap classes, meaning disabled fields didn’t look disabled, labels weren’t above fields and fields were the wrong size.
- Add bootstrap classes
- Keep page title and h1 consistent
- Move warning message out of well to avoid nesting
- Stop nested labels around passphrase field

Before:
![screen shot 2014-10-06 at 11 13 23](https://cloud.githubusercontent.com/assets/319055/4524589/5776efa0-4d46-11e4-8884-47b67ce1aedf.png)

After:
![screen shot 2014-10-06 at 11 45 13](https://cloud.githubusercontent.com/assets/319055/4524592/5cb17c56-4d46-11e4-8160-f20c249c0f2b.png)
