### PR TITLE
Allow retirement of applications 

### DIFF
--- a/app/controllers/doorkeeper_applications_controller.rb
+++ b/app/controllers/doorkeeper_applications_controller.rb
@@ -38,6 +38,7 @@ class DoorkeeperApplicationsController < ApplicationController
       :uid,
       :secret,
       :redirect_uri,
+      :retired,
       :home_uri,
       :supports_push_updates,
     )

--- a/app/models/enhancements/application.rb
+++ b/app/models/enhancements/application.rb
@@ -11,6 +11,7 @@ class ::Doorkeeper::Application < ActiveRecord::Base
     joins(supported_permissions: :user_application_permissions)
       .where('user_application_permissions.user_id' => user.id)
       .where('supported_permissions.name' => 'signin')
+      .where(retired: false)
   }
   scope :with_signin_delegatable, -> {
     joins(:supported_permissions)

--- a/app/views/doorkeeper_applications/edit.html.erb
+++ b/app/views/doorkeeper_applications/edit.html.erb
@@ -67,6 +67,16 @@
     </label>
   </p>
 
+  <p class="checkbox">
+    <label>
+      <%= f.check_box :retired %> This application is retired
+    </label>
+    <span class="help-block">
+      Retiring an application will hide the application from the dashboard. It will
+      not delete data. If you're retiring an app you should also disable push updates.
+    </span>
+  </p>
+
   <% if policy(Doorkeeper::Application).edit? %>
     <hr />
     <p class="add-top-margin">

--- a/app/views/doorkeeper_applications/index.html.erb
+++ b/app/views/doorkeeper_applications/index.html.erb
@@ -6,7 +6,6 @@
   <thead>
     <tr class="table-header">
       <th scope="col">Name</th>
-      <th scope="col">Redirect URI</th>
       <th scope="col">Home URI</th>
       <th scope="col">Actions</th>
     </tr>
@@ -19,7 +18,6 @@
           <br>
           <%= application.description %>
         </td>
-        <td><%= application.redirect_uri %></td>
         <td><%= link_to_if application.home_uri, application.home_uri, application.home_uri %></td>
         <td><%= link_to "Edit", edit_doorkeeper_application_path(application) %></td>
       </tr>

--- a/app/views/doorkeeper_applications/index.html.erb
+++ b/app/views/doorkeeper_applications/index.html.erb
@@ -14,7 +14,11 @@
     <% @applications.each do |application| %>
       <tr>
         <td>
-          <%= link_to application.name, edit_doorkeeper_application_path(application) %>
+          <% if application.retired? %>
+            <del><%= link_to application.name, edit_doorkeeper_application_path(application) %> (retired)</del>
+          <% else %>
+            <%= link_to application.name, edit_doorkeeper_application_path(application) %>
+          <% end %>
           <br>
           <%= application.description %>
         </td>

--- a/app/views/shared/_user_permissions.html.erb
+++ b/app/views/shared/_user_permissions.html.erb
@@ -18,7 +18,11 @@
        supported_permission_field_prefix = "#{attribute_name}_application_#{application.id}_supported_permission" %>
       <tr>
         <td>
-          <%= application.name %>
+          <% if application.retired? %>
+            <del><%= application.name %></del>
+          <% else %>
+            <%= application.name %>
+          <% end %>
         </td>
         <% if user_object.api_user? %>
           <%

--- a/db/migrate/20170216105512_add_retired_to_applications.rb
+++ b/db/migrate/20170216105512_add_retired_to_applications.rb
@@ -1,0 +1,5 @@
+class AddRetiredToApplications < ActiveRecord::Migration
+  def change
+    add_column :oauth_applications, :retired, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160420145549) do
+ActiveRecord::Schema.define(version: 20170216105512) do
 
   create_table "batch_invitation_application_permissions", force: :cascade do |t|
     t.integer  "batch_invitation_id",     limit: 4, null: false
@@ -93,6 +93,7 @@ ActiveRecord::Schema.define(version: 20160420145549) do
     t.string   "home_uri",              limit: 255
     t.string   "description",           limit: 255
     t.boolean  "supports_push_updates",             default: true
+    t.boolean  "retired",                           default: false
   end
 
   add_index "oauth_applications", ["name"], name: "unique_application_name", unique: true, using: :btree

--- a/test/integration/superadmin_application_edit_test.rb
+++ b/test/integration/superadmin_application_edit_test.rb
@@ -57,6 +57,20 @@ class SuperAdminApplicationEditTest < ActionDispatch::IntegrationTest
       # trigger a push update for reauth
       remote_logout(@user)
     end
+
+    should "be able to retire applications" do
+      @application.update_attribute :retired, false
+      click_link @application.name
+
+      refute page.has_checked_field?("This application is retired")
+      check "This application is retired"
+      click_button "Update Application"
+
+      click_link @application.name
+
+      assert page.has_checked_field?("This application is retired")
+      assert @application.reload.retired?, "The record should be retired"
+    end
   end
 
   def remote_logout(user)

--- a/test/models/doorkeeper_application_test.rb
+++ b/test/models/doorkeeper_application_test.rb
@@ -57,6 +57,14 @@ class ::Doorkeeper::ApplicationTest < ActiveSupport::TestCase
       assert_includes Doorkeeper::Application.can_signin(user), application
     end
 
+    should "not return applications that are retired" do
+      user = create(:user)
+      application = create(:application, retired: true)
+      user.grant_application_permission(application, 'signin')
+
+      assert_empty Doorkeeper::Application.can_signin(user)
+    end
+
     should "not return applications that the user can't signin into" do
       user = create(:user)
       application = create(:application)


### PR DESCRIPTION
This adds a checkbox to the application edit page that allows users to mark the application as "retired". It's intentionally non-destructive and reversible.

It's an alternative to the soft-deletion https://github.com/alphagov/signon/pull/527 (reverted in https://github.com/alphagov/signon/pull/530 because it didn't work as expected).

## Applications list

![screen shot 2017-02-16 at 12 22 36](https://cloud.githubusercontent.com/assets/233676/23021339/64957048-f443-11e6-8468-ffa3ea13bfb0.png)

## Application edit form

![screen shot 2017-02-16 at 12 24 45](https://cloud.githubusercontent.com/assets/233676/23021360/7589e154-f443-11e6-83d3-f0b52d88e877.png)

Part of https://trello.com/c/dGPNmVub/482-retire-panopticon