### PR TITLE
Model HMCTS correctly within Signon

### DIFF
--- a/db/migrate/20170926101024_model_hmcts_org_structure.rb
+++ b/db/migrate/20170926101024_model_hmcts_org_structure.rb
@@ -1,0 +1,98 @@
+class ModelHmctsOrgStructure < ActiveRecord::Migration
+  def up
+    # Make sure parent of HMCTS is MOJ
+
+    hmcts = Organisation.find_by(name: "HM Courts & Tribunals Service")
+    moj = Organisation.find_by(name: "Ministry of Justice")
+    if moj.present?
+      if hmcts.parent != moj
+        begin
+          hmcts.update_attribute(parent: moj)
+          puts "Assigned HMCTS to have MOJ as parent"
+        rescue => error
+          puts "Could not update parent for #{hmcts.name} to MOJ because of error: #{error.message}"
+        end
+      else
+        puts "HMCTS already had MOJ as parent"
+      end
+    else
+      puts "!! Could not find Ministry of Justice"
+    end
+
+    # Make sure children of HMCTS are assigned to HMCTS
+
+    organisation_names = [
+        "Bankruptcy Court",
+        "First-tier Tribunal (Mental Health)",
+        "First-tier Tribunal (General Regulatory Chamber)",
+        "First-tier Tribunal (War Pensions and Armed Forces Compensation)",
+        "First-tier Tribunal (Asylum Support)",
+        "First-tier Tribunal (Tax)",
+        "Gangmasters Licensing Appeals",
+        "First-tier Tribunal (Criminal Injuries Compensation)",
+        "First-tier Tribunal (Care Standards)",
+        "Employment Tribunal",
+        "Employment Appeal Tribunal",
+        "Senior Courts Costs Office",
+        "First-tier Tribunal (Social Security and Child Support)",
+        "Court of Protection",
+        "Reserve Forces Appeal Tribunal",
+        "First-tier Tribunal (Property Chamber)",
+        "Upper Tribunal (Tax and Chancery Chamber)",
+        "Upper Tribunal (Lands Chamber)",
+        "Upper Tribunal (Administrative Appeals Chamber)",
+        "First-tier Tribunal (Immigration and Asylum)",
+        "Upper Tribunal (Immigration and Asylum Chamber)",
+        "First-tier Tribunal (Special Educational Needs and Disability)",
+        "Admiralty Court",
+        "Family Division of the High Court",
+        "Planning Court",
+        "Technology and Construction Court",
+        "Mercantile Court",
+        "Commercial Court",
+        "Companies Court",
+        "Intellectual Property Enterprise Court",
+        "Court of Appeal Civil Division",
+        "Northampton County Court Business Centre",
+        "Patents Court",
+        "Court of Appeal Criminal Division",
+        "Queen's Bench Division of the High Court",
+        "Administrative Court",
+        "Chancery Division of the High Court",
+        "HM Courts Service"
+    ]
+
+    missing_orgs = []
+
+    organisation_names.each do |child_name|
+      org = Organisation.find_by(name: child_name)
+      if org.nil?
+        missing_orgs << child_name
+        puts "!! Couldn't find #{child_name}"
+      else
+        if org.parent != hmcts
+          begin
+            old_parent_name = org.parent.nil?? "nil" : org.parent.name
+            puts "Checking parent for #{child_name}. Old parent is #{old_parent_name}"
+            org.update_attributes!(parent: hmcts)
+            puts "Updated parent for #{child_name} from #{old_parent_name} to hmcts"
+          rescue => error
+            puts "Parent re-assignment failed for: #{child_name} with error '#{error.message}'"
+          end
+        else
+          puts "Parent for #{child_name} is correct"
+        end
+      end
+    end
+
+    if missing_orgs.empty?
+      puts "All organisations were found"
+    else
+      puts "Missing organisations: #{missing_orgs.join("\n")}"
+    end
+  end
+
+  def down
+    # This change cannot be reversed
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170908160100) do
+ActiveRecord::Schema.define(version: 20170926101024) do
 
   create_table "batch_invitation_application_permissions", force: :cascade do |t|
     t.integer  "batch_invitation_id",     limit: 4, null: false


### PR DESCRIPTION
For: https://trello.com/c/c3d52nTH/228-model-hmcts-correctly-within-signon

## WHAT
Checks that the ancestry for HMCTS is modeled correctly. If it finds that some of HMCTS' children are not properly assigned, it re-assigns them.

| Parent                         | Children                             |
| ------------------------------ | ------------------------------------ |
| HM Courts & Tribunals Service  | Bankruptcy Court                     |
|                                | First-tier Tribunal (Mental Health)  |
|                                | ...                                  |

Also, "HM Courts Service" was a closed organisation with no parent. It will now be assigned to "HM Courts & Tribunals Service" together will all its other children. 

## WHY 

Building on the work of devolving responsibilities to Organisation Admins and Super Organisation Admins, we want to extend this to being able to have responsibilities on all org's child accounts.

