### PR TITLE
Handle signin permission during oauth

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,10 +21,36 @@ class ApplicationController < ActionController::Base
   end
 
   def current_resource_owner
-    User.find(doorkeeper_token.resource_owner_id) if doorkeeper_token
+    @_current_resource_owner ||= User.find(doorkeeper_token.resource_owner_id) if doorkeeper_token
+  end
+
+  def application_making_request
+    @_application_making_request ||= ::Doorkeeper::Application.find(doorkeeper_token.application_id) if doorkeeper_token
   end
 
   private
+
+  def doorkeeper_authorize!
+    original_return_value = super
+    return original_return_value if api_user_via_token_has_signin_permission_on_app?
+    # The following code is a distillation of the error path of
+    # doorkeeper_authorize! from Doorkeeper::Rails::Helpers which is the
+    # super version called above.
+    options = doorkeeper_unauthorized_render_options
+    status = :unauthorized
+    if options.blank?
+      head status
+    else
+      options[:status] = status
+      options[:layout] = false if options[:layout].nil?
+      render options
+    end
+    original_return_value
+  end
+
+  def api_user_via_token_has_signin_permission_on_app?
+    current_resource_owner && application_making_request && current_resource_owner.has_access_to?(application_making_request)
+  end
 
   def user_not_authorized(exception)
     flash[:alert] = "You do not have permission to perform this action."

--- a/app/controllers/batch_invitations_controller.rb
+++ b/app/controllers/batch_invitations_controller.rb
@@ -15,6 +15,7 @@ class BatchInvitationsController < ApplicationController
   def create
     @batch_invitation = BatchInvitation.new(user: current_user, organisation_id: params[:batch_invitation][:organisation_id])
     @batch_invitation.supported_permission_ids = params[:user][:supported_permission_ids] if params[:user]
+    grant_default_permissions(@batch_invitation)
     authorize @batch_invitation
 
     unless file_uploaded?
@@ -68,6 +69,12 @@ class BatchInvitationsController < ApplicationController
       false
     else
       true
+    end
+  end
+
+  def grant_default_permissions(batch_invitation)
+    SupportedPermission.default.each do |default_permission|
+      batch_invitation.supported_permissions << default_permission
     end
   end
 end

--- a/app/controllers/bulk_grant_permission_sets_controller.rb
+++ b/app/controllers/bulk_grant_permission_sets_controller.rb
@@ -1,0 +1,27 @@
+class BulkGrantPermissionSetsController < ApplicationController
+  include UserPermissionsControllerMethods
+  before_filter :authenticate_user!
+
+  helper_method :applications_and_permissions
+
+  def new
+    @bulk_grant_permission_set = BulkGrantPermissionSet.new
+    authorize @bulk_grant_permission_set
+  end
+
+  def create
+    @bulk_grant_permission_set = BulkGrantPermissionSet.new(user: current_user)
+    @bulk_grant_permission_set.supported_permission_ids = params[:user][:supported_permission_ids] if params[:user]
+    authorize @bulk_grant_permission_set
+
+    @bulk_grant_permission_set.save
+    @bulk_grant_permission_set.enqueue
+    flash[:notice] = "Scheduled grant of #{@bulk_grant_permission_set.supported_permission_ids.count} permissions to all users"
+    redirect_to bulk_grant_permission_set_path(@bulk_grant_permission_set)
+  end
+
+  def show
+    @bulk_grant_permission_set = BulkGrantPermissionSet.find(params[:id])
+    authorize @bulk_grant_permission_set
+  end
+end

--- a/app/controllers/bulk_grant_permission_sets_controller.rb
+++ b/app/controllers/bulk_grant_permission_sets_controller.rb
@@ -14,10 +14,14 @@ class BulkGrantPermissionSetsController < ApplicationController
     @bulk_grant_permission_set.supported_permission_ids = params[:user][:supported_permission_ids] if params[:user]
     authorize @bulk_grant_permission_set
 
-    @bulk_grant_permission_set.save
-    @bulk_grant_permission_set.enqueue
-    flash[:notice] = "Scheduled grant of #{@bulk_grant_permission_set.supported_permission_ids.count} permissions to all users"
-    redirect_to bulk_grant_permission_set_path(@bulk_grant_permission_set)
+    if @bulk_grant_permission_set.save
+      @bulk_grant_permission_set.enqueue
+      flash[:notice] = "Scheduled grant of #{@bulk_grant_permission_set.supported_permission_ids.count} permissions to all users"
+      redirect_to bulk_grant_permission_set_path(@bulk_grant_permission_set)
+    else
+      flash.now[:alert] = "Couldn't schedule granting #{@bulk_grant_permission_set.supported_permission_ids.count} permissions to all users, please try again"
+      render :new
+    end
   end
 
   def show

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -26,6 +26,7 @@ class InvitationsController < Devise::InvitationsController
 
       self.resource = resource_class.invite!(resource_params, current_inviter)
       if resource.errors.empty?
+        grant_default_permissions(self.resource)
         set_flash_message :notice, :send_instructions, email: self.resource.email
         respond_with resource, location: after_invite_path_for(resource)
       else
@@ -103,5 +104,11 @@ class InvitationsController < Devise::InvitationsController
 
   def update_resource_params
     resource_params
+  end
+
+  def grant_default_permissions(user)
+    SupportedPermission.default.each do |default_permission|
+      user.grant_permission(default_permission)
+    end
   end
 end

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -4,8 +4,7 @@ class RootController < ApplicationController
   skip_after_filter :verify_authorized
 
   def index
-    applications = (::Doorkeeper::Application.can_signin(current_user) <<
-                    ::Doorkeeper::Application.where(name: 'Support').first).compact.uniq
+    applications = ::Doorkeeper::Application.can_signin(current_user)
 
     @applications_and_permissions = zip_permissions(applications, current_user)
   end

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -9,4 +9,8 @@ class RootController < ApplicationController
 
     @applications_and_permissions = zip_permissions(applications, current_user)
   end
+
+  def signin_required
+    @application = ::Doorkeeper::Application.find_by_id(session.delete(:signin_missing_for_application))
+  end
 end

--- a/app/controllers/signin_required_authorizations_controller.rb
+++ b/app/controllers/signin_required_authorizations_controller.rb
@@ -1,0 +1,40 @@
+class SigninRequiredAuthorizationsController < Doorkeeper::AuthorizationsController
+  def new
+    if pre_auth.authorizable?
+      if skip_authorization? || matching_token?
+        if user_has_signin_permission_to_application?
+          auth = authorization.authorize
+          redirect_to auth.redirect_uri
+        else
+          session[:signin_missing_for_application] = application.try(:id)
+          redirect_to signin_required_path
+        end
+      else
+        render :new
+      end
+    else
+      render :error
+    end
+  end
+
+  def create
+    if user_has_signin_permission_to_application?
+      redirect_or_render authorization.authorize
+    else
+      session[:signin_missing_for_application] = application.try(:id)
+      redirect_to signin_required_path
+    end
+  end
+
+private
+
+  def user_has_signin_permission_to_application?
+    return false if application.nil?
+    return false if current_resource_owner.nil?
+    current_resource_owner.has_access_to?(application)
+  end
+
+  def application
+    pre_auth.try(:client).try(:application)
+  end
+end

--- a/app/controllers/signin_required_authorizations_controller.rb
+++ b/app/controllers/signin_required_authorizations_controller.rb
@@ -1,4 +1,6 @@
 class SigninRequiredAuthorizationsController < Doorkeeper::AuthorizationsController
+  EXPECTED_DOORKEEPER_VERSION = '4.2.0'
+
   def new
     if pre_auth.authorizable?
       if skip_authorization? || matching_token?

--- a/app/controllers/signin_required_authorizations_controller.rb
+++ b/app/controllers/signin_required_authorizations_controller.rb
@@ -1,4 +1,5 @@
 class SigninRequiredAuthorizationsController < Doorkeeper::AuthorizationsController
+  include Pundit
   EXPECTED_DOORKEEPER_VERSION = '4.2.0'
 
   def new

--- a/app/controllers/supported_permissions_controller.rb
+++ b/app/controllers/supported_permissions_controller.rb
@@ -39,7 +39,7 @@ private
   end
 
   def supported_permission_parameters
