### PR TITLE
s/signin/signon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Signon
 
-Signin is a centralised OAuth2 based single sign-on provider for GDS services
+Signon is a centralised OAuth2 based single sign-on provider for GDS services
 that provides username/password and 2-Factor authentication.
 
 ## Live example


### PR DESCRIPTION
I'm assuming this is just a typo, or something that is now confusing since the rename.