### PR TITLE
Change what organisation admins can do

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -40,8 +40,7 @@ class UsersController < ApplicationController
   end
 
   def update
-    raise Pundit::NotAuthorizedError if current_user.organisation_admin? &&
-        ! current_user.organisation.subtree.map(&:id).include?(params[:user][:organisation_id].to_i)
+    raise Pundit::NotAuthorizedError if params[:user][:organisation_id].present? && !policy(@user).assign_organisations?
 
     updater = UserUpdate.new(@user, user_params, current_user)
     if updater.update

--- a/app/policies/batch_invitation_policy.rb
+++ b/app/policies/batch_invitation_policy.rb
@@ -1,7 +1,6 @@
 class BatchInvitationPolicy < BasePolicy
   def new?
     return true if current_user.superadmin? || current_user.admin?
-    return belong_to_same_organisation_subtree?(current_user, record) if current_user.organisation_admin?
 
     false
   end

--- a/app/policies/organisation_policy.rb
+++ b/app/policies/organisation_policy.rb
@@ -17,7 +17,7 @@ class OrganisationPolicy < BasePolicy
       elsif current_user.admin? || current_user.superadmin?
         scope.all
       else
-        []
+        scope.none
       end
     end
   end

--- a/app/policies/organisation_policy.rb
+++ b/app/policies/organisation_policy.rb
@@ -1,20 +1,17 @@
 class OrganisationPolicy < BasePolicy
   def index?
-    current_user.superadmin? || current_user.admin? || current_user.organisation_admin?
+    current_user.superadmin? || current_user.admin?
   end
 
   def can_assign?
     return true if current_user.superadmin? || current_user.admin?
-    return current_user.organisation.subtree.pluck(:id).include?(record.id) if current_user.organisation_admin?
 
     false
   end
 
   class Scope < ::BasePolicy::Scope
     def resolve
-      if current_user.organisation_admin?
-        current_user.organisation.subtree
-      elsif current_user.admin? || current_user.superadmin?
+      if current_user.admin? || current_user.superadmin?
         scope.all
       else
         scope.none

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -69,6 +69,8 @@ class UserPolicy < BasePolicy
         scope.web_users.where(role: %w(admin organisation_admin normal))
       elsif current_user.organisation_admin?
         scope.web_users.where(role: %w(organisation_admin normal)).where(organisation_id: current_user.organisation_id)
+      else
+        scope.none
       end
     end
   end

--- a/app/views/users/_form_fields.html.erb
+++ b/app/views/users/_form_fields.html.erb
@@ -65,10 +65,12 @@
   </dl>
 <% end %>
 
-<p class="form-group">
-  <%= f.label :organisation_id, "Organisation" %><br />
-  <%= f.select :organisation_id, organisation_options(f), organisation_select_options, { class: "chosen-select form-control", 'data-module' => 'chosen' } %>
-</p>
+<% if policy(User).assign_organisations? %>
+  <p class="form-group">
+    <%= f.label :organisation_id, "Organisation" %><br />
+    <%= f.select :organisation_id, organisation_options(f), organisation_select_options, { class: "chosen-select form-control", 'data-module' => 'chosen' } %>
+  </p>
+<% end %>
 
 <h2 class="add-vertical-margins">Permissions</h2>
 

--- a/spec/policies/batch_invitation_policy_spec.rb
+++ b/spec/policies/batch_invitation_policy_spec.rb
@@ -9,17 +9,16 @@ describe BatchInvitationPolicy do
       expect(subject).to permit(create(:user_in_organisation, role: 'admin'), BatchInvitation.new)
     end
 
-    context 'organisation admin' do
-      let(:organisation_admin) { create(:user_in_organisation, role: 'organisation_admin') }
+    it 'is forbidden for organisation admins to create new batch uploads even within their organisation subtree' do
+      organisation_admin = create(:user_in_organisation, role: 'organisation_admin')
 
-      it 'allows new batch upload for organisations within their organisation subtree' do
-        expect(subject).to permit(organisation_admin, BatchInvitation.new(organisation_id: organisation_admin.organisation_id))
-      end
+      expect(subject).not_to permit(organisation_admin, BatchInvitation.new)
+      expect(subject).not_to permit(organisation_admin, BatchInvitation.new(organisation_id: create(:organisation).id))
+      expect(subject).not_to permit(organisation_admin, BatchInvitation.new(organisation_id: organisation_admin.organisation_id))
+    end
 