-    params.require(:supported_permission).permit(:name, :delegatable)
+    params.require(:supported_permission).permit(:name, :delegatable, :default)
   end
 
   def supported_permission

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -170,10 +170,6 @@ class UsersController < ApplicationController
       params[:two_step_status].present?
   end
 
-  def application_making_request
-    ::Doorkeeper::Application.find(doorkeeper_token.application_id)
-  end
-
   def validate_token_matches_client_id
     # FIXME: Once gds-sso is updated everywhere, this should always validate
     # the client_id param.  It should 401 if no client_id is given.

--- a/app/helpers/batch_invitations_helper.rb
+++ b/app/helpers/batch_invitations_helper.rb
@@ -1,5 +1,5 @@
 module BatchInvitationsHelper
-  def status_message(batch_invitation)
+  def batch_invite_status_message(batch_invitation)
     if batch_invitation.in_progress?
       "In progress. " +
         "#{batch_invitation.batch_invitation_users.processed.count} of " +

--- a/app/helpers/bulk_grant_permission_sets_helper.rb
+++ b/app/helpers/bulk_grant_permission_sets_helper.rb
@@ -1,0 +1,29 @@
+module BulkGrantPermissionSetsHelper
+  def bulk_grant_permission_set_status_message(bulk_grant_permission_set)
+    if bulk_grant_permission_set.in_progress?
+      "In progress. #{bulk_grant_permission_set.processed_users} of #{bulk_grant_permission_set.total_users} users processed."
+    elsif bulk_grant_permission_set.successful?
+      "All #{bulk_grant_permission_set.processed_users} users processed."
+    else
+      "Only #{bulk_grant_permission_set.processed_users} of #{bulk_grant_permission_set.total_users} users processed."
+    end
+  end
+
+  def bulk_grant_permission_set_status_class(bulk_grant_permission_set)
+    if bulk_grant_permission_set.in_progress?
+      "alert-info"
+    elsif bulk_grant_permission_set.successful?
+      "alert-success"
+    else
+      "alert-danger"
+    end
+  end
+
+  def bulk_grant_permissions_by_application(bulk_grant_permission_set)
+    bulk_grant_permission_set.
+      supported_permissions.
+      includes(:application).
+      order('oauth_applications.name, supported_permissions.name').
+      group_by(&:application)
+  end
+end

--- a/app/jobs/bulk_grant_permission_set_job.rb
+++ b/app/jobs/bulk_grant_permission_set_job.rb
@@ -1,0 +1,5 @@
+class BulkGrantPermissionSetJob < ActiveJob::Base
+  def perform(id, options = {})
+    BulkGrantPermissionSet.find(id).perform(options)
+  end
+end

--- a/app/models/bulk_grant_permission_set.rb
+++ b/app/models/bulk_grant_permission_set.rb
@@ -36,6 +36,6 @@ class BulkGrantPermissionSet < ActiveRecord::Base
 private
 
   def must_have_at_least_one_supported_permission
-    errors.add(:supported_permissions, 'must add at least one permission to grant to all users') if bulk_grant_permission_set_application_permissions.size.zero?
+    errors.add(:supported_permissions, 'must not be blank. Choose at least one permission to grant to all users.') if bulk_grant_permission_set_application_permissions.size.zero?
   end
 end

--- a/app/models/bulk_grant_permission_set.rb
+++ b/app/models/bulk_grant_permission_set.rb
@@ -1,0 +1,32 @@
+class BulkGrantPermissionSet < ActiveRecord::Base
+  belongs_to :user
+  has_many :bulk_grant_permission_set_application_permissions, inverse_of: :bulk_grant_permission_set, dependent: :destroy
+  has_many :supported_permissions, through: :bulk_grant_permission_set_application_permissions
+
+  validates :user, presence: true
+  validates :outcome, inclusion: { in: %w(success fail), allow_nil: true }
+  validate :must_have_at_least_one_supported_permission
+
+  def enqueue
+    BulkGrantPermissionSetJob.perform_later(self.id)
+  end
+
+  def perform(_options = {})
+    User.find_each do |user|
+      supported_permissions.each do |permission|
+        user.application_permissions.where(supported_permission_id: permission.id).first_or_create!
+      end
+    end
+    self.outcome = "success"
+    self.save!
+  rescue StandardError
+    self.update_column(:outcome, "fail")
+    raise
+  end
+
+private
+
+  def must_have_at_least_one_supported_permission
+    errors.add(:supported_permissions, 'must add at least one permission to grant to all users') if bulk_grant_permission_set_application_permissions.size.zero?
+  end
+end

--- a/app/models/bulk_grant_permission_set_application_permission.rb
+++ b/app/models/bulk_grant_permission_set_application_permission.rb
@@ -1,0 +1,7 @@
+class BulkGrantPermissionSetApplicationPermission < ActiveRecord::Base
+  belongs_to :bulk_grant_permission_set, inverse_of: :bulk_grant_permission_set_application_permissions
+  belongs_to :supported_permission
+
+  validates :bulk_grant_permission_set, :supported_permission, presence: true
+  validates :supported_permission_id, uniqueness: { scope: :bulk_grant_permission_set_id }
+end

--- a/app/models/supported_permission.rb
+++ b/app/models/supported_permission.rb
@@ -10,6 +10,7 @@ class SupportedPermission < ActiveRecord::Base
   default_scope { order(:name) }
   scope :delegatable, -> { where(delegatable: true) }
   scope :grantable_from_ui, -> { where(grantable_from_ui: true) }
+  scope :default, -> { where(default: true) }
 
 private
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -142,8 +142,12 @@ class User < ActiveRecord::Base
   def grant_application_permissions(application, supported_permission_names)
     supported_permission_names.map do |supported_permission_name|
       supported_permission = SupportedPermission.find_by_application_id_and_name(application.id, supported_permission_name)
-      application_permissions.where(supported_permission_id: supported_permission.id).first_or_create!
+      grant_permission(supported_permission)
     end
+  end
+
+  def grant_permission(supported_permission)
+    application_permissions.where(supported_permission_id: supported_permission.id).first_or_create!
   end
 
   # override Devise::Recoverable behavior to:

--- a/app/policies/bulk_grant_permission_set_policy.rb
+++ b/app/policies/bulk_grant_permission_set_policy.rb
@@ -1,0 +1,9 @@
+class BulkGrantPermissionSetPolicy < BasePolicy
+  def new?
+    return true if current_user.superadmin? || current_user.admin?
+
+    false
+  end
+  alias_method :create?, :new?
+  alias_method :show?, :new?
+end

--- a/app/views/batch_invitations/new.html.erb
+++ b/app/views/batch_invitations/new.html.erb
@@ -21,7 +21,7 @@
               <%= batch_invitation.batch_invitation_users.count %> users by <%= batch_invitation.user.name %> at <%= batch_invitation.created_at.to_s(:govuk_date) %>
             <% end %>
           </td>
-          <td><%= status_message(batch_invitation) %></td>
+          <td><%= batch_invite_status_message(batch_invitation) %></td>
         </tr>
       <% end %>
     </tbody>

--- a/app/views/batch_invitations/show.html.erb
+++ b/app/views/batch_invitations/show.html.erb
@@ -12,15 +12,15 @@
 
 <% if @batch_invitation.in_progress? %>
   <div class="alert alert-info">
-    <%= status_message(@batch_invitation) %>
+    <%= batch_invite_status_message(@batch_invitation) %>
   </div>
 <% elsif @batch_invitation.all_successful? %>
   <div class="alert alert-success">
-    <%= status_message(@batch_invitation) %>
+    <%= batch_invite_status_message(@batch_invitation) %>
   </div>
 <% else %>
   <div class="alert alert-danger">
-    <%= status_message(@batch_invitation) %>
+    <%= batch_invite_status_message(@batch_invitation) %>
   </div>
 <% end %>
 

--- a/app/views/bulk_grant_permission_sets/new.html.erb
+++ b/app/views/bulk_grant_permission_sets/new.html.erb
@@ -8,6 +8,16 @@
   <%= form_for @bulk_grant_permission_set do |f| %>
     <h2>Permissions to grant</h2>
 
