### PR TITLE
Be explicit about index key length on user_agents

### DIFF
--- a/db/migrate/20170905111153_create_user_agents.rb
+++ b/db/migrate/20170905111153_create_user_agents.rb
@@ -1,7 +1,9 @@
 class CreateUserAgents < ActiveRecord::Migration
   def change
     create_table :user_agents do |t|
-      t.string :user_agent_string,    index: true, null: false, :limit => 1000
+      t.string :user_agent_string, null: false, :limit => 1000
     end
+
+    add_index :user_agents, :user_agent_string, length: { user_agent_string: 255 }
   end
 end


### PR DESCRIPTION
MySQL only supports key lengths of 767 bytes (which means about 255
characters as a character can take up to 3 bytes to store).  In MySQL
5.5 it would silently truncate the key for you, however in MySQL 5.6
it won't (see: https://bugs.mysql.com/bug.php?id=68453).  We plan to use
MySQL 5.6 on our new AWS infrastructure and this migration won't load
because of this bug.  We can work around it by explicitly telling MySQL
to only use the first 255 chars of the field rather than assuming it
would do this for us.