### PR TITLE
Add super organisation admin role

### DIFF
--- a/app/helpers/user_filter_helper.rb
+++ b/app/helpers/user_filter_helper.rb
@@ -28,7 +28,11 @@ module UserFilterHelper
             when :status
               User::USER_STATUSES
             when :organisation
-              Organisation.order(:name).joins(:users).uniq.map {|org| [org.id, org.name_with_abbreviation]}
+              if is_super_org_admin?
+                current_user.organisation.subtree.order(:name).joins(:users).uniq.map { |org| [org.id, org.name_with_abbreviation] }
+              else
+                Organisation.order(:name).joins(:users).uniq.map { |org| [org.id, org.name_with_abbreviation] }
+              end
             when :two_step_status
               #rubocop:disable Style/WordArray
               [['true', 'Enabled'], ['false', 'Not set up']]

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -10,7 +10,7 @@ module UsersHelper
   end
 
   def organisation_select_options
-    { include_blank: is_org_admin? ? false : 'None' }
+    { include_blank: (is_org_admin? || is_super_org_admin?) ? false : 'None' }
   end
 
   def user_email_tokens(user = current_user)

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -26,7 +26,11 @@ module UsersHelper
   end
 
   def is_org_admin?
-    current_user.role == 'organisation_admin'
+    current_user.organisation_admin?
+  end
+
+  def is_super_org_admin?
+    current_user.super_organisation_admin?
   end
 
   def sync_needed?(permissions)

--- a/app/models/enhancements/application.rb
+++ b/app/models/enhancements/application.rb
@@ -24,7 +24,7 @@ class ::Doorkeeper::Application < ActiveRecord::Base
   def self.policy_class; ApplicationPolicy; end
 
   def supported_permission_strings(user = nil)
-    if user && user.role == 'organisation_admin'
+    if user && %w(organisation_admin super_organisation_admin).include?(user.role)
       supported_permissions.delegatable.pluck(:name) & user.permissions_for(self)
     else
       supported_permissions.pluck(:name)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -300,8 +300,8 @@ private
   end
 
   def organisation_admin_belongs_to_organisation
-    if self.role == 'organisation_admin' && self.organisation_id.blank?
-      errors.add(:organisation_id, "can't be 'None' for an Organisation admin")
+    if %w(organisation_admin super_organisation_admin).include?(self.role) && self.organisation_id.blank?
+      errors.add(:organisation_id, "can't be 'None' for #{self.role.titleize}")
     end
   end
 

--- a/app/policies/base_policy.rb
+++ b/app/policies/base_policy.rb
@@ -12,7 +12,11 @@ class BasePolicy
 
   protected
 
-  def belong_to_same_organisation_subtree?
+  def record_in_own_organisation?
+    record.organisation && (record.organisation_id == current_user.organisation_id)
+  end
+
+  def record_in_child_organisation?
     current_user.organisation.subtree.include?(record.organisation)
   end
 

--- a/app/policies/base_policy.rb
+++ b/app/policies/base_policy.rb
@@ -12,8 +12,8 @@ class BasePolicy
 
   protected
 
-  def belong_to_same_organisation_subtree?(current_user, record)
-    current_user.organisation.subtree.pluck(:id).include?(record.organisation_id.to_i)
+  def belong_to_same_organisation_subtree?
+    current_user.organisation.subtree.include?(record.organisation)
   end
 
   class Scope

--- a/app/policies/supported_permission_policy.rb
+++ b/app/policies/supported_permission_policy.rb
@@ -5,6 +5,9 @@ class SupportedPermissionPolicy < BasePolicy
         scope.all
       elsif current_user.admin?
         scope.all
+      elsif current_user.super_organisation_admin?
+        app_ids = Pundit.policy_scope(current_user, :user_permission_manageable_application).pluck(:id)
+        scope.joins(:application).where(oauth_applications: { id: app_ids })
       elsif current_user.organisation_admin?
         app_ids = Pundit.policy_scope(current_user, :user_permission_manageable_application).pluck(:id)
         scope.joins(:application).where(oauth_applications: { id: app_ids })

--- a/app/policies/user_permission_manageable_application_policy.rb
+++ b/app/policies/user_permission_manageable_application_policy.rb
@@ -23,6 +23,8 @@ class UserPermissionManageableApplicationPolicy
         applications
       elsif current_user.admin?
         applications
+      elsif current_user.super_organisation_admin?
+        applications.can_signin(current_user).with_signin_delegatable
       elsif current_user.organisation_admin?
         applications.can_signin(current_user).with_signin_delegatable
       else

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -1,10 +1,10 @@
 class UserPolicy < BasePolicy
   def index?
-    current_user.superadmin? || current_user.admin? || current_user.organisation_admin?
+    %w(superadmin admin super_organisation_admin organisation_admin).include? current_user.role
   end
 
   def new? # invitations#new
-    current_user.superadmin? || current_user.admin?
+    %w(superadmin admin).include? current_user.role
   end
   alias_method :assign_organisations?, :new?
 
@@ -17,7 +17,9 @@ class UserPolicy < BasePolicy
     when 'superadmin'
       true
     when 'admin'
-      !record.superadmin?
+      can_manage?
+    when 'super_organisation_admin'
+      allow_self_only || (can_manage? && record_in_own_organisation?)
     when 'organisation_admin'
       allow_self_only || (can_manage? && record_in_own_organisation?)
     else # 'normal'
@@ -68,7 +70,11 @@ private
   end
 
   def record_in_own_organisation?
-    record.organisation && (record.organisation.id == current_user.organisation.id)
+    record.organisation && (record.organisation_id == current_user.organisation_id)
+  end
+
+  def record_in_child_organisation?
+    current_user.organisation.subtree_ids.include?(record.organisation_id)
   end
 
   class Scope < ::BasePolicy::Scope
@@ -76,9 +82,9 @@ private
       if current_user.superadmin?
         scope.web_users
       elsif current_user.admin?
-        scope.web_users.where(role: %w(admin organisation_admin normal))
-      elsif current_user.organisation_admin?
-        scope.web_users.where(role: %w(organisation_admin normal)).where(organisation_id: current_user.organisation_id)
+        scope.web_users.where(role: current_user.manageable_roles)
+      elsif current_user.super_organisation_admin? || current_user.organisation_admin?
+        scope.web_users.where(role: current_user.manageable_roles).where(organisation: current_user.organisation)
       else
         scope.none
       end

--- a/app/views/users/_form_fields.html.erb
+++ b/app/views/users/_form_fields.html.erb
@@ -72,10 +72,10 @@
   </p>
 <% end %>
 
-<h2 class="add-vertical-margins"> <%= "Editable " if is_org_admin? %>Permissions</h2>
+<h2 class="add-vertical-margins"> <%= "Editable " if (is_org_admin? || is_super_org_admin?) %>Permissions</h2>
 <%= render partial: "shared/user_permissions", locals: { user_object: f.object }%>
 
-<% if is_org_admin? %>
+<% if is_org_admin? || is_super_org_admin? %>
     <h2 class="add-vertical-margins">All Permissions for this user</h2>
     <%= render partial: "app_permissions", locals: { user_object: f.object }%>
 <% end %>

--- a/app/views/users/_user_filter.html.erb
+++ b/app/views/users/_user_filter.html.erb
@@ -14,7 +14,7 @@
         </li>
         <%= render partial: 'user_filter_group', locals: {filter_type: :role} %>
         <%= render partial: 'user_filter_group', locals: {filter_type: :status} %>
-        <% if is_org_admin? || is_super_org_admin? %>
+        <% if is_org_admin? %>
           <li class="nav-pill-text text-muted"><%= current_user.organisation.name %></li>
         <% else %>
           <%= render partial: 'user_filter_group', locals: {filter_type: :organisation} %>

