### PR TITLE
Fix wording of email change notification

### DIFF
--- a/app/views/user_mailer/email_changed_notification.html.erb
+++ b/app/views/user_mailer/email_changed_notification.html.erb
@@ -1,5 +1,5 @@
 <p>Your <%= link_to t('department.name'), t('department.url') %> Signon <%= account_name %> email address is being changed from <%= @user.email %> to <%= @user.unconfirmed_email %>.</p>
 
-<p>You should follow the instructions sent to your new email address: <%= @user.email %> to confirm this change.</p>
+<p>You should follow the instructions sent to your new email address: <%= @user.unconfirmed_email %> to confirm this change.</p>
 
 <p>If your email address shouldn't have changed you should contact a managing <%= t('department.name') %> editor in your organisation or your parent organisation.</p>


### PR DESCRIPTION
The email tells you that "You should follow the instructions sent to your new email address". This refers to your new, unconfirmed email address, not your current one.

cc @tuzz 