### PR TITLE
Stop org admin editing a user clearing non delegatable permissions

### DIFF
--- a/app/policies/supported_permission_policy.rb
+++ b/app/policies/supported_permission_policy.rb
@@ -1,0 +1,16 @@
+class SupportedPermissionPolicy < BasePolicy
+  class Scope < ::BasePolicy::Scope
+    def resolve
+      if current_user.superadmin?
+        scope.all
+      elsif current_user.admin?
+        scope.all
+      elsif current_user.organisation_admin?
+        app_ids = Pundit.policy_scope(current_user, :user_permission_manageable_application).pluck(:id)
+        scope.joins(:application).where(oauth_applications: { id: app_ids })
+      else
+        scope.none
+      end
+    end
+  end
+end

--- a/app/policies/user_permission_manageable_application_policy.rb
+++ b/app/policies/user_permission_manageable_application_policy.rb
@@ -1,0 +1,39 @@
+# This policy controls which applications a given user is allowed to
+# manage the permissions that other users have for it
+class UserPermissionManageableApplicationPolicy
+  attr_reader :current_user
+
+  def initialize(current_user, _ = nil)
+    @current_user = current_user
+  end
+
+  def scope
+    PermissionGrantableApplicationPolicy::Scope.new(current_user).resolve
+  end
+
+  class Scope
+    attr_reader :current_user
+
+    def initialize(current_user, _ = nil)
+      @current_user = current_user
+    end
+
+    def resolve
+      if current_user.superadmin?
+        applications
+      elsif current_user.admin?
+        applications
+      elsif current_user.organisation_admin?
+        applications.can_signin(current_user).with_signin_delegatable
+      else
+        applications.none
+      end
+    end
+
+  private
+
+    def applications
+      ::Doorkeeper::Application.includes(:supported_permissions)
+    end
+  end
+end

--- a/app/services/user_update.rb
+++ b/app/services/user_update.rb
@@ -24,47 +24,13 @@ class UserUpdate
 
 private
 
-  class SupportedPermissionsSanitizer
-    attr_reader :current_user, :user, :param_set
-    def initialize(current_user, user, param_set)
-      @current_user = current_user
-      @user = user
-      @param_set = param_set
-    end
-
-    def sanitized_supported_permission_ids
-      # any permissions not in "attempting_to_add" should be removed if we're
-      # allowed to manipulate them
-      allowed_to_be_removed = authorised_supported_permission_ids - attempting_to_set_supported_permission_ids
-      # any permissions in "attempting_to_add" should be added if they're in the
-      # set we're allowed to manipulate
-      allowed_to_be_added = attempting_to_set_supported_permission_ids & authorised_supported_permission_ids
-
-      (existing_supported_permission_ids - allowed_to_be_removed) | allowed_to_be_added
-    end
-
-  private
-
-    def authorised_supported_permission_ids
-      @authorised_supported_permissions ||= Pundit.policy_scope(current_user, SupportedPermission).pluck(:id).map(&:to_s)
-    end
-
-    def existing_supported_permission_ids
-      @existing_supported_permission_ids ||= user.supported_permission_ids.map(&:to_s)
-    end
-
-    def attempting_to_set_supported_permission_ids
-      @attempting_to_set_supported_permission_ids ||= param_set.fetch(:supported_permission_ids, []).map(&:to_s)
-    end
-  end
-
-  def sanitised_user_params
-    sanitizer = SupportedPermissionsSanitizer.new(current_user, user, user_params)
-    user_params.merge(supported_permission_ids: sanitizer.sanitized_supported_permission_ids)
+  def filtered_user_params
+    filter = SupportedPermissionParameterFilter.new(current_user, user, user_params)
+    user_params.merge(supported_permission_ids: filter.filtered_supported_permission_ids)
   end
 
   def update_user
-    user.update_attributes(sanitised_user_params)
+    user.update_attributes(filtered_user_params)
   end
 
   def record_permission_changes(old_permissions)