--- a/app/views/users/_user_filter.html.erb
+++ b/app/views/users/_user_filter.html.erb
@@ -14,7 +14,7 @@
         </li>
         <%= render partial: 'user_filter_group', locals: {filter_type: :role} %>
         <%= render partial: 'user_filter_group', locals: {filter_type: :status} %>
-        <% if is_org_admin? %>
+        <% if is_org_admin? || is_super_org_admin? %>
           <li class="nav-pill-text text-muted"><%= current_user.organisation.name %></li>
         <% else %>
           <%= render partial: 'user_filter_group', locals: {filter_type: :organisation} %>

--- a/lib/roles/admin.rb
+++ b/lib/roles/admin.rb
@@ -21,7 +21,7 @@ module Roles
     def self.level; 1; end
 
     def self.manageable_roles
-      %w{normal organisation_admin admin}
+      %w{normal organisation_admin super_organisation_admin admin}
     end
   end
 end

--- a/lib/roles/normal.rb
+++ b/lib/roles/normal.rb
@@ -8,7 +8,7 @@ module Roles
       'normal'
     end
 
-    def self.level; 3; end
+    def self.level; 4; end
 
     def self.manageable_roles
       []

--- a/lib/roles/organisation_admin.rb
+++ b/lib/roles/organisation_admin.rb
@@ -18,7 +18,7 @@ module Roles
       'organisation_admin'
     end
 
-    def self.level; 2; end
+    def self.level; 3; end
 
     def self.manageable_roles
       %w{normal organisation_admin}

--- a/lib/roles/super_organisation_admin.rb
+++ b/lib/roles/super_organisation_admin.rb
@@ -1,0 +1,27 @@
+module Roles
+  class SuperOrganisationAdmin < Base
+    def self.permitted_user_params
+      [
+          :uid,
+          :name,
+          :email,
+          :password,
+          :password_confirmation,
+          :organisation_id,
+          :unconfirmed_email,
+          :confirmation_token,
+          { supported_permission_ids: [] },
+      ]
+    end
+
+    def self.role_name
+      'super_organisation_admin'
+    end
+
+    def self.level; 2; end
+
+    def self.manageable_roles
+      %w{normal organisation_admin super_organisation_admin}
+    end
+  end
+end

--- a/lib/user_parameter_sanitiser.rb
+++ b/lib/user_parameter_sanitiser.rb
@@ -28,6 +28,7 @@ private
     {
       normal: Roles::Normal.permitted_user_params,
       organisation_admin: Roles::OrganisationAdmin.permitted_user_params,
+      super_organisation_admin: Roles::SuperOrganisationAdmin.permitted_user_params,
       admin: Roles::Admin.permitted_user_params,
       superadmin: Roles::Superadmin.permitted_user_params,
     }

--- a/spec/policies/api_user_policy_spec.rb
+++ b/spec/policies/api_user_policy_spec.rb
@@ -9,6 +9,7 @@ describe ApiUserPolicy do
         expect(subject).to permit(create(:superadmin_user), User)
 
         expect(subject).not_to permit(create(:admin_user), User)
+        expect(subject).not_to permit(create(:super_org_admin), User)
         expect(subject).not_to permit(create(:organisation_admin), User)
         expect(subject).not_to permit(create(:user), User)
       end

--- a/spec/policies/application_policy_spec.rb
+++ b/spec/policies/application_policy_spec.rb
@@ -9,6 +9,7 @@ describe ApplicationPolicy do
         expect(subject).to permit(create(:superadmin_user), User)
 
         expect(subject).not_to permit(create(:admin_user), User)
+        expect(subject).not_to permit(create(:super_org_admin), User)
         expect(subject).not_to permit(create(:organisation_admin), User)
         expect(subject).not_to permit(create(:user), User)
       end

--- a/spec/policies/batch_invitation_policy_spec.rb
+++ b/spec/policies/batch_invitation_policy_spec.rb
@@ -17,6 +17,14 @@ describe BatchInvitationPolicy do
       expect(subject).not_to permit(organisation_admin, BatchInvitation.new(organisation_id: organisation_admin.organisation_id))
     end
 
+    it 'is forbidden for super organisation admins to create new batch uploads even within their organisation subtree' do
+      super_org_admin = create(:user_in_organisation, role: 'super_organisation_admin')
+
+      expect(subject).not_to permit(super_org_admin, BatchInvitation.new)
+      expect(subject).not_to permit(super_org_admin, BatchInvitation.new(organisation_id: create(:organisation).id))
+      expect(subject).not_to permit(super_org_admin, BatchInvitation.new(organisation_id: super_org_admin.organisation_id))
+    end
+
     it 'is forbidden for normal users' do
       expect(subject).not_to permit(create(:user), BatchInvitation.new)
     end

--- a/spec/policies/organisation_policy_spec.rb
+++ b/spec/policies/organisation_policy_spec.rb
@@ -48,12 +48,12 @@ describe OrganisationPolicy do
   end
 
   describe described_class::Scope do
-    let!(:org_root_one) { create(:organisation) }
-    let!(:org_root_one_child_one) { create(:organisation, parent: org_root_one) }
-    let!(:org_root_one_child_two) { create(:organisation, parent: org_root_one) }
-    let!(:org_root_one_grandchild_one) { create(:organisation, parent: org_root_one_child_one) }
-    let!(:org_root_two) { create(:organisation) }
-    let!(:org_root_two_child_one) { create(:organisation, parent: org_root_two) }
+    let!(:parent_organisation) { create(:organisation) }
+    let!(:child_organisation_one) { create(:organisation, parent: parent_organisation) }
+    let!(:child_organisation_two) { create(:organisation, parent: parent_organisation) }
+    let!(:grandchild_organisation_one) { create(:organisation, parent: child_organisation_one) }
+    let!(:second_parent_organisation) { create(:organisation) }
+    let!(:child_second_organisation) { create(:organisation, parent: second_parent_organisation) }
     subject { described_class.new(user, Organisation.all) }
     let(:resolved_scope) { subject.resolve }
 
@@ -61,12 +61,12 @@ describe OrganisationPolicy do
       let(:user) { create(:superadmin_user) }
 
       it 'includes all organisations' do
-        expect(resolved_scope).to include(org_root_one)
-        expect(resolved_scope).to include(org_root_one_child_one)
-        expect(resolved_scope).to include(org_root_one_child_two)
-        expect(resolved_scope).to include(org_root_one_grandchild_one)
-        expect(resolved_scope).to include(org_root_two)
-        expect(resolved_scope).to include(org_root_two_child_one)
+        expect(resolved_scope).to include(parent_organisation)
+        expect(resolved_scope).to include(child_organisation_one)
+        expect(resolved_scope).to include(child_organisation_two)
+        expect(resolved_scope).to include(grandchild_organisation_one)
+        expect(resolved_scope).to include(second_parent_organisation)
+        expect(resolved_scope).to include(child_second_organisation)
       end
     end
 
@@ -74,17 +74,17 @@ describe OrganisationPolicy do
       let(:user) { create(:admin_user) }
 
       it 'includes all organisations' do
-        expect(resolved_scope).to include(org_root_one)
-        expect(resolved_scope).to include(org_root_one_child_one)
-        expect(resolved_scope).to include(org_root_one_child_two)
-        expect(resolved_scope).to include(org_root_one_grandchild_one)
-        expect(resolved_scope).to include(org_root_two)
-        expect(resolved_scope).to include(org_root_two_child_one)
+        expect(resolved_scope).to include(parent_organisation)
+        expect(resolved_scope).to include(child_organisation_one)
+        expect(resolved_scope).to include(child_organisation_two)
+        expect(resolved_scope).to include(grandchild_organisation_one)
+        expect(resolved_scope).to include(second_parent_organisation)
+        expect(resolved_scope).to include(child_second_organisation)
       end
     end
 
     context 'for super organisation admins' do
