### PR TITLE
[DISCUSS] Add signin on support to all users

### DIFF
--- a/app/controllers/batch_invitations_controller.rb
+++ b/app/controllers/batch_invitations_controller.rb
@@ -73,9 +73,8 @@ class BatchInvitationsController < ApplicationController
   end
 
   def grant_default_permissions(batch_invitation)
-    support_app = ::Doorkeeper::Application.find_by(name: 'support')
-    if support_app.present?
-      batch_invitation.supported_permissions << support_app.signin_permission
+    Signon.default_permissions_for_all_users.each do |default_permission|
+      batch_invitation.supported_permissions << default_permission
     end
   end
 end

--- a/app/controllers/batch_invitations_controller.rb
+++ b/app/controllers/batch_invitations_controller.rb
@@ -15,6 +15,7 @@ class BatchInvitationsController < ApplicationController
   def create
     @batch_invitation = BatchInvitation.new(user: current_user, organisation_id: params[:batch_invitation][:organisation_id])
     @batch_invitation.supported_permission_ids = params[:user][:supported_permission_ids] if params[:user]
+    grant_default_permissions(@batch_invitation)
     authorize @batch_invitation
 
     unless file_uploaded?
@@ -68,6 +69,13 @@ class BatchInvitationsController < ApplicationController
       false
     else
       true
+    end
+  end
+
+  def grant_default_permissions(batch_invitation)
+    support_app = ::Doorkeeper::Application.find_by(name: 'support')
+    if support_app.present?
+      batch_invitation.supported_permissions << support_app.signin_permission
     end
   end
 end

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -105,9 +105,8 @@ class InvitationsController < Devise::InvitationsController
   end
 
   def grant_default_permissions(user)
-    support_application = ::Doorkeeper::Application.find_by(name: 'support')
-    if support_application.present?
-      user.grant_application_permission(support_application, 'signin')
+    Signon.default_permissions_for_all_users.each do |default_permission|
+      user.grant_permission(default_permission)
     end
   end
 end

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -26,6 +26,7 @@ class InvitationsController < Devise::InvitationsController
 
       self.resource = resource_class.invite!(resource_params, current_inviter)
       if resource.errors.empty?
+        grant_default_permissions(self.resource)
         set_flash_message :notice, :send_instructions, email: self.resource.email
         respond_with resource, location: after_invite_path_for(resource)
       else
@@ -101,5 +102,12 @@ class InvitationsController < Devise::InvitationsController
 
   def update_resource_params
     resource_params
+  end
+
+  def grant_default_permissions(user)
+    support_application = ::Doorkeeper::Application.find_by(name: 'support')
+    if support_application.present?
+      user.grant_application_permission(support_application, 'signin')
+    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -142,8 +142,12 @@ class User < ActiveRecord::Base
   def grant_application_permissions(application, supported_permission_names)
     supported_permission_names.map do |supported_permission_name|
       supported_permission = SupportedPermission.find_by_application_id_and_name(application.id, supported_permission_name)
-      application_permissions.where(supported_permission_id: supported_permission.id).first_or_create!
+      grant_permission(supported_permission)
     end
+  end
+
+  def grant_permission(supported_permission)
+    application_permissions.where(supported_permission_id: supported_permission.id).first_or_create!
   end
 
   # override Devise::Recoverable behavior to:

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,6 +12,8 @@ module Signon
     ENV.fetch("SIGNONOTRON2_DB_ADAPTER", "mysql") == "mysql"
   end
 
+  mattr_accessor :default_permissions_for_all_users
+
   class Application < Rails::Application
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers

