### PR TITLE
Allow org admins to edit other org admins

### DIFF
--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -19,8 +19,7 @@ class UserPolicy < BasePolicy
     when 'admin'
       !record.superadmin?
     when 'organisation_admin'
-      allow_self_only ||
-        (record.normal? && record_in_own_organisation?)
+      allow_self_only || (can_manage? && record_in_own_organisation?)
     else # 'normal'
       false
     end
@@ -62,6 +61,10 @@ private
 
   def allow_self_only
     current_user.id == record.id
+  end
+
+  def can_manage?
+    Roles.const_get(current_user.role.classify).can_manage?(record.role)
   end
 
   def record_in_own_organisation?

--- a/lib/roles.rb
+++ b/lib/roles.rb
@@ -17,13 +17,15 @@ module Roles
 
   module ClassMethods
     def role_classes
-      (Roles.constants.select { |c| Class === Roles.const_get(c) }).map do |role_class|
+      class_names = Roles.constants.select { |c| Class === Roles.const_get(c) && Roles.const_get(c) != Roles::Base }
+
+      class_names.map do |role_class|
         "Roles::#{role_class}".constantize
       end
     end
 
     def admin_role_classes
-      role_classes - [Roles::Normal]
+      role_classes - [Roles::Normal, Roles::Base]
     end
 
     def roles

--- a/lib/roles/admin.rb
+++ b/lib/roles/admin.rb
@@ -1,5 +1,5 @@
 module Roles
-  class Admin
+  class Admin < Base
     def self.permitted_user_params
       [
         :uid,

--- a/lib/roles/base.rb
+++ b/lib/roles/base.rb
@@ -1,0 +1,7 @@
+module Roles
+  class Base
+    def self.can_manage?(role)
+      manageable_roles.include?(role)
+    end
+  end
+end

--- a/lib/roles/normal.rb
+++ b/lib/roles/normal.rb
@@ -1,5 +1,5 @@
 module Roles
-  class Normal
+  class Normal < Base
     def self.permitted_user_params
       [:uid, :name, :email, :password, :password_confirmation]
     end

--- a/lib/roles/organisation_admin.rb
+++ b/lib/roles/organisation_admin.rb
@@ -21,7 +21,7 @@ module Roles
     def self.level; 2; end
 
     def self.manageable_roles
-      ['normal']
+      %w{normal organisation_admin}
     end
   end
 end

--- a/lib/roles/organisation_admin.rb
+++ b/lib/roles/organisation_admin.rb
@@ -1,5 +1,5 @@
 module Roles
-  class OrganisationAdmin
+  class OrganisationAdmin < Base
     def self.permitted_user_params
       [
         :uid,

--- a/lib/roles/superadmin.rb
+++ b/lib/roles/superadmin.rb
@@ -1,5 +1,5 @@
 module Roles
-  class Superadmin
+  class Superadmin < Base
     def self.permitted_user_params
       [
         :uid,


### PR DESCRIPTION
For: https://trello.com/c/Cvttl8Sx/209-can-org-admins-unsuspend-other-org-admins

Following a request from an org admin to be able to unsuspend other org admins (from their own org), we are now increasing the level at which org admins are allowed to operate.

Previously, they were only allowed control on `normal` users, without being able to manage other org admins. This is not true for superadmins, where they can edit users with the same role.