-      let(:user) { create(:super_org_admin, organisation: org_root_one) }
+      let(:user) { create(:super_org_admin, organisation: parent_organisation) }
 
       it 'is empty' do
         expect(resolved_scope).to be_empty
@@ -92,7 +92,7 @@ describe OrganisationPolicy do
     end
 
     context 'for organisation admins' do
-      let(:user) { create(:organisation_admin, organisation: org_root_one) }
+      let(:user) { create(:organisation_admin, organisation: parent_organisation) }
 
       it 'is empty' do
         expect(resolved_scope).to be_empty

--- a/spec/policies/supported_permission_policy_spec.rb
+++ b/spec/policies/supported_permission_policy_spec.rb
@@ -72,7 +72,38 @@ describe SupportedPermissionPolicy do
       end
     end
 
-    context 'for org admins' do
+    context 'for super organisation admins' do
+      let(:user) do
+        create(:super_org_admin).tap do |u|
+          u.grant_application_permission(app_one, 'signin')
+          u.grant_application_permission(app_two, 'signin')
+        end
+      end
+
+      it 'contains all permissions for apps with delegatable signin permission that the super organisation admin has access to' do
+        expect(resolved_scope).to include(app_one_signin_permission)
+        expect(resolved_scope).to include(app_one_cat_permission)
+        expect(resolved_scope).to include(app_one_hat_permission)
+      end
+
+      it 'does not contain any permissions for apps with non-delegatbale signin permission the super organisation admin has access to' do
+        expect(resolved_scope).not_to include(app_two_signin_permission)
+        expect(resolved_scope).not_to include(app_two_rat_permission)
+        expect(resolved_scope).not_to include(app_two_bat_permission)
+      end
+
+      it 'does not contain any permissions for apps the super organisation admin does not have access to' do
+        expect(resolved_scope).not_to include(app_three_signin_permission)
+        expect(resolved_scope).not_to include(app_three_fat_permission)
+        expect(resolved_scope).not_to include(app_three_vat_permission)
+
+        expect(resolved_scope).not_to include(app_four_signin_permission)
+        expect(resolved_scope).not_to include(app_four_pat_permission)
+        expect(resolved_scope).not_to include(app_four_sat_permission)
+      end
+    end
+
+    context 'for organisation admins' do
       let(:user) do
         create(:organisation_admin).tap do |u|
           u.grant_application_permission(app_one, 'signin')
@@ -80,19 +111,19 @@ describe SupportedPermissionPolicy do
         end
       end
 
-      it 'contains all permissions for apps with delegatable signin permission that the org admin has access to' do
+      it 'contains all permissions for apps with delegatable signin permission that the organisation admin has access to' do
         expect(resolved_scope).to include(app_one_signin_permission)
         expect(resolved_scope).to include(app_one_cat_permission)
         expect(resolved_scope).to include(app_one_hat_permission)
       end
 
-      it 'does not contain any permissions for apps with non-delegatbale signin permission the org admin has access to' do
+      it 'does not contain any permissions for apps with non-delegatbale signin permission the organisation admin has access to' do
         expect(resolved_scope).not_to include(app_two_signin_permission)
         expect(resolved_scope).not_to include(app_two_rat_permission)
         expect(resolved_scope).not_to include(app_two_bat_permission)
       end
 
-      it 'does not contain any permissions for apps the org admin does not have access to' do
+      it 'does not contain any permissions for apps the organisation admin does not have access to' do
         expect(resolved_scope).not_to include(app_three_signin_permission)
         expect(resolved_scope).not_to include(app_three_fat_permission)
         expect(resolved_scope).not_to include(app_three_vat_permission)

--- a/spec/policies/user_permission_manageable_application_policy_spec.rb
+++ b/spec/policies/user_permission_manageable_application_policy_spec.rb
@@ -39,7 +39,29 @@ describe UserPermissionManageableApplicationPolicy do
       end
     end
 
-    context 'for org admins' do
+    context 'for super organisation admins' do
+      let(:acting_user) { create(:super_org_admin) }
+
+      before do
+        acting_user.grant_application_permission(app_one, 'signin')
+        acting_user.grant_application_permission(app_two, 'signin')
+      end
+
+      it 'includes applications with delegatable signin that the super organisation admin has access to' do
+        expect(resolved_scope).to include(app_one)
+      end
+
+      it 'does not include applications without delegatable signin that the super organisation admin does has access to' do
+        expect(resolved_scope).not_to include(app_two)
+      end
+
+      it 'does not include applications that the super organisation admin does not have access to' do
+        expect(resolved_scope).not_to include(app_three)
+        expect(resolved_scope).not_to include(app_four)
+      end
+    end
+
+    context 'for organisation admins' do
       let(:acting_user) { create(:organisation_admin) }
 
       before do
@@ -47,15 +69,15 @@ describe UserPermissionManageableApplicationPolicy do
         acting_user.grant_application_permission(app_two, 'signin')
       end
 
-      it 'includes applications with delegatable signin that the org admin has access to' do
+      it 'includes applications with delegatable signin that the organisation admin has access to' do
         expect(resolved_scope).to include(app_one)
       end
 
-      it 'does not include applications without delegatable signin that the org admin does has access to' do
+      it 'does not include applications without delegatable signin that the organisation admin does has access to' do
         expect(resolved_scope).not_to include(app_two)
       end
 
-      it 'does not include applications that the org admin does not have access to' do
+      it 'does not include applications that the organisation admin does not have access to' do
         expect(resolved_scope).not_to include(app_three)
         expect(resolved_scope).not_to include(app_four)
       end

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -2,15 +2,21 @@ require 'rails_helper'
 
 describe UserPolicy do
   subject { described_class }
-  let(:organisation_admin) { create(:organisation_admin) }
+  let(:parent_organisation)         { create(:organisation) }
+  let(:child_organisation)          { create(:organisation, parent: parent_organisation) }
+  let(:super_org_admin)             { create(:super_org_admin, organisation: parent_organisation) }
+  let(:organisation_admin)          { create(:organisation_admin, organisation: parent_organisation) }
 
   primary_management_actions = [:new?, :assign_organisations?]
   user_management_actions = [:edit?, :create?, :update?, :unlock?, :suspension?, :cancel_email_change?, :resend_email_change?, :event_logs?]
   self_management_actions = [:edit_email_or_passphrase?, :update_email?, :update_passphrase?, :cancel_email_change?, :resend_email_change?]
-  superadmin_actions = [:assign_role?, :flag_2sv?, :reset_2sv?]
   disallowed_actions_org_admin = [:create?, :assign_organisations?]
+  disallowed_actions_super_org_admin = [:create?, :assign_organisations?]
+
   org_admin_actions = user_management_actions - disallowed_actions_org_admin
+  super_org_admin_actions = user_management_actions - disallowed_actions_super_org_admin
   admin_actions = user_management_actions - self_management_actions
+  superadmin_actions = [:assign_role?, :flag_2sv?, :reset_2sv?]
 
   context "for superadmins" do
     permissions :index? do
@@ -34,6 +40,7 @@ describe UserPolicy do
 
           expect(subject).to permit(superadmin, build(:user))
           expect(subject).to permit(superadmin, build(:organisation_admin))
+          expect(subject).to permit(superadmin, build(:super_org_admin))
           expect(subject).to permit(superadmin, build(:admin_user))
           expect(subject).to permit(superadmin, build(:superadmin_user))
         end
@@ -71,6 +78,7 @@ describe UserPolicy do
 
           expect(subject).not_to permit(admin, build(:superadmin_user))
           expect(subject).to permit(admin, build(:admin_user))
