### PR TITLE
Model Department of Health, Department for Work and Pensions, and Home Office correctly

### DIFF
--- a/db/migrate/20171026164712_model_dh_org_structure.rb
+++ b/db/migrate/20171026164712_model_dh_org_structure.rb
@@ -1,0 +1,146 @@
+class ModelDhOrgStructure < ActiveRecord::Migration
+  def up
+    dh = Organisation.find_by(name: "Department of Health")
+
+    child_org_names = [
+      'Medicines and Healthcare products Regulatory Agency',
+      'Care Quality Commission',
+      'Human Fertilisation and Embryology Authority',
+      'Human Tissue Authority',
+      'Monitor',
+      'National Institute for Health and Care Excellence',
+      'Public Health England',
+      'Health Research Authority',
+      'NHS Trust Development Authority',
+      'NHS Blood and Transplant',
+      'NHS England',
+      'NHS Litigation Authority',
+      'Advisory Committee on Clinical Excellence Awards',
+      'Administration of Radioactive Substances Advisory Committee',
+      'British Pharmacopoeia Commission',
+      'Commission on Human Medicines',
+      'Committee on Mutagenicity of Chemicals in Food, Consumer Products and the Environment',
+      'Independent Reconfiguration Panel',
+      'NHS Business Services Authority',
+      'Review Body on Doctors\' and Dentists\' Remuneration',
+      'NHS Pay Review Body',
+      'Broadmoor Hospital investigation',
+      'Health and Social Care Information Centre',
+      'Health Education England',
+      'Healthcare UK',
+      'Office for Life Sciences',
+      'Morecambe Bay Investigation',
+      'National Information Board',
+      'Accelerated Access Review',
+      'National Data Guardian',
+      'Porton Biopharma Limited',
+      'NHS Improvement',
+      'NHS Digital',
+      'Council for Healthcare Regulatory Excellence',
+      'National Biological Standards Board',
+      'National Blood Authority',
+      'Prescription Pricing Authority',
+      'UK Transplant',
+      'United Kingdom Blood Transfusion Services',
+    ]
+    closed_child_org_names = [
+      'Alcohol Education and Research Council',
+      'Commission for Health Improvement',
+      'Commission for Patient and Public Involvement in Health',
+      'Commission for Social Care Inspection',
+      'Cooksey Review',
+      'Dental Practice Board',
+      'Dental Vocational Training Authority',
+      'Eastern Health and Social Services Board',
+      'Family Health Services Appeal Authority',
+      'General Social Care Council',
+      'Healthcare Commission',
+      'Health Protection Agency',
+      'Hearing Aid Council',
+      'Mental Health Act Commission',
+      'National Care Standards Commission',
+      'National Patient Safety Agency',
+      'National Treatment Agency for Substance Misuse',
+      'NHS Appointments Commission',
+      'NHS Direct National Health Service Trust',
+      'NHS Estates',
+      'NHS Information Centre',
+      'NHS Institute for Innovation and Improvement',
+      'NHS Logistics Authority',
+      'NHS Pensions Agency',
+      'NHS Professionals',
+      'NHS Purchasing and Supply Agency',
+      'Office of the Health Professions Adjudicator',
+      'Professional Standards Authority for Health and Social Care',
+      'Review Body for Nursing and Other Health Professions',
+      'National Radiological Protection Board',
+      'National School of Government',
+      'Public Health Laboratory Service Board',
+    ]
+
+    missing_orgs = []
+
+    child_org_names.each do |child_name|
+      org = Organisation.find_by(name: child_name)
+      if org.nil?
+        missing_orgs << child_name
+        puts "!! Couldn't find #{child_name}"
+      else
+        update_parent(org, dh)
+      end
+    end
+
+    closed_child_org_names.each do |child_name|
+      org = Organisation.find_by(name: child_name)
+      if org.nil?
+        missing_orgs << child_name
+        puts "!! Couldn't find #{child_name}"
+      else
+        update_parent(org, dh)
+        if org.closed?
+          puts "#{child_name} already closed"
+        else
+          org.update_attributes(closed: true)
+          puts "Marking #{child_name} as closed"
+        end
+      end
+    end
+
+    # Grand children
+    nbsa = Organisation.find_by(name: 'NHS Business Services Authority')
+    ['Counter Fraud and Security Management Service'].each do |child_name|
+      org = Organisation.find_by(name: child_name)
+      if org.nil?
+        missing_orgs << child_name
+        puts "!! Couldn't find #{child_name}"
+      else
+        update_parent(org, nbsa)
+      end
+    end
+
+    if missing_orgs.empty?
+      puts "All organisations were found"
+    else
+      puts "Missing organisations: #{missing_orgs.join("\n")}"
+    end
+  end
+
+  def update_parent(org, parent)
+    if org.parent != parent
+      begin
+        old_parent_name = org.parent.nil?? "nil" : org.parent.name
+        puts "Checking parent for #{org.name}. Old parent is #{old_parent_name}"
+        org.update_attributes!(parent: parent)
+        puts "Updating parent for #{org.name} from #{old_parent_name} to #{parent.name}"
+      rescue => error
+        puts "Parent re-assignment failed for: #{org.name} with error '#{error.message}'"
+      end
+    else
+      puts "Parent for #{org.name} is correct"
+    end
+  end
+
+  def down
+    # This change cannot be reversed
+  end
+end