--- a/lib/supported_permission_parameter_filter.rb
+++ b/lib/supported_permission_parameter_filter.rb
@@ -1,0 +1,33 @@
+class SupportedPermissionParameterFilter
+  attr_reader :current_user, :user, :param_set
+  def initialize(current_user, user, param_set)
+    @current_user = current_user
+    @user = user
+    @param_set = param_set
+  end
+
+  def filtered_supported_permission_ids
+    # any permissions not in "attempting_to_add" should be removed if we're
+    # allowed to manipulate them
+    allowed_to_be_removed = authorised_supported_permission_ids - attempting_to_set_supported_permission_ids
+    # any permissions in "attempting_to_add" should be added if they're in the
+    # set we're allowed to manipulate
+    allowed_to_be_added = attempting_to_set_supported_permission_ids & authorised_supported_permission_ids
+
+    (existing_supported_permission_ids - allowed_to_be_removed) | allowed_to_be_added
+  end
+
+private
+
+  def authorised_supported_permission_ids
+    @authorised_supported_permissions ||= Pundit.policy_scope(current_user, SupportedPermission).pluck(:id).map(&:to_s)
+  end
+
+  def existing_supported_permission_ids
+    @existing_supported_permission_ids ||= user.supported_permission_ids.map(&:to_s)
+  end
+
+  def attempting_to_set_supported_permission_ids
+    @attempting_to_set_supported_permission_ids ||= param_set.fetch(:supported_permission_ids, []).map(&:to_s)
+  end
+end

--- a/lib/user_permissions_controller_methods.rb
+++ b/lib/user_permissions_controller_methods.rb
@@ -1,15 +1,17 @@
 module UserPermissionsControllerMethods
-  private
+private
 
   def visible_applications(user)
-    applications = Doorkeeper::Application.includes(:supported_permissions)
     if user.api_user?
-      authorised_application_ids = user.authorisations.where(revoked_at: nil).pluck(:application_id)
-      visible_applications = applications.where(id: authorised_application_ids)
-    elsif current_user.superadmin? || current_user.admin?
-      visible_applications = applications
+      applications = ::Doorkeeper::Application.includes(:supported_permissions)
+      if current_user.superadmin?
+        api_user_authorised_apps = user.authorisations.where(revoked_at: nil).pluck(:application_id)
+        applications.where(id: api_user_authorised_apps)
+      else
+        applications.none
+      end
     else
-      visible_applications = applications.can_signin(current_user).with_signin_delegatable
+      policy_scope(:user_permission_manageable_application)
     end
   end
 