+          expect(subject).to permit(admin, build(:super_org_admin))
           expect(subject).to permit(admin, build(:organisation_admin))
           expect(subject).to permit(admin, build(:user))
         end
@@ -86,7 +94,73 @@ describe UserPolicy do
     end
   end
 
-  context "for org admins" do
+  context "for super organisation admins" do
+    permissions :index? do
+      it "is allowed for super organisation admins" do
+        expect(subject).to permit(build(:super_org_admin), User)
+      end
+    end
+
+    primary_management_actions.each do |permission|
+      permissions permission do
+        it "is forbidden for super organisation admins" do
+          expect(subject).not_to permit(build(:super_org_admin), User)
+        end
+      end
+    end
+
+    disallowed_actions_super_org_admin.each do |disallowed_super_org_admin_permission|
+      permissions disallowed_super_org_admin_permission do
+        it "is forbidden for super organisation admins to create any type of user or assign organisations to them" do
+          expect(subject).not_to permit(super_org_admin, build(:superadmin_user))
+          expect(subject).not_to permit(super_org_admin, build(:admin_user))
+          expect(subject).not_to permit(super_org_admin, build(:super_org_admin))
+          expect(subject).not_to permit(super_org_admin, build(:organisation_admin))
+          expect(subject).not_to permit(super_org_admin, build(:user_in_organisation))
+          expect(subject).not_to permit(super_org_admin, build(:user_in_organisation, organisation: organisation_admin.organisation))
+        end
+      end
+    end
+
+    super_org_admin_actions.each do |allowed_super_org_admin_permission|
+      permissions allowed_super_org_admin_permission do
+        it "is allowed for super organisation admins to access users of similar permissions or below from within their own organisation" do
+          expect(subject).to permit(super_org_admin, build(:user_in_organisation, organisation: super_org_admin.organisation))
+          expect(subject).to permit(super_org_admin, build(:organisation_admin, organisation: super_org_admin.organisation))
+          expect(subject).to permit(super_org_admin, build(:super_org_admin, organisation: super_org_admin.organisation))
+
+          expect(subject).not_to permit(super_org_admin, build(:superadmin_user))
+          expect(subject).not_to permit(super_org_admin, build(:admin_user))
+        end
+
+        it "is forbidden for super organisation admins to access users of similar permissions or below from within their own organisation's subtree" do
+          expect(subject).not_to permit(super_org_admin, build(:user_in_organisation, organisation: child_organisation))
+          expect(subject).not_to permit(super_org_admin, build(:organisation_admin, organisation: child_organisation))
+          expect(subject).not_to permit(super_org_admin, build(:super_org_admin, organisation: child_organisation))
+          expect(subject).not_to permit(super_org_admin, build(:superadmin_user, organisation: child_organisation))
+          expect(subject).not_to permit(super_org_admin, build(:admin_user, organisation: child_organisation))
+        end
+
+        it "is forbidden for super organisation admins to access users from other organisations" do
+          expect(subject).not_to permit(super_org_admin, build(:user_in_organisation))
+          expect(subject).not_to permit(super_org_admin, build(:organisation_admin))
+          expect(subject).not_to permit(super_org_admin, build(:super_org_admin))
+          expect(subject).not_to permit(super_org_admin, build(:superadmin_user))
+          expect(subject).not_to permit(super_org_admin, build(:admin_user))
+        end
+      end
+    end
+
+    superadmin_actions.each do |permission_name|
+      permissions permission_name do
+        it "is forbidden for super organisation admins" do
+          expect(subject).not_to permit(create(:super_org_admin), User)
+        end
+      end
+    end
+  end
+
+  context "for organisation admins" do
     permissions :index? do
       it "is allowed for organisation admins" do
         expect(subject).to permit(build(:organisation_admin), User)
@@ -103,9 +177,10 @@ describe UserPolicy do
 
     disallowed_actions_org_admin.each do |disallowed_org_admin_permission|
       permissions disallowed_org_admin_permission do
-        it "is forbidden for org admins to create any type of user or assign orgs to them" do
+        it "is forbidden for organisation admins to create any type of user or assign organisations to them" do
           expect(subject).not_to permit(organisation_admin, build(:superadmin_user))
           expect(subject).not_to permit(organisation_admin, build(:admin_user))
+          expect(subject).not_to permit(organisation_admin, build(:super_org_admin))
           expect(subject).not_to permit(organisation_admin, build(:organisation_admin))
           expect(subject).not_to permit(organisation_admin, build(:user_in_organisation))
           expect(subject).not_to permit(organisation_admin, build(:user_in_organisation, organisation: organisation_admin.organisation))
@@ -115,23 +190,27 @@ describe UserPolicy do
 
     org_admin_actions.each do |allowed_org_admin_permission|
       permissions allowed_org_admin_permission do
-        it "is allowed for org admins to access normal users from within their own organisation" do
-          expect(subject).not_to permit(organisation_admin, build(:user_in_organisation))
-        end
-
-        it "is forbidden for org admins to access normal users from other organisations" do
+        it "is forbidden for organisation admins to access users of similar permissions or below from within their own organisation" do
           expect(subject).to permit(organisation_admin, build(:user_in_organisation, organisation: organisation_admin.organisation))
-        end
-
-        it "is allowed for org admins to access org admins from within their own organisation" do
           expect(subject).to permit(organisation_admin, build(:organisation_admin, organisation: organisation_admin.organisation))
+
+          expect(subject).not_to permit(organisation_admin, build(:super_org_admin, organisation: organisation_admin.organisation))
+          expect(subject).not_to permit(organisation_admin, build(:superadmin_user))
+          expect(subject).not_to permit(organisation_admin, build(:admin_user))
         end
 
-        it "is forbidden for org admins to access org admins from other organisations" do
-          expect(subject).to permit(organisation_admin, build(:organisation_admin, organisation: organisation_admin.organisation))
+        it "is allowed for organisation admins to access users from within their own organisation's subtree" do
+          expect(subject).not_to permit(organisation_admin, build(:user_in_organisation, organisation: child_organisation))
+          expect(subject).not_to permit(organisation_admin, build(:organisation_admin, organisation: child_organisation))
+          expect(subject).not_to permit(organisation_admin, build(:super_org_admin, organisation: child_organisation))
+          expect(subject).not_to permit(organisation_admin, build(:superadmin_user, organisation: child_organisation))
+          expect(subject).not_to permit(organisation_admin, build(:admin_user, organisation: child_organisation))
         end
 
-        it "is forbidden for org admins to access superadmins and admin users from either their own or other organisations" do
+        it "is forbidden for organisation admins to access users from other organisations" do
+          expect(subject).not_to permit(organisation_admin, build(:user_in_organisation))
+          expect(subject).not_to permit(organisation_admin, build(:organisation_admin))
+          expect(subject).not_to permit(organisation_admin, build(:super_org_admin))
           expect(subject).not_to permit(organisation_admin, build(:superadmin_user))
           expect(subject).not_to permit(organisation_admin, build(:admin_user))
         end
@@ -200,20 +279,29 @@ describe UserPolicy do
   end
 
   describe described_class::Scope do