+    <% if @bulk_grant_permission_set.errors.count > 0 %>
+      <div class="alert alert-danger">
+        <ul>
+          <% @bulk_grant_permission_set.errors.full_messages.each do |message| %>
+            <%= content_tag :li, message, data: track_analytics_data(:danger, message) %>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+
     <%= render partial: "shared/user_permissions", locals: { user_object: User.new } %>
 
     <%= f.submit "Grant permissions to all users", :class => 'btn btn-success' %>

--- a/app/views/bulk_grant_permission_sets/new.html.erb
+++ b/app/views/bulk_grant_permission_sets/new.html.erb
@@ -1,0 +1,15 @@
+<% content_for :title, "Grant permissions to all users" %>
+
+<div class="page-title">
+  <h1>Grant permissions to all users</h1>
+</div>
+
+<div class="well">
+  <%= form_for @bulk_grant_permission_set do |f| %>
+    <h2>Permissions to grant</h2>
+
+    <%= render partial: "shared/user_permissions", locals: { user_object: User.new } %>
+
+    <%= f.submit "Grant permissions to all users", :class => 'btn btn-success' %>
+  <% end %>
+</div>

--- a/app/views/bulk_grant_permission_sets/show.html.erb
+++ b/app/views/bulk_grant_permission_sets/show.html.erb
@@ -1,0 +1,53 @@
+<% content_for :title, "Granting permissions to all users" %>
+
+<% if @bulk_grant_permission_set.in_progress? %>
+  <% content_for(:content_for_head) do %>
+    <meta http-equiv="refresh" content="3">
+  <% end %>
+<% end %>
+
+<div class="page-title">
+  <h1>Granting permissions to all users</h1>
+</div>
+
+<div class="alert <%= bulk_grant_permission_set_status_class(@bulk_grant_permission_set) %>">
+  <%= bulk_grant_permission_set_status_message(@bulk_grant_permission_set) %>
+</div>
+
+<table class="table table-bordered table-striped table-on-white">
+  <thead>
+    <tr class="table-header">
+      <th>Application</th>
+      <th>Has access to?</th>
+      <th>Other Permissions</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% bulk_grant_permissions_by_application(@bulk_grant_permission_set).each do |(application, permissions)| %>
+      <tr>
+        <td>
+          <% if application.retired? %>
+            <del><%= application.name %></del>
+          <% else %>
+            <%= application.name %>
+          <% end %>
+        </td>
+        <td>
+          <% if permissions.include? application.signin_permission %>
+            Yes
+          <% else %>
+            No
+          <% end %>
+        </td>
+        <td>
+          <%= (permissions - [application.signin_permission]).map { |p| p.name }.to_sentence %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+
+<div class="well">
+  <%= link_to "All users", users_path, class: "btn btn-primary" %>
+</div>

--- a/app/views/root/signin_required.html.erb
+++ b/app/views/root/signin_required.html.erb
@@ -1,0 +1,11 @@
+<h1>Sorry, you don't have permission to access <%= @application.present? ? @application.name : 'this application' %></h1>
+
+<p>Please contact your Delivery Manager or main GDS contact if you need access.</p>
+
+<p>If you think something is wrong, try <%= link_to "signing out", destroy_user_session_path %> and then
+  <%- if @application.present? -%>
+    <%= link_to 'back in', @application.home_uri -%>
+  <%- else -%>
+    back in
+  <%- end %>.</p>
+

--- a/app/views/supported_permissions/_form.html.erb
+++ b/app/views/supported_permissions/_form.html.erb
@@ -24,6 +24,11 @@
         <%= f.check_box :delegatable %> <%= t('supported_permissions.form.delegatable') %>
       </label>
     </p>
+    <p class="checkbox">
+      <label>
+        <%= f.check_box :default %> <%= t('supported_permissions.form.default') %>
+      </label>
+    </p>
     <hr />
     <%= f.submit "Save permission", class: "btn btn-success" %>
   <% end %>

--- a/app/views/supported_permissions/index.html.erb
+++ b/app/views/supported_permissions/index.html.erb
@@ -27,6 +27,9 @@
         Can be delegated?
       </th>
       <th>
+        Is a default permission given to all new users?
+      </th>
+      <th>
         Actions
       </th>
     </tr>
@@ -42,6 +45,9 @@
         </td>
         <td class="delegatable">
           <%= supported_permission.delegatable? ? 'Yes' : 'No' %>
+        </td>
+        <td class="default">
+          <%= supported_permission.default? ? 'Yes' : 'No' %>
         </td>
         <td>
           <%= link_to 'Edit', edit_doorkeeper_application_supported_permission_path(@application, supported_permission) %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -5,7 +5,10 @@
   <div class="pull-right add-top-margin">
     <%= link_to "Create user", new_user_invitation_path, class: "btn btn-success add-right-margin" %>
     <% if policy(User).new? %>
-      <%= link_to "Upload a batch of users", new_batch_invitation_path, class: "btn btn-default" %>
+      <%= link_to "Upload a batch of users", new_batch_invitation_path, class: "btn btn-default add-right-margin" %>
+    <% end %>
+    <% if policy(BulkGrantPermissionSet).new? %>
+      <%= link_to "Grant permissions to all users", new_bulk_grant_permission_set_path, class: "btn btn-default" %>
     <% end %>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -26,6 +26,7 @@ en:
   supported_permissions:
     form:
       delegatable: 'Can be delegated'
+      default: 'Default permission added to all new users'
       placeholder:
         name: 'Name of application permission'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,6 +37,7 @@ Signon::Application.routes.draw do
   resource :user, only: [:show]
 
   resources :batch_invitations, only: [:new, :create, :show]
