### PR TITLE
Add role descriptions for (super) org admins

### DIFF
--- a/app/views/users/_form_fields.html.erb
+++ b/app/views/users/_form_fields.html.erb
@@ -30,8 +30,10 @@
     <%= f.label :role %><br />
     <%= f.select :role, options_for_select(filtered_user_roles.map(&:humanize).zip(filtered_user_roles), f.object.role), {}, class: "chosen-select form-control", 'data-module' => 'chosen' %>
     <span class="help-block">
+      <strong>Superadmins</strong> can create and edit all user types and edit applications.<br />
       <strong>Admins</strong> can create and edit normal users.<br />
-      <strong>Superadmins</strong> can create and edit all user types and edit applications.
+      <strong>Super Organisation Admins</strong> can unlock and unsuspend their organisation and related organisation accounts.<br />
+      <strong>Organisation Admins</strong> can unlock and unsuspend their organisation accounts.
     </span>
   </p>
 <% end %>

--- a/db/migrate/20171005140101_assign_apha_org_to_new_parent.rb
+++ b/db/migrate/20171005140101_assign_apha_org_to_new_parent.rb
@@ -1,0 +1,26 @@
+class AssignAphaOrgToNewParent < ActiveRecord::Migration
+  def up
+    defra = Organisation.find_by(name: "Department for Environment, Food & Rural Affairs")
+
+    apha = Organisation.find_by(name: "Animal and Plant Health Agency")
+    if apha.nil?
+      puts "!! Couldn't find 'Animal and Plant Health Agency'"
+    else
+      if apha.parent != defra
+        begin
+          old_parent_name = apha.parent.nil?? "nil" : apha.parent.name
+          apha.update_attributes!(parent: defra)
+          puts "Updating parent for 'Animal and Plant Health Agency' from #{old_parent_name} to #{defra.name}"
+        rescue => error
+          puts "Parent re-assignment failed for: 'Animal and Plant Health Agency' with error '#{error.message}'"
+        end
+      else
+        puts "Parent for 'Animal and Plant Health Agency' is correct"
+      end
+    end
+  end
+
+  def down
+    # This change cannot be reversed
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171002120204) do
+ActiveRecord::Schema.define(version: 20171005140101) do
   create_table "batch_invitation_application_permissions", force: :cascade do |t|
     t.integer  "batch_invitation_id",     limit: 4, null: false
     t.integer  "supported_permission_id", limit: 4, null: false


### PR DESCRIPTION
For: https://trello.com/c/GwkV3LWw/262-super-org-admin-tweaks

This will add a description under the role dropdown on the edit user page. It describes what org admins and super org admins can do.