-      it 'blocks batch upload for organisations outside their organisation subtree' do
-        expect(subject).not_to permit(create(:user_in_organisation, role: 'organisation_admin'), BatchInvitation.new)
-        expect(subject).not_to permit(create(:user_in_organisation, role: 'organisation_admin'), BatchInvitation.new(organisation_id: create(:organisation).id))
-      end
+    it 'is forbidden for normal users' do
+      expect(subject).not_to permit(create(:user), BatchInvitation.new)
     end
   end
 end

--- a/spec/policies/organisation_policy_spec.rb
+++ b/spec/policies/organisation_policy_spec.rb
@@ -4,11 +4,11 @@ describe OrganisationPolicy do
   subject { described_class }
 
   permissions :index? do
-    it "is forbidden only for normal users" do
+    it "is forbidden to organisation admins and normal users" do
       expect(subject).to permit(create(:superadmin_user), Organisation)
       expect(subject).to permit(create(:admin_user), Organisation)
-      expect(subject).to permit(create(:organisation_admin), Organisation)
 
+      expect(subject).not_to permit(create(:organisation_admin), Organisation)
       expect(subject).not_to permit(create(:user), Organisation)
     end
   end
@@ -19,15 +19,17 @@ describe OrganisationPolicy do
       expect(subject).to permit(create(:user_in_organisation, role: 'admin'), build(:organisation))
     end
 
-    it "allows organisation admins to assign a user only to organisations within their organisation subtree" do
+    it "is forbidden for organisation admins" do
       organisation_admin = create(:organisation_admin)
       admins_organisation = organisation_admin.organisation
       child_organisation = create(:organisation, parent_id: admins_organisation.id)
 
-      expect(subject).to permit(organisation_admin, admins_organisation)
-      expect(subject).to permit(organisation_admin, child_organisation)
-
+      # can't assign some random org
       expect(subject).not_to permit(organisation_admin, build(:organisation))
+      # can't assign the org they are an admin for
+      expect(subject).not_to permit(organisation_admin, admins_organisation)
+      # can't assign an org that is in the subtree of the one they are an admin for
+      expect(subject).not_to permit(organisation_admin, child_organisation)
     end
   end
 
@@ -70,13 +72,8 @@ describe OrganisationPolicy do
     context 'for org admins' do
       let(:user) { create(:organisation_admin, organisation: org_root_one) }
 
-      it 'includes only organisations within their orgs subtree' do
-        expect(resolved_scope).to include(org_root_one)
-        expect(resolved_scope).to include(org_root_one_child_one)
-        expect(resolved_scope).to include(org_root_one_child_two)
-        expect(resolved_scope).to include(org_root_one_grandchild_one)
-        expect(resolved_scope).not_to include(org_root_two)
-        expect(resolved_scope).not_to include(org_root_two_child_one)
+      it 'is empty' do
+        expect(resolved_scope).to be_empty
       end
     end
 

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -121,4 +121,108 @@ describe UserPolicy do
       expect(subject).not_to permit(create(:user), User)
     end
   end