+  resources :bulk_grant_permission_sets, only: [:new, :create, :show]
   resources :organisations, only: [:index]
   resources :suspensions, only: [:edit, :update]
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Signon::Application.routes.draw do
-  use_doorkeeper
+  use_doorkeeper do
+    controllers authorizations: 'signin_required_authorizations'
+  end
 
   devise_for :users, controllers: {
     invitations: 'invitations',
@@ -63,6 +65,8 @@ Signon::Application.routes.draw do
   # Prototyping
   get '/phone-unavailable' => 'prototype#phone_unavailable'
   get '/recover-account'   => 'prototype#recover_account'
+
+  get '/signin-required' => 'root#signin_required'
 
   root to: 'root#index'
 end

--- a/db/migrate/20170816153804_add_bulk_grant_permission_sets.rb
+++ b/db/migrate/20170816153804_add_bulk_grant_permission_sets.rb
@@ -3,6 +3,8 @@ class AddBulkGrantPermissionSets < ActiveRecord::Migration
     create_table :bulk_grant_permission_sets do |t|
       t.belongs_to :user, null: false
       t.string :outcome
+      t.integer :processed_users, default: 0, null: false
+      t.integer :total_users, default: 0, null: false
       t.timestamps
     end
 

--- a/db/migrate/20170816153804_add_bulk_grant_permission_sets.rb
+++ b/db/migrate/20170816153804_add_bulk_grant_permission_sets.rb
@@ -1,0 +1,19 @@
+class AddBulkGrantPermissionSets < ActiveRecord::Migration
+  def change
+    create_table :bulk_grant_permission_sets do |t|
+      t.belongs_to :user, null: false
+      t.string :outcome
+      t.timestamps
+    end
+
+    create_table :bulk_grant_permission_set_application_permissions do |t|
+      t.belongs_to :bulk_grant_permission_set, null: false
+      t.belongs_to :supported_permission, null: false
+      t.timestamps
+    end
+
+    add_index :bulk_grant_permission_set_application_permissions, [:bulk_grant_permission_set_id, :supported_permission_id],
+                unique: true,
+                name: "index_app_permissions_on_bulk_grant_permission_set"
+  end
+end

--- a/db/migrate/20170818134716_add_default_flag_to_supported_permissions.rb
+++ b/db/migrate/20170818134716_add_default_flag_to_supported_permissions.rb
@@ -1,0 +1,5 @@
+class AddDefaultFlagToSupportedPermissions < ActiveRecord::Migration
+  def change
+    add_column :supported_permissions, :default, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20171107153427_add_default_permissions_and_bulk_grant_them_to_all_users.rb
+++ b/db/migrate/20171107153427_add_default_permissions_and_bulk_grant_them_to_all_users.rb
@@ -1,0 +1,36 @@
+require 'enhancements/application'
+
+class AddDefaultPermissionsAndBulkGrantThemToAllUsers < ActiveRecord::Migration
+  def up
+    support_app = Doorkeeper::Application.find_by!(name: 'Support')
+    content_preview_app = Doorkeeper::Application.find_by!(name: 'Content Preview')
+
+    say_with_time 'Marking signin on support and content preview as default permissions' do
+      support_app.signin_permission.update_attributes(default: true)
+
+      content_preview_app.signin_permission.update_attributes(default: true)
+    end
+
+    say_with_time 'Enqueuing bulk grant permissions job as a super admin to make sure all existing users have the default permissions' do
+      superadmin = User.with_status('active').where(role: 'superadmin').first
+      bulk_grant = BulkGrantPermissionSet.create!(
+        user: superadmin,
+        supported_permission_ids: [support_app.signin_permission.id, content_preview_app.signin_permission.id]
+      )
+      bulk_grant.enqueue
+    end
+  end
+
+  def down
+    # We can't undo the bulk grant because we don't know who had these
+    # permissions explicitly before we bulk granted them
+
+    say_with_time 'Removing default permission status from signin on support and content preview' do
+      content_preview_app = Doorkeeper::Application.find_by(name: 'Content Preview')
+      content_preview_app.signin_permission.update_attributes(default: false)
+
+      support_app = Doorkeeper::Application.find_by(name: 'Support')
+      support_app.signin_permission.update_attributes(default: false)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -44,6 +44,22 @@ ActiveRecord::Schema.define(version: 20171103151119) do
 
   add_index "batch_invitations", ["outcome"], name: "index_batch_invitations_on_outcome", using: :btree
 
+  create_table "bulk_grant_permission_set_application_permissions", force: :cascade do |t|
+    t.integer  "bulk_grant_permission_set_id", limit: 4, null: false
+    t.integer  "supported_permission_id",      limit: 4, null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "bulk_grant_permission_set_application_permissions", ["bulk_grant_permission_set_id", "supported_permission_id"], name: "index_app_permissions_on_bulk_grant_permission_set", unique: true, using: :btree
+
+  create_table "bulk_grant_permission_sets", force: :cascade do |t|
+    t.integer  "user_id",    limit: 4,   null: false
+    t.string   "outcome",    limit: 255
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
   create_table "event_logs", force: :cascade do |t|
     t.string   "uid",              limit: 255, null: false
     t.datetime "created_at",                   null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -153,6 +153,7 @@ ActiveRecord::Schema.define(version: 20171103151119) do
     t.datetime "updated_at"
     t.boolean  "delegatable",                   default: false
     t.boolean  "grantable_from_ui",             default: true,  null: false
+    t.boolean  "default",                       default: false, null: false
   end
 
   add_index "supported_permissions", ["application_id", "name"], name: "index_supported_permissions_on_application_id_and_name", unique: true, using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -54,8 +54,10 @@ ActiveRecord::Schema.define(version: 20171103151119) do
   add_index "bulk_grant_permission_set_application_permissions", ["bulk_grant_permission_set_id", "supported_permission_id"], name: "index_app_permissions_on_bulk_grant_permission_set", unique: true, using: :btree
 
   create_table "bulk_grant_permission_sets", force: :cascade do |t|
-    t.integer  "user_id",    limit: 4,   null: false
-    t.string   "outcome",    limit: 255
+    t.integer  "user_id",         limit: 4,               null: false
+    t.string   "outcome",         limit: 255
+    t.integer  "processed_users", limit: 4,   default: 0, null: false
+    t.integer  "total_users",     limit: 4,   default: 0, null: false
     t.datetime "created_at"
     t.datetime "updated_at"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171103151119) do
+ActiveRecord::Schema.define(version: 20171107153427) do
 
   create_table "batch_invitation_application_permissions", force: :cascade do |t|
     t.integer  "batch_invitation_id",     limit: 4, null: false

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -11,10 +11,6 @@ namespace :users do
     permissions = ENV.fetch('permissions', '').split(',').uniq
 
     applications.each do |application|
-      unsupported_permissions = permissions - application.supported_permission_strings
-      if unsupported_permissions.any?
-        raise UnsupportedPermissionError, "Cannot grant '#{unsupported_permissions.join("', '")}' permission(s), they are not supported by the '#{application.name}' application"
-      end
       user.grant_application_permission(application, 'signin')
     end
 

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -3,22 +3,13 @@ namespace :users do
   task create: :environment do
     raise "Requires name, email and applications specified in environment" unless ENV['name'] && ENV['email'] && ENV['applications']
 
-    applications = ENV['applications'].split(',').uniq.map do |application_name|
-      Doorkeeper::Application.find_by_name!(application_name)
-    end
+    user_creator = UserCreator.new(ENV['name'], ENV['email'], ENV['applications'])
+    user_creator.create_user!
 
-    user = User.invite!(name: ENV['name'].dup, email: ENV['email'].dup)
-    permissions = ENV.fetch('permissions', '').split(',').uniq
-
-    applications.each do |application|
-      user.grant_application_permission(application, 'signin')
-    end
-
-    invitation_url = "#{Plek.find('signon')}/users/invitation/accept?invitation_token=#{user.raw_invitation_token}"
-    puts "User created: user.name <#{user.name}>"
-    puts "              user.email <#{user.email}>"
-    puts "              signin permissions for: '#{applications.map(&:name).join("', '")}' "
-    puts "              follow this link to set a password: #{invitation_url}"
+    puts "User created: user.name <#{user_creator.user.name}>"
+    puts "              user.email <#{user_creator.user.email}>"
+    puts "              signin permissions for: '#{user_creator.applications.map(&:name).join("', '")}' "
+    puts "              follow this link to set a password: #{user_creator.invitation_url}"
   end
 
   desc "Remind users that their account will get suspended"

--- a/lib/user_creator.rb
+++ b/lib/user_creator.rb
@@ -10,16 +10,13 @@ class UserCreator
   end
 
   def applications
-    @applications ||= (application_names.split(',')).uniq.map do |application_name|
-      Doorkeeper::Application.find_by_name!(application_name)
-    end
+    @applications ||= extract_applications_from_names
   end
 
   def create_user!
     @user = User.invite!(name: name, email: email)
-    applications.each do |application|
-      @user.grant_application_permission(application, 'signin')
-    end
+    grant_requested_signin_permissions
+    grant_default_permissions
   end
 
   def invitation_url
@@ -29,4 +26,22 @@ class UserCreator
 private
 
   attr_reader :name, :email, :application_names
+
+  def extract_applications_from_names
+    (application_names.split(',')).uniq.map do |application_name|
+      Doorkeeper::Application.find_by_name!(application_name)
+    end
+  end
+
+  def grant_requested_signin_permissions
+    applications.each do |application|
+      user.grant_application_permission(application, 'signin')
+    end
+  end
+
+  def grant_default_permissions
+    SupportedPermission.default.each do |default_permission|
+      user.grant_permission(default_permission)
+    end
+  end
 end

--- a/lib/user_creator.rb
+++ b/lib/user_creator.rb
@@ -1,0 +1,32 @@
+require 'plek'
+
+class UserCreator
+  attr_reader :user
+
+  def initialize(name, email, application_names)
+    @name = name.dup
+    @email = email.dup
+    @application_names = application_names.dup
+  end
+
+  def applications
+    @applications ||= (application_names.split(',')).uniq.map do |application_name|
+      Doorkeeper::Application.find_by_name!(application_name)
+    end
+  end
+
+  def create_user!
+    @user = User.invite!(name: name, email: email)
+    applications.each do |application|
+      @user.grant_application_permission(application, 'signin')
+    end
+  end
+
+  def invitation_url
+    "#{Plek.find('signon')}/users/invitation/accept?invitation_token=#{user.raw_invitation_token}"
+  end
+
+private
+
+  attr_reader :name, :email, :application_names
+end