--- a/spec/policies/supported_permission_policy_spec.rb
+++ b/spec/policies/supported_permission_policy_spec.rb
@@ -1,0 +1,114 @@
+require 'rails_helper'
+
+describe SupportedPermissionPolicy do
+  subject { described_class }
+
+  describe described_class::Scope do
+    subject { described_class.new(user, SupportedPermission.all) }
+    let(:resolved_scope) { subject.resolve }
+
+    let(:app_one) { create(:application, name: 'App one') }
+    let(:app_two) { create(:application, name: 'App two') }
+    let(:app_three) { create(:application, name: 'App three') }
+    let(:app_four) { create(:application, name: 'App four') }
+
+    let!(:app_one_signin_permission) { app_one.signin_permission.tap { |s| s.update_attributes(delegatable: true) } }
+    let!(:app_two_signin_permission) { app_two.signin_permission.tap { |s| s.update_attributes(delegatable: false) } }
+    let!(:app_three_signin_permission) { app_three.signin_permission.tap { |s| s.update_attributes(delegatable: true) } }
+    let!(:app_four_signin_permission) { app_four.signin_permission.tap { |s| s.update_attributes(delegatable: false) } }
+
+    let!(:app_one_hat_permission) { create(:non_delegatable_supported_permission, application: app_one, name: 'hat') }
+    let!(:app_one_cat_permission) { create(:delegatable_supported_permission, application: app_one, name: 'cat') }
+
+    let!(:app_two_rat_permission) { create(:non_delegatable_supported_permission, application: app_two, name: 'rat') }
+    let!(:app_two_bat_permission) { create(:delegatable_supported_permission, application: app_two, name: 'bat') }
+
+    let!(:app_three_fat_permission) { create(:non_delegatable_supported_permission, application: app_three, name: 'fat') }
+    let!(:app_three_vat_permission) { create(:delegatable_supported_permission, application: app_three, name: 'vat') }
+
+    let!(:app_four_pat_permission) { create(:non_delegatable_supported_permission, application: app_three, name: 'pat') }
+    let!(:app_four_sat_permission) { create(:delegatable_supported_permission, application: app_three, name: 'sat') }
+
+    context 'for super admins' do
+      let(:user) { create(:superadmin_user) }
+
+      it 'includes all permissions' do
+        expect(resolved_scope).to include(app_one_signin_permission)
+        expect(resolved_scope).to include(app_one_hat_permission)
+        expect(resolved_scope).to include(app_one_cat_permission)
+
+        expect(resolved_scope).to include(app_two_signin_permission)
+        expect(resolved_scope).to include(app_two_rat_permission)
+        expect(resolved_scope).to include(app_two_bat_permission)
+
+        expect(resolved_scope).to include(app_three_signin_permission)
+        expect(resolved_scope).to include(app_three_fat_permission)
+        expect(resolved_scope).to include(app_three_vat_permission)
+
+        expect(resolved_scope).to include(app_four_signin_permission)
+        expect(resolved_scope).to include(app_four_pat_permission)
+        expect(resolved_scope).to include(app_four_sat_permission)
+      end
+    end
+
+    context 'for admins' do
+      let(:user) { create(:admin_user) }
+
+      it 'includes all permissions' do
+        expect(resolved_scope).to include(app_one_signin_permission)
+        expect(resolved_scope).to include(app_one_hat_permission)
+        expect(resolved_scope).to include(app_one_cat_permission)
+
+        expect(resolved_scope).to include(app_two_signin_permission)
+        expect(resolved_scope).to include(app_two_rat_permission)
+        expect(resolved_scope).to include(app_two_bat_permission)
+
+        expect(resolved_scope).to include(app_three_signin_permission)
+        expect(resolved_scope).to include(app_three_fat_permission)
+        expect(resolved_scope).to include(app_three_vat_permission)
+
+        expect(resolved_scope).to include(app_four_pat_permission)
+        expect(resolved_scope).to include(app_four_sat_permission)
+      end
+    end
+
+    context 'for org admins' do
+      let(:user) do
+        create(:organisation_admin).tap do |u|
+          u.grant_application_permission(app_one, 'signin')
+          u.grant_application_permission(app_two, 'signin')
+        end
+      end
+
+      it 'contains all permissions for apps with delegatable signin permission that the org admin has access to' do
+        expect(resolved_scope).to include(app_one_signin_permission)
+        expect(resolved_scope).to include(app_one_cat_permission)
+        expect(resolved_scope).to include(app_one_hat_permission)
+      end
+
+      it 'does not contain any permissions for apps with non-delegatbale signin permission the org admin has access to' do
+        expect(resolved_scope).not_to include(app_two_signin_permission)
+        expect(resolved_scope).not_to include(app_two_rat_permission)
+        expect(resolved_scope).not_to include(app_two_bat_permission)
+      end
+
+      it 'does not contain any permissions for apps the org admin does not have access to' do
+        expect(resolved_scope).not_to include(app_three_signin_permission)
+        expect(resolved_scope).not_to include(app_three_fat_permission)
+        expect(resolved_scope).not_to include(app_three_vat_permission)
+
+        expect(resolved_scope).not_to include(app_four_signin_permission)
+        expect(resolved_scope).not_to include(app_four_pat_permission)
+        expect(resolved_scope).not_to include(app_four_sat_permission)
+      end
+    end
+
+    context 'for normal users' do
+      let(:user) { create(:user) }
+
+      it 'is empty' do
+        expect(resolved_scope).to be_empty
+      end
+    end
+  end
+end