+
+  describe described_class::Scope do
+    let!(:superadmin_user) { create(:superadmin_user) }
+    let!(:admin_user) { create(:admin_user) }
+    let!(:api_user) { create(:api_user) }
+
+    let(:org_root_one) { create(:organisation) }
+    let(:org_root_two) { create(:organisation) }
+    let(:org_root_one_child) { create(:organisation, parent: org_root_one) }
+
+    let!(:normal_user_in_org) { create(:user_in_organisation, organisation: org_root_one) }
+    let!(:org_admin_user_in_org) { create(:organisation_admin, organisation: org_root_one) }
+    let!(:normal_user_in_child_org) { create(:user_in_organisation, organisation: org_root_one_child) }
+    let!(:org_admin_user_in_child_org) { create(:organisation_admin, organisation: org_root_one_child) }
+    let!(:normal_user_in_other_org) { create(:user_in_organisation, organisation: org_root_two) }
+    let!(:org_admin_user_in_other_org) { create(:organisation_admin, organisation: org_root_two) }
+
+    subject { described_class.new(user, User.all) }
+    let(:resolved_scope) { subject.resolve }
+
+    context 'for super admins' do
+      let(:user) { create(:superadmin_user) }
+
+      it 'includes all web users' do
+        expect(resolved_scope).to include(superadmin_user)
+        expect(resolved_scope).to include(admin_user)
+        expect(resolved_scope).to include(normal_user_in_org)
+        expect(resolved_scope).to include(org_admin_user_in_org)
+        expect(resolved_scope).to include(normal_user_in_child_org)
+        expect(resolved_scope).to include(org_admin_user_in_child_org)
+        expect(resolved_scope).to include(normal_user_in_other_org)
+        expect(resolved_scope).to include(org_admin_user_in_other_org)
+      end
+
+      it 'does not include api users' do
+        expect(resolved_scope).not_to include(api_user)
+      end
+    end
+
+    context 'for admins' do
+      let(:user) { create(:admin_user) }
+
+      it 'includes all web users of similar permissions' do
+        expect(resolved_scope).to include(admin_user)
+        expect(resolved_scope).to include(normal_user_in_org)
+        expect(resolved_scope).to include(org_admin_user_in_org)
+        expect(resolved_scope).to include(normal_user_in_child_org)
+        expect(resolved_scope).to include(org_admin_user_in_child_org)
+        expect(resolved_scope).to include(normal_user_in_other_org)
+        expect(resolved_scope).to include(org_admin_user_in_other_org)
+      end
+
+      it 'does not include api users' do
+        expect(resolved_scope).not_to include(api_user)
+      end
+
+      it 'does not include superadmins' do
+        expect(resolved_scope).not_to include(superadmin_user)
+      end
+    end
+
+    context 'for org admins' do
+      let(:user) { create(:organisation_admin, organisation: org_root_one) }
+
+      it 'includes only org admins and users belonging to their org' do
+        expect(resolved_scope).to include(normal_user_in_org)
+        expect(resolved_scope).to include(org_admin_user_in_org)
+      end
+
+      it 'does not include users belonging to organisations in their subtree' do
+        expect(resolved_scope).not_to include(normal_user_in_child_org)
+        expect(resolved_scope).not_to include(org_admin_user_in_child_org)
+      end
+
+      it 'does not include users belonging to other orgs' do
+        expect(resolved_scope).not_to include(normal_user_in_other_org)
+        expect(resolved_scope).not_to include(org_admin_user_in_other_org)
+      end
+
+      it 'does not include api users' do
+        expect(resolved_scope).not_to include(api_user)
+      end
+
+      it 'does not include superadmins (even if they are in the same org)' do
+        superadmin_in_same_org = create(:superadmin_user, organisation: user.organisation)
+        expect(resolved_scope).not_to include(superadmin_user)
+        expect(resolved_scope).not_to include(superadmin_in_same_org)
+      end
+
+      it 'does not include admins (even if they are in the same org)' do
+        admin_in_same_org = create(:admin_user, organisation: user.organisation)
+        expect(resolved_scope).not_to include(admin_user)
+        expect(resolved_scope).not_to include(admin_in_same_org)
+      end
+    end
+
+    context 'for normal users' do
+      let(:user) { create(:user) }
+
+      it 'is empty' do
+        expect(resolved_scope).to be_empty
+      end
+    end
+  end
 end

--- a/test/controllers/invitations_controller_test.rb
+++ b/test/controllers/invitations_controller_test.rb
@@ -7,49 +7,27 @@ class InvitationsControllerTest < ActionController::TestCase
     sign_in @user
   end
 
-  should "disallow access to non-admins" do
-    @user.update_column(:role, 'normal')
-    get :new
-    assert_redirected_to root_path
-  end
-
   context "GET new" do
-    context "organisation admin" do
-      should "can select only organisations under them" do
-        admin = create(:organisation_admin)
-        sub_organisation = create(:organisation, parent: admin.organisation)
-        outside_organisation = create(:organisation)
-        sign_in admin
-
-        get :new
-
-        assert_select ".container" do
-          assert_select "option", count: 0, text: outside_organisation.name_with_abbreviation
-          assert_select "option", count: 1, text: admin.organisation.name_with_abbreviation
-          assert_select "option", count: 1, text: sub_organisation.name_with_abbreviation
-        end
-      end
+    should "disallow access to non-admins" do
+      @user.update_column(:role, 'normal')
+      get :new
+      assert_redirected_to root_path
     end
 
-    context "organisation admin" do
-      should "can give permissions to only applications where signin is delegatable and they have access to" do
-        delegatable_app = create(:application, with_delegatable_supported_permissions: ["signin"])
-        non_delegatable_app = create(:application, with_supported_permissions: ['signin'])
-        admin = create(:organisation_admin, with_signin_permissions_for: [delegatable_app, non_delegatable_app])
-
-        sign_in admin
-
-        get :new
-
-        assert_select ".container" do
-          assert_select "td", { count: 1, text: delegatable_app.name }
-          assert_select "td", { count: 0, text: non_delegatable_app.name }
-        end
-      end
+    should "disallow access to organisation admins" do
+      @user.update_attributes(role: 'organisation_admin', organisation_id: create(:organisation).id)
+      get :new
+      assert_redirected_to root_path
     end
   end
 
   context "POST create" do
