### PR TITLE
Track more details in event logs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,6 +69,8 @@ end
 
 gem 'logstasher', '0.4.8'
 
+gem 'browser'
+
 group :test do
   gem 'rspec-rails', '~> 3.3.3'
   gem 'capybara', '~> 2.5.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,6 +63,7 @@ GEM
     bootstrap-sass (3.3.5.1)
       autoprefixer-rails (>= 5.0.0.1)
       sass (>= 3.3.0)
+    browser (2.5.0)
     builder (3.2.3)
     byebug (9.0.6)
     capybara (2.5.0)
@@ -363,6 +364,7 @@ DEPENDENCIES
   better_errors (= 2.1.1)
   binding_of_caller (= 0.7.2)
   bootstrap-kaminari-views (= 0.0.5)
+  browser
   capybara (~> 2.5.0)
   capybara-email (~> 2.4.0)
   ci_reporter (= 1.7.0)

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -31,6 +31,8 @@ class InvitationsController < Devise::InvitationsController
       else
         respond_with_navigational(resource) { render :new }
       end
+
+      EventLog.record_account_invitation(@user, current_user)
     end
   end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -16,11 +16,20 @@ class SessionsController < Devise::SessionsController
 
   def log_event
     if current_user.present?
-      EventLog.record_event(current_user, EventLog::SUCCESSFUL_LOGIN)
+      EventLog.record_event(current_user, EventLog::SUCCESSFUL_LOGIN,
+                            trailing_message: user_ip_address + ' ' + user_browser)
     else
       # Call to_s to flatten out any unexpected params (eg a hash).
       user = User.find_by_email(params[:user][:email].to_s)
       EventLog.record_event(user, EventLog::UNSUCCESSFUL_LOGIN) if user
     end
+  end
+
+  def user_ip_address
+    request.remote_ip
+  end
+
+  def user_browser
+    browser.name
   end
 end

--- a/app/models/event_log.rb
+++ b/app/models/event_log.rb
@@ -40,6 +40,7 @@ class EventLog < ActiveRecord::Base
     ACCOUNT_UPDATED                           = LogEntry.new(id: 34, description: "Account updated", require_initiator: true),
     PERMISSIONS_ADDED                         = LogEntry.new(id: 35, description: "Permissions added", require_initiator: true),
     PERMISSIONS_REMOVED                       = LogEntry.new(id: 36, description: "Permissions removed", require_initiator: true),
+    ACCOUNT_INVITED                           = LogEntry.new(id: 37, description: "Account was invited", require_initiator: true),
   ]
 
   EVENTS_REQUIRING_INITIATOR   = EVENTS.select(&:require_initiator?)
@@ -80,6 +81,10 @@ class EventLog < ActiveRecord::Base
 
   def self.record_role_change(user, previous_role, new_role, initiator)
     record_event(user, ROLE_CHANGED, initiator: initiator, trailing_message: "from #{previous_role} to #{new_role}")
+  end
+
+  def self.record_account_invitation(user, initiator)
+    record_event(user, ACCOUNT_INVITED, initiator: initiator)
   end
 
   def self.for(user)

--- a/app/models/event_log.rb
+++ b/app/models/event_log.rb
@@ -1,3 +1,4 @@
+require "resolv"
 class EventLog < ActiveRecord::Base
   deprecated_columns :event
 
@@ -46,7 +47,7 @@ class EventLog < ActiveRecord::Base
   EVENTS_REQUIRING_INITIATOR   = EVENTS.select(&:require_initiator?)
   EVENTS_REQUIRING_APPLICATION = EVENTS.select(&:require_application?)
 
-  VALID_OPTIONS = [:initiator, :application, :application_id, :trailing_message]
+  VALID_OPTIONS = [:initiator, :application, :application_id, :trailing_message, :ip_address, :user_agent_id]
 
   validates :uid, presence: true
   validates_presence_of :event_id
@@ -56,6 +57,9 @@ class EventLog < ActiveRecord::Base
 
   belongs_to :initiator, class_name: "User"
   belongs_to :application, class_name: "Doorkeeper::Application"
+  belongs_to :user_agent
+
+  delegate :user_agent_string, to: :user_agent
 
   def event
     entry.description
@@ -65,7 +69,19 @@ class EventLog < ActiveRecord::Base
     EVENTS.detect { |event| event.id == event_id }
   end
 
+  def ip_address_string
+    self.class.convert_integer_to_ip_address(self.ip_address)
+  end
+
   def self.record_event(user, event, options = {})
