### PR TITLE
Corrected HTML template for mailer

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -81,6 +81,7 @@ class User < ActiveRecord::Base
     user = User.find_by_email(attributes[:email])
     if user.present? && user.suspended?
       UserMailer.delay.notify_reset_password_disallowed_due_to_suspension(user)
+      user
     else
       super
     end

--- a/app/views/user_mailer/notify_reset_password_disallowed_due_to_suspension.html.erb
+++ b/app/views/user_mailer/notify_reset_password_disallowed_due_to_suspension.html.erb
@@ -1,14 +1,14 @@
-Hello <%= @user.name %>,
+<p>Hello <%= @user.name %>,</p>
 
-Your <%= link_to 'GOV.UK', "https://www.gov.uk" %> Signon <%= account_name %>, for <%= @user.email %>, is suspended. You can't request a passphrase reset on a suspended account.
+<p>Your <%= link_to 'GOV.UK', "https://www.gov.uk" %> Signon <%= account_name %>, for <%= @user.email %>, is suspended. You can't request a passphrase reset on a suspended account.</p>
 
 <% if instance_name.present? %>
-<%= account_name.humanize %> suspensions do not suspend production accounts.
+<p><%= account_name.humanize %> suspensions do not suspend production accounts.</p>
 <% end %>
 
-If you believe your account has been suspended in error, please contact a managing <%= link_to 'GOV.UK', "https://www.gov.uk" %> editor in your organisation (or your parent organisation). They can either unsuspend your account themselves or use the support form to get help from the <%= link_to 'GOV.UK', "https://www.gov.uk" %> team.
+<p>If you believe your account has been suspended in error, please contact a managing <%= link_to 'GOV.UK', "https://www.gov.uk" %> editor in your organisation (or your parent organisation). They can either unsuspend your account themselves or use the support form to get help from the <%= link_to 'GOV.UK', "https://www.gov.uk" %> team.</p>
 
-All the best,
+<p>All the best,</p>
 
-<%= link_to 'GOV.UK', "https://www.gov.uk" %> team
-Government Digital Service
+<p><%= link_to 'GOV.UK', "https://www.gov.uk" %> team</p>
+<p>Government Digital Service</p>

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -326,15 +326,22 @@ class UserTest < ActiveSupport::TestCase
   end
 
   context ".send_reset_password_instructions" do
-    should "notify a user that reset password is disallowed if their account is suspended and not send reset instructions" do
-      user = create(:suspended_user)
+    context "for a suspended user" do
+      should "return the user" do
+        user = create(:suspended_user)
+        assert_equal user, User.send_reset_password_instructions({ email: user.email })
+      end
 
-      User.send_reset_password_instructions({ email: user.email })
+      should "notify them that reset password is disallowed and not send reset instructions" do
+        user = create(:suspended_user)
 
-      delayed_mailer_jobs = Sidekiq::Extensions::DelayedMailer.jobs
-      assert_equal 1, delayed_mailer_jobs.size
-      assert_equal [UserMailer, :notify_reset_password_disallowed_due_to_suspension, [user]],
-        YAML.load(delayed_mailer_jobs.first['args'].first)
+        User.send_reset_password_instructions({ email: user.email })
+
+        delayed_mailer_jobs = Sidekiq::Extensions::DelayedMailer.jobs
+        assert_equal 1, delayed_mailer_jobs.size
+        assert_equal [UserMailer, :notify_reset_password_disallowed_due_to_suspension, [user]],
+          YAML.load(delayed_mailer_jobs.first['args'].first)
+      end
     end
 
     should "return the resource even if AWS has blacklisted the resource's email" do


### PR DESCRIPTION
www.agileplannerapp.com/boards/173808/cards/5250

the email to suspended users trying to reset their password was missing some HTML formatting.

also, changed the overridden `Devise::Recoverable.send_reset_password_instructions` method to return the user in each case, because the controller expects that.