-    let!(:superadmin_user) { create(:superadmin_user) }
-    let!(:admin_user) { create(:admin_user) }
+    let(:parent_organisation) { create(:organisation) }
+    let(:child_organisation) { create(:organisation, parent: parent_organisation) }
+    let(:other_organisation) { create(:organisation) }
+
+    let!(:super_admin_in_org) { create(:superadmin_user, organisation: parent_organisation) }
+    let!(:admin_in_org) { create(:admin_user, organisation: parent_organisation) }
+    let!(:super_org_admin_in_org) { create(:super_org_admin, organisation: parent_organisation) }
+    let!(:org_admin_in_org) { create(:organisation_admin, organisation: parent_organisation) }
+    let!(:normal_user_in_org) { create(:user_in_organisation, organisation: parent_organisation) }
+
+    let!(:super_admin_in_child_org) { create(:superadmin_user, organisation: child_organisation) }
+    let!(:admin_in_child_org) { create(:admin_user, organisation: child_organisation) }
+    let!(:super_org_admin_in_child_org) { create(:super_org_admin, organisation: child_organisation) }
+    let!(:org_admin_in_child_org) { create(:organisation_admin, organisation: child_organisation) }
+    let!(:normal_user_in_child_org) { create(:user_in_organisation, organisation: child_organisation) }
+
+    let!(:super_admin_in_other_org) { create(:superadmin_user, organisation: other_organisation) }
+    let!(:admin_in_other_org) { create(:admin_user, organisation: other_organisation) }
+    let!(:super_org_admin_in_other_org) { create(:super_org_admin, organisation: other_organisation) }
+    let!(:org_admin_in_other_org) { create(:organisation_admin, organisation: other_organisation) }
+    let!(:normal_user_in_other_org) { create(:user_in_organisation, organisation: other_organisation) }
+
     let!(:api_user) { create(:api_user) }
-
-    let(:org_root_one) { create(:organisation) }
-    let(:org_root_two) { create(:organisation) }
-    let(:org_root_one_child) { create(:organisation, parent: org_root_one) }
-
-    let!(:normal_user_in_org) { create(:user_in_organisation, organisation: org_root_one) }
-    let!(:org_admin_user_in_org) { create(:organisation_admin, organisation: org_root_one) }
-    let!(:normal_user_in_child_org) { create(:user_in_organisation, organisation: org_root_one_child) }
-    let!(:org_admin_user_in_child_org) { create(:organisation_admin, organisation: org_root_one_child) }
-    let!(:normal_user_in_other_org) { create(:user_in_organisation, organisation: org_root_two) }
-    let!(:org_admin_user_in_other_org) { create(:organisation_admin, organisation: org_root_two) }
 
     subject { described_class.new(user, User.all) }
     let(:resolved_scope) { subject.resolve }
@@ -222,14 +310,23 @@ describe UserPolicy do
       let(:user) { create(:superadmin_user) }
 
       it 'includes all web users' do
-        expect(resolved_scope).to include(superadmin_user)
-        expect(resolved_scope).to include(admin_user)
+        expect(resolved_scope).to include(super_admin_in_org)
+        expect(resolved_scope).to include(admin_in_org)
+        expect(resolved_scope).to include(super_org_admin_in_org)
+        expect(resolved_scope).to include(org_admin_in_org)
         expect(resolved_scope).to include(normal_user_in_org)
-        expect(resolved_scope).to include(org_admin_user_in_org)
+
+        expect(resolved_scope).to include(super_admin_in_child_org)
+        expect(resolved_scope).to include(admin_in_child_org)
+        expect(resolved_scope).to include(super_org_admin_in_child_org)
+        expect(resolved_scope).to include(org_admin_in_child_org)
         expect(resolved_scope).to include(normal_user_in_child_org)
-        expect(resolved_scope).to include(org_admin_user_in_child_org)
+
+        expect(resolved_scope).to include(super_admin_in_other_org)
+        expect(resolved_scope).to include(admin_in_other_org)
+        expect(resolved_scope).to include(super_org_admin_in_other_org)
+        expect(resolved_scope).to include(org_admin_in_other_org)
         expect(resolved_scope).to include(normal_user_in_other_org)
-        expect(resolved_scope).to include(org_admin_user_in_other_org)
       end
 
       it 'does not include api users' do
@@ -240,57 +337,96 @@ describe UserPolicy do
     context 'for admins' do
       let(:user) { create(:admin_user) }
 
-      it 'includes all web users of similar permissions' do
-        expect(resolved_scope).to include(admin_user)
+      it 'includes all web users of similar permissions or below belonging to their organisation' do
+        expect(resolved_scope).not_to include(super_admin_in_org)
+        expect(resolved_scope).to include(admin_in_org)
+        expect(resolved_scope).to include(super_org_admin_in_org)
+        expect(resolved_scope).to include(org_admin_in_org)
         expect(resolved_scope).to include(normal_user_in_org)
-        expect(resolved_scope).to include(org_admin_user_in_org)
+      end
+
+      it 'includes all web users of similar permissions or below belonging to a child organisation' do
+        expect(resolved_scope).not_to include(super_admin_in_child_org)
+        expect(resolved_scope).to include(admin_in_child_org)
+        expect(resolved_scope).to include(super_org_admin_in_child_org)
+        expect(resolved_scope).to include(org_admin_in_child_org)
         expect(resolved_scope).to include(normal_user_in_child_org)
-        expect(resolved_scope).to include(org_admin_user_in_child_org)
+      end
+
+      it 'includes all web users of similar permissions or below belonging to another organisation' do
+        expect(resolved_scope).not_to include(super_admin_in_other_org)
+        expect(resolved_scope).to include(admin_in_other_org)
+        expect(resolved_scope).to include(super_org_admin_in_other_org)
+        expect(resolved_scope).to include(org_admin_in_other_org)
         expect(resolved_scope).to include(normal_user_in_other_org)
-        expect(resolved_scope).to include(org_admin_user_in_other_org)
       end
 
       it 'does not include api users' do
         expect(resolved_scope).not_to include(api_user)
-      end
-
-      it 'does not include superadmins' do
-        expect(resolved_scope).not_to include(superadmin_user)
       end
     end
 
-    context 'for org admins' do
-      let(:user) { create(:organisation_admin, organisation: org_root_one) }
+    context 'for super organisation admins' do
+      let(:user) { create(:super_org_admin, organisation: parent_organisation) }
 
-      it 'includes only org admins and users belonging to their org' do
+      it 'includes users of similar permission or below belonging to their organisation' do
+        expect(resolved_scope).not_to include(super_admin_in_org)
+        expect(resolved_scope).not_to include(admin_in_org)
+        expect(resolved_scope).to include(super_org_admin_in_org)
+        expect(resolved_scope).to include(org_admin_in_org)
         expect(resolved_scope).to include(normal_user_in_org)
-        expect(resolved_scope).to include(org_admin_user_in_org)
       end
 
-      it 'does not include users belonging to organisations in their subtree' do
+      it 'includes users of similar permission or below belonging to a child organisation' do
+        expect(resolved_scope).not_to include(super_admin_in_child_org)
+        expect(resolved_scope).not_to include(admin_in_child_org)
+        expect(resolved_scope).not_to include(super_org_admin_in_child_org)
+        expect(resolved_scope).not_to include(org_admin_in_child_org)
         expect(resolved_scope).not_to include(normal_user_in_child_org)
-        expect(resolved_scope).not_to include(org_admin_user_in_child_org)
       end
 
-      it 'does not include users belonging to other orgs' do
+      it 'does not include users of similar permission or below belonging to another organisation' do
+        expect(resolved_scope).not_to include(super_admin_in_other_org)
+        expect(resolved_scope).not_to include(admin_in_other_org)
+        expect(resolved_scope).not_to include(super_org_admin_in_other_org)
+        expect(resolved_scope).not_to include(org_admin_in_other_org)
         expect(resolved_scope).not_to include(normal_user_in_other_org)
-        expect(resolved_scope).not_to include(org_admin_user_in_other_org)
       end
 
       it 'does not include api users' do
         expect(resolved_scope).not_to include(api_user)
       end
+    end
 