+    if options[:ip_address]
+      if options[:ip_address] =~ Resolv::IPv6::Regex
+        Raven.capture_message("Received IP address: #{options[:ip_address]}. IPv6 logging is not supported yet")
+        options[:ip_address] = nil
+      else
+        options[:ip_address] = convert_ip_address_to_integer(options[:ip_address])
+      end
+    end
     attributes = {
       uid: user.uid,
       event_id: event.id
@@ -92,9 +108,18 @@ class EventLog < ActiveRecord::Base
   end
 
 private
+
   def validate_event_mappable
     unless entry
       errors.add(:event_id, "must have a corresponding `LogEntry` for #{event_id}")
     end
+  end
+
+  def self.convert_ip_address_to_integer(ip_address_string)
+    ip_address_string.split(/\./).map(&:to_i).pack("C*").unpack("N").first
+  end
+
+  def self.convert_integer_to_ip_address(integer)
+    [integer].pack("N").unpack("C*").join "."
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -94,7 +94,7 @@ class User < ActiveRecord::Base
   end
 
   def event_logs
-    EventLog.where(uid: uid).order(created_at: :desc)
+    EventLog.where(uid: uid).order(created_at: :desc).includes(:user_agent)
   end
 
   def generate_uid

--- a/app/models/user_agent.rb
+++ b/app/models/user_agent.rb
@@ -1,0 +1,3 @@
+class UserAgent < ActiveRecord::Base
+  validates_presence_of :user_agent_string
+end

--- a/app/views/users/event_logs.html.erb
+++ b/app/views/users/event_logs.html.erb
@@ -33,6 +33,13 @@
               by <strong><%= link_to log.initiator.name, users_path(filter: log.initiator.email), title: log.initiator.email %></strong>
             <% end %>
             <%= log.trailing_message %>
+            <% if log.ip_address %>
+              <%= log.ip_address_string %>
+            <% end %>
+            <% if log.user_agent_id %>
+                <% browser = Browser.new(log.user_agent_string) %>
+                <%= browser.name + ' ' + browser.version %>
+            <% end %>
           </td>
         </tr>
       <% end %>

--- a/test/integration/event_log_test.rb
+++ b/test/integration/event_log_test.rb
@@ -237,22 +237,25 @@ class EventLogIntegrationTest < ActionDispatch::IntegrationTest
     assert page.has_content?("You do not have permission to perform this action")
   end
 
-  test "record user's login ip address" do
-    page.driver.options[:headers] = { 'REMOTE_ADDR' => '1.2.3.4' }
-    visit root_path
-    signin_with(@user)
+  context "recording user's ip address" do
+    should "record user's ip address on login" do
+      page.driver.options[:headers] = { 'REMOTE_ADDR' => '1.2.3.4' }
+      visit root_path
+      signin_with(@user)
 
-    ip_address = @user.event_logs.last.trailing_message.split.first
-    assert_equal '1.2.3.4', ip_address
-  end
+      ip_address = @user.event_logs.first.ip_address_string
+      assert_equal '1.2.3.4', ip_address
+    end
 
-  test "record user's login browser" do
-    page.driver.header('User-agent', 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.113 Safari/537.36')
-    visit root_path
-    signin_with(@user)
+    should "call Raven for ipv6 addresses" do
+      page.driver.options[:headers] = { 'REMOTE_ADDR' => '2001:0db8:0000:0000:0008:0800:200c:417a' }
+      Raven.expects(:capture_message)
+      visit root_path
+      signin_with(@user)
 
-    browser_name = @user.event_logs.last.trailing_message.split.last
-    assert_equal "Chrome", browser_name
+      ip_address = @user.event_logs.first.ip_address
+      assert_equal nil, ip_address
+    end
   end
 
   test "record who the account was created by" do

--- a/test/integration/user_agent_test.rb
+++ b/test/integration/user_agent_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+require 'helpers/passphrase_support'
+
+class UserAgentIntegrationTest < ActionDispatch::IntegrationTest
+  include PassPhraseSupport
+
+  setup do
+    @user = create(:user, name: "Normal User")
+  end
+
+  test "record user's user-agent string on login" do
+    user_agent_test = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.113 Safari/537.36'
+    page.driver.header('User-agent', user_agent_test)
+    visit root_path
+    signin_with(@user)
+
+    assert_equal user_agent_test, UserAgent.last.user_agent_string
+    user_agent = @user.event_logs.first.user_agent_string
+    assert_equal user_agent_test, user_agent
+  end
+end

--- a/test/models/event_log_test.rb
+++ b/test/models/event_log_test.rb
@@ -104,4 +104,13 @@ class EventLogTest < ActiveSupport::TestCase
     assert_equal log.entry, EventLog::PASSPHRASE_RESET_REQUEST
     assert_not_nil log.created_at
   end
+
+  test "can record an account invitation" do
+    user = create(:user)
+    admin = create(:admin_user)
+
+    event_log = EventLog.record_account_invitation(user, admin)
+    assert_equal admin, event_log.initiator
+    assert_equal EventLog::ACCOUNT_INVITED, event_log.entry
+  end
 end

--- a/test/models/user_agent_test.rb
+++ b/test/models/user_agent_test.rb
@@ -1,0 +1,15 @@
+require 'test_helper'
+
+class UserAgentTest < ActiveSupport::TestCase
+  setup do
+    @user_agent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.113 Safari/537.36'
+  end
+
+  test "can create a valid record" do
+    assert UserAgent.new(user_agent_string: @user_agent).valid?
+  end
+
+  test "requires an user agent" do
+    refute UserAgent.new.valid?
+  end
+end


### PR DESCRIPTION
For: https://trello.com/c/Lf1TWggV/211-log-more-information-for-signon-events

This resurrects #563 without the migration that we did separately in #566.  The original migration required us to add columns to the `event_logs` table which in production had ~18 million rows.  Adding columns would lock the table and make the app unusable while it completed.  The version in #566 used the [`lhm`](https://github.com/soundcloud/lhm/) tool to do an "online" schema change that results in no downtime.  We've deployed that migration so now we're ready to deploy the code that uses these fields.

Our ultimate goal here is to store ip address and user agent info against sign in attempts, and to store a handful of extra events that will be useful for GDPR compliance.