### PR TITLE
Add extra info in account access logs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,6 +67,8 @@ end
 
 gem 'logstasher', '0.4.8'
 
+gem 'browser'
+
 group :test do
   gem 'rspec-rails', '~> 3.3.3'
   gem 'capybara', '~> 2.5.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,6 +63,7 @@ GEM
     bootstrap-sass (3.3.5.1)
       autoprefixer-rails (>= 5.0.0.1)
       sass (>= 3.3.0)
+    browser (2.5.0)
     builder (3.2.3)
     byebug (9.0.6)
     capybara (2.5.0)
@@ -362,6 +363,7 @@ DEPENDENCIES
   better_errors (= 2.1.1)
   binding_of_caller (= 0.7.2)
   bootstrap-kaminari-views (= 0.0.5)
+  browser
   capybara (~> 2.5.0)
   capybara-email (~> 2.4.0)
   ci_reporter (= 1.7.0)

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -31,6 +31,8 @@ class InvitationsController < Devise::InvitationsController
       else
         respond_with_navigational(resource) { render :new }
       end
+
+      EventLog.record_account_invitation(@user, current_user)
     end
   end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -16,11 +16,20 @@ class SessionsController < Devise::SessionsController
 
   def log_event
     if current_user.present?
-      EventLog.record_event(current_user, EventLog::SUCCESSFUL_LOGIN)
+      EventLog.record_event(current_user, EventLog::SUCCESSFUL_LOGIN,
+                            trailing_message: user_ip_address + ' ' + user_browser)
     else
       # Call to_s to flatten out any unexpected params (eg a hash).
       user = User.find_by_email(params[:user][:email].to_s)
       EventLog.record_event(user, EventLog::UNSUCCESSFUL_LOGIN) if user
     end
+  end
+
+  def user_ip_address
+    request.remote_ip
+  end
+
+  def user_browser
+    browser.name
   end
 end

--- a/app/models/event_log.rb
+++ b/app/models/event_log.rb
@@ -40,6 +40,7 @@ class EventLog < ActiveRecord::Base
     ACCOUNT_UPDATED                           = LogEntry.new(id: 34, description: "Account updated", require_initiator: true),
     PERMISSIONS_ADDED                         = LogEntry.new(id: 35, description: "Permissions added", require_initiator: true),
     PERMISSIONS_REMOVED                       = LogEntry.new(id: 36, description: "Permissions removed", require_initiator: true),
+    ACCOUNT_INVITED                           = LogEntry.new(id: 37, description: "Account was invited", require_initiator: true),
   ]
 
   EVENTS_REQUIRING_INITIATOR   = EVENTS.select(&:require_initiator?)
@@ -80,6 +81,10 @@ class EventLog < ActiveRecord::Base
 
   def self.record_role_change(user, previous_role, new_role, initiator)
     record_event(user, ROLE_CHANGED, initiator: initiator, trailing_message: "from #{previous_role} to #{new_role}")
+  end
+
+  def self.record_account_invitation(user, initiator)
+    record_event(user, ACCOUNT_INVITED, initiator: initiator)
   end
 
   def self.for(user)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -94,7 +94,7 @@ class User < ActiveRecord::Base
   end
 
   def event_logs
-    EventLog.where(uid: uid).order(created_at: :desc)
+    EventLog.where(uid: uid).order(created_at: :desc).includes(:user_agent)
   end
 
   def generate_uid

--- a/app/models/user_agent.rb
+++ b/app/models/user_agent.rb
@@ -1,0 +1,3 @@
+class UserAgent < ActiveRecord::Base
+  validates_presence_of :user_agent_string
+end

--- a/app/views/users/event_logs.html.erb
+++ b/app/views/users/event_logs.html.erb
@@ -33,6 +33,13 @@
               by <strong><%= link_to log.initiator.name, users_path(filter: log.initiator.email), title: log.initiator.email %></strong>
             <% end %>
             <%= log.trailing_message %>
+            <% if log.ip_address %>
+              <%= log.ip_address_string %>
+            <% end %>
+            <% if log.user_agent_id %>
+                <% browser = Browser.new(log.user_agent_string) %>
+                <%= browser.name + ' ' + browser.version %>
+            <% end %>
           </td>
         </tr>
       <% end %>