--- a/spec/policies/bulk_grant_permission_set_policy_spec.rb
+++ b/spec/policies/bulk_grant_permission_set_policy_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+describe BulkGrantPermissionSetPolicy do
+  subject { described_class }
+
+  permissions :new? do
+    it 'allows superadmins to create new bulk grant permission sets' do
+      expect(subject).to permit(create(:superadmin_user), BulkGrantPermissionSet.new)
+    end
+
+    it 'allows admins to create new bulk grant permission sets' do
+      expect(subject).to permit(create(:admin_user), BulkGrantPermissionSet.new)
+    end
+
+    it 'is forbidden for super organisation admins' do
+      expect(subject).not_to permit(create(:super_org_admin), BulkGrantPermissionSet.new)
+    end
+
+    it 'is forbidden for organisation admins' do
+      expect(subject).not_to permit(create(:organisation_admin), BulkGrantPermissionSet.new)
+    end
+
+    it 'is forbidden for normal users' do
+      expect(subject).not_to permit(create(:user), BulkGrantPermissionSet.new)
+    end
+  end
+end

--- a/test/controllers/root_controller_test.rb
+++ b/test/controllers/root_controller_test.rb
@@ -33,17 +33,6 @@ class RootControllerTest < ActionController::TestCase
     get :index
 
     assert_select "h3", "Everybody app"
-    assert_select "h3", "Support"
-    assert_select "h3", count: 2
-  end
-
-  # Because currently, permissions aren't required for the Support app
-  test "Your Applications should include the 'Support' app if it exists, whether or not you have signin permission" do
-    user = create(:user)
-    sign_in user
-
-    get :index
-
-    assert_select "h3", "Support"
+    assert_select "h3", count: 1
   end
 end

