### PR TITLE
Model multiple orgs correctly

### DIFF
--- a/db/migrate/20171108144303_model_dit_org_structure.rb
+++ b/db/migrate/20171108144303_model_dit_org_structure.rb
@@ -1,0 +1,42 @@
+class ModelDitOrgStructure < ActiveRecord::Migration
+  def up
+    dit = Organisation.find_by(name: "Department for International Trade")
+
+    missing_orgs = []
+
+    ["Export Control Organisation", "Department for International Trade Defence & Security Organisation"].each do |child_name|
+      org = Organisation.find_by(name: child_name)
+      if org.nil?
+        missing_orgs << child_name
+        puts "!! Couldn't find #{child_name}"
+      else
+        update_parent(org, dit)
+      end
+    end
+
+    if missing_orgs.empty?
+      puts "All organisations were found"
+    else
+      puts "Missing organisations: #{missing_orgs.join("\n")}"
+    end
+  end
+
+  def update_parent(org, parent)
+    if org.parent != parent
+      begin
+        old_parent_name = org.parent.nil?? "nil" : org.parent.name
+        puts "Checking parent for #{org.name}. Old parent is #{old_parent_name}"
+        org.update_attributes!(parent: parent)
+        puts "Updating parent for #{org.name} from #{old_parent_name} to #{parent.name}"
+      rescue => error
+        puts "Parent re-assignment failed for: #{org.name} with error '#{error.message}'"
+      end
+    else
+      puts "Parent for #{org.name} is correct"
+    end
+  end
+
+  def down
+    # This change cannot be reversed
+  end
+end

--- a/db/migrate/20171108144431_model_fco_org_structure.rb
+++ b/db/migrate/20171108144431_model_fco_org_structure.rb
@@ -1,0 +1,63 @@
+class ModelFcoOrgStructure < ActiveRecord::Migration
+  def up
+    fco = Organisation.find_by(name: "Foreign & Commonwealth Office")
+    gch = Organisation.find_by(name: "Government Communications Headquarters")
+
+    parent_child_orgs = {
+        fco => ["BBC World Service",
+                "British Council",
+                "Chevening Scholarship Programme",
+                "FCO Services",
+                "Government Communications Headquarters",
+                "Great Britain-China Centre",
+                "Marshall Aid Commemoration Commission",
+                "Preventing Sexual Violence Initiative",
+                "Secret Intelligence Service",
+                "Westminster Foundation for Democracy",
+                "Wilton Park"
+        ],
+        gch => ["CESG",
+                "National Cyber Security Centre"
+        ]
+    }
+
+    missing_orgs = []
+
+    parent_child_orgs.each do |expected_parent, children|
+      children.each do |child_name|
+        org = Organisation.find_by(name: child_name)
+        if org.nil?
+          missing_orgs << child_name
+          puts "!! Couldn't find #{child_name}"
+        else
+          update_parent(org, expected_parent)
+        end
+      end
+    end
+
+    if missing_orgs.empty?
+      puts "All organisations were found"
+    else
+      puts "Missing organisations: #{missing_orgs.join("\n")}"
+    end
+  end
+
+  def update_parent(org, parent)
+    if org.parent != parent
+      begin
+        old_parent_name = org.parent.nil?? "nil" : org.parent.name
+        puts "Checking parent for #{org.name}. Old parent is #{old_parent_name}"
+        org.update_attributes!(parent: parent)
+        puts "Updating parent for #{org.name} from #{old_parent_name} to #{parent.name}"
+      rescue => error
+        puts "Parent re-assignment failed for: #{org.name} with error '#{error.message}'"
+      end
+    else
+      puts "Parent for #{org.name} is correct"
+    end
+  end
+
+  def down
+    # This change cannot be reversed
+  end
+end