--- a/db/migrate/20170905111153_create_user_agents.rb
+++ b/db/migrate/20170905111153_create_user_agents.rb
@@ -1,0 +1,9 @@
+class CreateUserAgents < ActiveRecord::Migration
+  def change
+    create_table :user_agents do |t|
+      t.string :user_agent_string,           :limit => 1000
+    end
+
+    add_index :user_agents, :user_agent_string
+  end
+end

--- a/db/migrate/20170906090625_add_ip_address_and_user_agent_id_to_event_log.rb
+++ b/db/migrate/20170906090625_add_ip_address_and_user_agent_id_to_event_log.rb
@@ -1,0 +1,8 @@
+class AddIpAddressAndUserAgentIdToEventLog < ActiveRecord::Migration
+  def change
+    add_column :event_logs, :ip_address, :integer, limit: 8
+    add_column :event_logs, :user_agent_id, :integer
+
+    add_foreign_key :event_logs, :user_agents
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170216105512) do
+ActiveRecord::Schema.define(version: 20170906090625) do
 
   create_table "batch_invitation_application_permissions", force: :cascade do |t|
     t.integer  "batch_invitation_id",     limit: 4, null: false
@@ -51,9 +51,12 @@ ActiveRecord::Schema.define(version: 20170216105512) do
     t.integer  "application_id",   limit: 4
     t.string   "trailing_message", limit: 255
     t.integer  "event_id",         limit: 4
+    t.integer  "ip_address",       limit: 8
+    t.integer  "user_agent_id",    limit: 4
   end
 
   add_index "event_logs", ["uid", "created_at"], name: "index_event_logs_on_uid_and_created_at", using: :btree
+  add_index "event_logs", ["user_agent_id"], name: "fk_rails_bb74fefe1d", using: :btree
 
   create_table "oauth_access_grants", force: :cascade do |t|
     t.integer  "resource_owner_id", limit: 4,   null: false
@@ -137,6 +140,12 @@ ActiveRecord::Schema.define(version: 20170216105512) do
   add_index "supported_permissions", ["application_id", "name"], name: "index_supported_permissions_on_application_id_and_name", unique: true, using: :btree
   add_index "supported_permissions", ["application_id"], name: "index_supported_permissions_on_application_id", using: :btree
 
+  create_table "user_agents", force: :cascade do |t|
+    t.string "user_agent_string", limit: 1000
+  end
+
+  add_index "user_agents", ["user_agent_string"], name: "index_user_agents_on_user_agent_string", length: {"user_agent_string"=>255}, using: :btree
+
   create_table "user_application_permissions", force: :cascade do |t|
     t.integer  "user_id",                 limit: 4, null: false
     t.integer  "application_id",          limit: 4, null: false
@@ -197,4 +206,5 @@ ActiveRecord::Schema.define(version: 20170216105512) do
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
   add_index "users", ["unlock_token"], name: "index_users_on_unlock_token", unique: true, using: :btree
 
+  add_foreign_key "event_logs", "user_agents"
 end

--- a/test/integration/event_log_test.rb
+++ b/test/integration/event_log_test.rb
@@ -237,22 +237,25 @@ class EventLogIntegrationTest < ActionDispatch::IntegrationTest
     assert page.has_content?("You do not have permission to perform this action")
   end
 
-  test "record user's login ip address" do
-    page.driver.options[:headers] = { 'REMOTE_ADDR' => '1.2.3.4' }
-    visit root_path
-    signin_with(@user)
+  context "recording user's ip address" do
+    should "record user's ip address on login" do
+      page.driver.options[:headers] = { 'REMOTE_ADDR' => '1.2.3.4' }
+      visit root_path
+      signin_with(@user)
 
-    ip_address = @user.event_logs.last.trailing_message.split.first
-    assert_equal '1.2.3.4', ip_address
-  end
+      ip_address = @user.event_logs.first.ip_address_string
+      assert_equal '1.2.3.4', ip_address
+    end
 
