### PR TITLE
Add user agent table and new columns to event logs table

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,8 @@ gem 'sprockets-rails', '~> 3.1.1'
 # This change was made via Snyk to fix a vulnerability
 gem 'uglifier', '>= 3.0.4'
 
+gem 'lhm'
+
 group :development do
   gem 'quiet_assets', '1.0.2'
   gem 'better_errors', '2.1.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,6 +159,7 @@ GEM
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
     kgio (2.11.0)
+    lhm (2.2.0)
     link_header (0.0.8)
     logstash-event (1.1.5)
     logstasher (0.4.8)
@@ -381,6 +382,7 @@ DEPENDENCIES
   jasmine (= 2.1.0)
   json (= 1.8.3)
   kaminari (~> 0.16.3)
+  lhm
   logstasher (= 0.4.8)
   minitest (~> 5.8.0)
   mocha (= 1.1.0)

--- a/db/migrate/20170905111153_create_user_agents.rb
+++ b/db/migrate/20170905111153_create_user_agents.rb
@@ -1,0 +1,7 @@
+class CreateUserAgents < ActiveRecord::Migration
+  def change
+    create_table :user_agents do |t|
+      t.string :user_agent_string,    index: true, null: false, :limit => 1000
+    end
+  end
+end

--- a/db/migrate/20170908160100_add_ip_address_and_user_agent_id_to_event_logs.rb
+++ b/db/migrate/20170908160100_add_ip_address_and_user_agent_id_to_event_logs.rb
@@ -1,0 +1,21 @@
+require 'lhm'
+
+class AddIpAddressAndUserAgentIdToEventLogs < ActiveRecord::Migration
+  def self.up
+    Lhm.cleanup(:run)
+    Lhm.change_table :event_logs do |m|
+      m.add_column :ip_address, "BIGINT"
+      m.add_column :user_agent_id, "INT"
+      m.ddl("ALTER TABLE %s ADD CONSTRAINT event_logs_user_agent_id_fk FOREIGN KEY (user_agent_id) REFERENCES user_agents(id)" % m.name)
+    end
+  end
+
+  def self.down
+    remove_foreign_key :event_logs, name: :event_logs_user_agent_id_fk
+    Lhm.cleanup(:run)
+    Lhm.change_table :event_logs do |m|
+      m.remove_column :user_agent_id
+      m.remove_column :ip_address
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170216105512) do
+ActiveRecord::Schema.define(version: 20170908160100) do
 
   create_table "batch_invitation_application_permissions", force: :cascade do |t|
     t.integer  "batch_invitation_id",     limit: 4, null: false
@@ -51,9 +51,13 @@ ActiveRecord::Schema.define(version: 20170216105512) do
     t.integer  "application_id",   limit: 4
     t.string   "trailing_message", limit: 255
     t.integer  "event_id",         limit: 4
+    t.integer  "ip_address",       limit: 8
+    t.integer  "user_agent_id",    limit: 4
   end
 
   add_index "event_logs", ["uid", "created_at"], name: "index_event_logs_on_uid_and_created_at", using: :btree
+  add_index "event_logs", ["user_agent_id"], name: "event_logs_user_agent_id_fk", using: :btree
+
 
   create_table "oauth_access_grants", force: :cascade do |t|
     t.integer  "resource_owner_id", limit: 4,   null: false
@@ -137,6 +141,12 @@ ActiveRecord::Schema.define(version: 20170216105512) do
   add_index "supported_permissions", ["application_id", "name"], name: "index_supported_permissions_on_application_id_and_name", unique: true, using: :btree
   add_index "supported_permissions", ["application_id"], name: "index_supported_permissions_on_application_id", using: :btree
 
+  create_table "user_agents", force: :cascade do |t|
+    t.string "user_agent_string", limit: 1000, null: false
+  end
+
+  add_index "user_agents", ["user_agent_string"], name: "index_user_agents_on_user_agent_string", length: {"user_agent_string"=>255}, using: :btree
+
   create_table "user_application_permissions", force: :cascade do |t|
     t.integer  "user_id",                 limit: 4, null: false
     t.integer  "application_id",          limit: 4, null: false
@@ -197,4 +207,5 @@ ActiveRecord::Schema.define(version: 20170216105512) do
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
   add_index "users", ["unlock_token"], name: "index_users_on_unlock_token", unique: true, using: :btree
 
+  add_foreign_key "event_logs", "user_agents", name: "event_logs_user_agent_id_fk"
 end


### PR DESCRIPTION
Event logs table has has two new columns for storing ip addresses
and foreign key user_agent_id, which references a new user agent
table. These two tables will be used together to display extra
logging information of a user signing in. Gem 'lhm' is used to
perform the migration without locking the database, which is
necessary as the event logs table has over 18M records.

Follows on from #565 