--- a/spec/policies/user_permission_manageable_application_policy_spec.rb
+++ b/spec/policies/user_permission_manageable_application_policy_spec.rb
@@ -1,0 +1,72 @@
+require 'rails_helper'
+
+describe UserPermissionManageableApplicationPolicy do
+  subject { described_class }
+
+  describe described_class::Scope do
+    subject { described_class.new(acting_user) }
+    let(:resolved_scope) { subject.resolve }
+
+    let(:app_one) { create(:application, name: 'App one') }
+    let(:app_two) { create(:application, name: 'App two') }
+    let(:app_three) { create(:application, name: 'App three') }
+    let(:app_four) { create(:application, name: 'App four') }
+
+    let!(:app_one_signin_permission) { app_one.signin_permission.tap { |s| s.update_attributes(delegatable: true) } }
+    let!(:app_two_signin_permission) { app_two.signin_permission.tap { |s| s.update_attributes(delegatable: false) } }
+    let!(:app_three_signin_permission) { app_three.signin_permission.tap { |s| s.update_attributes(delegatable: true) } }
+    let!(:app_four_signin_permission) { app_four.signin_permission.tap { |s| s.update_attributes(delegatable: false) } }
+
+    context 'for super admins' do
+      let(:acting_user) { create(:superadmin_user) }
+
+      it 'includes all applications' do
+        expect(resolved_scope).to include(app_one)
+        expect(resolved_scope).to include(app_two)
+        expect(resolved_scope).to include(app_three)
+        expect(resolved_scope).to include(app_four)
+      end
+    end
+
+    context 'for admins' do
+      let(:acting_user) { create(:admin_user) }
+
+      it 'includes all applications' do
+        expect(resolved_scope).to include(app_one)
+        expect(resolved_scope).to include(app_two)
+        expect(resolved_scope).to include(app_three)
+        expect(resolved_scope).to include(app_four)
+      end
+    end
+
+    context 'for org admins' do
+      let(:acting_user) { create(:organisation_admin) }
+
+      before do
+        acting_user.grant_application_permission(app_one, 'signin')
+        acting_user.grant_application_permission(app_two, 'signin')
+      end
+
+      it 'includes applications with delegatable signin that the org admin has access to' do
+        expect(resolved_scope).to include(app_one)
+      end
+
+      it 'does not include applications without delegatable signin that the org admin does has access to' do
+        expect(resolved_scope).not_to include(app_two)
+      end
+
+      it 'does not include applications that the org admin does not have access to' do
+        expect(resolved_scope).not_to include(app_three)
+        expect(resolved_scope).not_to include(app_four)
+      end
+    end
+
+    context 'for normal users' do
+      let(:acting_user) { create(:user) }
+
+      it 'is empty' do
+        expect(resolved_scope).to be_empty
+      end
+    end
+  end
+end

--- a/test/integration/granting_permissions_test.rb
+++ b/test/integration/granting_permissions_test.rb
@@ -1,42 +1,146 @@
 require 'test_helper'
 
 class GrantingPermissionsTest < ActionDispatch::IntegrationTest
-  setup do
-    @admin = create(:superadmin_user)
-    @user = create(:user)
+  context "as a super admin" do
+    setup do
+      @admin = create(:superadmin_user)
+      @user = create(:user)
 