--- a/db/migrate/20171108144458_model_fsa_org_structure.rb
+++ b/db/migrate/20171108144458_model_fsa_org_structure.rb
@@ -1,0 +1,72 @@
+class ModelFsaOrgStructure < ActiveRecord::Migration
+  def up
+    fsa = Organisation.find_by(name: "Food Standards Agency")
+
+    child_org_names = [
+        "Advisory Committee on Animal Feedingstuffs",
+        "Advisory Committee on Novel Foods and Processes",
+        "Advisory Committee on the Microbiological Safety of Food",
+        "Committee on Toxicity of Chemicals in Food, Consumer Products and the Environment",
+        "General Advisory Committee on Science",
+        "Social Science Research Committee"
+    ]
+
+    closed_child_org_names = [
+        "British Potato Council",
+        "Meat Hygiene Service"
+    ]
+
+    missing_orgs = []
+
+    child_org_names.each do |child_name|
+      org = Organisation.find_by(name: child_name)
+      if org.nil?
+        missing_orgs << child_name
+        puts "!! Couldn't find #{child_name}"
+      else
+        update_parent(org, fsa)
+      end
+    end
+
+    closed_child_org_names.each do |child_name|
+      org = Organisation.find_by(name: child_name)
+      if org.nil?
+        missing_orgs << child_name
+        puts "!! Couldn't find #{child_name}"
+      else
+        update_parent(org, fsa)
+        if org.closed?
+          puts "#{child_name} already closed"
+        else
+          org.update_attributes(closed: true)
+          puts "Marking #{child_name} as closed"
+        end
+      end
+    end
+
+    if missing_orgs.empty?
+      puts "All organisations were found"
+    else
+      puts "Missing organisations: #{missing_orgs.join("\n")}"
+    end
+  end
+
+  def update_parent(org, parent)
+    if org.parent != parent
+      begin
+        old_parent_name = org.parent.nil?? "nil" : org.parent.name
+        puts "Checking parent for #{org.name}. Old parent is #{old_parent_name}"
+        org.update_attributes!(parent: parent)
+        puts "Updating parent for #{org.name} from #{old_parent_name} to #{parent.name}"
+      rescue => error
+        puts "Parent re-assignment failed for: #{org.name} with error '#{error.message}'"
+      end
+    else
+      puts "Parent for #{org.name} is correct"
+    end
+  end
+
+  def down
+    # This change cannot be reversed
+  end
+end

--- a/db/migrate/20171108144537_model_hmt_org_structure.rb
+++ b/db/migrate/20171108144537_model_hmt_org_structure.rb
@@ -1,0 +1,94 @@
+class ModelHmtOrgStructure < ActiveRecord::Migration
+  def up
+    hmt = Organisation.find_by(name: "HM Treasury")
+    ukgi = Organisation.find_by(name: "UK Government Investments")
+
+    parent_child_orgs = {
+        hmt => [
+            "Financial Conduct Authority",
+            "Financial Services Trade and Investment Board",
+            "Government Internal Audit Agency",
+            "Infrastructure UK",
+            "National Infrastructure Commission",
+            "Office for Budget Responsibility",
+            "Office of Financial Sanctions Implementation",
+            "Payment Systems Regulator",
+            "Royal Mint",
+            "Royal Mint Advisory Committee",
+            "NS&I",
+            "The Crown Estate",
+            "UK Debt Management Office",
+            "UK Government Investments"
+        ],
+        ukgi => [
+            "UK Financial Investments Limited",
+            "Government Corporate Finance Profession"
+        ]
+    }
+
+    closed_child_org_names = [
+        "Asset Protection Agency",
+        "Office of HM Paymaster General",
+        "Office of Tax Simplification",
+        "Royal Mail",
+        "Royal Trustees' Office",
+        "Exchequer and Audit Department",
+        "Public Accounts Commission"
+    ]
+
+    missing_orgs = []
+
+    parent_child_orgs.each do |expected_parent, children|
+      children.each do |child_name|
+        org = Organisation.find_by(name: child_name)
+        if org.nil?
+          missing_orgs << child_name
+          puts "!! Couldn't find #{child_name}"
+        else
+          update_parent(org, expected_parent)
+        end
+      end
+    end
+
+    closed_child_org_names.each do |child_name|
+      org = Organisation.find_by(name: child_name)
+      if org.nil?
+        missing_orgs << child_name
+        puts "!! Couldn't find #{child_name}"
+      else
+        update_parent(org, hmt)
+        if org.closed?
+          puts "#{child_name} already closed"
+        else
+          org.update_attributes(closed: true)
+          puts "Marking #{child_name} as closed"
+        end
+      end
+    end
+
+    if missing_orgs.empty?
+      puts "All organisations were found"
+    else
+      puts "Missing organisations: #{missing_orgs.join("\n")}"
+    end
+  end
+
+  def update_parent(org, parent)
+    if org.parent != parent
+      begin
+        old_parent_name = org.parent.nil?? "nil" : org.parent.name
+        puts "Checking parent for #{org.name}. Old parent is #{old_parent_name}"
+        org.update_attributes!(parent: parent)
+        puts "Updating parent for #{org.name} from #{old_parent_name} to #{parent.name}"
+      rescue => error
+        puts "Parent re-assignment failed for: #{org.name} with error '#{error.message}'"
+      end
+    else
+      puts "Parent for #{org.name} is correct"
+    end
+  end
+
+  def down
+    # This change cannot be reversed
+  end
+end

