### PR TITLE
Add new short-url-manager permission.

### DIFF
--- a/db/migrate/20171017152038_add_short_url_manager_permission.rb
+++ b/db/migrate/20171017152038_add_short_url_manager_permission.rb
@@ -1,0 +1,15 @@
+class AddShortUrlManagerPermission < ActiveRecord::Migration
+  def up
+    app = Doorkeeper::Application.find_by(name: "Short URL Manager")
+    manage_short_urls = SupportedPermission.find_by(application: app, name: "manage_short_urls")
+    receive_notifications = SupportedPermission.create!(application: app, name: "receive_notifications")
+    manage_short_urls.user_application_permissions.each do |uap|
+      UserApplicationPermission.create!(user: uap.user, supported_permission: receive_notifications)
+    end
+  end
+
+  def down
+    app = Doorkeeper::Application.find_by(name: "Short URL Manager")
+    SupportedPermission.find_by(application: app, name: "receive_notifications").destroy
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171005140101) do
+ActiveRecord::Schema.define(version: 20171017152038) do
+
   create_table "batch_invitation_application_permissions", force: :cascade do |t|
     t.integer  "batch_invitation_id",     limit: 4, null: false
     t.integer  "supported_permission_id", limit: 4, null: false
@@ -57,7 +58,6 @@ ActiveRecord::Schema.define(version: 20171005140101) do
   add_index "event_logs", ["uid", "created_at"], name: "index_event_logs_on_uid_and_created_at", using: :btree
   add_index "event_logs", ["user_agent_id"], name: "event_logs_user_agent_id_fk", using: :btree
 
-
   create_table "oauth_access_grants", force: :cascade do |t|
     t.integer  "resource_owner_id", limit: 4,   null: false
     t.integer  "application_id",    limit: 4,   null: false
@@ -88,11 +88,11 @@ ActiveRecord::Schema.define(version: 20171005140101) do
 
   create_table "oauth_applications", force: :cascade do |t|
     t.string   "name",                  limit: 255
-    t.string   "uid",                   limit: 255,                null: false
-    t.string   "secret",                limit: 255,                null: false
-    t.string   "redirect_uri",          limit: 255,                null: false
-    t.datetime "created_at",                                       null: false
-    t.datetime "updated_at",                                       null: false
+    t.string   "uid",                   limit: 255,                 null: false
+    t.string   "secret",                limit: 255,                 null: false
+    t.string   "redirect_uri",          limit: 255,                 null: false
+    t.datetime "created_at",                                        null: false
+    t.datetime "updated_at",                                        null: false
     t.string   "home_uri",              limit: 255
     t.string   "description",           limit: 255
     t.boolean  "supports_push_updates",             default: true


### PR DESCRIPTION
The functionality to receive notifications when a new short URL is
requested was split off into the new `receive_notifications`
permission in https://github.com/alphagov/short-url-manager/pull/99.

This migration creates the permission and assigns it to
all users who have the `manage_short_urls` permission.