### PR TITLE
Remove references to old GOV.UK applications

### DIFF
--- a/app/views/user_mailer/suspension_notification.html.erb
+++ b/app/views/user_mailer/suspension_notification.html.erb
@@ -1,6 +1,6 @@
 <p><%= link_to t('department.name'), t('department.url') %> Signon accounts are suspended after <%= User::SUSPENSION_THRESHOLD_PERIOD.inspect %> of inactivity.</p>
 
-<p>Your <%= link_to t('department.name'), t('department.url') %> Signon <%= account_name %>, for <%= @user.email %>, has now been suspended and you won't be able to access any <%= link_to t('department.name'), t('department.url') %> <%= account_name %> applications, eg Whitehall Publisher or Licensing.</p>
+<p>Your <%= link_to t('department.name'), t('department.url') %> Signon <%= account_name %>, for <%= @user.email %>, has now been suspended and you won't be able to access any <%= link_to t('department.name'), t('department.url') %> <%= account_name %> publishing applications.</p>
 
 <% if instance_name.present? %>
 <p><%= account_name.humanize %> suspensions do not suspend production accounts or remove access to <%= link_to t('department.name'), t('department.url') %> production applications.</p>

--- a/app/views/user_mailer/suspension_notification.text.erb
+++ b/app/views/user_mailer/suspension_notification.text.erb
@@ -1,6 +1,6 @@
 <%= t('department.name') %> Signon accounts are suspended after <%= User::SUSPENSION_THRESHOLD_PERIOD.inspect %> of inactivity.
 
-Your <%= t('department.name') %> Signon <%= account_name %>, for <%= @user.email %>, has now been suspended and you won't be able to access any <%= t('department.name') %> <%= account_name %> applications, eg Whitehall Publisher or Licensing.
+Your <%= t('department.name') %> Signon <%= account_name %>, for <%= @user.email %>, has now been suspended and you won't be able to access any <%= t('department.name') %> <%= account_name %> publishing applications.
 
 <% if instance_name.present? %>
 <%= account_name.humanize %> suspensions do not suspend production accounts or remove access to <%= t('department.name') %> production applications.

--- a/app/views/user_mailer/suspension_reminder.html.erb
+++ b/app/views/user_mailer/suspension_reminder.html.erb
@@ -1,6 +1,6 @@
 <p><%= link_to t('department.name'), t('department.url') %> Signon accounts are suspended after <%= User::SUSPENSION_THRESHOLD_PERIOD.inspect %> of inactivity.</p>
 
-<p>Your <%= link_to t('department.name'), t('department.url') %> Signon <%= account_name %>, for <%= @user.email %>, will be suspended <%= suspension_time %>. After suspension you won't be able to access any <%= link_to t('department.name'), t('department.url') %> <%= account_name %> applications, eg Whitehall Publisher or Licensing.</p>
+<p>Your <%= link_to t('department.name'), t('department.url') %> Signon <%= account_name %>, for <%= @user.email %>, will be suspended <%= suspension_time %>. After suspension you won't be able to access any <%= link_to t('department.name'), t('department.url') %> <%= account_name %> publishing applications.</p>
 
 <% if instance_name.present? %>
 <p><%= account_name.humanize %> suspensions do not suspend production accounts or remove access to <%= link_to t('department.name'), t('department.url') %> production applications.</p>

--- a/app/views/user_mailer/suspension_reminder.text.erb
+++ b/app/views/user_mailer/suspension_reminder.text.erb
@@ -1,6 +1,6 @@
 <%= t('department.name') %> Signon accounts are suspended after <%= User::SUSPENSION_THRESHOLD_PERIOD.inspect %> of inactivity.
 
-Your <%= t('department.name') %> Signon <%= account_name %>, for <%= @user.email %>, will be suspended <%= suspension_time %>. After suspension you won't be able to access any <%= t('department.name') %> <%= account_name %> applications, eg Whitehall Publisher or Licensing.
+Your <%= t('department.name') %> Signon <%= account_name %>, for <%= @user.email %>, will be suspended <%= suspension_time %>. After suspension you won't be able to access any <%= t('department.name') %> <%= account_name %> publishing applications.
 
 <% if instance_name.present? %>
 <%= account_name.humanize %> suspensions do not suspend production accounts or remove access to <%= t('department.name') %> production applications.


### PR DESCRIPTION
Whitehall Publisher and Licensing are 2 applications which we're specifically trying to improve or replace, so constantly telling our users about them by email is confusing.

Also https://insidegovuk.blog.gov.uk/2016/07/20/changes-to-the-style-guide-no-more-eg-and-ie-etc/