### PR TITLE
Add rake task for updating the organisation slug

### DIFF
--- a/lib/organisation_slug_updater.rb
+++ b/lib/organisation_slug_updater.rb
@@ -1,0 +1,33 @@
+class OrganisationSlugUpdater
+  def initialize(old_slug, new_slug, logger = nil)
+    @old_slug = old_slug.sub(%r{^/}, '')
+    @new_slug = new_slug.sub(%r{^/}, '')
+    @logger   = logger || Logger.new(nil)
+  end
+
+  def call
+    if organisation
+      update_organisation_slug
+    else
+      logger.error("No organisation found for slug: #{old_slug}")
+      false
+    end
+  end
+
+private
+  attr_reader(
+    :old_slug,
+    :new_slug,
+    :logger,
+  )
+
+  def organisation
+    @organisation ||= Organisation.where(slug: old_slug).first
+  end
+
+  def update_organisation_slug
+    updated_result = organisation.update_attribute(:slug, new_slug)
+    logger.info("Updated organisation with slug '#{old_slug}' to use slug '#{new_slug}'")
+    updated_result
+  end
+end

--- a/lib/tasks/update_organisation_slug.rake
+++ b/lib/tasks/update_organisation_slug.rake
@@ -1,0 +1,7 @@
+desc "Update an organisation slug"
+task :update_organisation_slug, [:old_slug, :new_slug] => :environment do |_task, args|
+  logger = Logger.new(STDOUT)
+  logger.error("You must specify [old_slug,new_slug]") unless args.old_slug.present? && args.new_slug.present?
+
+  exit(1) unless OrganisationSlugUpdater.new(old_slug, new_slug, logger).call
+end

--- a/test/unit/lib/organisation_slug_updater_test.rb
+++ b/test/unit/lib/organisation_slug_updater_test.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+
+class OrganisationSlugUpdaterTest < ActionView::TestCase
+
+  def setup
+    @new_slug = "my-new-slug"
+    @organisation = FactoryGirl.create(:organisation)
+  end
+
+  def test_returns_true_if_updated
+    assert(OrganisationSlugUpdater.new(@organisation.slug, @new_slug).call)
+  end
+
+  def test_organisation_slug_updated
+    OrganisationSlugUpdater.new(@organisation.slug, @new_slug).call
+    assert_equal(@new_slug, @organisation.reload.slug)
+  end
+
+  def test_organisation_slug_doesnt_contain_leading_slash
+    OrganisationSlugUpdater.new(@organisation.slug, "/new-slug-with-leading-slash").call
+    assert_equal("new-slug-with-leading-slash", @organisation.reload.slug)
+  end
+
+  def test_returns_false_if_there_is_no_organisation
+    assert_equal(false, OrganisationSlugUpdater.new('anything', @new_slug).call)
+  end
+end


### PR DESCRIPTION
This rake task allows for slugs to be changed for an organisation. This task will only make changes however to signon-o-tron and is expected to be run from a higher level fabric task.