-  test "record user's login browser" do
-    page.driver.header('User-agent', 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.113 Safari/537.36')
-    visit root_path
-    signin_with(@user)
+    should "call Raven for ipv6 addresses" do
+      page.driver.options[:headers] = { 'REMOTE_ADDR' => '2001:0db8:0000:0000:0008:0800:200c:417a' }
+      Raven.expects(:capture_message)
+      visit root_path
+      signin_with(@user)
 
-    browser_name = @user.event_logs.last.trailing_message.split.last
-    assert_equal "Chrome", browser_name
+      ip_address = @user.event_logs.first.ip_address
+      assert_equal nil, ip_address
+    end
   end
 
   test "record who the account was created by" do

--- a/test/integration/event_log_test.rb
+++ b/test/integration/event_log_test.rb
@@ -36,7 +36,7 @@ class EventLogIntegrationTest < ActionDispatch::IntegrationTest
     should "not blow up if not given a string for the email" do
       # Assert we don't blow up when looking up the attempted user
       # when people have been messing with the posted params.
-      post "/users/sign_in", "user" => {"email" => {"foo" => "bar"}, :password => "anything"}
+      post "/users/sign_in", "user" => { "email" => { "foo" => "bar" }, :password => "anything" }
 
       assert response.success?
     end
@@ -235,6 +235,38 @@ class EventLogIntegrationTest < ActionDispatch::IntegrationTest
     visit event_logs_user_path(@user)
 
     assert page.has_content?("You do not have permission to perform this action")
+  end
+
+  test "record user's login ip address" do
+    page.driver.options[:headers] = { 'REMOTE_ADDR' => '1.2.3.4' }
+    visit root_path
+    signin_with(@user)
+
+    ip_address = @user.event_logs.last.trailing_message.split.first
+    assert_equal '1.2.3.4', ip_address
+  end
+
+  test "record user's login browser" do
+    page.driver.header('User-agent', 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.113 Safari/537.36')
+    visit root_path
+    signin_with(@user)
+
+    browser_name = @user.event_logs.last.trailing_message.split.last
+    assert_equal "Chrome", browser_name
+  end
+
+  test "record who the account was created by" do
+    visit root_path
+    signin_with(@admin)
+    visit users_path
+    click_on "Create user"
+    fill_in 'Name', with: 'New User'
+    fill_in 'Email', with: 'test@test.com'
+    click_on "Create user and send email"
+
+    event_log = User.last.event_logs.first
+    assert_equal @admin, event_log.initiator
+    assert_equal EventLog::ACCOUNT_INVITED, event_log.entry
   end
 
   def assert_account_access_log_page_content(user)

--- a/test/integration/user_agent_test.rb
+++ b/test/integration/user_agent_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+require 'helpers/passphrase_support'
+
+class UserAgentIntegrationTest < ActionDispatch::IntegrationTest
+  include PassPhraseSupport
+
+  setup do
+    @user = create(:user, name: "Normal User")
+  end
+
+  test "record user's user-agent string on login" do
+    user_agent_test = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.113 Safari/537.36'
+    page.driver.header('User-agent', user_agent_test)
+    visit root_path
+    signin_with(@user)
+
+    assert_equal user_agent_test, UserAgent.last.user_agent_string
+    user_agent = @user.event_logs.first.user_agent_string
+    assert_equal user_agent_test, user_agent
+  end
+end

--- a/test/models/event_log_test.rb
+++ b/test/models/event_log_test.rb
@@ -104,4 +104,13 @@ class EventLogTest < ActiveSupport::TestCase
     assert_equal log.entry, EventLog::PASSPHRASE_RESET_REQUEST
     assert_not_nil log.created_at
   end
+
+  test "can record an account invitation" do
+    user = create(:user)
+    admin = create(:admin_user)
+
+    event_log = EventLog.record_account_invitation(user, admin)
+    assert_equal admin, event_log.initiator
+    assert_equal EventLog::ACCOUNT_INVITED, event_log.entry
+  end
 end

--- a/test/models/user_agent_test.rb
+++ b/test/models/user_agent_test.rb
@@ -1,0 +1,15 @@
+require 'test_helper'
+
+class UserAgentTest < ActiveSupport::TestCase
+  setup do
+    @user_agent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.113 Safari/537.36'
+  end
+
+  test "can create a valid record" do
+    assert UserAgent.new(user_agent_string: @user_agent).valid?
+  end
+
+  test "requires an user agent" do
+    refute UserAgent.new.valid?
+  end
+end


### PR DESCRIPTION
For: https://trello.com/c/Lf1TWggV

Ip address and browser of user is now recorded on each successful
sign in. 'browser' gem is used to retrieve the browser that the
user is using to sign in.

When a new user account is created by an existing admin, the new
account has a record of who it was invited by.

These extra logging should make it easier to retroactively
trace user behaviour in the case of an incident.