### PR TITLE
Extend grace period for newly unsuspended users

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,7 +10,7 @@ class User < ActiveRecord::Base
   self.include_root_in_json = true
 
   SUSPENSION_THRESHOLD_PERIOD = 45.days
-  UNSUSPENSION_GRACE_PERIOD = 3.days
+  UNSUSPENSION_GRACE_PERIOD = 7.days
 
   MAX_2SV_LOGIN_ATTEMPTS = 10
   MAX_2SV_DRIFT_SECONDS = 30

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -184,16 +184,16 @@ class UserTest < ActiveSupport::TestCase
       assert_includes User.not_recently_unsuspended, @user
     end
 
-    should "not return users who have been unsuspended less than 3 days ago" do
+    should "not return users who have been unsuspended less than 7 days ago" do
       user2 = create(:suspended_user)
-      Timecop.travel(2.days.ago) { user2.unsuspend }
+      Timecop.travel(6.days.ago) { user2.unsuspend }
 
       assert_not_includes User.not_recently_unsuspended, user2
     end
 
-    should "return users who have been unsuspended more than 3 days ago" do
+    should "return users who have been unsuspended more than 7 days ago" do
       user2 = create(:suspended_user)
-      Timecop.travel(4.days.ago) { user2.unsuspend }
+      Timecop.travel(8.days.ago) { user2.unsuspend }
 
       assert_includes User.not_recently_unsuspended, user2
     end


### PR DESCRIPTION
Before this functionality was added, the following would happen:

1. User reaches inactivity time and gets automatically suspended at 5am
2. User is unsuspended but doesn't yet log in
3. User gets re-suspended at 5am the next day

This grace period was originally set at 3 days to combat this. However
it causes issues where people are off a day either side of a weekend
and is still generating repeat tickets. We’re going to try 7 days to
see if it reduces the number of support requests we receive.