--- a/config/initializers/default_permissions_for_all_users.rb
+++ b/config/initializers/default_permissions_for_all_users.rb
@@ -1,0 +1,18 @@
+Rails.application.config.after_initialize do
+  def Signon.add_default_permission(app_name, permission_name)
+    app = ::Doorkeeper::Application.find_by(name: app_name)
+    if app.present?
+      perm = app.supported_permissions.find_by(name: permission_name)
+      if perm.present?
+        Signon.default_permissions_for_all_users << perm
+      else
+        Rails.logger.warn("Attempting to add '#{permission_name}' for '#{app_name}' app as default permission but the permission is missing!")
+      end
+    else
+      Rails.logger.warn("Attempting to add '#{permission_name}' for '#{app_name}' app as default permission but the app is missing!")
+    end
+  end
+  Signon.default_permissions_for_all_users ||= []
+
+  Signon.add_default_permission 'support', 'signin' unless Rails.env.test?
+end

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -3,22 +3,13 @@ namespace :users do
   task create: :environment do
     raise "Requires name, email and applications specified in environment" unless ENV['name'] && ENV['email'] && ENV['applications']
 
-    applications = ENV['applications'].split(',').uniq.map do |application_name|
-      Doorkeeper::Application.find_by_name!(application_name)
-    end
+    user_creator = UserCreator.new(ENV['name'], ENV['email'], ENV['applications'])
+    user_creator.create_user!
 
-    user = User.invite!(name: ENV['name'].dup, email: ENV['email'].dup)
-    permissions = ENV.fetch('permissions', '').split(',').uniq
-
-    applications.each do |application|
-      user.grant_application_permission(application, 'signin')
-    end
-
-    invitation_url = "#{Plek.current.find('signon')}/users/invitation/accept?invitation_token=#{user.raw_invitation_token}"
-    puts "User created: user.name <#{user.name}>"
-    puts "              user.email <#{user.email}>"
-    puts "              signin permissions for: '#{applications.map(&:name).join("', '")}' "
-    puts "              follow this link to set a password: #{invitation_url}"
+    puts "User created: user.name <#{user_creator.user.name}>"
+    puts "              user.email <#{user_creator.user.email}>"
+    puts "              signin permissions for: '#{user_creator.applications.map(&:name).join("', '")}' "
+    puts "              follow this link to set a password: #{user_creator.invitation_url}"
   end
 
   desc "Remind users that their account will get suspended"

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -11,10 +11,6 @@ namespace :users do
     permissions = ENV.fetch('permissions', '').split(',').uniq
 
     applications.each do |application|
-      unsupported_permissions = permissions - application.supported_permission_strings
-      if unsupported_permissions.any?
-        raise UnsupportedPermissionError, "Cannot grant '#{unsupported_permissions.join("', '")}' permission(s), they are not supported by the '#{application.name}' application"
-      end
       user.grant_application_permission(application, 'signin')
     end
 

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -113,4 +113,9 @@ namespace :users do
 
     UserPermissionMigrator.migrate(source: source_application, target: target_application)
   end
+
+  desc "Add permission for a given app to all users"
+  task :bulk_add_permission, [:permission, :application] => :envuronment do
+    UserPermissionsBulkGranter.new(args[:application]).grant!(args[:permission])
+  end
 end

--- a/lib/user_creator.rb
+++ b/lib/user_creator.rb
@@ -1,0 +1,32 @@
+require 'plek'
+
+class UserCreator
+  attr_reader :user
+
+  def initialize(name, email, application_names)
+    @name = name.dup
+    @email = email.dup
+    @application_names = application_names.dup
+  end
+
+  def applications
+    @applications ||= (application_names.split(',')).uniq.map do |application_name|
+      Doorkeeper::Application.find_by_name!(application_name)
+    end
+  end
+
+  def create_user!
+    @user = User.invite!(name: name, email: email)
+    applications.each do |application|
+      @user.grant_application_permission(application, 'signin')
+    end
+  end
+
+  def invitation_url
+    "#{Plek.current.find('signon')}/users/invitation/accept?invitation_token=#{user.raw_invitation_token}"
+  end
+
+private
+
+  attr_reader :name, :email, :application_names
+end