-    visit root_path
-    signin_with(@admin)
+      visit root_path
+      signin_with(@admin)
+    end
+
+    should "support granting signin permissions" do
+      app = create(:application, name: "MyApp")
+
+      visit edit_user_path(@user)
+      check "Has access to MyApp?"
+      click_button "Update User"
+
+      assert @user.has_access_to?(app)
+    end
+
+    should "support granting app-specific permissions" do
+      app = create(:application, name: "MyApp",
+                   with_supported_permissions: ["pre-existing", "adding", "never"])
+      @user.grant_application_permission(app, "pre-existing")
+
+      visit edit_user_path(@user)
+      select "adding", from: "Permissions for MyApp"
+      click_button "Update User"
+
+      assert_includes @user.permissions_for(app), "pre-existing"
+      assert_includes @user.permissions_for(app), "adding"
+      assert_not_includes @user.permissions_for(app), "never"
+    end
+
+    should "not be able to grant permissions that are not grantable_from_ui" do
+      create(:application, name: "MyApp", with_supported_permissions_not_grantable_from_ui: ['user_update_permission'])
+
+      visit edit_user_path(@user)
+      assert page.has_no_select?('Permissions for MyApp', options: ['user_update_permission'])
+    end
   end
 
-  should "support granting signin permissions" do
-    app = create(:application, name: "MyApp")
+  context "as an admin" do
+    setup do
+      @admin = create(:admin_user)
+      @user = create(:user)
 
-    visit edit_user_path(@user)
-    check "Has access to MyApp?"
-    click_button "Update User"
+      visit root_path
+      signin_with(@admin)
+    end
 
-    assert @user.has_access_to?(app)
+    should "support granting signin permissions" do
+      app = create(:application, name: "MyApp")
+
+      visit edit_user_path(@user)
+      check "Has access to MyApp?"
+      click_button "Update User"
+
+      assert @user.has_access_to?(app)
+    end
+
+    should "support granting app-specific permissions" do
+      app = create(:application, name: "MyApp",
+                   with_supported_permissions: ["pre-existing", "adding", "never"])
+      @user.grant_application_permission(app, "pre-existing")
+
+      visit edit_user_path(@user)
+      select "adding", from: "Permissions for MyApp"
+      click_button "Update User"
+
+      assert_includes @user.permissions_for(app), "pre-existing"
+      assert_includes @user.permissions_for(app), "adding"
+      assert_not_includes @user.permissions_for(app), "never"
+    end
+
+    should "not be able to grant permissions that are not grantable_from_ui" do
+      create(:application, name: "MyApp", with_supported_permissions_not_grantable_from_ui: ['user_update_permission'])
+
+      visit edit_user_path(@user)
+      assert page.has_no_select?('Permissions for MyApp', options: ['user_update_permission'])
+    end
   end
 
-  should "support granting app-specific permissions" do
-    app = create(:application, name: "MyApp",
-                 with_supported_permissions: ["pre-existing", "adding", "never"])
-    @user.grant_application_permission(app, "pre-existing")
+  context "as an org admin" do
+    setup do
+      @admin = create(:organisation_admin)
+      @user = create(:user, organisation: @admin.organisation)
 
-    visit edit_user_path(@user)
-    select "adding", from: "Permissions for MyApp"
-    click_button "Update User"
+      visit root_path
+      signin_with(@admin)
+    end
 
-    assert_includes @user.permissions_for(app), "pre-existing"
-    assert_includes @user.permissions_for(app), "adding"
-    assert_not_includes @user.permissions_for(app), "never"
-  end
+    should "support granting signin permissions to delegatable apps that the org admin has access to" do
+      app = create(:application, name: 'MyApp', with_delegatable_supported_permissions: ["signin"])
+      @admin.grant_application_permission(app, 'signin')
 
-  should "not be able to assign fields that are not grantable_from_ui" do
-    create(:application, name: "MyApp", with_supported_permissions_not_grantable_from_ui: ['user_update_permission'])
+      visit edit_user_path(@user)
+      check "Has access to MyApp?"
+      click_button "Update User"
 