-      it 'does not include superadmins (even if they are in the same org)' do
-        superadmin_in_same_org = create(:superadmin_user, organisation: user.organisation)
-        expect(resolved_scope).not_to include(superadmin_user)
-        expect(resolved_scope).not_to include(superadmin_in_same_org)
+    context 'for organisation admins' do
+      let(:user) { create(:organisation_admin, organisation: parent_organisation) }
+
+      it 'includes users of similar permission or below belonging to their organisation' do
+        expect(resolved_scope).not_to include(super_admin_in_org)
+        expect(resolved_scope).not_to include(admin_in_org)
+        expect(resolved_scope).not_to include(super_org_admin_in_org)
+        expect(resolved_scope).to include(org_admin_in_org)
+        expect(resolved_scope).to include(normal_user_in_org)
       end
 
-      it 'does not include admins (even if they are in the same org)' do
-        admin_in_same_org = create(:admin_user, organisation: user.organisation)
-        expect(resolved_scope).not_to include(admin_user)
-        expect(resolved_scope).not_to include(admin_in_same_org)
+      it 'does not include users of similar permission or below belonging to a child organisation' do
+        expect(resolved_scope).not_to include(super_admin_in_child_org)
+        expect(resolved_scope).not_to include(admin_in_child_org)
+        expect(resolved_scope).not_to include(super_org_admin_in_child_org)
+        expect(resolved_scope).not_to include(org_admin_in_child_org)
+        expect(resolved_scope).not_to include(normal_user_in_child_org)
+      end
+
+      it 'does not include users of similar permission or below belonging to another organisation' do
+        expect(resolved_scope).not_to include(super_admin_in_other_org)
+        expect(resolved_scope).not_to include(admin_in_other_org)
+        expect(resolved_scope).not_to include(super_org_admin_in_other_org)
+        expect(resolved_scope).not_to include(org_admin_in_other_org)
+        expect(resolved_scope).not_to include(normal_user_in_other_org)
+      end
+
+      it 'does not include api users' do
+        expect(resolved_scope).not_to include(api_user)
       end
     end
 

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -133,10 +133,11 @@ describe UserPolicy do
           expect(subject).not_to permit(super_org_admin, build(:admin_user))
         end
 
-        it "is forbidden for super organisation admins to access users of similar permissions or below from within their own organisation's subtree" do
-          expect(subject).not_to permit(super_org_admin, build(:user_in_organisation, organisation: child_organisation))
-          expect(subject).not_to permit(super_org_admin, build(:organisation_admin, organisation: child_organisation))
-          expect(subject).not_to permit(super_org_admin, build(:super_org_admin, organisation: child_organisation))
+        it "is allowed for super organisation admins to access users of similar permissions or below from within their own organisation's subtree" do
+          expect(subject).to permit(super_org_admin, build(:user_in_organisation, organisation: child_organisation))
+          expect(subject).to permit(super_org_admin, build(:organisation_admin, organisation: child_organisation))
+          expect(subject).to permit(super_org_admin, build(:super_org_admin, organisation: child_organisation))
+
           expect(subject).not_to permit(super_org_admin, build(:superadmin_user, organisation: child_organisation))
           expect(subject).not_to permit(super_org_admin, build(:admin_user, organisation: child_organisation))
         end
@@ -380,9 +381,9 @@ describe UserPolicy do
       it 'includes users of similar permission or below belonging to a child organisation' do
         expect(resolved_scope).not_to include(super_admin_in_child_org)
         expect(resolved_scope).not_to include(admin_in_child_org)
-        expect(resolved_scope).not_to include(super_org_admin_in_child_org)
-        expect(resolved_scope).not_to include(org_admin_in_child_org)
-        expect(resolved_scope).not_to include(normal_user_in_child_org)
+        expect(resolved_scope).to include(super_org_admin_in_child_org)
+        expect(resolved_scope).to include(org_admin_in_child_org)
+        expect(resolved_scope).to include(normal_user_in_child_org)
       end
 
       it 'does not include users of similar permission or below belonging to another organisation' do

--- a/test/controllers/invitations_controller_test.rb
+++ b/test/controllers/invitations_controller_test.rb
@@ -19,6 +19,12 @@ class InvitationsControllerTest < ActionController::TestCase
       get :new
       assert_redirected_to root_path
     end
+
+    should "disallow access to super organisation admins" do
+      @user.update_attributes(role: 'super_organisation_admin', organisation_id: create(:organisation).id)
+      get :new
+      assert_redirected_to root_path
+    end
   end
 
   context "POST create" do
@@ -48,6 +54,12 @@ class InvitationsControllerTest < ActionController::TestCase
       post :create, user: { name: 'Testing Org Admins', email: 'testing_org_admins@example.com' }
       assert_redirected_to root_path
     end
+
+    should "disallow access to super organisation admins" do
+      @user.update_attributes(role: 'super_organisation_admin', organisation_id: create(:organisation).id)
+      post :create, user: { name: 'Testing Org Admins', email: 'testing_org_admins@example.com' }
+      assert_redirected_to root_path
+    end
   end
 
   context "POST resend" do
@@ -60,6 +72,13 @@ class InvitationsControllerTest < ActionController::TestCase
 
     should "disallow access to organisation admins" do
       @user.update_attributes(role: 'organisation_admin', organisation_id: create(:organisation).id)
+      user_to_resend_for = create(:user)
+      post :resend, id: user_to_resend_for.id
+      assert_redirected_to root_path
+    end
+
+    should "disallow access to super organisation admins" do
+      @user.update_attributes(role: 'super_organisation_admin', organisation_id: create(:organisation).id)
       user_to_resend_for = create(:user)
       post :resend, id: user_to_resend_for.id
       assert_redirected_to root_path

--- a/test/controllers/suspensions_controller_test.rb
+++ b/test/controllers/suspensions_controller_test.rb
@@ -24,7 +24,7 @@ class SuspensionsControllerTest < ActionController::TestCase
   end
 
   context "super organisation admin" do
-    should "be unable to control suspension of a user outside their organisation" do
+    should "be unable to control suspension of a user outside their organisation subtree" do
       user = create(:suspended_user, reason_for_suspension: "Negligence")
       super_org_admin = create(:super_org_admin)
       sign_in super_org_admin
@@ -38,6 +38,18 @@ class SuspensionsControllerTest < ActionController::TestCase
       super_org_admin = create(:super_org_admin)
       sign_in super_org_admin
       user = create(:suspended_user, reason_for_suspension: "Negligence", organisation: super_org_admin.organisation)
+
+      put :update, id: user.id, user: { suspended: "0" }
+
+      refute user.reload.suspended?
+    end
+
+    should "be able to control suspension of a user within child organisations" do
+      super_org_admin = create(:super_org_admin)
+      child_org = create(:organisation, parent: super_org_admin.organisation)
+
+      sign_in super_org_admin
+      user = create(:suspended_user, reason_for_suspension: "Negligence", organisation: child_org)
 
       put :update, id: user.id, user: { suspended: "0" }
 

--- a/test/controllers/suspensions_controller_test.rb
+++ b/test/controllers/suspensions_controller_test.rb
@@ -4,8 +4,8 @@ class SuspensionsControllerTest < ActionController::TestCase
   context "organisation admin" do
     should "be unable to control suspension of a user outside their organisation" do
       user = create(:suspended_user, reason_for_suspension: "Negligence")
-      admin = create(:organisation_admin)
-      sign_in admin
+      organisation_admin = create(:organisation_admin)
+      sign_in organisation_admin
 
       put :update, id: user.id, user: { suspended: "0" }
 
@@ -13,9 +13,31 @@ class SuspensionsControllerTest < ActionController::TestCase
     end
 
     should "be able to control suspension of a user within their organisation" do