+    should "disallow access to non-admins" do
+      @user.update_column(:role, 'normal')
+      post :create, user: { name: 'Testing Non-admins', email: 'testing_non_admins@example.com' }
+      assert_redirected_to root_path
+    end
+
     should "not allow creation of api users" do
       post :create, user: { name: 'Testing APIs', email: 'api@example.com', api_user: true }
 
@@ -65,40 +43,35 @@ class InvitationsControllerTest < ActionController::TestCase
       assert_equal "User already invited. If you want to, you can click 'Resend signup email'.", flash[:alert]
     end
 
-    context "organisation admin" do
-      should "not assign organisations not under them" do
-        admin = create(:organisation_admin)
-        outside_organisation = create(:organisation)
-        sign_in admin
-
-        post :create, user: { name: "John Smith", email: "jsmith@digital.cabinet-office.gov.uk", organisation_id: outside_organisation.id }
-
-        assert_redirected_to root_path
-        assert_equal "You do not have permission to perform this action.", flash[:alert]
-      end
-
-      should "assign only organisations under them" do
-        admin = create(:organisation_admin)
-        sub_organisation = create(:organisation, parent: admin.organisation)
-        sign_in admin
-
-        post :create, user: { name: "John Smith", email: "jsmith@digital.cabinet-office.gov.uk", organisation_id: sub_organisation.id }
-
-        assert_redirected_to users_path
-        assert_equal "An invitation email has been sent to jsmith@digital.cabinet-office.gov.uk.", flash[:notice]
-        assert_equal sub_organisation.id, User.last.organisation_id
-      end
+    should "disallow access to organisation admins" do
+      @user.update_attributes(role: 'organisation_admin', organisation_id: create(:organisation).id)
+      post :create, user: { name: 'Testing Org Admins', email: 'testing_org_admins@example.com' }
+      assert_redirected_to root_path
     end
   end
 
   context "POST resend" do
+    should "disallow access to non-admins" do
+      @user.update_column(:role, 'normal')
+      user_to_resend_for = create(:user)
+      post :resend, id: user_to_resend_for.id
+      assert_redirected_to root_path
+    end
+
+    should "disallow access to organisation admins" do
+      @user.update_attributes(role: 'organisation_admin', organisation_id: create(:organisation).id)
+      user_to_resend_for = create(:user)
+      post :resend, id: user_to_resend_for.id
+      assert_redirected_to root_path
+    end
+
     should "resend account signup email to user" do
       admin = create(:admin_user)
-      user = create(:user)
+      user_to_resend_for = create(:user)
       User.any_instance.expects(:invite!).once
       sign_in admin
 
-      post :resend, id: user.id
+      post :resend, id: user_to_resend_for.id
 
       assert_redirected_to users_path
     end

--- a/test/integration/batch_inviting_users_test.rb
+++ b/test/integration/batch_inviting_users_test.rb
@@ -3,20 +3,30 @@ require 'test_helper'
 class BatchInvitingUsersTest < ActionDispatch::IntegrationTest
   include ActiveJob::TestHelper
 
-
-  should "admin user can create users whose details are specified in a CSV file" do
+  should "superadmin user can create users whose details are specified in a CSV file" do
     application = create(:application)
-    user = create(:user, role: "admin")
+    user = create(:superadmin_user)
 
     perform_batch_invite_with_user(user, application)
   end
 
-  should "organisation admin user can create users whose details are specified in a CSV file" do
+  should "admin user can create users whose details are specified in a CSV file" do
+    application = create(:application)
+    user = create(:admin_user)
+
+    perform_batch_invite_with_user(user, application)
+  end
+
+  should "organisation admin user can not create users whose details are specified in a CSV file" do
     application = create(:application)
     user = create(:user_in_organisation, role: 'organisation_admin')
     user.grant_application_permission(application, ['signin'])
 
-    perform_batch_invite_with_user(user, application)
+    visit root_path
+    signin_with(user)
+
+    visit new_batch_invitation_path
+    assert_equal root_path, current_path
   end
 
   def perform_batch_invite_with_user(user, application)


### PR DESCRIPTION
For: https://trello.com/c/B4Y7e22o/164-self-service-or-devolved-unlock-spike

Our goal is to increase the number of org admins there are so we can increase the number of people that can do simple user support requests.  Before this change: Org admins are basically admins who are limited in scope to just users in their org (or sometimes their org and it's children, grandchildre, etc..).  After this change: org admins can no longer create new users (directly or via batch invite), see a list of organisations, affect users in their subtree - they can only affect users that belong directly to their org.

The existing org admins (there are 7) have been spoken to and none have an issue with the restriction of their permissions.