--- a/db/migrate/20171108144557_model_moj_org_structure.rb
+++ b/db/migrate/20171108144557_model_moj_org_structure.rb
@@ -1,0 +1,163 @@
+class ModelMojOrgStructure < ActiveRecord::Migration
+  def up
+    moj = Organisation.find_by(name: "Ministry of Justice")
+    hmcts = Organisation.find_by(name: "HM Courts & Tribunals Service")
+    noms = Organisation.find_by(name: "National Offender Management Service")
+
+    parent_child_orgs = {
+        moj => [
+            "Academy for Justice Commissioning",
+            "Academy for Social Justice Commissioning",
+            "Administrative Justice and Tribunals Council",
+            "Advisory Panel on Public Sector Information",
+            "Advisory Committees on Justices of the Peace",
+            "Cafcass",
+            "Civil Justice Council",
+            "Civil Procedure Rule Committee",
+            "Criminal Injuries Compensation Authority",
+            "Criminal Cases Review Commission",
+            "Criminal Procedure Rule Committee",
+            "Family Justice Council",
+            "Family Procedure Rule Committee",
+            "Her Majesty's Magistrates Courts Service Inspectorate",
+            "HM Courts & Tribunals Service",
+            "HM Inspectorate of Prisons",
+            "HM Inspectorate of Probation",
+            "HM Prison Service",
+            "Independent Advisory Panel on Deaths in Custody",
+            "Independent Monitoring Boards",
+            "Judicial Appointments and Conduct Ombudsman",
+            "Judicial Appointments Commission",
+            "Judicial Office",
+            "Law Commission",
+            "Legal Aid Agency",
+            "Legal Services Board",
+            "Legal Services Commission",
+            "National Offender Management Service",
+            "Official Solicitor and Public Trustee",
+            "Office of the Public Guardian",
+            "Parole Board",
+            "Prisons and Probation Ombudsman",
+            "Prison Service Pay Review Body",
+            "Sentencing Council for England and Wales",
+            "The Jeffrey Review",
+            "The Legal Ombudsman",
+            "Tribunal Procedure Committee",
+            "Victims' Advisory Panel",
+            "Victims' Commissioner",
+            "Youth Justice Board for England and Wales"
+        ],
+        hmcts => [
+            "Bankruptcy Court",
+            "First-tier Tribunal (Mental Health)",
+            "First-tier Tribunal (General Regulatory Chamber)",
+            "First-tier Tribunal (War Pensions and Armed Forces Compensation)",
+            "First-tier Tribunal (Asylum Support)",
+            "First-tier Tribunal (Tax)",
+            "Gangmasters Licensing Appeals",
+            "First-tier Tribunal (Criminal Injuries Compensation)",
+            "First-tier Tribunal (Care Standards)",
+            "Employment Tribunal",
+            "Employment Appeal Tribunal",
+            "Senior Courts Costs Office",
+            "First-tier Tribunal (Social Security and Child Support)",
+            "Court of Protection",
+            "Reserve Forces Appeal Tribunal",
+            "First-tier Tribunal (Property Chamber)",
+            "Upper Tribunal (Tax and Chancery Chamber)",
+            "Upper Tribunal (Lands Chamber)",
+            "Upper Tribunal (Administrative Appeals Chamber)",
+            "First-tier Tribunal (Immigration and Asylum)",
+            "Upper Tribunal (Immigration and Asylum Chamber)",
+            "First-tier Tribunal (Special Educational Needs and Disability)",
+            "Admiralty Court",
+            "Family Division of the High Court",
+            "Planning Court",
+            "Technology and Construction Court",
+            "Mercantile Court",
+            "Commercial Court",
+            "Companies Court",
+            "Intellectual Property Enterprise Court",
+            "Court of Appeal Civil Division",
+            "Northampton County Court Business Centre",
+            "Patents Court",
+            "Court of Appeal Criminal Division",
+            "Queen's Bench Division of the High Court",
+            "Administrative Court",
+            "Chancery Division of the High Court"
+        ],
+        noms => ["National Probation Service"]
+    }
+
+    closed_child_org_names = [
+        "Criminal Injuries Compensation Appeals Panel",
+        "H.M. Inspectorate of Court Administration",
+        "Administrative Justice and Tribunals Council Welsh Committee",
+        "Appeals Service Agency",
+        "Council on Tribunals",
+        "Department for Constitutional Affairs",
+        "Department of Constitutional Affairs",
+        "Foreign Compensation Commission",
+        "Lord Chancellor's Department",
+        "Office for Criminal Justice Reform",
+        "Office of the Lay Observer",
+        "Office of the Legal Services Complaints Commissioner",
+        "Office of the Legal Services Ombudsman"
+    ]
+
+    missing_orgs = []
+
+    parent_child_orgs.each do |expected_parent, children|
+      children.each do |child_name|
+        org = Organisation.find_by(name: child_name)
+        if org.nil?
+          missing_orgs << child_name
+          puts "!! Couldn't find #{child_name}"
+        else
+          update_parent(org, expected_parent)
+        end
+      end
+    end
+
+    closed_child_org_names.each do |child_name|
+      org = Organisation.find_by(name: child_name)
+      if org.nil?
+        missing_orgs << child_name
+        puts "!! Couldn't find #{child_name}"
+      else
+        update_parent(org, moj)
+        if org.closed?
+          puts "#{child_name} already closed"
+        else
+          org.update_attributes(closed: true)
+          puts "Marking #{child_name} as closed"
+        end
+      end
+    end
+
+    if missing_orgs.empty?
+      puts "All organisations were found"
+    else
+      puts "Missing organisations: #{missing_orgs.join("\n")}"
+    end
+  end
+
+  def update_parent(org, parent)
+    if org.parent != parent
+      begin
+        old_parent_name = org.parent.nil?? "nil" : org.parent.name
+        puts "Checking parent for #{org.name}. Old parent is #{old_parent_name}"
+        org.update_attributes!(parent: parent)
+        puts "Updating parent for #{org.name} from #{old_parent_name} to #{parent.name}"
+      rescue => error
+        puts "Parent re-assignment failed for: #{org.name} with error '#{error.message}'"
+      end
+    else
+      puts "Parent for #{org.name} is correct"
+    end
+  end
+
+  def down
+    # This change cannot be reversed
+  end
+end