--- a/db/migrate/20171027112449_model_dwp_org_structure.rb
+++ b/db/migrate/20171027112449_model_dwp_org_structure.rb
@@ -1,0 +1,88 @@
+class ModelDwpOrgStructure < ActiveRecord::Migration
+  def up
+    dwp = Organisation.find_by(name: "Department for Work and Pensions")
+
+    child_org_names = [
+      'Industrial Injuries Advisory Council',
+      'Social Security Advisory Committee',
+      'Health and Safety Executive',
+      'The Pensions Advisory Service',
+      'The Pensions Regulator',
+      'Pension Protection Fund Ombudsman',
+      'Pensions Ombudsman',
+      'National Employment Savings Trust (NEST) Corporation',
+      'Pension Protection Fund',
+      'Independent Case Examiner',
+      'Office for Nuclear Regulation',
+      'Office for Disability Issues'
+    ]
+    closed_child_org_names = [
+      'Child Maintenance and Enforcement Commission',
+      'Disabled People’s Employment Corporation',
+      'Remploy Ltd',
+      'Independent Living Fund',
+      'Equality 2025',
+      'Children\'s Workforce Development Council',
+      'Department for Social Development',
+      'Department of Social Security',
+      'Disability and Carers Service',
+      'Parliamentary Contributory Pension Fund',
+      'Pension Service',
+      'Pension, Disability and Carers Service',
+      'Personal Accounts Delivery Authority'
+    ]
+
+    missing_orgs = []
+
+    child_org_names.each do |child_name|
+      org = Organisation.find_by(name: child_name)
+      if org.nil?
+        missing_orgs << child_name
+        puts "!! Couldn't find #{child_name}"
+      else
+        update_parent(org, dwp)
+      end
+    end
+
+    closed_child_org_names.each do |child_name|
+      org = Organisation.find_by(name: child_name)
+      if org.nil?
+        missing_orgs << child_name
+        puts "!! Couldn't find #{child_name}"
+      else
+        update_parent(org, dwp)
+        if org.closed?
+          puts "#{child_name} already closed"
+        else
+          org.update_attributes(closed: true)
+          puts "Marking #{child_name} as closed"
+        end
+      end
+    end
+
+    if missing_orgs.empty?
+      puts "All organisations were found"
+    else
+      puts "Missing organisations: #{missing_orgs.join("\n")}"
+    end
+  end
+
+  def update_parent(org, parent)
+    if org.parent != parent
+      begin
+        old_parent_name = org.parent.nil?? "nil" : org.parent.name
+        puts "Checking parent for #{org.name}. Old parent is #{old_parent_name}"
+        org.update_attributes!(parent: parent)
+        puts "Updating parent for #{org.name} from #{old_parent_name} to #{parent.name}"
+      rescue => error
+        puts "Parent re-assignment failed for: #{org.name} with error '#{error.message}'"
+      end
+    else
+      puts "Parent for #{org.name} is correct"
+    end
+  end
+
+  def down
+    # This change cannot be reversed
+  end
+end