--- a/lib/user_creator.rb
+++ b/lib/user_creator.rb
@@ -10,9 +10,7 @@ class UserCreator
   end
 
   def applications
-    @applications ||= (application_names.split(',')).uniq.map do |application_name|
-      Doorkeeper::Application.find_by_name!(application_name)
-    end
+    @applications ||= (extract_applications_from_names + default_applications).uniq
   end
 
   def create_user!
@@ -29,4 +27,14 @@ class UserCreator
 private
 
   attr_reader :name, :email, :application_names
+
+  def extract_applications_from_names
+    (application_names.split(',')).uniq.map do |application_name|
+      Doorkeeper::Application.find_by_name!(application_name)
+    end
+  end
+
+  def default_applications
+    ['support'].map { |default_app| ::Doorkeeper::Application.find_by(name: default_app) }.compact
+  end
 end

--- a/lib/user_permissions_bulk_granter.rb
+++ b/lib/user_permissions_bulk_granter.rb
@@ -1,0 +1,17 @@
+class UserPermissionsBulkGranter
+  attr_reader :application
+  def initialize(application_name)
+    @application = ::Doorkeeper::Application.find_by(name: application_name)
+    raise "No such application: '#{application_name}'" if @application.nil?
+  end
+
+  def grant(permission_name)
+    permission = application.supported_permissions.find_by(name: permission_name)
+    raise "No such permission: '#{permission_name}' for application: '#{application.name}'" if permission.nil?
+    User.includes(application_permissions: :supported_permission).find_each do |user|
+      unless user.eager_loaded_permission_for(application).include? permission.name
+        user.application_permissions.create!(supported_permission_id: permission.id)
+      end
+    end
+  end
+end

--- a/test/integration/batch_inviting_users_test.rb
+++ b/test/integration/batch_inviting_users_test.rb
@@ -19,6 +19,27 @@ class BatchInvitingUsersTest < ActionDispatch::IntegrationTest
     perform_batch_invite_with_user(user, application)
   end
 
+  should "batch invited users get signin access to 'support' app even when not checked in UI" do
+    application = create(:application)
+    support_application = create(:application, name: 'support', with_supported_permissions: ['signin'])
+    user = create(:user_in_organisation, role: 'admin')
+
+    visit root_path
+    signin_with(user)
+
+    perform_enqueued_jobs do
+      visit new_batch_invitation_path
+      path = File.join(::Rails.root, "test", "fixtures", "users.csv")
+      attach_file("Choose a CSV file of users with names and email addresses", path)
+      uncheck "Has access to #{support_application.name}?"
+      check "Has access to #{application.name}?"
+      click_button "Create users and send emails"
+
+      invited_user = User.find_by_email("fred@example.com")
+      assert invited_user.has_access_to?(support_application)
+    end
+  end
+
   def perform_batch_invite_with_user(user, application)
     perform_enqueued_jobs do
       visit root_path

--- a/test/integration/batch_inviting_users_test.rb
+++ b/test/integration/batch_inviting_users_test.rb
@@ -3,7 +3,6 @@ require 'test_helper'
 class BatchInvitingUsersTest < ActionDispatch::IntegrationTest
   include ActiveJob::TestHelper
 
-
   should "admin user can create users whose details are specified in a CSV file" do
     application = create(:application)
     user = create(:user, role: "admin")
@@ -22,6 +21,7 @@ class BatchInvitingUsersTest < ActionDispatch::IntegrationTest
   should "batch invited users get signin access to 'support' app even when not checked in UI" do
     application = create(:application)
     support_application = create(:application, name: 'support', with_supported_permissions: ['signin'])
+    Signon.add_default_permission('support', 'signin')
     user = create(:user_in_organisation, role: 'admin')
 
     visit root_path