--- a/test/controllers/signin_required_authorizations_controller_test.rb
+++ b/test/controllers/signin_required_authorizations_controller_test.rb
@@ -1,0 +1,231 @@
+require 'test_helper'
+
+class SigninRequiredAuthorizationsControllerTest < ActionController::TestCase
+  def fragments(param)
+    fragment = URI.parse(response.location).fragment
+    Rack::Utils.parse_query(fragment)[param]
+  end
+
+  def translated_error_message(key)
+    I18n.translate key, scope: [:doorkeeper, :errors, :messages]
+  end
+
+  def default_scopes_exist(*scopes)
+    Doorkeeper.configuration.stubs(default_scopes: Doorkeeper::OAuth::Scopes.from_array(scopes))
+  end
+
+  def auth_type_is_allowed(*grant_flows)
+    Doorkeeper.configuration.stubs(grant_flows: grant_flows)
+    # for some reason this value isn't being recalculated between tests
+    # so we stub it too
+    Doorkeeper.configuration.stubs(authorization_response_types: Doorkeeper.configuration.send(:calculate_authorization_response_types))
+  end
+
+  setup do
+    @application = create(:application)
+    @user = create(:user, with_signin_permissions_for: [@application])
+    auth_type_is_allowed("implicit")
+    @controller.stubs(current_resource_owner: @user)
+  end
+
+  context 'POST #create' do
+    setup do
+      post :create, client_id: @application.uid, response_type: 'token', redirect_uri: @application.redirect_uri
+    end
+
+    should 'redirect after authorization' do
+      assert_response :redirect
+    end
+
+    should 'redirect to client redirect uri' do
+      assert_redirected_to(/^#{@application.redirect_uri}/)
+    end
+
+    should 'include access token in fragment' do
+      assert_equal Doorkeeper::AccessToken.first.token, fragments('access_token')
+    end
+
+    should 'include token type in fragment' do
+      assert_equal 'bearer', fragments('token_type')
+    end
+
+    should 'include token expiration in fragment' do
+      assert_equal 2.hours.to_i, fragments('expires_in').to_i
+    end
+
+    should 'issue the token for the current client' do
+      assert_equal @application.id, Doorkeeper::AccessToken.first.application_id
+    end
+
+    should 'issue the token for the current resource owner' do
+      assert_equal @user.id, Doorkeeper::AccessToken.first.resource_owner_id
+    end
+  end
+
+  context 'POST #create with errors' do
+    setup do
+      default_scopes_exist :public
+      post :create, client_id: @application.uid, response_type: 'token', scope: 'invalid', redirect_uri: @application.redirect_uri
+    end
+
+    should 'redirect after authorization' do
+      assert_response :redirect
+    end
+
+    should 'redirect to client redirect uri' do
+      assert_redirected_to(/^#{@application.redirect_uri}/)
+    end
+
+    should 'not include access token in fragment' do
+      assert_nil fragments('access_token')
+    end
+
+    should 'include error in fragment' do
+      assert_equal 'invalid_scope', fragments('error')
+    end
+
+    should 'include error description in fragment' do
+      assert_equal translated_error_message(:invalid_scope), fragments('error_description')
+    end
+
+    should 'not issue any access token' do
+      assert Doorkeeper::AccessToken.all.empty?
+    end
+  end
+
+  context 'POST #create when the user does not have signin permission for the app' do
+    setup do
+      @user.application_permissions.where(supported_permission_id: @application.signin_permission).destroy_all
+      @user.application_permissions.reload
+      post :create, client_id: @application.uid, response_type: 'token', redirect_uri: @application.redirect_uri
+    end
+
+    should 'redirect after authorization' do
+      assert_response :redirect
+    end
+
+    should 'redirect to signin required error path' do
+      assert_redirected_to signin_required_path
+    end
+
+    should 'not issue any access token' do
+      assert Doorkeeper::AccessToken.all.empty?
+    end
+  end
+
+  context 'GET #new token request with native url and skip_authorization true' do
+    setup do
+      # technically redundant as this is our configuration anyway
+      Doorkeeper.configuration.stubs(skip_authorization: ->(*_args) { true })
+      @application.update_attribute :redirect_uri, 'urn:ietf:wg:oauth:2.0:oob'
+      get :new, client_id: @application.uid, response_type: 'token', redirect_uri: @application.redirect_uri
+    end
+
+    should 'redirect immediately' do
+      assert_response :redirect
+      assert_redirected_to(/oauth\/token\/info\?access_token=/)
+    end
+
+    should 'not issue a grant' do
+      assert_equal 0, Doorkeeper::AccessGrant.count
+    end
+
+    should 'issue a token' do
+      assert_equal 1, Doorkeeper::AccessToken.count
+    end
+  end
+
+  context 'GET #new code request with native url and skip_authorization true' do
+    setup do
+      auth_type_is_allowed 'authorization_code'
+      # technically redundant as this is our configuration anyway
+      Doorkeeper.configuration.stubs(skip_authorization: ->(*_args) { true })
+      @application.update_attribute :redirect_uri, 'urn:ietf:wg:oauth:2.0:oob'
+      get :new, client_id: @application.uid, response_type: 'code', redirect_uri: @application.redirect_uri
+    end
+
+    should 'redirect immediately' do
+      assert_response :redirect
+      assert_redirected_to(/oauth\/authorize\//)
+    end
+
+    should 'issue a grant' do
+      assert_equal 1, Doorkeeper::AccessGrant.count
+    end
+
+    should 'not issue a token' do
+      assert_equal 0, Doorkeeper::AccessToken.count
+    end
+  end
+
+  context 'GET #new with skip_authorization true' do
+    setup do
+      # technically redundant as this is our configuration anyway
+      Doorkeeper.configuration.stubs(skip_authorization: ->(*_args) { true })
+      get :new, client_id: @application.uid, response_type: 'token', redirect_uri: @application.redirect_uri
+    end
+
+    should 'redirect immediately' do
+      assert_response :redirect
+      assert_redirected_to(/^#{@application.redirect_uri}/)
+    end
+
+    should 'issue a token' do
+      assert_equal 1, Doorkeeper::AccessToken.count
+    end
+
+    should 'include token type in fragment' do
+      assert_equal 'bearer', fragments('token_type')
+    end
+
+    should 'include token expiration in fragment' do
+      assert_equal 2.hours.to_i, fragments('expires_in').to_i
+    end
+
+    should 'issue the token for the current client' do
+      assert_equal @application.id, Doorkeeper::AccessToken.first.application_id
+    end
+
+    should 'issue the token for the current resource owner' do
+      assert_equal @user.id, Doorkeeper::AccessToken.first.resource_owner_id
+    end
+  end
+
+  context 'GET #new with errors' do
+    setup do
+      default_scopes_exist :public
+      get :new, an_invalid: 'request'
+    end
+
+    should 'not redirect' do
+      assert_response :ok
+    end
+
+    should 'not issue any token' do
+      assert_equal 0, Doorkeeper::AccessGrant.count
+      assert_equal 0, Doorkeeper::AccessToken.count
+    end
+  end
+
+  context 'GET #new with skip_authorization true when the user does not have signin permission for the app' do
+    setup do
+      @user.application_permissions.where(supported_permission_id: @application.signin_permission).destroy_all
+      @user.application_permissions.reload
+      # technically redundant as this is our configuration anyway
+      Doorkeeper.configuration.stubs(skip_authorization: ->(*_args) { true })
+      get :new, client_id: @application.uid, response_type: 'token', redirect_uri: @application.redirect_uri
+    end
+
+    should 'redirect after authorization' do
+      assert_response :redirect
+    end
+
+    should 'redirect to signin required error path' do
+      assert_redirected_to signin_required_path
+    end
+
+    should 'not issue any access token' do
+      assert Doorkeeper::AccessToken.all.empty?
+    end
+  end
+end

--- a/test/controllers/signin_required_authorizations_controller_test.rb
+++ b/test/controllers/signin_required_authorizations_controller_test.rb
@@ -28,6 +28,15 @@ class SigninRequiredAuthorizationsControllerTest < ActionController::TestCase
     @controller.stubs(current_resource_owner: @user)
   end
 
+  test 'warn if doorkeeper has been updated' do
+    # We extracted SigninRequiredAuthorizationsController and its tests from
+    # those for Doorkeeper::AuthorizationsController in version 4.2.0 it's very
+    # possible that future versions of doorkeeper change the implementation or
+    # tests and we should keep our versions up to date.  They may also have
+    # introduced a better way for us to customise the behaviour.
+    assert_equal SigninRequiredAuthorizationsController::EXPECTED_DOORKEEPER_VERSION, Doorkeeper::VERSION, "SigninRequiredAuthorizationsController was extracted from Doorkeeper::AuthorizationsController and has been checked against version #{SigninRequiredAuthorizationsController::EXPECTED_DOORKEEPER_VERSION} of the Gem.  It's now #{Doorkeeper::VERSION} so review the new version to check for updates."
+  end
+
   context 'POST #create' do
     setup do
       post :create, client_id: @application.uid, response_type: 'token', redirect_uri: @application.redirect_uri

--- a/test/controllers/supported_permissions_controller_test.rb
+++ b/test/controllers/supported_permissions_controller_test.rb
@@ -15,6 +15,7 @@ class SupportedPermissionsControllerTest < ActionController::TestCase
       assert_select "h1", /My first app/
       assert_select "td[class=name]", /permission1/
       assert_select "td[class=delegatable]", /Yes/
+      assert_select "td[class=default]", /No/
       assert_select "a[id='add']", true
     end
   end
@@ -26,6 +27,8 @@ class SupportedPermissionsControllerTest < ActionController::TestCase
       assert_select "h1", /Add permission/
       assert_select ".breadcrumb li", /My first app/
       assert_select "input[name='supported_permission[name]']", true
+      assert_select "input[name='supported_permission[delegatable]']", true
+      assert_select "input[name='supported_permission[default]']", true
     end
   end
 
@@ -42,36 +45,53 @@ class SupportedPermissionsControllerTest < ActionController::TestCase
     should "create a new permission" do
       app = create(:application, name: "My first app")
 
-      post :create, doorkeeper_application_id: app.id, supported_permission: { name: "permission1" }
+      post :create, doorkeeper_application_id: app.id, supported_permission: { name: "permission1", default: '1' }
 
       assert_redirected_to(controller: "supported_permissions", action: :index)
       assert_equal "Successfully added permission permission1 to My first app", flash[:notice]
-      assert_equal app.reload.supported_permissions.first.name, "permission1"
+      new_permission = app.reload.supported_permissions.first
+      assert_equal new_permission.name, "permission1"
+      assert new_permission.default
     end
   end
 
   context "PUT update" do
     should "show error if name is not provided and not edit the permission" do
       app = create(:application, name: "My first app")
-      perm = create(:supported_permission, application_id: app.id,
-                                  name: "permission1", delegatable: true, created_at: 2.days.ago)
+      perm = create(
+        :supported_permission,
+        application_id: app.id,
+        name: "permission1",
+        delegatable: true,
+        default: true,
+        created_at: 2.days.ago
+      )
 
-      put :update, doorkeeper_application_id: app.id, id: perm.id, supported_permission: { name: "", delegatable: false }
+      put :update, doorkeeper_application_id: app.id, id: perm.id, supported_permission: { name: "", delegatable: '0', default: '0' }
 
       assert_select "ul[class='errors'] li", "Name can't be blank"
-      assert perm.reload.delegatable
+      perm.reload
+      assert perm.delegatable
+      assert perm.default
     end
 
     should "edit permission" do
       app = create(:application, name: "My first app")
-      perm = create(:supported_permission, application_id: app.id,
-                                  name: "permission1", delegatable: true, created_at: 2.days.ago)
+      perm = create(
+        :supported_permission,
+        application_id: app.id,
+        name: "permission1",
+        delegatable: true,
+        default: true,
+        created_at: 2.days.ago)
 
-      put :update, doorkeeper_application_id: app.id, id: perm.id, supported_permission: { delegatable: false }
+      put :update, doorkeeper_application_id: app.id, id: perm.id, supported_permission: { delegatable: '0', default: '0' }
 
       assert_redirected_to(controller: "supported_permissions", action: :index)
       assert_equal "Successfully updated permission permission1", flash[:notice]
-      refute perm.reload.delegatable
+      perm.reload
+      refute perm.delegatable
+      refute perm.default
     end
   end
 end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -237,14 +237,14 @@ class UsersControllerTest < ActionController::TestCase
       assert_not_nil user.application_permissions.first.last_synced_at
     end
 
-    should "fetching json profile should succeed even if no permission for relevant app" do
+    should "fetching json profile should fail if no signin permission for relevant app" do
       user = create(:user)
       token = create(:access_token, application: @application, resource_owner_id: user.id)
 
       @request.env['HTTP_AUTHORIZATION'] = "Bearer #{token.token}"
       get :show, {client_id: @application.uid, format: :json}
 
-      assert_response :ok
+      assert_response :unauthorized
     end
   end
 

--- a/test/factories/bulk_grant_permission_set.rb
+++ b/test/factories/bulk_grant_permission_set.rb
@@ -1,0 +1,16 @@
+FactoryGirl.define do
+  factory :bulk_grant_permission_set do
+    transient do
+      with_permissions { [create(:supported_permission)] }
+    end
+
+    association :user, factory: :admin_user
+    after(:build) do |permission_set, evaluator|
+      if evaluator.with_permissions
+        evaluator.with_permissions.each do |supported_permission|
+          permission_set.bulk_grant_permission_set_application_permissions.build(supported_permission: supported_permission)
+        end
+      end
+    end
+  end
+end

--- a/test/factories/supported_permission.rb
+++ b/test/factories/supported_permission.rb
@@ -1,5 +1,6 @@
 FactoryGirl.define do
   factory :supported_permission, aliases: [:non_delegatable_supported_permission] do
+    sequence(:name) { |n| "Permission ##{n}" }
     association :application, factory: :application
   end
 

--- a/test/integration/bulk_granting_permisions_test.rb
+++ b/test/integration/bulk_granting_permisions_test.rb
@@ -1,0 +1,115 @@
+require 'test_helper'
+
+class BulkGrantingPermissionsTest < ActionDispatch::IntegrationTest
+  include ActiveJob::TestHelper
+
+  setup do
+    @users = create_list(:user, 2)
+    @org_admins = create_list(:organisation_admin, 2)
+    @admins = create_list(:admin_user, 2)
+    @superadmins = create_list(:superadmin_user, 2)
+
+    @application_one = create(:application, with_supported_permissions: %w(signin admin editor))
+    @application_two = create(:application, with_supported_permissions: %w(signin reviewer))
+  end
+
+  should "superadmin user can grant multiple permissions to all users in one go" do
+    user = create(:superadmin_user)
+
+    permissions = {
+      @application_one => %w(signin editor),
+      @application_two => ['reviewer']
+    }
+
+    perform_bulk_grant_as_user(user, permissions)
+  end
+
+  should "admin user can grant multiple permissions to all users in one go" do
+    user = create(:admin_user)
+
+    permissions = {
+      @application_one => %w(signin editor),
+      @application_two => ['reviewer']
+    }
+
+    perform_bulk_grant_as_user(user, permissions)
+  end
+
+  should "super organisation admin user can not grant multiple permissions to all users in one go" do
+    user = create(:super_org_admin)
+
+    visit root_path
+    signin_with(user)
+
+    visit new_bulk_grant_permission_set_path
+    assert_equal root_path, current_path
+  end
+
+  should "organisation admin user can not grant multiple permissions to all users in one go" do
+    user = create(:organisation_admin)
+
+    visit root_path
+    signin_with(user)
+
+    visit new_bulk_grant_permission_set_path
+    assert_equal root_path, current_path
+  end
+
+  should "normal user can not grant multiple permissions to all users in one go" do
+    user = create(:user)
+
+    visit root_path
+    signin_with(user)
+
+    visit new_bulk_grant_permission_set_path
+    assert_equal root_path, current_path
+  end
+
+  def perform_bulk_grant_as_user(acting_user, permissions)
+    perform_enqueued_jobs do
+      visit root_path
+      signin_with(acting_user)
+
+      visit new_bulk_grant_permission_set_path
+
+      permissions.each do |application, app_permissions|
+        app_permissions.each do |app_permission|
+          if app_permission == 'signin'
+            check "Has access to #{application.name}?"
+          else
+            select app_permission, from: "Permissions for #{application.name}"
+          end
+        end
+      end
+
+      click_button "Grant permissions to all users"
+
+      assert_response_contains("Scheduled grant of #{permissions.map { |_app, perms| perms.count }.inject(:+)} permissions to all users")
+      assert_response_contains("Granting permissions to all users")
+      assert_response_contains("All #{User.all.count} users processed")
+
+      permissions.each do |application, app_permissions|
+        app_permissions_line = "#{application.name} "
+        app_permissions_line <<
+          if app_permissions.include? 'signin'
+            'Yes '
+          else
+            'No '
+          end
+        app_permissions_line << (app_permissions - ['signin']).sort.to_sentence
+        assert_response_contains app_permissions_line
+      end
+
+      [acting_user, @users, @org_admins, @admins, @superadmins].flatten.each do |user|
+        user.reload
+        assert_has_permissions user, permissions
+      end
+    end
+  end
+
+  def assert_has_permissions(user, permissions)
+    permissions.each do |application, app_permissions|
+      assert_equal app_permissions.sort, user.permissions_for(application).sort
+    end
+  end
+end

--- a/test/integration/bulk_granting_permisions_test.rb
+++ b/test/integration/bulk_granting_permisions_test.rb
@@ -35,6 +35,20 @@ class BulkGrantingPermissionsTest < ActionDispatch::IntegrationTest
     perform_bulk_grant_as_user(user, permissions)
   end
 
+  should "present errors when no permissions are selected to grant" do
+    user = create(:admin_user)
+
+    visit root_path
+    signin_with(user)
+
+    visit new_bulk_grant_permission_set_path
+
+    click_button "Grant permissions to all users"
+
+    assert_response_contains("Couldn't schedule granting 0 permissions to all users")
+    assert_response_contains("Supported permissions must not be blank. Choose at least one permission to grant to all users.")
+  end
+
   should "super organisation admin user can not grant multiple permissions to all users in one go" do
     user = create(:super_org_admin)
 

--- a/test/models/bulk_grant_permission_set_test.rb
+++ b/test/models/bulk_grant_permission_set_test.rb
@@ -1,0 +1,98 @@
+require 'test_helper'
+
+class BulkGrantPermissionSetTest < ActiveSupport::TestCase
+  setup do
+    @app = create(:application)
+    @permission_set = create(:bulk_grant_permission_set, with_permissions: [@app.signin_permission])
+  end
+
+  should "require a user" do
+    permission_set = build(:bulk_grant_permission_set, user: nil)
+
+    refute permission_set.valid?
+    assert_equal ["can't be blank"], permission_set.errors[:user]
+  end
+
+  should "require at least one supported permission" do
+    permission_set = build(:bulk_grant_permission_set, with_permissions: [])
+
+    refute permission_set.valid?
+    assert_equal ["must add at least one permission to grant to all users"], permission_set.errors[:supported_permissions]
+  end
+
+  context "validating #outcome" do
+    should "allow nil" do
+      permission_set = build(:bulk_grant_permission_set, outcome: nil)
+
+      assert permission_set.valid?
+    end
+
+    should "allow 'success'" do
+      permission_set = build(:bulk_grant_permission_set, outcome: 'success')
+
+      assert permission_set.valid?
+    end
+
+    should "allow 'fail'" do
+      permission_set = build(:bulk_grant_permission_set, outcome: 'fail')
+
+      assert permission_set.valid?
+    end
+
+    should "reject other values" do
+      permission_set = build(:bulk_grant_permission_set, outcome: 'unsucessful')
+
+      refute permission_set.valid?
+      assert_equal ["is not included in the list"], permission_set.errors[:outcome]
+    end
+  end
+
+  context "perform" do
+    should "grant the supplied permissions to all users" do
+      user = create(:user)
+      admin_user = create(:admin_user)
+      superadmin_user = create(:superadmin_user)
+      orgadmin_user = create(:organisation_admin)
+
+      @permission_set.perform
+
+      assert_equal %w(signin), user.permissions_for(@app)
+      assert_equal %w(signin), admin_user.permissions_for(@app)
+      assert_equal %w(signin), superadmin_user.permissions_for(@app)
+      assert_equal %w(signin), orgadmin_user.permissions_for(@app)
+    end
+
+    should "record the outcome against the BulkGrantPermissionSet" do
+      @permission_set.perform
+      assert_equal "success", @permission_set.outcome
+    end
+
+    should "not fail if a user already has one of the supplied permissions" do
+      user = create(:user, with_permissions: { @app => %w(signin) })
+
+      @permission_set.perform
+
+      assert_equal %w(signin), user.permissions_for(@app)
+    end
+
+    should "not remove permissions a user has that are not part of the supplied ones for the bulk grant set" do
+      other_app = create(:application, with_supported_permissions: %w(editor))
+      create(:supported_permission, application: @app, name: 'admin')
+      user = create(:user, with_permissions: { other_app => %w(editor), @app => %w(admin) })
+
+      @permission_set.perform
+
+      assert_equal %w(editor), user.permissions_for(other_app)
+      assert_equal %w(signin admin).sort, user.permissions_for(@app).sort
+    end
+
+    should "mark it as failed if there is an error during processing and pass the error on for the worker to record the error details" do
+      UserApplicationPermission.any_instance.expects(:save!).raises("ArbitraryError")
+
+      assert_raises RuntimeError, "ArbitraryError" do
+        @permission_set.perform
+      end
+      assert_equal "fail", @permission_set.outcome
+    end
+  end
+end

--- a/test/models/bulk_grant_permission_set_test.rb
+++ b/test/models/bulk_grant_permission_set_test.rb
@@ -17,7 +17,7 @@ class BulkGrantPermissionSetTest < ActiveSupport::TestCase
     permission_set = build(:bulk_grant_permission_set, with_permissions: [])
 
     refute permission_set.valid?
-    assert_equal ["must add at least one permission to grant to all users"], permission_set.errors[:supported_permissions]
+    assert_equal ["must not be blank. Choose at least one permission to grant to all users."], permission_set.errors[:supported_permissions]
   end
 
   context "validating #outcome" do

--- a/test/models/lib/user_creator_test.rb
+++ b/test/models/lib/user_creator_test.rb
@@ -1,0 +1,34 @@
+require 'test_helper'
+
+class UserCreatorTest < ActiveSupport::TestCase
+  test 'it creates a new user with the supplied name and email' do
+    FactoryGirl.create(:application, name: 'app-o-tron', with_supported_permissions: ['signin'])
+    user_creator = UserCreator.new('Alicia', 'alicia@example.com', 'app-o-tron')
+
+    user_creator.create_user!
+
+    assert user_creator.user.persisted?
+    assert_equal 'Alicia', user_creator.user.name
+    assert_equal 'alicia@example.com', user_creator.user.email
+  end
+
+  test 'invites the new user, so they must validate their email before they can signin' do
+    FactoryGirl.create(:application, name: 'app-o-tron', with_supported_permissions: ['signin'])
+    user_creator = UserCreator.new('Alicia', 'alicia@example.com', 'app-o-tron')
+
+    user_creator.create_user!
+
+    assert user_creator.user.invited_but_not_yet_accepted?
+  end
+
+  test 'it grants "signin" permission to each application supplied' do
+    app_o_tron = FactoryGirl.create(:application, name: 'app-o-tron', with_supported_permissions: ['signin'])
+    app_erator = FactoryGirl.create(:application, name: 'app-erator', with_supported_permissions: ['signin'])
+    user_creator = UserCreator.new('Alicia', 'alicia@example.com', 'app-o-tron,app-erator')
+
+    user_creator.create_user!
+
+    assert user_creator.user.has_access_to? app_o_tron
+    assert user_creator.user.has_access_to? app_erator
+  end
+end

--- a/test/models/lib/user_creator_test.rb
+++ b/test/models/lib/user_creator_test.rb
@@ -31,4 +31,18 @@ class UserCreatorTest < ActiveSupport::TestCase
     assert user_creator.user.has_access_to? app_o_tron
     assert user_creator.user.has_access_to? app_erator
   end
+
+  test 'it grants all default permissions, even if not signin' do
+    app_o_tron = FactoryGirl.create(:application, name: 'app-o-tron', with_supported_permissions: %w(signin))
+    app_erator = FactoryGirl.create(:application, name: 'app-erator', with_supported_permissions: %w(signin fall))
+    create(:supported_permission, application: app_o_tron, name: 'bounce', default: true)
+    app_erator.signin_permission.update_attributes(default: true)
+    user_creator = UserCreator.new('Alicia', 'alicia@example.com', '')
+
+    user_creator.create_user!
+
+    created_user = user_creator.user
+    assert_equal ['bounce'], created_user.permissions_for(app_o_tron)
+    assert_equal ['signin'], created_user.permissions_for(app_erator)
+  end
 end

--- a/test/models/supported_permission_test.rb
+++ b/test/models/supported_permission_test.rb
@@ -27,4 +27,24 @@ class SupportedPermissionTest < ActiveSupport::TestCase
 
     assert_empty user.reload.application_permissions
   end
+
+  test 'we can find all the default permissions' do
+    application_one = create(:application)
+    permission_one = create(:supported_permission, application: application_one, name: 'writer')
+    permission_two = create(:supported_permission, application: application_one, name: 'reader', default: true)
+    permission_three = create(:supported_permission, application: application_one, name: 'critic')
+
+    application_two = create(:application)
+    application_two.signin_permission.update_attributes(default: true)
+    permission_four = create(:supported_permission, application: application_two, name: 'ignorer', default: true)
+
+    default_permissions = SupportedPermission.default
+    assert default_permissions.include? permission_two
+    assert default_permissions.include? permission_four
+    assert default_permissions.include? application_two.signin_permission
+
+    refute default_permissions.include? permission_one
+    refute default_permissions.include? permission_three
+    refute default_permissions.include? application_one.signin_permission
+  end
 end


### PR DESCRIPTION
For: https://trello.com/c/c4bgclDp/195-implement-rfc-78-make-signon-handle-signin-permission-during-oauth

Implements: https://github.com/alphagov/govuk-rfcs/blob/8cbb2a0de86de02f54ae37b245e79b46ad62cb6a/rfc-078-re-architect-signin-permissions-in-signon.md

This is a work-in-progress that I'm pushing up to get some extra eyes on it earlier rather than later.  In particular, I'm interested in any thoughts people have on the 2nd commit [`Add signin permission requirement to doorkeeper_authorize!`](8820988eefbd9258abe7f6d4f75630159c3ce90a) as I'm not 100% sure it's a required change.  I would definitely be grateful for any advice from people who know a bunch of stuff about oauth.

### Todo

- [x] Signon MUST check for 'signin' permission during the oauth handshake with an application and reject users that do not have this permission. (commits 1 and 2 in this PR)
- [x] Signon MUST allow a super admin to grant permissions to all users in one go. (commits 3-9 in this PR)
- [x] Signon SHOULD allow super admins to mark permissions for an application as 'default' meaning it is added to all new users. (commits 10-13 - mostly repurposed from #553)
- [x] gds-sso SHOULD deprecate require_signin_permission!. (https://github.com/alphagov/gds-sso/pull/119)
- [x] applications using signon SHOULD be audited to make sure they will continue to function after these changes are made - see https://docs.google.com/spreadsheets/d/1ypHdDHaHJZELkdQC3xQprMxJpkPCLTfnJPsEtPhhENI/edit#gid=0
- [x] applications using signon SHOULD be audited to collect the set of default permissions that should be created and bulk granted to all existing users.
- [x] ~~omniauth-gds SHOULD deprecate whatever it does with signin permissions~~ omniauth-gds doesn't do anything wrt signin permissions, each app that uses it does this manually

Some of these will be completed by doing work in other repos, I'll link to the relevant PRs when they're done.

This will be easiest reviewed commit-by-commit as it's a big change, however, github has messed up the commit order.  To review in the correct order do them in this sequence (it's the git graph order, not the date order that github shows):

1. 1656e10c6243c4cb8d01c19c3ac58c3bf3d7f4d5 Require signin permission to complete oauth authorisation
2. 9c1c76057636a21beb250fee844debeff2986ba1 Add signin permission requirement to doorkeeper_authorize!
3. 3ab1b9f644e25ea9a290c5262ce7f2d27c705cf1 Add name to supported_permissions factory
4. 718077d77c971a944e06d5b614924e441d1372d7 Introduce BulkGrantPermissionSet model and job
5. 55f7246417d8922cb3ce05a9edfe9a4c7bda8913 Rename status_message helper to batch_invite_status_message
6. cdf24b88d582cf4acc8ad2b1af90fa29fb7d0582 Add processed and total user counts to bulk grant permission set
7. f63e48d1e23336b6728eb68e6489caab0bc6f498 Restrict bulk grant permission set to admins and superadmins
8. 03e56b135e7f4b2211a1f7c3045e509d600a3f60 Add UI to allow bulk granting permissions
9. 03eda8786c0923b0facd84027883f2a21f344e37 Represent the bulk grant form if there are errors
10. 9c40ce14e0d4efb583b4bd5fd63b51130fa4805c Add default flag to supported permissions
11. 6dc5b58e7a3072cced651dc6f7bdd2498cab8a40 Remove unsupported permissions check from rake users:create
12. 4f5f0aa14cc60bacb7eecf4f56fbf669c0b0d5ef Extract internals of rake users:create to an object in lib
13. 04ef7198baa54067cd0da4f8f9e8542decc331c6 New users are granted default permissions
14. 30ce041ada2aeab6c012619c182469c865564a21 Remove special case for support app on dashboard
15. f4d92b7381786e484796a0aadbd11a60030c35d6 Record an EventLog when bulk granting permissions

## Screenshots

1.  UI for granting permissions to all users

![creating-bulk-grant-permission-set](https://user-images.githubusercontent.com/608/32449752-53105202-c30a-11e7-8104-9c868c786b63.png)

2. UI for watching that bulk grant being processed

![processing-bulk-grant-permission-set](https://user-images.githubusercontent.com/608/32449751-52fafab0-c30a-11e7-9b4a-839456618b53.png)

These take "inspiration" (e.g. are copy+paste jobs pretty much) from the existing UI for batch inviting a CSV file of users and granting them permissions.