--- a/db/migrate/20171027112810_model_cabinet_office_org_shared_children_structure.rb
+++ b/db/migrate/20171027112810_model_cabinet_office_org_shared_children_structure.rb
@@ -1,0 +1,43 @@
+class ModelCabinetOfficeOrgSharedChildrenStructure < ActiveRecord::Migration
+  def up
+    cabinet_office = Organisation.find_by(name: "Cabinet Office")
+
+    organisation_names = [
+      'Social Mobility and Child Poverty Commission',
+      'Social Mobility Commission'
+    ]
+
+    missing_orgs = []
+
+    organisation_names.each do |child_name|
+      org = Organisation.find_by(name: child_name)
+      if org.nil?
+        missing_orgs << child_name
+        puts "!! Couldn't find #{child_name}"
+      else
+        if org.parent != cabinet_office
+          begin
+            old_parent_name = org.parent.nil?? "nil" : org.parent.name
+            puts "Checking parent for #{child_name}. Old parent is #{old_parent_name}"
+            org.update_attributes!(parent: cabinet_office)
+            puts "Updating parent for #{child_name} from #{old_parent_name} to #{cabinet_office.name}"
+          rescue => error
+            puts "Parent re-assignment failed for: #{child_name} with error '#{error.message}'"
+          end
+        else
+          puts "Parent for #{child_name} is correct"
+        end
+      end
+    end
+
+    if missing_orgs.empty?
+      puts "All organisations were found"
+    else
+      puts "Missing organisations: #{missing_orgs.join("\n")}"
+    end
+  end
+
+  def down
+    # This change cannot be reversed
+  end
+end