--- a/test/integration/inviting_users_test.rb
+++ b/test/integration/inviting_users_test.rb
@@ -4,6 +4,17 @@ class InvitingUsersTest < ActionDispatch::IntegrationTest
   include EmailHelpers
   include ActiveJob::TestHelper
 
+  should "send the user an invitation token" do
+    user = User.invite!(name: "Jim", email: "jim@web.com")
+    visit accept_user_invitation_path(invitation_token: user.raw_invitation_token)
+
+    fill_in "New passphrase", with: "this 1s 4 v3333ry s3cur3 p4ssw0rd.!Z"
+    fill_in "Confirm new passphrase", with: "this 1s 4 v3333ry s3cur3 p4ssw0rd.!Z"
+    click_button "Set my passphrase"
+
+    assert_response_contains("You are now signed in")
+  end
+
   context "for non-superadmins" do
     should "not display the 2SV flagging checkbox" do
       admin = create(:admin_user)
@@ -17,12 +28,14 @@ class InvitingUsersTest < ActionDispatch::IntegrationTest
   end
 
   context "for an end-user by an admin" do
+    setup do
+      admin = create(:user, role: "admin")
+      visit root_path
+      signin_with(admin)
+    end
+
     should "create and notify the user" do
       perform_enqueued_jobs do
-        admin = create(:user, role: "admin")
-        visit root_path
-        signin_with(admin)
-
         visit new_user_invitation_path
         fill_in "Name", with: "Fred Bloggs"
         fill_in "Email", with: "fred@example.com"
@@ -34,22 +47,19 @@ class InvitingUsersTest < ActionDispatch::IntegrationTest
       end
     end
 
-    should "send the user an invitation token" do
-      user = User.invite!(name: "Jim", email: "jim@web.com")
-      visit accept_user_invitation_path(invitation_token: user.raw_invitation_token)
+    should "give the user signin access to the support app" do
+      support_app = FactoryGirl.create(:application, name: 'support', with_supported_permissions: ['signin'])
 
-      fill_in "New passphrase", with: "this 1s 4 v3333ry s3cur3 p4ssw0rd.!Z"
-      fill_in "Confirm new passphrase", with: "this 1s 4 v3333ry s3cur3 p4ssw0rd.!Z"
-      click_button "Set my passphrase"
+      visit new_user_invitation_path
+      fill_in "Name", with: "Alicia Smith"
+      fill_in "Email", with: "alicia@example.com"
+      click_button "Create user and send email"
 
-      assert_response_contains("You are now signed in")
+      u = User.find_by(email: 'alicia@example.com')
+      assert u.has_access_to? support_app
     end
 
     should "show an error message when attempting to create a user without an email" do
-      admin = create(:user, role: "admin")
-      visit root_path
-      signin_with(admin)
-
       visit new_user_invitation_path
       fill_in "Name", with: "Fred Bloggs"
       click_button "Create user and send email"
@@ -59,12 +69,14 @@ class InvitingUsersTest < ActionDispatch::IntegrationTest
   end
 
   context "for an admin by a superadmin" do
+    setup do
+      admin = create(:user, role: "superadmin")
+      visit root_path
+      signin_with(admin)
+    end
+
     should "create and notify the admin" do
       perform_enqueued_jobs do
-        admin = create(:user, role: "superadmin")
-        visit root_path
-        signin_with(admin)
-
         visit new_user_invitation_path
         fill_in "Name", with: "Fred Bloggs"
         select "Admin", from: "Role"
@@ -81,15 +93,29 @@ class InvitingUsersTest < ActionDispatch::IntegrationTest
         assert_match 'Please confirm your account', last_email.subject
       end
     end
+
+    should "give the user signin access to the support app" do
+      support_app = FactoryGirl.create(:application, name: 'support', with_supported_permissions: ['signin'])
+
+      visit new_user_invitation_path
+      fill_in "Name", with: "Alicia Smith"
+      fill_in "Email", with: "alicia@example.com"
+      click_button "Create user and send email"
+
+      u = User.find_by(email: 'alicia@example.com')
+      assert u.has_access_to? support_app
+    end
   end
 
   context "a normal user being invited by an admin" do