-      admin = create(:organisation_admin)
-      sign_in admin
-      user = create(:suspended_user, reason_for_suspension: "Negligence", organisation: admin.organisation)
+      organisation_admin = create(:organisation_admin)
+      sign_in organisation_admin
+      user = create(:suspended_user, reason_for_suspension: "Negligence", organisation: organisation_admin.organisation)
+
+      put :update, id: user.id, user: { suspended: "0" }
+
+      refute user.reload.suspended?
+    end
+  end
+
+  context "super organisation admin" do
+    should "be unable to control suspension of a user outside their organisation" do
+      user = create(:suspended_user, reason_for_suspension: "Negligence")
+      super_org_admin = create(:super_org_admin)
+      sign_in super_org_admin
+
+      put :update, id: user.id, user: { suspended: "0" }
+
+      assert user.reload.suspended?
+    end
+
+    should "be able to control suspension of a user within their organisation" do
+      super_org_admin = create(:super_org_admin)
+      sign_in super_org_admin
+      user = create(:suspended_user, reason_for_suspension: "Negligence", organisation: super_org_admin.organisation)
 
       put :update, id: user.id, user: { suspended: "0" }
 

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -49,14 +49,18 @@ FactoryGirl.define do
     confirmation_sent_at Time.zone.now
   end
 
+  factory :superadmin_user, parent: :user do
+    sequence(:email) { |n| "superadmin#{n}@example.com" }
+    role "superadmin"
+  end
+
   factory :admin_user, parent: :user do
     sequence(:email) { |n| "admin#{n}@example.com" }
     role "admin"
   end
 
-  factory :superadmin_user, parent: :user do
-    sequence(:email) { |n| "superadmin#{n}@example.com" }
-    role "superadmin"
+  factory :super_org_admin, parent: :user_in_organisation do
+    role "super_organisation_admin"
   end
 
   factory :organisation_admin, parent: :user_in_organisation do

--- a/test/integration/batch_inviting_users_test.rb
+++ b/test/integration/batch_inviting_users_test.rb
@@ -17,9 +17,21 @@ class BatchInvitingUsersTest < ActionDispatch::IntegrationTest
     perform_batch_invite_with_user(user, application)
   end
 
-  should "organisation admin user can not create users whose details are specified in a CSV file" do
+  should "not allow organisation admin user to create users whose details are specified in a CSV file" do
     application = create(:application)
     user = create(:user_in_organisation, role: 'organisation_admin')
+    user.grant_application_permission(application, ['signin'])
+
+    visit root_path
+    signin_with(user)
+
+    visit new_batch_invitation_path
+    assert_equal root_path, current_path
+  end
+
+  should "not allow super organisation admin user to create users whose details are specified in a CSV file" do
+    application = create(:application)
+    user = create(:user_in_organisation, role: 'super_organisation_admin')
     user.grant_application_permission(application, ['signin'])
 
     visit root_path

--- a/test/integration/event_log_test.rb
+++ b/test/integration/event_log_test.rb
@@ -227,6 +227,20 @@ class EventLogIntegrationTest < ActionDispatch::IntegrationTest
     assert_account_access_log_page_content(user)
   end
 
+  test "super organisation admins have permission to view access logs of users belonging to child organisations" do
+    super_org_admin = create(:super_org_admin)
+    child_org = create(:organisation, parent: super_org_admin.organisation)
+    user = create(:user_in_organisation, organisation: child_org)
+    user.lock_access!
+
+    visit root_path
+    signin_with(super_org_admin)
+    visit edit_user_path(user)
+    click_on 'Account access log'
+
+    assert_account_access_log_page_content(user)
+  end
+
   test "super organisation admins don't have permission to view access logs of users belonging to another organisation" do
     super_org_admin = create(:super_org_admin)
 

--- a/test/integration/event_log_test.rb
+++ b/test/integration/event_log_test.rb
@@ -214,13 +214,36 @@ class EventLogIntegrationTest < ActionDispatch::IntegrationTest
     assert_account_access_log_page_content(@user)
   end
 
-  test "organisation admins have permission to view access logs of users belonging to their organisation" do
-    admin = create(:organisation_admin)
-    user = create(:user_in_organisation, organisation: admin.organisation)
+  test "super organisation admins have permission to view access logs of users belonging to their organisation" do
+    super_org_admin = create(:super_org_admin)
+    user = create(:user_in_organisation, organisation: super_org_admin.organisation)
     user.lock_access!
 
     visit root_path
-    signin_with(admin)
+    signin_with(super_org_admin)
+    visit edit_user_path(user)
+    click_on 'Account access log'
+
+    assert_account_access_log_page_content(user)
+  end
+
+  test "super organisation admins don't have permission to view access logs of users belonging to another organisation" do
+    super_org_admin = create(:super_org_admin)
+
+    visit root_path
+    signin_with(super_org_admin)
+    visit event_logs_user_path(@user)
+
+    assert page.has_content?("You do not have permission to perform this action")
+  end
+
+  test "organisation admins have permission to view access logs of users belonging to their organisation" do
+    organisation_admin = create(:organisation_admin)
+    user = create(:user_in_organisation, organisation: organisation_admin.organisation)
+    user.lock_access!
+
+    visit root_path
+    signin_with(organisation_admin)
     visit edit_user_path(user)
     click_on 'Account access log'
 
@@ -228,10 +251,10 @@ class EventLogIntegrationTest < ActionDispatch::IntegrationTest
   end
 
   test "organisation admins don't have permission to view access logs of users belonging to another organisation" do
-    admin = create(:organisation_admin)
+    organisation_admin = create(:organisation_admin)
 
     visit root_path
-    signin_with(admin)
+    signin_with(organisation_admin)
     visit event_logs_user_path(@user)
 
     assert page.has_content?("You do not have permission to perform this action")

--- a/test/integration/granting_permissions_test.rb
+++ b/test/integration/granting_permissions_test.rb
@@ -83,18 +83,18 @@ class GrantingPermissionsTest < ActionDispatch::IntegrationTest
     end
   end
 
-  context "as an org admin" do
+  context "as a super organisation admin" do
     setup do
-      @admin = create(:organisation_admin)
-      @user = create(:user, organisation: @admin.organisation)
+      @super_org_admin = create(:super_org_admin)
+      @user = create(:user, organisation: @super_org_admin.organisation)
 
       visit root_path
-      signin_with(@admin)
+      signin_with(@super_org_admin)
     end
 
-    should "support granting signin permissions to delegatable apps that the org admin has access to" do
+    should "support granting signin permissions to delegatable apps that the super organisation admin has access to" do
       app = create(:application, name: 'MyApp', with_delegatable_supported_permissions: ["signin"])
-      @admin.grant_application_permission(app, 'signin')
+      @super_org_admin.grant_application_permission(app, 'signin')
 
       visit edit_user_path(@user)
       check "Has access to MyApp?"
@@ -103,24 +103,24 @@ class GrantingPermissionsTest < ActionDispatch::IntegrationTest
       assert @user.reload.has_access_to?(app)
     end
 
-    should "not support granting signin permissions to non-delegatable apps that the org admin has access to" do
+    should "not support granting signin permissions to non-delegatable apps that the super organisation admin has access to" do
       app = create(:application, name: 'MyApp')
       signin_permission = app.signin_permission
       signin_permission.update_attributes(delegatable: false)
-      @admin.grant_application_permission(app, 'signin')
+      @super_org_admin.grant_application_permission(app, 'signin')
 
       visit edit_user_path(@user)
       assert page.has_no_field? "Has access to MyApp?"
     end
 
-    should "not support granting signin permissions to apps that the org admin doesn't have access to" do
+    should "not support granting signin permissions to apps that the super organisation admin doesn't have access to" do
       create(:application, name: 'MyApp', with_delegatable_supported_permissions: ['signin'])
 
       visit edit_user_path(@user)
       assert page.has_no_field? "Has access to MyApp?"
     end
 
