### PR TITLE
Require client_id in /user.json endpoint

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -70,12 +70,8 @@ class UsersController < ApplicationController
     end
 
   def validate_token_matches_client_id
-    # FIXME: Once gds-sso is updated everywhere, this should always validate
-    # the client_id param.  It should 401 if no client_id is given.
-    if params[:client_id].present?
-      if params[:client_id] != doorkeeper_token.application.uid
-        head :unauthorized
-      end
+    if params[:client_id] != doorkeeper_token.application.uid
+      head :unauthorized
     end
   end
 end

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -139,9 +139,7 @@ class UsersControllerTest < ActionController::TestCase
       assert_equal presenter.as_hash.to_json, response.body
     end
 
-    should "fetching json profile with a valid oauth token, but no client_id should succeed" do
-      # For now.  Once gds-sso is updated everywhere, this will 401.
-
+    should "fetching json profile with a valid oauth token, but no client_id should fail" do
       user = create(:user)
       permission = create(:permission, user_id: user.id, application_id: @application.id)
       token = create(:access_token, :application => @application, :resource_owner_id => user.id)
@@ -149,9 +147,7 @@ class UsersControllerTest < ActionController::TestCase
       @request.env['HTTP_AUTHORIZATION'] = "Bearer #{token.token}"
       get :show, {:format => :json}
 
-      assert_equal "200", response.code
-      presenter = UserOAuthPresenter.new(user, @application)
-      assert_equal presenter.as_hash.to_json, response.body
+      assert_equal "401", response.code
     end
 
     should "fetching json profile with an invalid oauth token should not succeed" do

--- a/test/integration/api_authentication_test.rb
+++ b/test/integration/api_authentication_test.rb
@@ -22,15 +22,10 @@ class ApiAuthenticationTest < ActionDispatch::IntegrationTest
     assert parsed_response['user']['permissions'].is_a?(Array)
   end
 
-  should "grant access to the user details with a valid token, and no client_id specified" do
-    # To maintain backwards compatibilty.  A client_id will be made mandatory
-    # once all the clients have been upgraded to the new gds-sso
-
+  should "not grant access to the user details with a valid token, and no client_id specified" do
     access_user_endpoint(get_valid_token.token)
 
-    parsed_response = JSON.parse(response.body)
-    assert parsed_response.has_key?('user')
-    assert parsed_response['user']['permissions'].is_a?(Array)
+    assert_equal 401, response.status
   end
 
   should "not grant access without an access token" do


### PR DESCRIPTION
This makes this parameter mandatory when an application is asking signon for
information about a user trying to authenticate to it.

Follow up to 6e33fd1eff8b01a4478ba9cc6e3ac54676147683

This change means that Signon will always check that the token the user has
supplied is for the application making the request, rather than another
application.

~~This is blocked until @tombooth and co have updated and released the performance platform apps that use Signon to supply the parameter.~~