+    setup do
+      admin = create(:admin_user)
+      visit root_path
+      signin_with(admin)
+    end
+
     should "create and notify the user" do
       perform_enqueued_jobs do
-        admin = create(:admin_user)
-        visit root_path
-        signin_with(admin)
-
         visit new_user_invitation_path
         assert has_no_select?("Role")
         fill_in "Name", with: "Fred Bloggs"
@@ -100,6 +126,18 @@ class InvitingUsersTest < ActionDispatch::IntegrationTest
         assert_equal "normal_fred@example.com", last_email.to[0]
         assert_match 'Please confirm your account', last_email.subject
       end
+    end
+
+    should "give the user signin access to the support app" do
+      support_app = FactoryGirl.create(:application, name: 'support', with_supported_permissions: ['signin'])
+
+      visit new_user_invitation_path
+      fill_in "Name", with: "Alicia Smith"
+      fill_in "Email", with: "alicia@example.com"
+      click_button "Create user and send email"
+
+      u = User.find_by(email: 'alicia@example.com')
+      assert u.has_access_to? support_app
     end
   end
 end

--- a/test/integration/inviting_users_test.rb
+++ b/test/integration/inviting_users_test.rb
@@ -4,6 +4,11 @@ class InvitingUsersTest < ActionDispatch::IntegrationTest
   include EmailHelpers
   include ActiveJob::TestHelper
 
+  def setup_signin_on_support_as_default_permission
+    FactoryGirl.create(:application, name: 'support', with_supported_permissions: ['signin'])
+    Signon.add_default_permission('support', 'signin')
+  end
+
   should "send the user an invitation token" do
     user = User.invite!(name: "Jim", email: "jim@web.com")
     visit accept_user_invitation_path(invitation_token: user.raw_invitation_token)
@@ -48,7 +53,7 @@ class InvitingUsersTest < ActionDispatch::IntegrationTest
     end
 
     should "give the user signin access to the support app" do
-      support_app = FactoryGirl.create(:application, name: 'support', with_supported_permissions: ['signin'])
+      setup_signin_on_support_as_default_permission
 
       visit new_user_invitation_path
       fill_in "Name", with: "Alicia Smith"
@@ -56,7 +61,7 @@ class InvitingUsersTest < ActionDispatch::IntegrationTest
       click_button "Create user and send email"
 
       u = User.find_by(email: 'alicia@example.com')
-      assert u.has_access_to? support_app
+      assert u.has_access_to? ::Doorkeeper::Application.find_by!(name: 'support')
     end
 
     should "show an error message when attempting to create a user without an email" do
@@ -95,7 +100,7 @@ class InvitingUsersTest < ActionDispatch::IntegrationTest
     end
 
     should "give the user signin access to the support app" do
-      support_app = FactoryGirl.create(:application, name: 'support', with_supported_permissions: ['signin'])
+      setup_signin_on_support_as_default_permission
 
       visit new_user_invitation_path
       fill_in "Name", with: "Alicia Smith"
@@ -103,7 +108,7 @@ class InvitingUsersTest < ActionDispatch::IntegrationTest
       click_button "Create user and send email"
 
       u = User.find_by(email: 'alicia@example.com')
-      assert u.has_access_to? support_app
+      assert u.has_access_to? ::Doorkeeper::Application.find_by!(name: 'support')
     end
   end
 
@@ -129,7 +134,7 @@ class InvitingUsersTest < ActionDispatch::IntegrationTest
     end
 
     should "give the user signin access to the support app" do
-      support_app = FactoryGirl.create(:application, name: 'support', with_supported_permissions: ['signin'])
+      setup_signin_on_support_as_default_permission
 
       visit new_user_invitation_path
       fill_in "Name", with: "Alicia Smith"
