### PR TITLE
Use ruby 2 compatible whenever gem version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'govuk_admin_template', '1.1.6'
 gem 'airbrake', '3.1.15'
 gem 'plek', '1.7.0'
 gem 'json', '1.7.7'
-gem 'whenever', '0.7.3', require: false
+gem 'whenever', '~> 0.9.4', require: false
 
 gem 'uuid'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,7 +62,7 @@ GEM
       xpath (~> 2.0)
     celluloid (0.15.2)
       timers (~> 1.1.0)
-    chronic (0.6.7)
+    chronic (0.10.2)
     ci_reporter (1.7.0)
       builder (>= 2.1.2)
     cliver (0.3.2)
@@ -240,9 +240,8 @@ GEM
       addressable (>= 2.2.7)
       crack (>= 0.3.2)
     websocket-driver (0.3.2)
-    whenever (0.7.3)
-      activesupport (>= 2.3.4)
-      chronic (~> 0.6.3)
+    whenever (0.9.4)
+      chronic (>= 0.6.3)
     xpath (2.0.0)
       nokogiri (~> 1.3)
     zeroclipboard-rails (0.1.0)
@@ -295,5 +294,5 @@ DEPENDENCIES
   unicorn (= 4.3.1)
   uuid
   webmock (= 1.17.3)
-  whenever (= 0.7.3)
+  whenever (~> 0.9.4)
   zeroclipboard-rails


### PR DESCRIPTION
whenever's dependency chronic's older version was not ruby 2.x compatible. this was causing Signon deploys to fail when trying to update cron tasks.