-    visit edit_user_path(@user)
-    assert page.has_no_select?('Permissions for MyApp', options: ['user_update_permission'])
+      assert @user.reload.has_access_to?(app)
+    end
+
+    should "not support granting signin permissions to non-delegatable apps that the org admin has access to" do
+      app = create(:application, name: 'MyApp')
+      signin_permission = app.signin_permission
+      signin_permission.update_attributes(delegatable: false)
+      @admin.grant_application_permission(app, 'signin')
+
+      visit edit_user_path(@user)
+      assert page.has_no_field? "Has access to MyApp?"
+    end
+
+    should "not support granting signin permissions to apps that the org admin doesn't have access to" do
+      create(:application, name: 'MyApp', with_delegatable_supported_permissions: ['signin'])
+
+      visit edit_user_path(@user)
+      assert page.has_no_field? "Has access to MyApp?"
+    end
+
+    should "support granting app-specific permissions" do
+      app = create(:application, name: "MyApp",
+                   with_supported_permissions: ["pre-existing", "adding", "never"])
+      @admin.grant_application_permission(app, 'signin')
+      @user.grant_application_permission(app, "pre-existing")
+
+      visit edit_user_path(@user)
+      select "adding", from: "Permissions for MyApp"
+      click_button "Update User"
+
+      assert_includes @user.permissions_for(app), "pre-existing"
+      assert_includes @user.permissions_for(app), "adding"
+      assert_not_includes @user.permissions_for(app), "never"
+    end
+
+    should "not be able to grant permissions that are not grantable_from_ui" do
+      app = create(:application, name: "MyApp", with_supported_permissions_not_grantable_from_ui: ['user_update_permission'])
+      @admin.grant_application_permission(app, 'signin')
+
+      visit edit_user_path(@user)
+      assert page.has_no_select?('Permissions for MyApp', options: ['user_update_permission'])
+    end
   end
 end

--- a/test/services/user_update_test.rb
+++ b/test/services/user_update_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class UserUpdateTest < ActionView::TestCase
   should "record an event" do
     affected_user = create(:user)
-    current_user = create(:user)
+    current_user = create(:superadmin_user)
 
     UserUpdate.new(affected_user, {}, current_user).update
 
@@ -11,7 +11,7 @@ class UserUpdateTest < ActionView::TestCase
   end
 
   should "records permission changes" do
-    current_user = create(:user)
+    current_user = create(:superadmin_user)
 
     affected_user = create(:user)
     app = create(:application, name: "App", with_supported_permissions: ["Editor", "signin", "Something Else"])


### PR DESCRIPTION
For: https://trello.com/c/uT9YI5mR/188-devolve-unlock-resetting-permissions

After rolling out org-admin permissions to more people (see #555) we had some reports that saving a user as an org admin was resetting their permissions.  Turns out this is a long-standing bug that we didn't know about because we didn't have many org admins.  When updating a user the `UserUpdater` sets their `supported_permission_ids` to whatever is passed in.  When presenting a user to a superadmin or admin user we show the complete set of permissions and submit the selected ones.  Meaning that the `UserUpdater` is given the full set of permissions that the user should be granted.  When presenting a user to an org admin however, we show a limited set of permissions based on the apps that the org admin has access to that allow delegation of permissions.  This means the `UserUpdater` is only given a subset of permissions but doesn't know there's a difference and will assume it is the complete set.

In this PR we change the `UserUpdater` to filter the permission ids so that it will only add or remove permissions from the user being managed that the user doing the managing is allowed to manage.  Meaning that if a super admin gives you access to whitehall (an app that does not allow delegation of permissions) then an org admin editing you will not clear that permission as they aren't allowed to change it.

There are some more details in the individual commits so it's worth looking at those.

An unanswered question is around permissions that are not grantable from the ui - these are filtered out in the view so they can never be presented to any admin user, but are not currently filtered out by the code we've added to make sure we don't add/remove permissions we're not allowed to change.  This means any user with a permission that is not grantable from the ui will have that permission stripped if they are edited and saved via the UI by an admin.  I don't know that it's a huge problem as the only permissions that are not grantable from the UI at the moment are the `user_update_permission` ones which are only granted to the `Signonotron API Client (permission and suspension updater)` user.   That said, it's a weird edge-case that we should probably fix, I'm juust not really sure what the intention really is for these permissions that you can't grant from the UI.