@@ -137,7 +142,7 @@ class InvitingUsersTest < ActionDispatch::IntegrationTest
       click_button "Create user and send email"
 
       u = User.find_by(email: 'alicia@example.com')
-      assert u.has_access_to? support_app
+      assert u.has_access_to? ::Doorkeeper::Application.find_by!(name: 'support')
     end
   end
 end

--- a/test/models/lib/user_creator_test.rb
+++ b/test/models/lib/user_creator_test.rb
@@ -1,0 +1,34 @@
+require 'test_helper'
+
+class UserCreatorTest < ActiveSupport::TestCase
+  test 'it creates a new user with the supplied name and email' do
+    FactoryGirl.create(:application, name: 'app-o-tron', with_supported_permissions: ['signin'])
+    user_creator = UserCreator.new('Alicia', 'alicia@example.com', 'app-o-tron')
+
+    user_creator.create_user!
+
+    assert user_creator.user.persisted?
+    assert_equal 'Alicia', user_creator.user.name
+    assert_equal 'alicia@example.com', user_creator.user.email
+  end
+
+  test 'invites the new user, so they must validate their email before they can signin' do
+    FactoryGirl.create(:application, name: 'app-o-tron', with_supported_permissions: ['signin'])
+    user_creator = UserCreator.new('Alicia', 'alicia@example.com', 'app-o-tron')
+
+    user_creator.create_user!
+
+    assert user_creator.user.invited_but_not_yet_accepted?
+  end
+
+  test 'it grants "signin" permission to each application supplied' do
+    app_o_tron = FactoryGirl.create(:application, name: 'app-o-tron', with_supported_permissions: ['signin'])
+    app_erator = FactoryGirl.create(:application, name: 'app-erator', with_supported_permissions: ['signin'])
+    user_creator = UserCreator.new('Alicia', 'alicia@example.com', 'app-o-tron,app-erator')
+
+    user_creator.create_user!
+
+    assert user_creator.user.has_access_to? app_o_tron
+    assert user_creator.user.has_access_to? app_erator
+  end
+end

--- a/test/models/lib/user_creator_test.rb
+++ b/test/models/lib/user_creator_test.rb
@@ -31,4 +31,15 @@ class UserCreatorTest < ActiveSupport::TestCase
     assert user_creator.user.has_access_to? app_o_tron
     assert user_creator.user.has_access_to? app_erator
   end
+
+  test 'it grants "signin" permission to the support app, even if not supplied' do
+    support_app = FactoryGirl.create(:application, name: 'support', with_supported_permissions: ['signin'])
+    app_o_tron = FactoryGirl.create(:application, name: 'app-o-tron', with_supported_permissions: ['signin'])
+    user_creator = UserCreator.new('Alicia', 'alicia@example.com', 'app-o-tron')
+
+    user_creator.create_user!
+
+    assert user_creator.user.has_access_to? app_o_tron
+    assert user_creator.user.has_access_to? support_app
+  end
 end

--- a/test/models/lib/user_creator_test.rb
+++ b/test/models/lib/user_creator_test.rb
@@ -32,14 +32,16 @@ class UserCreatorTest < ActiveSupport::TestCase
     assert user_creator.user.has_access_to? app_erator
   end
 
-  test 'it grants "signin" permission to the support app, even if not supplied' do
-    support_app = FactoryGirl.create(:application, name: 'support', with_supported_permissions: ['signin'])
+  test 'it grants all default permissions, even if not signin' do
     app_o_tron = FactoryGirl.create(:application, name: 'app-o-tron', with_supported_permissions: ['signin'])
+    app_erator = FactoryGirl.create(:application, name: 'app-erator', with_supported_permissions: %w(signin bounce))
+    Signon.add_default_permission('app-erator', 'bounce')
     user_creator = UserCreator.new('Alicia', 'alicia@example.com', 'app-o-tron')
 
     user_creator.create_user!
 
     assert user_creator.user.has_access_to? app_o_tron
