### PR TITLE
Adds migrations to clean up schema

### DIFF
--- a/db/migrate/20171006133438_cleanup_lhm_tables.rb
+++ b/db/migrate/20171006133438_cleanup_lhm_tables.rb
@@ -1,0 +1,9 @@
+class CleanupLhmTables < ActiveRecord::Migration
+  def up
+    Lhm.cleanup(:run)
+  end
+
+  def down
+    # This migration cannot be reversed
+  end
+end

--- a/db/migrate/20171006135205_cleanup_old_table.rb
+++ b/db/migrate/20171006135205_cleanup_old_table.rb
@@ -1,0 +1,9 @@
+class CleanupOldTable < ActiveRecord::Migration
+  def up
+    drop_table "_event_logs_old"
+  end
+
+  def down
+    # This migration cannot be reversed
+  end
+end

--- a/db/migrate/20171023161055_remove_soft_delete_correctly.rb
+++ b/db/migrate/20171023161055_remove_soft_delete_correctly.rb
@@ -1,0 +1,11 @@
+class RemoveSoftDeleteCorrectly < ActiveRecord::Migration
+  def up
+    remove_index :oauth_applications, :deleted_at if index_exists?(:oauth_applications, :deleted_at)
+    remove_column :oauth_applications, :deleted_at if column_exists?(:oauth_applications, :deleted_at)
+  end
+
+  def down
+    add_column :oauth_applications, :deleted_at, :time
+    add_index :oauth_applications, :deleted_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171020132253) do
+ActiveRecord::Schema.define(version: 20171023161055) do
 
   create_table "batch_invitation_application_permissions", force: :cascade do |t|
     t.integer  "batch_invitation_id",     limit: 4, null: false


### PR DESCRIPTION
For: https://trello.com/c/WzntS0j7/251-signon-fix-schema

Whenever a new migration gets created and run, 2 extra tables get added in the schema: 

1. A table starting with `lhm_<date>`. A migration was run using the LHM gem which is meant to be used for large databases with millions of rows. However, after using it, `lhm.cleanup` needs to be run in order to drop any temporary tables that it might have created in order to ensure zero downtime.

2. An `_old_event_logs` table which was not dropped properly

In addition to that, we also get a "deleted_at" field in the `oauth_applications` table, as well as an index on that column. This is a residue from when it was attempted to implement soft delete on doorkeeper tables using the `acts_as_paranoid` gem. This work was reverted, but the column was not dropped. We're correcting that in this PR. 