### PR TITLE
Make test run agnostic of locale

### DIFF
--- a/test/integration/batch_inviting_users_test.rb
+++ b/test/integration/batch_inviting_users_test.rb
@@ -22,7 +22,7 @@ class BatchInvitingUsersTest < ActionDispatch::IntegrationTest
       invited_user = User.find_by_email("fred@example.com")
       assert_not_nil invited_user
       assert invited_user.has_access_to?(application)
-      assert_equal "noreply-signon-development@digital.cabinet-office.gov.uk", last_email.from[0]
+      assert_match /noreply-signon-development@.+\.gov\.uk/, last_email.from[0]
       assert_equal nil, last_email.reply_to[0]
 
       assert_equal "fred@example.com", last_email.to[0]

--- a/test/integration/email_change_test.rb
+++ b/test/integration/email_change_test.rb
@@ -134,16 +134,20 @@ class EmailChangeTest < ActionDispatch::IntegrationTest
     end
 
     should "show an error and not send a confirmation if the email is blank" do
-      visit new_user_session_path
-      signin_with(@user)
+      ActionMailer::Base.deliveries.clear
+      perform_enqueued_jobs do
 
-      click_link "Change your email or passphrase"
-      fill_in "Email", with: ""
-      click_button "Change email"
+        visit new_user_session_path
+        signin_with(@user)
 
-      assert_response_contains "Email can't be blank"
+        click_link "Change your email or passphrase"
+        fill_in "Email", with: ""
+        click_button "Change email"
 
-      assert_nil last_email
+        assert_response_contains "Email can't be blank"
+
+        assert_nil last_email
+      end
     end
 
     should "be cancellable" do

--- a/test/integration/passphrase_reset_test.rb
+++ b/test/integration/passphrase_reset_test.rb
@@ -45,7 +45,7 @@ class PassphraseResetTest < ActionDispatch::IntegrationTest
 
       open_email(user.email)
       assert current_email
-      assert_equal "noreply-signon-development@digital.cabinet-office.gov.uk", current_email.from[0]
+      assert_match /noreply-signon-development@.+\.gov\.uk/, current_email.from[0]
       assert_equal nil, last_email.reply_to[0]
       assert_equal "Reset passphrase instructions", current_email.subject
 

--- a/test/models/noisy_batch_invitation_test.rb
+++ b/test/models/noisy_batch_invitation_test.rb
@@ -10,7 +10,7 @@ class NoisyBatchInvitationTest < ActionMailer::TestCase
     end
 
     should "come from noreply-signon@" do
-      assert_match /".* Signon development" <noreply-signon-development@.*\.gov\.uk>/, @email[:from].to_s
+      assert_match /"?.* Signon development"? <noreply-signon-development@.*\.gov\.uk>/, @email[:from].to_s
     end
 
     should "send to noreply-signon@" do
@@ -45,7 +45,7 @@ class NoisyBatchInvitationTest < ActionMailer::TestCase
     end
 
     should "from address should include the instance name" do
-      assert_match /".* Signon Test Fools" <noreply-signon-test-fools@.*\.gov\.uk>/, @email[:from].to_s
+      assert_match /"?.* Signon Test Fools"? <noreply-signon-test-fools@.*\.gov\.uk>/, @email[:from].to_s
     end
   end
 
@@ -60,7 +60,7 @@ class NoisyBatchInvitationTest < ActionMailer::TestCase
     end
 
     should "from address should include the instance name" do
-      assert_match /".* Signon" <noreply-signon@.*\.gov\.uk>/, @email[:from].to_s
+      assert_match /"?.* Signon"? <noreply-signon@.*\.gov\.uk>/, @email[:from].to_s
     end
   end
 end


### PR DESCRIPTION
We have removed the GOV.UK specific text from the application so that we can use pension wise specific text on our server. This was done using a pension wise specific locale file.

In order to test that everything works as expected and all locale text has been populated we want to be able to run the tests suite with our alternative locale file.

As a result, I removed and GOV.UK specific text from the tests and used regular express matches instead.
- Remove reference to "digital.cabinet-office"
- Deal with from address having optional quotes
  around the name portion of the email if the name 
  contains any special characters.  In this case 
  the '.' in 'GOV.UK'
