### PR TITLE
Fix logging of password reset failures

### DIFF
--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -27,7 +27,7 @@ class PasswordsController < Devise::PasswordsController
       if resource.valid?
         record_password_reset_success(resource)
       else
-        record_password_reset_failure(resource) if resource.persisted?
+        record_password_reset_failure(resource)
       end
     end
   end


### PR DESCRIPTION
Always log the validation errors when a password reset fails. Before, these were only being logged if the user's details had been persisted to the database. I suspect this was never true, because the record had just failed validation and so was never in a persisted state when this check was run.

We're currently trying to debug why a user cannot log into Signon, and these event logs are missing even though the user has reported validation errors and we can see that they have visited the password reset page.

It's not clear from the original commit (fe7ff13) why this check was necessary.