--- a/db/migrate/20171027141009_model_home_office_org_structure.rb
+++ b/db/migrate/20171027141009_model_home_office_org_structure.rb
@@ -1,0 +1,133 @@
+class ModelHomeOfficeOrgStructure < ActiveRecord::Migration
+  def up
+    ho = Organisation.find_by(name: "Home Office")
+
+    child_org_names = [
+      'Advisory Council on the Misuse of Drugs',
+      'Animals in Science Committee',
+      'Biometrics and Forensics Ethics Group',
+      'Biometrics Commissioner',
+      'Border Force',
+      'Disclosure and Barring Service',
+      'Forensic Science Regulator',
+      'Gangmasters Licensing Authority',
+      'HM Inspectorate of Constabulary',
+      'HM Passport Office',
+      'Immigration Enforcement',
+      'Independent Anti-slavery Commissioner',
+      'Independent Family Returns Panel',
+      'Independent Police Complaints Commission',
+      'Independent Reviewer of Terrorism Legislation',
+      'Intelligence Services Commissioner',
+      'Interception of Communications Commissioner',
+      'Investigatory Powers Tribunal',
+      'Migration Advisory Committee',
+      'National Counter Terrorism Security Office',
+      'National Crime Agency Remuneration Review Body',
+      'National DNA Database Ethics Group',
+      'Office of the Immigration Services Commissioner',
+      'Office of Surveillance Commissioners',
+      'Police Advisory Board for England and Wales',
+      'Police Arbitration Tribunal',
+      'Police Discipline Appeals Tribunal',
+      'Police Remuneration Review Body',
+      'Security Industry Authority',
+      'Serious Organised Crime Agency',
+      'Surveillance Camera Commissioner',
+      'Technical Advisory Board',
+      'UK Visas and Immigration'
+    ]
+    closed_child_org_names = [
+      'UK Passport Service',
+      'UK Border Agency',
+      'Chief Fire and Rescure Adviser',
+      'Police Negotiating Board',
+      'National Fraud Authority',
+      'Board of Inland Revenue',
+      'Department of Inland Revenue',
+      'H.M. Customs and Excise',
+      'Revenue and Customs Prosecutions Office',
+      'Animal Procedures Committee',
+      'Defence Vetting Agency',
+      'Assets Recovery Agency',
+      'Central Police Training and Development Authority',
+      'Criminal Records Bureau',
+      'Firearms Consultative Committee',
+      'Forensic Science Service',
+      'Independent Chief Inspector of Borders and Immigration',
+      'National Crime Agency',
+      'National Crime Squad',
+      'National Criminal Intelligence Service',
+      'National Policing Improvement Agency',
+      'Office of the Identity Commissioner',
+      'Police Information Technology Organisation',
+      'Identity and Passport Service',
+      'Police Complaints Authority'
+    ]
+
+    missing_orgs = []
+
+    child_org_names.each do |child_name|
+      org = Organisation.find_by(name: child_name)
+      if org.nil?
+        missing_orgs << child_name
+        puts "!! Couldn't find #{child_name}"
+      else
+        update_parent(org, ho)
+      end
+    end
+
+    closed_child_org_names.each do |child_name|
+      org = Organisation.find_by(name: child_name)
+      if org.nil?
+        missing_orgs << child_name
+        puts "!! Couldn't find #{child_name}"
+      else
+        update_parent(org, ho)
+        if org.closed?
+          puts "#{child_name} already closed"
+        else
+          org.update_attributes(closed: true)
+          puts "Marking #{child_name} as closed"
+        end
+      end
+    end
+
+    # Grand children
+    tab = Organisation.find_by(name: 'Technical Advisory Board')
+    ['Centre for the Protection of National Infrastructure'].each do |child_name|
+      org = Organisation.find_by(name: child_name)
+      if org.nil?
+        missing_orgs << child_name
+        puts "!! Couldn't find #{child_name}"
+      else
+        update_parent(org, tab)
+      end
+    end
+
+    if missing_orgs.empty?
+      puts "All organisations were found"
+    else
+      puts "Missing organisations: #{missing_orgs.join("\n")}"
+    end
+  end
+
+  def update_parent(org, parent)
+    if org.parent != parent
+      begin
+        old_parent_name = org.parent.nil?? "nil" : org.parent.name
+        puts "Checking parent for #{org.name}. Old parent is #{old_parent_name}"
+        org.update_attributes!(parent: parent)
+        puts "Updating parent for #{org.name} from #{old_parent_name} to #{parent.name}"
+      rescue => error
+        puts "Parent re-assignment failed for: #{org.name} with error '#{error.message}'"
+      end
+    else
+      puts "Parent for #{org.name} is correct"
+    end
+  end
+
+  def down
+    # This change cannot be reversed
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171023161055) do
+ActiveRecord::Schema.define(version: 20171026164712) do
 
   create_table "batch_invitation_application_permissions", force: :cascade do |t|
     t.integer  "batch_invitation_id",     limit: 4, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171026164712) do
+ActiveRecord::Schema.define(version: 20171027112810) do
 
   create_table "batch_invitation_application_permissions", force: :cascade do |t|
     t.integer  "batch_invitation_id",     limit: 4, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171027112810) do
+ActiveRecord::Schema.define(version: 20171027141009) do
 
   create_table "batch_invitation_application_permissions", force: :cascade do |t|
     t.integer  "batch_invitation_id",     limit: 4, null: false


### PR DESCRIPTION
For:

* https://trello.com/c/pQum6KSu/272-model-dh-correctly-within-signon
* https://trello.com/c/z976OdQw/274-model-dwp-correctly-within-signon
* https://trello.com/c/Rmt2hrLQ/281-model-home-office-correctly-within-signon

Similar to #578 we're making sure these organisations are modelled correctly (based on the hierarchy in whitehall).  For some cases where whitehall models dual parentage, we've decided which parent is the "primary" parent and used that one here in signon because signon only supports a single parent structure (which is why we've got a Cabinet Office fix in here too that we didn't have in #572).