-    assert user_creator.user.has_access_to? support_app
+    refute user_creator.user.has_access_to? app_erator
+    assert user_creator.user.permissions_for(app_erator).include? 'bounce'
   end
 end

--- a/test/models/lib/user_permissions_bulk_granter_test.rb
+++ b/test/models/lib/user_permissions_bulk_granter_test.rb
@@ -1,0 +1,56 @@
+require 'test_helper'
+
+class UserPermissionsBulkGranterTest < ActiveSupport::TestCase
+  context '.new' do
+    should 'raises an error if the supplied application cannot be found' do
+      assert_raises(RuntimeError) do
+        UserPermissionsBulkGranter.new('application-that-does-not-exist')
+      end
+    end
+
+    should 'fetches the supplied application' do
+      application = FactoryGirl.create(:application, name: 'application-that-does-exist')
+      bulk_granter = UserPermissionsBulkGranter.new('application-that-does-exist')
+
+      assert_equal application, bulk_granter.application
+    end
+  end
+  context '#grant' do
+    setup do
+      @application = FactoryGirl.create(:application, name: 'application-that-does-exist', with_supported_permissions: ['signin'])
+      @bulk_granter = UserPermissionsBulkGranter.new('application-that-does-exist')
+    end
+
+    should 'raises an error if the supplied permission does not exist for the application' do
+      assert_raises(RuntimeError) do
+        @bulk_granter.grant('be-a-super-admin')
+      end
+    end
+
+    should 'adds the permission to an active user' do
+      user = FactoryGirl.create(:user)
+      @bulk_granter.grant('signin')
+      assert user.reload.permissions_for(@application).include? 'signin'
+    end
+
+    should 'adds the permission to a suspended user' do
+      user = FactoryGirl.create(:suspended_user)
+      @bulk_granter.grant('signin')
+      assert user.reload.permissions_for(@application).include? 'signin'
+    end
+
+    should 'adds the permission to an api user' do
+      user = FactoryGirl.create(:api_user)
+      @bulk_granter.grant('signin')
+      assert user.reload.permissions_for(@application).include? 'signin'
+    end
+
+    should 'does not break when adding the permission to a user that user already has it' do
+      # The real assertion here is that the test doesn't explode when it
+      # tries to add the permission, not that the permission is there
+      user = FactoryGirl.create(:user, with_signin_permissions_for: [@application])
+      @bulk_granter.grant('signin')
+      assert user.reload.permissions_for(@application).include? 'signin'
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -23,6 +23,7 @@ class ActiveSupport::TestCase
     WebMock.reset!
     DatabaseCleaner.clean
     Mail::TestMailer.deliveries.clear
+    Signon.default_permissions_for_all_users = []
   end
 end
 


### PR DESCRIPTION
For: https://trello.com/c/FMBZdTvk/45-support-app-should-probably-require-signon-permission-to-access

Related to: https://github.com/alphagov/support/pull/315

We noticed that the support app, unlike all other signon apps didn't require 'signin' access to allow users to use the app.  This likely leads us into a false sense of security as when we uncheck a users' 'Has access?' checkbox for 'support' in the UI we'd reasonably expect that this would stop them from using the support app.  It doesn't though.  We've made [a change to support to require 'signin' permission](https://github.com/alphagov/support/pull/315) and this PR does the work in signon to make sure that this change doesn't revoke any access that people would have had.

1. A rake task to add a permission for an app to all users (we'll run this with "signin" on "support").
2. Adding a mechanism for a default set of permissions to be added to all users (a true MVP of this, no UI, requires dev effort to change)
3. Make the 3 places where the app creates users (`rake users:create`, batch invite, `users/new`) add these default set of permissions to the users they create

For discussion: is this the right thing to do?  Should we take the default stuff further and add UI on it, or just some docs?