### PR TITLE
Prevent environment label from occasionally wrapping

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'kaminari', '0.16.1'
 gem 'bootstrap-kaminari-views', '0.0.3'
 gem 'alphabetical_paginate', '2.2.3'
 gem 'mysql2'
-gem 'govuk_admin_template', '1.4.0'
+gem 'govuk_admin_template', '1.4.2'
 
 gem 'airbrake', '3.1.15'
 gem 'plek', '1.7.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,7 +100,7 @@ GEM
       null_logger
       plek
       rest-client (~> 1.6.3)
-    govuk_admin_template (1.4.0)
+    govuk_admin_template (1.4.2)
       bootstrap-sass (~> 3.3.1)
       jquery-rails (~> 3.1.1)
       rails (>= 3.2.0)
@@ -269,7 +269,7 @@ DEPENDENCIES
   doorkeeper (= 0.6.7)
   factory_girl_rails (= 4.3.0)
   gds-api-adapters (= 7.11.0)
-  govuk_admin_template (= 1.4.0)
+  govuk_admin_template (= 1.4.2)
   jasmine (= 2.1.0)
   json (= 1.7.7)
   kaminari (= 0.16.1)


### PR DESCRIPTION
- Bump admin gem to 1.4.2

See https://github.com/alphagov/govuk_admin_template/pull/54 for details.