-    should "not remove permissions the user has that the org admin does not have" do
+    should "not remove permissions the user has that the super organisation admin does not have" do
       app = create(:application, name: 'MyApp')
       @user.grant_application_permission(app, 'signin')
 
@@ -130,10 +130,10 @@ class GrantingPermissionsTest < ActionDispatch::IntegrationTest
       assert @user.reload.has_access_to?(app)
     end
 
-    should "not remove permissions the user has that the org admin cannot delegate" do
+    should "not remove permissions the user has that the super organisation admin cannot delegate" do
       app = create(:application, name: 'MyApp')
       app.signin_permission.update_attributes(delegatable: false)
-      @admin.grant_application_permission(app, 'signin')
+      @super_org_admin.grant_application_permission(app, 'signin')
       @user.grant_application_permission(app, 'signin')
 
       visit edit_user_path(@user)
@@ -145,7 +145,7 @@ class GrantingPermissionsTest < ActionDispatch::IntegrationTest
     should "support granting app-specific permissions" do
       app = create(:application, name: "MyApp",
                    with_supported_permissions: ["pre-existing", "adding", "never"])
-      @admin.grant_application_permission(app, 'signin')
+      @super_org_admin.grant_application_permission(app, 'signin')
       @user.grant_application_permission(app, "pre-existing")
 
       visit edit_user_path(@user)
@@ -159,7 +159,90 @@ class GrantingPermissionsTest < ActionDispatch::IntegrationTest
 
     should "not be able to grant permissions that are not grantable_from_ui" do
       app = create(:application, name: "MyApp", with_supported_permissions_not_grantable_from_ui: ['user_update_permission'])
-      @admin.grant_application_permission(app, 'signin')
+      @super_org_admin.grant_application_permission(app, 'signin')
+
+      visit edit_user_path(@user)
+      assert page.has_no_select?('Permissions for MyApp', options: ['user_update_permission'])
+    end
+  end
+
+  context "as an organisation admin" do
+    setup do
+      @organisation_admin = create(:organisation_admin)
+      @user = create(:user, organisation: @organisation_admin.organisation)
+
+      visit root_path
+      signin_with(@organisation_admin)
+    end
+
+    should "support granting signin permissions to delegatable apps that the organisation admin has access to" do
+      app = create(:application, name: 'MyApp', with_delegatable_supported_permissions: ["signin"])
+      @organisation_admin.grant_application_permission(app, 'signin')
+
+      visit edit_user_path(@user)
+      check "Has access to MyApp?"
+      click_button "Update User"
+
+      assert @user.reload.has_access_to?(app)
+    end
+
+    should "not support granting signin permissions to non-delegatable apps that the organisation admin has access to" do
+      app = create(:application, name: 'MyApp')
+      signin_permission = app.signin_permission
+      signin_permission.update_attributes(delegatable: false)
+      @organisation_admin.grant_application_permission(app, 'signin')
+
+      visit edit_user_path(@user)
+      assert page.has_no_field? "Has access to MyApp?"
+    end
+
+    should "not support granting signin permissions to apps that the organisation admin doesn't have access to" do
+      create(:application, name: 'MyApp', with_delegatable_supported_permissions: ['signin'])
+
+      visit edit_user_path(@user)
+      assert page.has_no_field? "Has access to MyApp?"
+    end
+
+    should "not remove permissions the user has that the organisation admin does not have" do
+      app = create(:application, name: 'MyApp')
+      @user.grant_application_permission(app, 'signin')
+
+      visit edit_user_path(@user)
+      click_button "Update User"
+
+      assert @user.reload.has_access_to?(app)
+    end
+
+    should "not remove permissions the user has that the organisation admin cannot delegate" do
+      app = create(:application, name: 'MyApp')
+      app.signin_permission.update_attributes(delegatable: false)
+      @organisation_admin.grant_application_permission(app, 'signin')
+      @user.grant_application_permission(app, 'signin')
+
+      visit edit_user_path(@user)
+      click_button "Update User"
+
+      assert @user.reload.has_access_to?(app)
+    end
+
+    should "support granting app-specific permissions" do
+      app = create(:application, name: "MyApp",
+                   with_supported_permissions: ["pre-existing", "adding", "never"])
+      @organisation_admin.grant_application_permission(app, 'signin')
+      @user.grant_application_permission(app, "pre-existing")
+
+      visit edit_user_path(@user)
+      select "adding", from: "Permissions for MyApp"
+      click_button "Update User"
+
+      assert_includes @user.permissions_for(app), "pre-existing"
+      assert_includes @user.permissions_for(app), "adding"
+      assert_not_includes @user.permissions_for(app), "never"
+    end
+
+    should "not be able to grant permissions that are not grantable_from_ui" do
+      app = create(:application, name: "MyApp", with_supported_permissions_not_grantable_from_ui: ['user_update_permission'])
+      @organisation_admin.grant_application_permission(app, 'signin')
 
       visit edit_user_path(@user)
       assert page.has_no_select?('Permissions for MyApp', options: ['user_update_permission'])

--- a/test/models/doorkeeper_application_test.rb
+++ b/test/models/doorkeeper_application_test.rb
@@ -32,11 +32,26 @@ class ::Doorkeeper::ApplicationTest < ActiveSupport::TestCase
       assert_equal %w(signin write), app.supported_permission_strings(user)
     end
 
+    should "only show permissions that super organisation admins themselves have" do
+      app = create(:application, with_delegatable_supported_permissions: %w(write approve))
+      super_org_admin = create(:super_org_admin, with_permissions: { app => ["write"] })
+
+      assert_equal ["write"], app.supported_permission_strings(super_org_admin)
+    end
+
+    should "only show delegatable permissions to super organisation admins" do
+      super_org_admin = create(:super_org_admin)
+      app = create(:application, with_delegatable_supported_permissions: ['write'], with_supported_permissions: ['approve'])
+      super_org_admin.grant_application_permissions(app, %w(write approve))
+
+      assert_equal ["write"], app.supported_permission_strings(super_org_admin)
+    end
+
     should "only show permissions that organisation admins themselves have" do
       app = create(:application, with_delegatable_supported_permissions: %w(write approve))
-      user = create(:organisation_admin, with_permissions: { app => ["write"] })
+      organisation_admin = create(:organisation_admin, with_permissions: { app => ["write"] })
 
-      assert_equal ["write"], app.supported_permission_strings(user)
+      assert_equal ["write"], app.supported_permission_strings(organisation_admin)
     end
 
     should "only show delegatable permissions to organisation admins" do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -298,7 +298,14 @@ class UserTest < ActiveSupport::TestCase
     user = build(:user, role: 'organisation_admin', organisation_id: nil)
 
     refute user.valid?
-    assert_equal "can't be 'None' for an Organisation admin", user.errors[:organisation_id].first
+    assert_equal "can't be 'None' for Organisation Admin", user.errors[:organisation_id].first
+  end
+
+  test "super organisation admin must belong to an organisation" do
+    user = build(:user, role: 'super_organisation_admin', organisation_id: nil)
+
+    refute user.valid?
+    assert_equal "can't be 'None' for Super Organisation Admin", user.errors[:organisation_id].first
   end
 
   test "it doesn't migrate password unless correct one given" do


### PR DESCRIPTION
For: https://trello.com/c/QXKlEEYa/226-create-super-org-admin-permissions-in-signon

## WHAT
This will create a `super_organisation_admin` role which will have the same permissions as an `organisation_admin`, but in addition will also be granted access these permissions for child organisations. 

## WHY
Building on the work of devolving unsuspend permissions to publishers, we want to extend this to being able to unsuspend their child accounts. 