--- a/db/migrate/20171108145415_model_nio_org_structure.rb
+++ b/db/migrate/20171108145415_model_nio_org_structure.rb
@@ -1,0 +1,54 @@
+class ModelNioOrgStructure < ActiveRecord::Migration
+  def up
+    nio = Organisation.find_by(name: "Northern Ireland Office")
+    so = Organisation.find_by(name: "Scotland Office")
+
+    parent_child_orgs = {
+        nio => [
+            "Boundary Commission for Northern Ireland",
+            "Northern Ireland Human Rights Commission",
+            "Parades Commission for Northern Ireland"
+        ],
+        so => ["Boundary Commission for Scotland"]
+    }
+
+    missing_orgs = []
+
+    parent_child_orgs.each do |expected_parent, children|
+      children.each do |child_name|
+        org = Organisation.find_by(name: child_name)
+        if org.nil?
+          missing_orgs << child_name
+          puts "!! Couldn't find #{child_name}"
+        else
+          update_parent(org, expected_parent)
+        end
+      end
+    end
+
+    if missing_orgs.empty?
+      puts "All organisations were found"
+    else
+      puts "Missing organisations: #{missing_orgs.join("\n")}"
+    end
+  end
+
+  def update_parent(org, parent)
+    if org.parent != parent
+      begin
+        old_parent_name = org.parent.nil?? "nil" : org.parent.name
+        puts "Checking parent for #{org.name}. Old parent is #{old_parent_name}"
+        org.update_attributes!(parent: parent)
+        puts "Updating parent for #{org.name} from #{old_parent_name} to #{parent.name}"
+      rescue => error
+        puts "Parent re-assignment failed for: #{org.name} with error '#{error.message}'"
+      end
+    else
+      puts "Parent for #{org.name} is correct"
+    end
+  end
+
+  def down
+    # This change cannot be reversed
+  end
+end

