### PR TITLE
Model mod org correctly

### DIFF
--- a/db/migrate/20171103111953_model_mod_org_structure.rb
+++ b/db/migrate/20171103111953_model_mod_org_structure.rb
@@ -1,0 +1,134 @@
+class ModelModOrgStructure < ActiveRecord::Migration
+  def up
+    mod = Organisation.find_by(name: 'Ministry of Defence')
+    dstl = Organisation.find_by(name: 'Defence Science and Technology Laboratory')
+    ukho = Organisation.find_by(name: 'UK Hydrographic Office')
+
+    parent_child_orgs = {
+        mod => [
+            "Advisory Committee on Conscientious Objectors",
+            "Advisory Group on Military Medicine",
+            "Armed Forces' Pay Review Body",
+            "Central Advisory Committee on Compensation",
+            "Central Advisory Committee on Pensions and Compensation",
+            "Defence Academy of the United Kingdom",
+            "Defence Electronics and Components Agency",
+            "Defence Equipment and Support",
+            "Defence Infrastructure Organisation",
+            "Defence Medical Education and Training Agency",
+            "Defence Nuclear Safety Committee",
+            "Defence, Press and Broadcasting Advisory Committee",
+            "Defence Safety Authority",
+            "Defence Science and Technology Laboratory",
+            "Defence Scientific Advisory Council",
+            "Defence and Security Media Advisory Committee",
+            "Defence Sixth Form College",
+            "Defence Support Group",
+            "Fleet Air Arm Museum",
+            "Independent Medical Expert Group",
+            "Joint Forces Command",
+            "Military Aviation Authority",
+            "National Army Museum",
+            "National Employer Advisory Board",
+            "National Museum of the Royal Navy",
+            "Nuclear Research Advisory Council",
+            "Queen's Harbour Master",
+            "Reserve Forces' and Cadets' Associations",
+            "Review Board for Government Contracts",
+            "Royal Air Force Museum",
+            "Royal Marines Museum",
+            "Royal Navy Submarine Museum",
+            "Scientific Advisory Committee on the Medical Implications of Less-Lethal Weapons",
+            "Service Children's Education",
+            "Service Complaints Commissioner",
+            "Service Complaints Ombudsman",
+            "Service Personnel and Veterans Agency",
+            "Service Prosecuting Authority",
+            "Single Source Regulations Office",
+            "The Oil and Pipelines Agency",
+            "UK Hydrographic Office",
+            "Veterans Advisory and Pensions Committees",
+            "Veterans UK",
+            "United Kingdom Reserve Forces Association"
+        ],
+        dstl => ["Centre for Defence Enterprise", "Defence and Security Accelerator"],
+        ukho => ["HM Nautical Almanac Office"]
+    }
+
+    closed_child_org_names = [
+        "Army Base Repair Organisation",
+        "Chemical and Biological Defence Establishment",
+        "Defence Analytical Services Agency",
+        "Defence Aviation Repair Agency",
+        "Defence Bills Agency",
+        "British Forces Post Office",
+        "Defence Estates",
+        "Defence Communication Services Agency",
+        "Defence Intelligence and Security Centre",
+        "Defence Procurement Agency",
+        "Defence Storage and Distribution Agency",
+        "Defence Transport and Movements Agency",
+        "Disposal Services Agency",
+        "Medical Supplies Agency",
+        "Ministry of Defence Police and Guarding Agency",
+        "People, Pay and Pensions Agency",
+        "Warship Support Agency",
+        "Armed Forces Personnel Administration Agency"
+    ]
+
+    missing_orgs = []
+
+    parent_child_orgs.each do |expected_parent, children|
+      children.each do |child_name|
+        org = Organisation.find_by(name: child_name)
+        if org.nil?
+          missing_orgs << child_name
+          puts "!! Couldn't find #{child_name}"
+        else
+          update_parent(org, expected_parent)
+        end
+      end
+    end
+
+    closed_child_org_names.each do |child_name|
+      org = Organisation.find_by(name: child_name)
+      if org.nil?
+        missing_orgs << child_name
+        puts "!! Couldn't find #{child_name}"
+      else
+        update_parent(org, mod)
+        if org.closed?
+          puts "#{child_name} already closed"
+        else
+          org.update_attributes(closed: true)
+          puts "Marking #{child_name} as closed"
+        end
+      end
+    end
+
+    if missing_orgs.empty?
+      puts "All organisations were found"
+    else
+      puts "Missing organisations: #{missing_orgs.join("\n")}"
+    end
+  end
+
+  def update_parent(org, parent)
+    if org.parent != parent
+      begin
+        old_parent_name = org.parent.nil?? "nil" : org.parent.name
+        puts "Checking parent for #{org.name}. Old parent is #{old_parent_name}"
+        org.update_attributes!(parent: parent)
+        puts "Updating parent for #{org.name} from #{old_parent_name} to #{parent.name}"
+      rescue => error
+        puts "Parent re-assignment failed for: #{org.name} with error '#{error.message}'"
+      end
+    else
+      puts "Parent for #{org.name} is correct"
+    end
+  end
+
+  def down
+    # This change cannot be reversed
+  end
+end

