### PR TITLE
Revert "Require client_id in /user.json endpoint"

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -70,8 +70,12 @@ class UsersController < ApplicationController
     end
 
   def validate_token_matches_client_id
-    if params[:client_id] != doorkeeper_token.application.uid
-      head :unauthorized
+    # FIXME: Once gds-sso is updated everywhere, this should always validate
+    # the client_id param.  It should 401 if no client_id is given.
+    if params[:client_id].present?
+      if params[:client_id] != doorkeeper_token.application.uid
+        head :unauthorized
+      end
     end
   end
 end

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -139,7 +139,9 @@ class UsersControllerTest < ActionController::TestCase
       assert_equal presenter.as_hash.to_json, response.body
     end
 
-    should "fetching json profile with a valid oauth token, but no client_id should fail" do
+    should "fetching json profile with a valid oauth token, but no client_id should succeed" do
+      # For now.  Once gds-sso is updated everywhere, this will 401.
+
       user = create(:user)
       permission = create(:permission, user_id: user.id, application_id: @application.id)
       token = create(:access_token, :application => @application, :resource_owner_id => user.id)
@@ -147,7 +149,9 @@ class UsersControllerTest < ActionController::TestCase
       @request.env['HTTP_AUTHORIZATION'] = "Bearer #{token.token}"
       get :show, {:format => :json}
 
-      assert_equal "401", response.code
+      assert_equal "200", response.code
+      presenter = UserOAuthPresenter.new(user, @application)
+      assert_equal presenter.as_hash.to_json, response.body
     end
 
     should "fetching json profile with an invalid oauth token should not succeed" do

--- a/test/integration/api_authentication_test.rb
+++ b/test/integration/api_authentication_test.rb
@@ -22,10 +22,15 @@ class ApiAuthenticationTest < ActionDispatch::IntegrationTest
     assert parsed_response['user']['permissions'].is_a?(Array)
   end
 
-  should "not grant access to the user details with a valid token, and no client_id specified" do
+  should "grant access to the user details with a valid token, and no client_id specified" do
+    # To maintain backwards compatibilty.  A client_id will be made mandatory
+    # once all the clients have been upgraded to the new gds-sso
+
     access_user_endpoint(get_valid_token.token)
 
-    assert_equal 401, response.status
+    parsed_response = JSON.parse(response.body)
+    assert parsed_response.has_key?('user')
+    assert parsed_response['user']['permissions'].is_a?(Array)
   end
 
   should "not grant access without an access token" do


### PR DESCRIPTION
Licensify hasn't been updated to support this new behaviour yet.

This reverts commit 7a313548c47e5d8b0ea8c3b648bb6901e962e4e7.