--- a/db/migrate/20171108150320_model_ukti_org_structure.rb
+++ b/db/migrate/20171108150320_model_ukti_org_structure.rb
@@ -1,0 +1,44 @@
+class ModelUktiOrgStructure < ActiveRecord::Migration
+  def up
+    ukti = Organisation.find_by(name: "UK Trade & Investment")
+
+    child_org_names = [
+        "UKTI Life Sciences Organisation",
+        "Regeneration Investment Organisation",
+        "Financial Services Organisation",
+        "UKTI Education"
+    ]
+
+    missing_orgs = []
+
+    child_org_names.each do |child_name|
+      org = Organisation.find_by(name: child_name)
+      if org.nil?
+        missing_orgs << child_name
+        puts "!! Couldn't find #{child_name}"
+      else
+        update_parent(org, ukti)
+      end
+    end
+  end
+
+  def update_parent(org, parent)
+    if org.parent != parent
+      begin
+        old_parent_name = org.parent.nil?? "nil" : org.parent.name
+        puts "Checking parent for #{org.name}. Old parent is #{old_parent_name}"
+        org.update_attributes!(parent: parent)
+        puts "Updating parent for #{org.name} from #{old_parent_name} to #{parent.name}"
+      rescue => error
+        puts "Parent re-assignment failed for: #{org.name} with error '#{error.message}'"
+      end
+    else
+      puts "Parent for #{org.name} is correct"
+    end
+  end
+
+
+  def down
+    # This change cannot be reversed
+  end
+end

--- a/db/migrate/20171108150355_model_welsh_gov_org_structure.rb
+++ b/db/migrate/20171108150355_model_welsh_gov_org_structure.rb
@@ -1,0 +1,70 @@
+class ModelWelshGovOrgStructure < ActiveRecord::Migration
+  def up
+    wg = Organisation.find_by(name: "Welsh Government")
+
+    closed_child_org_names = [
+        "Welsh Office",
+        "Arts Council of Wales",
+        "Examination team on child care procedures and practice in North Wales",
+        "Hybu Cig Cymru - Meat Promotion Wales",
+        "Sports Council for Wales",
+        "Wales Audit Office",
+        "Welsh Development Agency",
+        "Further and Higher Education Funding Councils for Wales"
+    ]
+
+    missing_orgs = []
+
+    ["Natural Resources Wales", "Careers Wales"].each do |child_name|
+      org = Organisation.find_by(name: child_name)
+      if org.nil?
+        missing_orgs << child_name
+        puts "!! Couldn't find #{child_name}"
+      else
+        update_parent(org, wg)
+      end
+    end
+
+    closed_child_org_names.each do |child_name|
+      org = Organisation.find_by(name: child_name)
+      if org.nil?
+        missing_orgs << child_name
+        puts "!! Couldn't find #{child_name}"
+      else
+        update_parent(org, wg)
+        if org.closed?
+          puts "#{child_name} already closed"
+        else
+          org.update_attributes(closed: true)
+          puts "Marking #{child_name} as closed"
+        end
+      end
+    end
+
+    if missing_orgs.empty?
+      puts "All organisations were found"
+    else
+      puts "Missing organisations: #{missing_orgs.join("\n")}"
+    end
+
+  end
+
+  def update_parent(org, parent)
+    if org.parent != parent
+      begin
+        old_parent_name = org.parent.nil?? "nil" : org.parent.name
+        puts "Checking parent for #{org.name}. Old parent is #{old_parent_name}"
+        org.update_attributes!(parent: parent)
+        puts "Updating parent for #{org.name} from #{old_parent_name} to #{parent.name}"
+      rescue => error
+        puts "Parent re-assignment failed for: #{org.name} with error '#{error.message}'"
+      end
+    else
+      puts "Parent for #{org.name} is correct"
+    end
+  end
+
+  def down
+    # This change cannot be reversed
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171107153427) do
+ActiveRecord::Schema.define(version: 20171108150355) do
 
   create_table "batch_invitation_application_permissions", force: :cascade do |t|
     t.integer  "batch_invitation_id",     limit: 4, null: false


### PR DESCRIPTION
For:

https://trello.com/c/y1E9av7z/273-model-dit-correctly-within-signon
https://trello.com/c/lGjMWdHM/275-model-fco-correctly-within-signon
https://trello.com/c/8MA3tUOe/276-model-fsa-correctly-within-signon
https://trello.com/c/bCAm6Vkh/277-model-hmt-correctly-within-signon
https://trello.com/c/FmZ6gAFV/279-model-moj-correctly-within-signon
https://trello.com/c/G7C9Y0hl/280-model-nio-and-scotland-office-correctly-within-signon
https://trello.com/c/JWVgB511/284-model-ukti-correctly-within-signon
https://trello.com/c/0UT6Ewmd/282-model-welsh-gov-correctly-within-signon

Similar to https://github.com/alphagov/signon/pull/583, we're making sure that these organisations have their organisational structure modelled correctly (based on the hierarchy in whitehall).

For some cases where an organisation has two parents in whitehall, we've decided which parent is the "primary" parent because signon only supports a single parent structure.