--- a/db/migrate/20171103145613_model_ago_org_structure.rb
+++ b/db/migrate/20171103145613_model_ago_org_structure.rb
@@ -1,0 +1,54 @@
+class ModelAgoOrgStructure < ActiveRecord::Migration
+  def up
+    ago = Organisation.find_by(name: "Attorney General's Office")
+    tsd = Organisation.find_by(name: "Treasury Solicitor’s Department")
+
+    parent_child_orgs = {
+        ago => ["Treasury Solicitor’s Department",
+                  "Crown Prosecution Service",
+                  "Serious Fraud Office",
+                  "HM Crown Prosecution Service Inspectorate",
+                  "Government Legal Department"],
+        tsd => ["Bank of England"]
+    }
+
+    missing_orgs = []
+
+    parent_child_orgs.each do |expected_parent, children|
+      children.each do |child_name|
+        org = Organisation.find_by(name: child_name)
+        if org.nil?
+          missing_orgs << child_name
+          puts "!! Couldn't find #{child_name}"
+        else
+          update_parent(org, expected_parent)
+        end
+      end
+    end
+
+    if missing_orgs.empty?
+      puts "All organisations were found"
+    else
+      puts "Missing organisations: #{missing_orgs.join("\n")}"
+    end
+  end
+
+  def update_parent(org, parent)
+    if org.parent != parent
+      begin
+        old_parent_name = org.parent.nil?? "nil" : org.parent.name
+        puts "Checking parent for #{org.name}. Old parent is #{old_parent_name}"
+        org.update_attributes!(parent: parent)
+        puts "Updating parent for #{org.name} from #{old_parent_name} to #{parent.name}"
+      rescue => error
+        puts "Parent re-assignment failed for: #{org.name} with error '#{error.message}'"
+      end
+    else
+      puts "Parent for #{org.name} is correct"
+    end
+  end
+
+  def down
+    # This change cannot be reversed
+  end
+end

