### PR TITLE
Simplify user permissions updater rake

### DIFF
--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -62,21 +62,8 @@ namespace :users do
     puts "User account unsuspended"
   end
 
-  desc "Push user permission information to applications passed as a comma-separated string in ENV variable 'APPLICATIONS'"
+  desc "Push user permission information to applications used by the user"
   task :push_permissions => :environment do
-    raise "Requires ENV variable APPLICATIONS to be set to a string containing comma-separated application names" if ENV['APPLICATIONS'].blank?
-
-    application_names = ENV['APPLICATIONS'].split(',').map(&:strip).map(&:titleize)
-    applications = Doorkeeper::Application.where(name: application_names)
-    puts "About to push user permission information to #{applications.map(&:name).to_sentence}"
-
-    application_users = applications.inject({}) do |result, application|
-      result[application] = User.where(id: application.permissions.pluck(:user_id).uniq)
-      result
-    end
-    application_users.each do |application, users|
-      puts "Pushing permission information of #{users.count} users to #{application.name}"
-      users.each { |user| PermissionUpdater.perform_async(user.uid, application.id) }
-    end
+    User.find_each { |user| PermissionUpdater.perform_on(user) }
   end
 end


### PR DESCRIPTION
The earlier version pushed permission information to applications irrespective of whether the user has used it in the past or not.
