### PR TITLE
Re-enable changing email while being unauthenticated

### DIFF
--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -54,8 +54,7 @@ class ConfirmationsController < Devise::ConfirmationsController
 
   private
   def confirmation_user
-    token = Devise.token_generator.digest(User, :confirmation_token, params[:confirmation_token])
-    @confirmation_user ||= resource_class.find_or_initialize_by(confirmation_token: token)
+    @confirmation_user ||= resource_class.find_or_initialize_by(confirmation_token: params[:confirmation_token])
   end
 
   def handle_new_token_needed

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -17,6 +17,12 @@ Signon::Application.configure do
   config.action_mailer.raise_delivery_errors = false
   config.action_mailer.default_url_options = { host: URI.parse(Plek.find('signon')).host }
 
+  # Send emails to the local MailHog instance
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    port: 1025
+  }
+
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 

--- a/test/helpers/confirmation_token_helper.rb
+++ b/test/helpers/confirmation_token_helper.rb
@@ -1,8 +1,8 @@
 module ConfirmationTokenHelper
   def token_sent_to(user)
-    raw, enc = Devise.token_generator.generate(User, :confirmation_token)
-    user.confirmation_token = enc
+    token = Devise.friendly_token
+    user.confirmation_token = token
     user.save(validate: false)
-    raw
+    token
   end
 end


### PR DESCRIPTION
Story: https://trello.com/c/kZoLDLrT/286-changing-your-email-address-in-signon-shows-a-confusing-error-message

This fixes a compatibility issue we encountered with Devise where we were continuing to use encrypted tokens for confirmations, where they have dropped this behaviour.

This also adds in SMTP config which will allow hooking up to Mailhog a la [Whitehall](https://github.com/alphagov/whitehall/blob/master/config/environments/development.rb#L45-L49)