### PR TITLE
Robustify the unsuccessful login logging.

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -15,7 +15,8 @@ class SessionsController < Devise::SessionsController
     if current_user.present?
       EventLog.record_event(current_user, EventLog::SUCCESSFUL_LOGIN)
     else
-      user = User.find_by_email(params[:user][:email])
+      # Call to_s to flatten out any unexpected params (eg a hash).
+      user = User.find_by_email(params[:user][:email].to_s)
       EventLog.record_event(user, EventLog::UNSUCCESSFUL_LOGIN) if user
     end
   end


### PR DESCRIPTION
Currently if someone nefarious messed with the params such that
`params[:user][:email]` was a hash instead of a string, this logging
would blow up when trying to lookup the attempted user.

And before anyone says anything, robustify is a perfectly cromulent
word.