--- a/db/migrate/20171103151119_model_dfe_org_structure.rb
+++ b/db/migrate/20171103151119_model_dfe_org_structure.rb
@@ -1,0 +1,149 @@
+class ModelDfeOrgStructure < ActiveRecord::Migration
+  def up
+    dfe = Organisation.find_by(name: "Department for Education")
+
+    child_org_names = ["Education Funding Agency",
+                       "Standards and Testing Agency",
+                       "Ofqual",
+                       "Ofsted",
+                       "Office of the Children's Commissioner",
+                       "School Teachers' Review Body",
+                       "National College for Teaching and Leadership",
+                       "National College for School Leadership",
+                       "Office of the Schools Adjudicator",
+                       "Schools Commissioners Group",
+                       "Government Equalities Office",
+                       "Equality and Human Rights Commission",
+                       "Skills Funding Agency",
+                       "Higher Education Funding Council for England",
+                       "Office for Fair Access",
+                       "Student Loans Company",
+                       "UK Commission for Employment and Skills",
+                       "Construction Industry Training Board",
+                       "Engineering Construction Industry Training Board",
+                       "Education and Skills Funding Agency",
+                       "Institute for Apprenticeships"]
+
+    closed_child_org_names = ["Department for Education and Skills",
+                              "Department for Children, Schools and Families",
+                              "Qualifications and Curriculum Authority",
+                              "Derby North East Education Action Zone",
+                              "Kitts Green and Shard End Education Action Zone",
+                              "Greenwich Education Action Zone",
+                              "Wolverhampton Education Action Zone",
+                              "Wednesbury Education Action Zone",
+                              "Bolton Education Action Zone",
+                              "Hamilton Oxford Education Action Zone",
+                              "Dudley Education Action Zone",
+                              "Westminster Education Action Zone",
+                              "North East Derbyshire Coalfields Education Action Zone",
+                              "Telford and Wrekin Education Action Zone",
+                              "Withernsea and Southern Holderness Education Action Zone",
+                              "Easington and Seaham Education Action Zone",
+                              "North Islington Education Action Zone",
+                              "Stoke Education Action Zone",
+                              "Sunderland Education Action Zone",
+                              "Peterlee Education Action Zone",
+                              "Southend Education Action Zone",
+                              "Bedford Education Action Zone",
+                              "Leigh Park Education Action Zone",
+                              "Downham and Bellingham Education Action Zone",
+                              "Corby Education Action Zone",
+                              "Bristol Education Action Zone",
+                              "North West Shropshire Education Action Zone",
+                              "Wythenshawe Education Action Zone",
+                              "Ellesmere Port Education Action Zone",
+                              "Camborne, Pool and Redruth Education Action Zone",
+                              "Coventry Education Action Zone",
+                              "North Gillingham Education Action Zone",
+                              "Gloucester Education Action Zone",
+                              "East Manchester Education Action Zone",
+                              "Clacton and Harwich Education Action Zone",
+                              "Hackney Education Action Zone",
+                              "Hastings and St Leonards Education Action Zone",
+                              "Kent and Somerset Education Action Zone",
+                              "Bridgwater Education Action Zone",
+                              "Wakefield Education Action Zone",
+                              "Great Yarmouth Education Action Zone",
+                              "South East England Virtual Education Action Zone",
+                              "Heart of Slough Education Action Zone",
+                              "Plymouth Education Action Zone",
+                              "Learning and Skills Council",
+                              "Barrow Education Action Zone",
+                              "Speke Garston Education Action Zone",
+                              "East Cleveland Education Action Zone",
+                              "South Bradford Education Action Zone",
+                              "North Stockton Education Action Zone",
+                              "Council for Catholic Maintained Schools",
+                              "Adult Learning Inspectorate",
+                              "Training and Development Agency for Schools",
+                              "National School of Government",
+                              "Postgraduate Medical Education and Training Board",
+                              "British Educational Communications and Technology Agency",
+                              "Qualifications and Curriculum Development Agency",
+                              "Young People's Learning Agency",
+                              "Polytechnics and Colleges Funding Council",
+                              "Commission for Racial Equality",
+                              "Equal Opportunities Commission",
+                              "Disability Rights Commission",
+                              "General Teaching Council for England",
+                              "Ashington Education Action Zone",
+                              "Further and Higher Education Funding Councils for Wales",
+                              "Investors in People UK",
+                              "School Food Trust"]
+
+
+    missing_orgs = []
+
+    child_org_names.each do |child_name|
+      org = Organisation.find_by(name: child_name)
+      if org.nil?
+        missing_orgs << child_name
+        puts "!! Couldn't find #{child_name}"
+      else
+        update_parent(org, dfe)
+      end
+    end
+
+    closed_child_org_names.each do |child_name|
+      org = Organisation.find_by(name: child_name)
+      if org.nil?
+        missing_orgs << child_name
+        puts "!! Couldn't find #{child_name}"
+      else
+        update_parent(org, dfe)
+        if org.closed?
+          puts "#{child_name} already closed"
+        else
+          org.update_attributes(closed: true)
+          puts "Marking #{child_name} as closed"
+        end
+      end
+    end
+
+    if missing_orgs.empty?
+      puts "All organisations were found"
+    else
+      puts "Missing organisations: #{missing_orgs.join("\n")}"
+    end
+  end
+
+  def update_parent(org, parent)
+    if org.parent != parent
+      begin
+        old_parent_name = org.parent.nil?? "nil" : org.parent.name
+        puts "Checking parent for #{org.name}. Old parent is #{old_parent_name}"
+        org.update_attributes!(parent: parent)
+        puts "Updating parent for #{org.name} from #{old_parent_name} to #{parent.name}"
+      rescue => error
+        puts "Parent re-assignment failed for: #{org.name} with error '#{error.message}'"
+      end
+    else
+      puts "Parent for #{org.name} is correct"
+    end
+  end
+
+  def down
+    # This change cannot be reversed
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171027141009) do
+ActiveRecord::Schema.define(version: 20171103151119) do
 
   create_table "batch_invitation_application_permissions", force: :cascade do |t|
     t.integer  "batch_invitation_id",     limit: 4, null: false


### PR DESCRIPTION
For: 

- https://trello.com/c/YUHzHhRg/278-model-mod-correctly-within-signon
- https://trello.com/c/Bq4Tyb7p/267-model-ago-correctly-within-signon
- https://trello.com/c/kKelVpbt/270-model-dfe-correctly-within-signon

Similar to https://github.com/alphagov/signon/pull/578 and https://github.com/alphagov/signon/pull/580, we're making sure that these organisations have their organisational structure modelled correctly (based on the hierarchy in whitehall). 

For some cases where an organisation has two parents in whitehall, we've decided which parent is the "primary" parent and assigned that one to the org in signon because signon only supports a single parent structure. 
