### PR TITLE
Add access permissions list on edit user page for org admins

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -39,6 +39,10 @@ class UsersController < ApplicationController
     end
   end
 
+  def edit
+    @application_permissions = all_applications_and_permissions_for(@user)
+  end
+
   def update
     raise Pundit::NotAuthorizedError if params[:user][:organisation_id].present? && !policy(@user).assign_organisations?
 

--- a/app/views/shared/_user_permissions.html.erb
+++ b/app/views/shared/_user_permissions.html.erb
@@ -1,4 +1,4 @@
-<table class="table table-bordered table-striped table-on-white">
+<table id="editable-permissions" class="table table-bordered table-striped table-on-white">
   <thead>
     <tr class="table-header">
       <th>Application</th>

--- a/app/views/users/_app_permissions.html.erb
+++ b/app/views/users/_app_permissions.html.erb
@@ -1,0 +1,34 @@
+<table id="all-permissions" class="table table-bordered table-striped table-on-white">
+  <thead>
+    <tr class="table-header">
+      <th>Application</th>
+      <% unless user_object.api_user? %>
+          <th>Has access?</th>
+      <% end %>
+      <th><%= "Other" unless user_object.api_user? %> Permissions</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @application_permissions.each do |application, permissions|
+      permission_names = permissions.map(&:name)
+    %>
+      <tr>
+        <td>
+          <% if application.retired? %>
+              <del><%= application.name %></del>
+          <% else %>
+              <%= application.name %>
+          <% end %>
+        </td>
+        <% unless user_object.api_user? %>
+          <td>
+            <%= permission_names.include?('signin') ? 'Yes' : 'No' %>
+          </td>
+        <% end %>
+        <td>
+          <%= permission_names.reject{|p| p == 'signin'}.to_sentence %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/users/_form_fields.html.erb
+++ b/app/views/users/_form_fields.html.erb
@@ -72,6 +72,10 @@
   </p>
 <% end %>
 
-<h2 class="add-vertical-margins">Permissions</h2>
-
+<h2 class="add-vertical-margins"> <%= "Editable " if is_org_admin? %>Permissions</h2>
 <%= render partial: "shared/user_permissions", locals: { user_object: f.object }%>
+
+<% if is_org_admin? %>
+    <h2 class="add-vertical-margins">All Permissions for this user</h2>
+    <%= render partial: "app_permissions", locals: { user_object: f.object }%>
+<% end %>

--- a/lib/user_permissions_controller_methods.rb
+++ b/lib/user_permissions_controller_methods.rb
@@ -24,4 +24,8 @@ private
       [application, user.application_permissions.where(application_id: application.id)]
     end
   end
+
+  def all_applications_and_permissions_for(user)
+    user.supported_permissions.includes(:application).group_by(&:application)
+  end
 end


### PR DESCRIPTION
For: https://trello.com/c/oEW7PsNs/192-devolve-unlock-ability-to-see-permissions

This will allow organisation admins to see all the permissions for a user, instead of seeing only the applications and permissions that the organisation admin has access to. 
