### PR TITLE
Specify migration versions

### DIFF
--- a/db/migrate/20120402120458_devise_create_users.rb
+++ b/db/migrate/20120402120458_devise_create_users.rb
@@ -1,4 +1,4 @@
-class DeviseCreateUsers < ActiveRecord::Migration
+class DeviseCreateUsers < ActiveRecord::Migration[4.2]
   def change
     create_table(:users) do |t|
       ## Database authenticatable

--- a/db/migrate/20120402150534_make_users_suspendable.rb
+++ b/db/migrate/20120402150534_make_users_suspendable.rb
@@ -1,4 +1,4 @@
-class MakeUsersSuspendable < ActiveRecord::Migration
+class MakeUsersSuspendable < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :suspended_at, :datetime
   end

--- a/db/migrate/20120403120725_create_doorkeeper_tables.rb
+++ b/db/migrate/20120403120725_create_doorkeeper_tables.rb
@@ -1,4 +1,4 @@
-class CreateDoorkeeperTables < ActiveRecord::Migration
+class CreateDoorkeeperTables < ActiveRecord::Migration[4.2]
   def change
     create_table :oauth_applications do |t|
       t.string :name,         :null => false

--- a/db/migrate/20120410094033_add_name_to_users.rb
+++ b/db/migrate/20120410094033_add_name_to_users.rb
@@ -1,4 +1,4 @@
-class AddNameToUsers < ActiveRecord::Migration
+class AddNameToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :name, :string
   end

--- a/db/migrate/20120410094527_add_uid_to_users.rb
+++ b/db/migrate/20120410094527_add_uid_to_users.rb
@@ -1,4 +1,4 @@
-class AddUidToUsers < ActiveRecord::Migration
+class AddUidToUsers < ActiveRecord::Migration[4.2][4.2]
   def change
     add_column :users, :uid, :string
   end

--- a/db/migrate/20120412131921_remove_rememberable_from_users.rb
+++ b/db/migrate/20120412131921_remove_rememberable_from_users.rb
@@ -1,4 +1,4 @@
-class RemoveRememberableFromUsers < ActiveRecord::Migration
+class RemoveRememberableFromUsers < ActiveRecord::Migration[4.2]
   def change
     remove_column :users, :remember_created_at
   end

--- a/db/migrate/20120609094354_add_admin_flag_to_users.rb
+++ b/db/migrate/20120609094354_add_admin_flag_to_users.rb
@@ -1,4 +1,4 @@
-class AddAdminFlagToUsers < ActiveRecord::Migration
+class AddAdminFlagToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :is_admin, :boolean, default: false, null: false
   end

--- a/db/migrate/20120609094747_add_indices_for_user.rb
+++ b/db/migrate/20120609094747_add_indices_for_user.rb
@@ -1,4 +1,4 @@
-class AddIndicesForUser < ActiveRecord::Migration
+class AddIndicesForUser < ActiveRecord::Migration[4.2]
   def try_to(&block)
     begin
       yield

--- a/db/migrate/20120611131259_create_permissions.rb
+++ b/db/migrate/20120611131259_create_permissions.rb
@@ -1,4 +1,4 @@
-class CreatePermissions < ActiveRecord::Migration
+class CreatePermissions < ActiveRecord::Migration[4.2]
   def change
     create_table :permissions do |t|
       t.references :user

--- a/db/migrate/20120612135328_devise_invitable_add_to_users.rb
+++ b/db/migrate/20120612135328_devise_invitable_add_to_users.rb
@@ -1,4 +1,4 @@
-class DeviseInvitableAddToUsers < ActiveRecord::Migration
+class DeviseInvitableAddToUsers < ActiveRecord::Migration[4.2]
   def up
     change_table :users do |t|
       t.string     :invitation_token, :limit => 60

--- a/db/migrate/20120619152849_insert_permissions_data.rb
+++ b/db/migrate/20120619152849_insert_permissions_data.rb
@@ -1,4 +1,4 @@
-class InsertPermissionsData < ActiveRecord::Migration
+class InsertPermissionsData < ActiveRecord::Migration[4.2]
   def up
     everything_app = ::Doorkeeper::Application.create!(name: "Everything", uid: "not-a-real-app", secret: "does-not-have-a-secret", redirect_uri: "https://not-a-domain.com")
     User.all.each do |user|

--- a/db/migrate/20120626083344_unique_permission_constraint.rb
+++ b/db/migrate/20120626083344_unique_permission_constraint.rb
@@ -1,4 +1,4 @@
-class UniquePermissionConstraint < ActiveRecord::Migration
+class UniquePermissionConstraint < ActiveRecord::Migration[4.2]
   def up
     add_index :permissions, [:application_id, :user_id], unique: true, name: "unique_permission_constraint"
   end

--- a/db/migrate/20120626083357_unique_application_constraint.rb
+++ b/db/migrate/20120626083357_unique_application_constraint.rb
@@ -1,4 +1,4 @@
-class UniqueApplicationConstraint < ActiveRecord::Migration
+class UniqueApplicationConstraint < ActiveRecord::Migration[4.2]
   def up
     add_index :oauth_applications, "name", unique: true, name: "unique_application_name"
   end

--- a/db/migrate/20120626094255_swap_magic_everything_permissions_for_real_ones.rb
+++ b/db/migrate/20120626094255_swap_magic_everything_permissions_for_real_ones.rb
@@ -11,7 +11,7 @@ class Permission < ActiveRecord::Base
   validates_presence_of :user_id
 end
 
-class SwapMagicEverythingPermissionsForRealOnes < ActiveRecord::Migration
+class SwapMagicEverythingPermissionsForRealOnes < ActiveRecord::Migration[4.2]
   class ::Doorkeeper::Application
     has_many :permissions, :dependent => :destroy
   end

--- a/db/migrate/20120704103854_add_supported_permissions.rb
+++ b/db/migrate/20120704103854_add_supported_permissions.rb
@@ -1,4 +1,4 @@
-class AddSupportedPermissions < ActiveRecord::Migration
+class AddSupportedPermissions < ActiveRecord::Migration[4.2][4.2]
   def change
     create_table :supported_permissions do |t|
       t.references :application

--- a/db/migrate/20120704154406_add_unique_index_to_supported_permissions.rb
+++ b/db/migrate/20120704154406_add_unique_index_to_supported_permissions.rb
@@ -1,4 +1,4 @@
-class AddUniqueIndexToSupportedPermissions < ActiveRecord::Migration
+class AddUniqueIndexToSupportedPermissions < ActiveRecord::Migration[4.2]
   def change
     add_index :supported_permissions, [:application_id, :name], unique: true
   end

--- a/db/migrate/20120704154718_add_admin_supported_permission_to_needo_tron.rb
+++ b/db/migrate/20120704154718_add_admin_supported_permission_to_needo_tron.rb
@@ -1,4 +1,4 @@
-class AddAdminSupportedPermissionToNeedoTron < ActiveRecord::Migration
+class AddAdminSupportedPermissionToNeedoTron < ActiveRecord::Migration[4.2][4.2]
   class SupportedPermission < ActiveRecord::Base
     belongs_to :application, class_name: 'Doorkeeper::Application'
   end

--- a/db/migrate/20120716130107_add_reason_for_suspension_to_user.rb
+++ b/db/migrate/20120716130107_add_reason_for_suspension_to_user.rb
@@ -1,4 +1,4 @@
-class AddReasonForSuspensionToUser < ActiveRecord::Migration
+class AddReasonForSuspensionToUser < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :reason_for_suspension, :string
   end

--- a/db/migrate/20120720131717_add_last_synced_at_to_permission.rb
+++ b/db/migrate/20120720131717_add_last_synced_at_to_permission.rb
@@ -1,4 +1,4 @@
-class AddLastSyncedAtToPermission < ActiveRecord::Migration
+class AddLastSyncedAtToPermission < ActiveRecord::Migration[4.2]
   def up
     add_column :permissions, :last_synced_at, :datetime
     execute("update permissions set last_synced_at = updated_at")

--- a/db/migrate/20120818153021_add_description_to_applications.rb
+++ b/db/migrate/20120818153021_add_description_to_applications.rb
@@ -1,4 +1,4 @@
-class AddDescriptionToApplications < ActiveRecord::Migration
+class AddDescriptionToApplications < ActiveRecord::Migration[4.2]
   def change
     add_column :oauth_applications, :home_uri, :string
     add_column :oauth_applications, :description, :string

--- a/db/migrate/20120828162043_create_permissions_for_licensing.rb
+++ b/db/migrate/20120828162043_create_permissions_for_licensing.rb
@@ -1,4 +1,4 @@
-class CreatePermissionsForLicensing < ActiveRecord::Migration
+class CreatePermissionsForLicensing < ActiveRecord::Migration[4.2]
   class SupportedPermission < ActiveRecord::Base
     belongs_to :application, class_name: 'Doorkeeper::Application'
   end

--- a/db/migrate/20120917131351_create_whitehall_editor_supported_permission.rb
+++ b/db/migrate/20120917131351_create_whitehall_editor_supported_permission.rb
@@ -1,4 +1,4 @@
-class CreateWhitehallEditorSupportedPermission < ActiveRecord::Migration
+class CreateWhitehallEditorSupportedPermission < ActiveRecord::Migration[4.2]
   class SupportedPermission < ActiveRecord::Base
     belongs_to :application, class_name: 'Doorkeeper::Application'
   end

--- a/db/migrate/20121005182447_add_password_salt_to_users.rb
+++ b/db/migrate/20121005182447_add_password_salt_to_users.rb
@@ -1,4 +1,4 @@
-class AddPasswordSaltToUsers < ActiveRecord::Migration
+class AddPasswordSaltToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :password_salt, :string
     change_column :users, :encrypted_password, :string, limit: 255

--- a/db/migrate/20121011155199_create_gds_admin_permission_for_licensing.rb
+++ b/db/migrate/20121011155199_create_gds_admin_permission_for_licensing.rb
@@ -1,4 +1,4 @@
-class CreateGdsAdminPermissionForLicensing < ActiveRecord::Migration
+class CreateGdsAdminPermissionForLicensing < ActiveRecord::Migration[4.2]
   def up
     create_permissions
   end

--- a/db/migrate/20121011166199_create_authority_permissions_for_licensing.rb
+++ b/db/migrate/20121011166199_create_authority_permissions_for_licensing.rb
@@ -1,4 +1,4 @@
-class CreateAuthorityPermissionsForLicensing < ActiveRecord::Migration
+class CreateAuthorityPermissionsForLicensing < ActiveRecord::Migration[4.2]
   def up
     create_permission("deni")
 create_permission("cefas")

--- a/db/migrate/20121113163308_add_unconfirmed_email.rb
+++ b/db/migrate/20121113163308_add_unconfirmed_email.rb
@@ -1,4 +1,4 @@
-class AddUnconfirmedEmail < ActiveRecord::Migration
+class AddUnconfirmedEmail < ActiveRecord::Migration[4.2]
   def up
     change_table(:users) do |t|
       t.string   :confirmation_token

--- a/db/migrate/20121203213600_fix_password_reset_for_existing_users.rb
+++ b/db/migrate/20121203213600_fix_password_reset_for_existing_users.rb
@@ -1,4 +1,4 @@
-class FixPasswordResetForExistingUsers < ActiveRecord::Migration
+class FixPasswordResetForExistingUsers < ActiveRecord::Migration[4.2]
   def up
     # devise_invitable #invite! calls #skip_confirmation!, which in turn sets confirmed_at to Time.zone.now.
     # That means that when the user accepts the invitation, they are already "confirmed", and everything works.

--- a/db/migrate/20121204162009_add_manage_keyword_permission.rb
+++ b/db/migrate/20121204162009_add_manage_keyword_permission.rb
@@ -1,4 +1,4 @@
-class AddManageKeywordPermission < ActiveRecord::Migration
+class AddManageKeywordPermission < ActiveRecord::Migration[4.2]
   def up
     unless panopticon.nil?
       SupportedPermission.create(application: panopticon, name: "manage_keywords")

--- a/db/migrate/20121206132458_licensing_new_test_authorities.rb
+++ b/db/migrate/20121206132458_licensing_new_test_authorities.rb
@@ -1,4 +1,4 @@
-class LicensingNewTestAuthorities < ActiveRecord::Migration
+class LicensingNewTestAuthorities < ActiveRecord::Migration[4.2]
   def up
     unless licensing.nil?
       SupportedPermission.create(application: licensing, name: "gds-test-2")

--- a/db/migrate/20130102141559_change_user_is_admin_to_role.rb
+++ b/db/migrate/20130102141559_change_user_is_admin_to_role.rb
@@ -1,4 +1,4 @@
-class ChangeUserIsAdminToRole < ActiveRecord::Migration
+class ChangeUserIsAdminToRole < ActiveRecord::Migration[4.2]
   class User < ActiveRecord::Base; end
 
   def up

--- a/db/migrate/20130308163556_fix_password_reset_for_some_users.rb
+++ b/db/migrate/20130308163556_fix_password_reset_for_some_users.rb
@@ -1,4 +1,4 @@
-class FixPasswordResetForSomeUsers < ActiveRecord::Migration
+class FixPasswordResetForSomeUsers < ActiveRecord::Migration[4.2][4.2]
   def up
     # For us, a user is "confirmed" when they're created, even though this is
     # conceptually confusing.

--- a/db/migrate/20130405143200_create_delayed_jobs.rb
+++ b/db/migrate/20130405143200_create_delayed_jobs.rb
@@ -1,4 +1,4 @@
-class CreateDelayedJobs < ActiveRecord::Migration
+class CreateDelayedJobs < ActiveRecord::Migration[4.2][4.2]
   def self.up
     create_table :delayed_jobs, :force => true do |table|
       table.integer  :priority, :default => 0      # Allows some jobs to jump to the front of the queue

--- a/db/migrate/20130405153812_add_batch_invitation.rb
+++ b/db/migrate/20130405153812_add_batch_invitation.rb
@@ -1,4 +1,4 @@
-class AddBatchInvitation < ActiveRecord::Migration
+class AddBatchInvitation < ActiveRecord::Migration[4.2]
   def up
     create_table :batch_invitations, force: true do |table|
       table.text :applications_and_permissions

--- a/db/migrate/20130408161502_relate_batch_invitations_to_users.rb
+++ b/db/migrate/20130408161502_relate_batch_invitations_to_users.rb
@@ -1,4 +1,4 @@
-class RelateBatchInvitationsToUsers < ActiveRecord::Migration
+class RelateBatchInvitationsToUsers < ActiveRecord::Migration[4.2][4.2]
   def up
     add_column :batch_invitations, :user_id, :integer, null: false
   end

--- a/db/migrate/20130417093614_ensure_user_name_is_not_nullable.rb
+++ b/db/migrate/20130417093614_ensure_user_name_is_not_nullable.rb
@@ -1,4 +1,4 @@
-class EnsureUserNameIsNotNullable < ActiveRecord::Migration
+class EnsureUserNameIsNotNullable < ActiveRecord::Migration[4.2][4.2]
   def up
     change_column_null(:users, :name, false)
   end

--- a/db/migrate/20130424141419_create_support_app_permissions.rb
+++ b/db/migrate/20130424141419_create_support_app_permissions.rb
@@ -1,4 +1,4 @@
-class CreateSupportAppPermissions < ActiveRecord::Migration
+class CreateSupportAppPermissions < ActiveRecord::Migration[4.2]
   class SupportedPermission < ActiveRecord::Base
     belongs_to :application, class_name: 'Doorkeeper::Application'
   end

--- a/db/migrate/20130430121058_create_user_managers_support_app_permission.rb
+++ b/db/migrate/20130430121058_create_user_managers_support_app_permission.rb
@@ -1,4 +1,4 @@
-class CreateUserManagersSupportAppPermission < ActiveRecord::Migration
+class CreateUserManagersSupportAppPermission < ActiveRecord::Migration[4.2]
   class SupportedPermission < ActiveRecord::Base
     belongs_to :application, class_name: 'Doorkeeper::Application'
   end

--- a/db/migrate/20130526064927_add_password_changed_at_to_users.rb
+++ b/db/migrate/20130526064927_add_password_changed_at_to_users.rb
@@ -1,4 +1,4 @@
-class AddPasswordChangedAtToUsers < ActiveRecord::Migration
+class AddPasswordChangedAtToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :password_changed_at, :datetime
     User.update_all "password_changed_at = GREATEST('2013-03-06 20:00:00', confirmed_at)"

--- a/db/migrate/20130621142506_create_ertp_support_app_permission.rb
+++ b/db/migrate/20130621142506_create_ertp_support_app_permission.rb
@@ -1,4 +1,4 @@
-class CreateErtpSupportAppPermission < ActiveRecord::Migration
+class CreateErtpSupportAppPermission < ActiveRecord::Migration[4.2]
   class SupportedPermission < ActiveRecord::Base
     belongs_to :application, class_name: 'Doorkeeper::Application'
   end

--- a/db/migrate/20130801170805_create_api_users_support_app_permission.rb
+++ b/db/migrate/20130801170805_create_api_users_support_app_permission.rb
@@ -1,4 +1,4 @@
-class CreateApiUsersSupportAppPermission < ActiveRecord::Migration
+class CreateApiUsersSupportAppPermission < ActiveRecord::Migration[4.2]
   class SupportedPermission < ActiveRecord::Base
     belongs_to :application, class_name: 'Doorkeeper::Application'
   end

--- a/db/migrate/20130913103447_create_fact_cave_edit_permission.rb
+++ b/db/migrate/20130913103447_create_fact_cave_edit_permission.rb
@@ -1,4 +1,4 @@
-class CreateFactCaveEditPermission < ActiveRecord::Migration
+class CreateFactCaveEditPermission < ActiveRecord::Migration[4.2]
 
   def up
     fact_cave = ::Doorkeeper::Application.find_by_name("Fact Cave")

--- a/db/migrate/20130926134720_remove_support_app_ertp_permission.rb
+++ b/db/migrate/20130926134720_remove_support_app_ertp_permission.rb
@@ -1,4 +1,4 @@
-class RemoveSupportAppErtpPermission < ActiveRecord::Migration
+class RemoveSupportAppErtpPermission < ActiveRecord::Migration[4.2]
   class SupportedPermission < ActiveRecord::Base; end
   class Permission < ActiveRecord::Base
     serialize :permissions, Array

--- a/db/migrate/20131021123740_create_organisations.rb
+++ b/db/migrate/20131021123740_create_organisations.rb
@@ -1,4 +1,4 @@
-class CreateOrganisations < ActiveRecord::Migration
+class CreateOrganisations < ActiveRecord::Migration[4.2][4.2]
   def change
     create_table :organisations do |t|
       t.string :slug, null: false

--- a/db/migrate/20131023081914_remove_closed_at_from_organisation.rb
+++ b/db/migrate/20131023081914_remove_closed_at_from_organisation.rb
@@ -1,4 +1,4 @@
-class RemoveClosedAtFromOrganisation < ActiveRecord::Migration
+class RemoveClosedAtFromOrganisation < ActiveRecord::Migration[4.2]
   def up
     remove_column :organisations, :closed_at
   end

--- a/db/migrate/20131101160634_user_in_single_organisation.rb
+++ b/db/migrate/20131101160634_user_in_single_organisation.rb
@@ -1,4 +1,4 @@
-class UserInSingleOrganisation < ActiveRecord::Migration
+class UserInSingleOrganisation < ActiveRecord::Migration[4.2][4.2]
   def up
     drop_table :organisations_users
 

--- a/db/migrate/20131118213228_create_feedex_support_app_permission.rb
+++ b/db/migrate/20131118213228_create_feedex_support_app_permission.rb
@@ -1,4 +1,4 @@
-class CreateFeedexSupportAppPermission < ActiveRecord::Migration
+class CreateFeedexSupportAppPermission < ActiveRecord::Migration[4.2]
   class SupportedPermission < ActiveRecord::Base
     belongs_to :application, class_name: 'Doorkeeper::Application'
   end

--- a/db/migrate/20131204154029_add_delegatable_to_supported_permissions.rb
+++ b/db/migrate/20131204154029_add_delegatable_to_supported_permissions.rb
@@ -1,4 +1,4 @@
-class AddDelegatableToSupportedPermissions < ActiveRecord::Migration
+class AddDelegatableToSupportedPermissions < ActiveRecord::Migration[4.2]
   def change
     add_column :supported_permissions, :delegatable, :boolean, default: false
   end

--- a/db/migrate/20131205160534_add_ancestry_to_organisations.rb
+++ b/db/migrate/20131205160534_add_ancestry_to_organisations.rb
@@ -1,4 +1,4 @@
-class AddAncestryToOrganisations < ActiveRecord::Migration
+class AddAncestryToOrganisations < ActiveRecord::Migration[4.2]
   def change
     add_column :organisations, :ancestry, :string
     add_index :organisations, :ancestry

--- a/db/migrate/20131216145229_add_organisation_id_to_batch_invitations.rb
+++ b/db/migrate/20131216145229_add_organisation_id_to_batch_invitations.rb
@@ -1,4 +1,4 @@
-class AddOrganisationIdToBatchInvitations < ActiveRecord::Migration
+class AddOrganisationIdToBatchInvitations < ActiveRecord::Migration[4.2][4.2]
   def change
     add_column :batch_invitations, :organisation_id, :integer
   end

--- a/db/migrate/20140114144500_signin_permissions_must_be_lowercase.rb
+++ b/db/migrate/20140114144500_signin_permissions_must_be_lowercase.rb
@@ -1,4 +1,4 @@
-class SigninPermissionsMustBeLowercase < ActiveRecord::Migration
+class SigninPermissionsMustBeLowercase < ActiveRecord::Migration[4.2]
   def up
     SupportedPermission.where(name: 'Signin')
                        .update_all(name: 'signin')

--- a/db/migrate/20140114145520_ensure_signin_supported_permission_present.rb
+++ b/db/migrate/20140114145520_ensure_signin_supported_permission_present.rb
@@ -1,4 +1,4 @@
-class EnsureSigninSupportedPermissionPresent < ActiveRecord::Migration
+class EnsureSigninSupportedPermissionPresent < ActiveRecord::Migration[4.2]
   def up
     require 'enhancements/application.rb'
 

--- a/db/migrate/20140114151134_remove_delayed_jobs.rb
+++ b/db/migrate/20140114151134_remove_delayed_jobs.rb
@@ -1,4 +1,4 @@
-class RemoveDelayedJobs < ActiveRecord::Migration
+class RemoveDelayedJobs < ActiveRecord::Migration[4.2]
   def up
     drop_table :delayed_jobs
   end

--- a/db/migrate/20140115153510_add_api_user_to_users.rb
+++ b/db/migrate/20140115153510_add_api_user_to_users.rb
@@ -1,4 +1,4 @@
-class AddApiUserToUsers < ActiveRecord::Migration
+class AddApiUserToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :api_user, :boolean, default: false, null: false
   end

--- a/db/migrate/20140115153833_update_api_user_in_users.rb
+++ b/db/migrate/20140115153833_update_api_user_in_users.rb
@@ -1,4 +1,4 @@
-class UpdateApiUserInUsers < ActiveRecord::Migration
+class UpdateApiUserInUsers < ActiveRecord::Migration[4.2]
   def up
     User.joins(:authorisations)
         .where('oauth_access_tokens.expires_in > ?', 5.years.to_i)

--- a/db/migrate/20140123152440_replace_apostrophe_in_user_emails.rb
+++ b/db/migrate/20140123152440_replace_apostrophe_in_user_emails.rb
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-class ReplaceApostropheInUserEmails < ActiveRecord::Migration
+class ReplaceApostropheInUserEmails < ActiveRecord::Migration[4.2]
   def up
     User.where("email LIKE '%’%'").update_all(email: %q{REPLACE(email, "’", "'") })
   end

--- a/db/migrate/20140130155326_add_supports_push_updates_to_applications.rb
+++ b/db/migrate/20140130155326_add_supports_push_updates_to_applications.rb
@@ -1,4 +1,4 @@
-class AddSupportsPushUpdatesToApplications < ActiveRecord::Migration
+class AddSupportsPushUpdatesToApplications < ActiveRecord::Migration[4.2]
   def change
     add_column :oauth_applications, :supports_push_updates, :boolean, default: true
   end

--- a/db/migrate/20140203105954_update_supports_push_updates_on_applications.rb
+++ b/db/migrate/20140203105954_update_supports_push_updates_on_applications.rb
@@ -1,4 +1,4 @@
-class UpdateSupportsPushUpdatesOnApplications < ActiveRecord::Migration
+class UpdateSupportsPushUpdatesOnApplications < ActiveRecord::Migration[4.2]
   def up
     Doorkeeper::Application.update_all supports_push_updates: true
   end

--- a/db/migrate/20140220150716_most_signin_permissions_should_not_be_delegable.rb
+++ b/db/migrate/20140220150716_most_signin_permissions_should_not_be_delegable.rb
@@ -1,4 +1,4 @@
-class MostSigninPermissionsShouldNotBeDelegable < ActiveRecord::Migration
+class MostSigninPermissionsShouldNotBeDelegable < ActiveRecord::Migration[4.2]
   def up
     require 'enhancements/application.rb'
 

--- a/db/migrate/20140319200000_create_editor_admin_perms_for_maslow.rb
+++ b/db/migrate/20140319200000_create_editor_admin_perms_for_maslow.rb
@@ -1,4 +1,4 @@
-class CreateEditorAdminPermsForMaslow < ActiveRecord::Migration
+class CreateEditorAdminPermsForMaslow < ActiveRecord::Migration[4.2][4.2]
   class ::Doorkeeper::Application < ActiveRecord::Base; end
   class SupportedPermission < ActiveRecord::Base
     belongs_to :application, class_name: 'Doorkeeper::Application'

--- a/db/migrate/20140319222924_grant_editor_perms_to_all_maslow_users.rb
+++ b/db/migrate/20140319222924_grant_editor_perms_to_all_maslow_users.rb
@@ -1,4 +1,4 @@
-class GrantEditorPermsToAllMaslowUsers < ActiveRecord::Migration
+class GrantEditorPermsToAllMaslowUsers < ActiveRecord::Migration[4.2][4.2]
   class Permission < ActiveRecord::Base
     serialize :permissions, Array
   end

--- a/db/migrate/20140320162328_fixup_invalid_emails.rb
+++ b/db/migrate/20140320162328_fixup_invalid_emails.rb
@@ -1,4 +1,4 @@
-class FixupInvalidEmails < ActiveRecord::Migration
+class FixupInvalidEmails < ActiveRecord::Migration[4.2]
   class TempUser < ActiveRecord::Base
     self.table_name = 'users'
   end

--- a/db/migrate/20140409170000_enable_devise_security_extension.rb
+++ b/db/migrate/20140409170000_enable_devise_security_extension.rb
@@ -1,4 +1,4 @@
-class EnableDeviseSecurityExtension < ActiveRecord::Migration
+class EnableDeviseSecurityExtension < ActiveRecord::Migration[4.2]
   def self.up
     create_table :old_passwords do |t|
       t.string   :encrypted_password, :null => false

--- a/db/migrate/20140519150300_add_event_logging.rb
+++ b/db/migrate/20140519150300_add_event_logging.rb
@@ -1,4 +1,4 @@
-class AddEventLogging < ActiveRecord::Migration
+class AddEventLogging < ActiveRecord::Migration[4.2][4.2]
   def self.up
     create_table :event_logs do |t|
       t.string   :uid, :null => false

--- a/db/migrate/20140623065028_add_initiator_id_to_event_logs.rb
+++ b/db/migrate/20140623065028_add_initiator_id_to_event_logs.rb
@@ -1,4 +1,4 @@
-class AddInitiatorIdToEventLogs < ActiveRecord::Migration
+class AddInitiatorIdToEventLogs < ActiveRecord::Migration[4.2]
   def change
     add_column :event_logs, :initiator_id, :integer
   end

--- a/db/migrate/20140723085640_add_application_id_to_event_logs.rb
+++ b/db/migrate/20140723085640_add_application_id_to_event_logs.rb
@@ -1,4 +1,4 @@
-class AddApplicationIdToEventLogs < ActiveRecord::Migration
+class AddApplicationIdToEventLogs < ActiveRecord::Migration[4.2]
   def change
     add_column :event_logs, :application_id, :integer
   end

--- a/db/migrate/20140917082742_update_event_log_indices.rb
+++ b/db/migrate/20140917082742_update_event_log_indices.rb
@@ -1,4 +1,4 @@
-class UpdateEventLogIndices < ActiveRecord::Migration
+class UpdateEventLogIndices < ActiveRecord::Migration[4.2][4.2]
   def up
     change_column :event_logs, :created_at, :datetime, :null => false
     add_index :event_logs, [:uid, :created_at]

--- a/db/migrate/20140917091319_add_unsuspended_at_to_user.rb
+++ b/db/migrate/20140917091319_add_unsuspended_at_to_user.rb
@@ -1,4 +1,4 @@
-class AddUnsuspendedAtToUser < ActiveRecord::Migration
+class AddUnsuspendedAtToUser < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :unsuspended_at, :datetime
   end

--- a/db/migrate/20150107063935_add_trailing_message_to_event_logs.rb
+++ b/db/migrate/20150107063935_add_trailing_message_to_event_logs.rb
@@ -1,4 +1,4 @@
-class AddTrailingMessageToEventLogs < ActiveRecord::Migration
+class AddTrailingMessageToEventLogs < ActiveRecord::Migration[4.2]
   def change
     add_column :event_logs, :trailing_message, :string
   end

--- a/db/migrate/20150109083425_create_join_table_user_application_permissions.rb
+++ b/db/migrate/20150109083425_create_join_table_user_application_permissions.rb
@@ -1,4 +1,4 @@
-class CreateJoinTableUserApplicationPermissions < ActiveRecord::Migration
+class CreateJoinTableUserApplicationPermissions < ActiveRecord::Migration[4.2]
   def change
     create_table :user_application_permissions do |t|
       t.integer :user_id, null: false

--- a/db/migrate/20150113064454_migrate_permissions_to_user_application_permissions_join_table.rb
+++ b/db/migrate/20150113064454_migrate_permissions_to_user_application_permissions_join_table.rb
@@ -4,7 +4,7 @@ class Permission < ActiveRecord::Base
   serialize :permissions, Array
 end
 
-class MigratePermissionsToUserApplicationPermissionsJoinTable < ActiveRecord::Migration
+class MigratePermissionsToUserApplicationPermissionsJoinTable < ActiveRecord::Migration[4.2]
   class Permission < ActiveRecord::Base
   end
 

--- a/db/migrate/20150121073933_create_join_table_batch_invitation_application_permissions.rb
+++ b/db/migrate/20150121073933_create_join_table_batch_invitation_application_permissions.rb
@@ -1,4 +1,4 @@
-class CreateJoinTableBatchInvitationApplicationPermissions < ActiveRecord::Migration
+class CreateJoinTableBatchInvitationApplicationPermissions < ActiveRecord::Migration[4.2]
   def change
     create_table :batch_invitation_application_permissions do |t|
       t.integer :batch_invitation_id, null: false

--- a/db/migrate/20150121092250_migrate_application_and_permissions_to_batch_invitation_application_permissions_join_table.rb
+++ b/db/migrate/20150121092250_migrate_application_and_permissions_to_batch_invitation_application_permissions_join_table.rb
@@ -1,4 +1,4 @@
-class MigrateApplicationAndPermissionsToBatchInvitationApplicationPermissionsJoinTable < ActiveRecord::Migration
+class MigrateApplicationAndPermissionsToBatchInvitationApplicationPermissionsJoinTable < ActiveRecord::Migration[4.2][4.2]
   def up
     puts "Updating #{BatchInvitation.count} batch invitations"
 

--- a/db/migrate/20150204115922_add_grantable_from_ui_to_supported_permissions.rb
+++ b/db/migrate/20150204115922_add_grantable_from_ui_to_supported_permissions.rb
@@ -1,4 +1,4 @@
-class AddGrantableFromUiToSupportedPermissions < ActiveRecord::Migration
+class AddGrantableFromUiToSupportedPermissions < ActiveRecord::Migration[4.2]
   def change
     add_column :supported_permissions, :grantable_from_ui, :boolean, null: false, default: true
   end

--- a/db/migrate/20150204132812_add_user_update_supported_permission_to_applications.rb
+++ b/db/migrate/20150204132812_add_user_update_supported_permission_to_applications.rb
@@ -1,6 +1,6 @@
 require 'enhancements/application'
 
-class AddUserUpdateSupportedPermissionToApplications < ActiveRecord::Migration
+class AddUserUpdateSupportedPermissionToApplications < ActiveRecord::Migration[4.2]
   def change
     Doorkeeper::Application.where(supports_push_updates: true).each do |application|
       application.supported_permissions.create!(name: 'user_update_permission', grantable_from_ui: false)

--- a/db/migrate/20150211091009_drop_permissions_table.rb
+++ b/db/migrate/20150211091009_drop_permissions_table.rb
@@ -1,4 +1,4 @@
-class DropPermissionsTable < ActiveRecord::Migration
+class DropPermissionsTable < ActiveRecord::Migration[4.2]
   def up
     drop_table :permissions
   end

--- a/db/migrate/20150212133251_fix_user_update_permission.rb
+++ b/db/migrate/20150212133251_fix_user_update_permission.rb
@@ -1,4 +1,4 @@
-class FixUserUpdatePermission < ActiveRecord::Migration
+class FixUserUpdatePermission < ActiveRecord::Migration[4.2][4.2]
   def up
     SupportedPermission.where(name: 'user_update_permission')
                        .update_all(grantable_from_ui: false)

--- a/db/migrate/20150420145301_add_content_id_to_organisations.rb
+++ b/db/migrate/20150420145301_add_content_id_to_organisations.rb
@@ -1,4 +1,4 @@
-class AddContentIdToOrganisations < ActiveRecord::Migration
+class AddContentIdToOrganisations < ActiveRecord::Migration[4.2][4.2]
   def change
     # This can be made not-nullable once populated
     add_column :organisations, :content_id, :string

--- a/db/migrate/20150421140645_make_organisation_content_id_not_nullable.rb
+++ b/db/migrate/20150421140645_make_organisation_content_id_not_nullable.rb
@@ -1,4 +1,4 @@
-class MakeOrganisationContentIdNotNullable < ActiveRecord::Migration
+class MakeOrganisationContentIdNotNullable < ActiveRecord::Migration[4.2]
   class User < ActiveRecord::Base
     belongs_to :organisation
   end

--- a/db/migrate/20150501101146_add_closed_to_organisation.rb
+++ b/db/migrate/20150501101146_add_closed_to_organisation.rb
@@ -1,4 +1,4 @@
-class AddClosedToOrganisation < ActiveRecord::Migration
+class AddClosedToOrganisation < ActiveRecord::Migration[4.2]
   def change
     add_column :organisations, :closed, :boolean, default: false
   end

--- a/db/migrate/20150507135123_add_invitation_created_at_to_users.rb
+++ b/db/migrate/20150507135123_add_invitation_created_at_to_users.rb
@@ -1,4 +1,4 @@
-class AddInvitationCreatedAtToUsers < ActiveRecord::Migration
+class AddInvitationCreatedAtToUsers < ActiveRecord::Migration[4.2][4.2]
   def change
     add_column :users, :invitation_created_at, :datetime
   end

--- a/db/migrate/20150507160746_remove_limit_from_invitation_token.rb
+++ b/db/migrate/20150507160746_remove_limit_from_invitation_token.rb
@@ -1,4 +1,4 @@
-class RemoveLimitFromInvitationToken < ActiveRecord::Migration
+class RemoveLimitFromInvitationToken < ActiveRecord::Migration[4.2]
   def up
     change_column :users, :invitation_token, :string, :limit => nil
   end

--- a/db/migrate/20150811150231_two_factor_authentication_add_to_users.rb
+++ b/db/migrate/20150811150231_two_factor_authentication_add_to_users.rb
@@ -1,4 +1,4 @@
-class TwoFactorAuthenticationAddToUsers < ActiveRecord::Migration
+class TwoFactorAuthenticationAddToUsers < ActiveRecord::Migration[4.2]
   def up
     change_table :users do |t|
       t.string   :otp_secret_key

--- a/db/migrate/20150928115351_add_requires2sv_to_users.rb
+++ b/db/migrate/20150928115351_add_requires2sv_to_users.rb
@@ -1,4 +1,4 @@
-class AddRequires2svToUsers < ActiveRecord::Migration
+class AddRequires2svToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :requires_2sv, :boolean, null: false, default: false
   end

--- a/db/migrate/20150929135437_rename_users_requires2sv.rb
+++ b/db/migrate/20150929135437_rename_users_requires2sv.rb
@@ -1,4 +1,4 @@
-class RenameUsersRequires2sv < ActiveRecord::Migration
+class RenameUsersRequires2sv < ActiveRecord::Migration[4.2]
   def change
     rename_column :users, :requires_2sv, :require_2sv
   end

--- a/db/migrate/20151001095709_add_unlock_token_to_users.rb
+++ b/db/migrate/20151001095709_add_unlock_token_to_users.rb
@@ -1,4 +1,4 @@
-class AddUnlockTokenToUsers < ActiveRecord::Migration
+class AddUnlockTokenToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :unlock_token, :string, length: 64
     add_index :users, :unlock_token, unique: true

--- a/db/migrate/20151006091244_add_deferred2sv_at_to_users.rb
+++ b/db/migrate/20151006091244_add_deferred2sv_at_to_users.rb
@@ -1,4 +1,4 @@
-class AddDeferred2svAtToUsers < ActiveRecord::Migration
+class AddDeferred2svAtToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :deferred_2sv_at, :datetime, null: true
   end

--- a/db/migrate/20151112110911_add_event_id_to_event_logs.rb
+++ b/db/migrate/20151112110911_add_event_id_to_event_logs.rb
@@ -1,4 +1,4 @@
-class AddEventIdToEventLogs < ActiveRecord::Migration
+class AddEventIdToEventLogs < ActiveRecord::Migration[4.2][4.2]
   def change
     add_column :event_logs, :event_id, :integer
   end

--- a/db/migrate/20151120134709_remove_deferred_at_from_users.rb
+++ b/db/migrate/20151120134709_remove_deferred_at_from_users.rb
@@ -1,4 +1,4 @@
-class RemoveDeferredAtFromUsers < ActiveRecord::Migration
+class RemoveDeferredAtFromUsers < ActiveRecord::Migration[4.2]
   def change
     remove_column :users, :deferred_2sv_at
   end

--- a/db/migrate/20151202120153_add_default_to_event_logs_event.rb
+++ b/db/migrate/20151202120153_add_default_to_event_logs_event.rb
@@ -1,4 +1,4 @@
-class AddDefaultToEventLogsEvent < ActiveRecord::Migration
+class AddDefaultToEventLogsEvent < ActiveRecord::Migration[4.2]
   def up
     change_column_default :event_logs, :event, ""
   end

--- a/db/migrate/20151203161459_remove_event_column.rb
+++ b/db/migrate/20151203161459_remove_event_column.rb
@@ -1,4 +1,4 @@
-class RemoveEventColumn < ActiveRecord::Migration
+class RemoveEventColumn < ActiveRecord::Migration[4.2]
   def change
     remove_column :event_logs, :event
   end

--- a/db/migrate/20160420145549_remove_appointed_person_for_england_and_wales_organisation.rb
+++ b/db/migrate/20160420145549_remove_appointed_person_for_england_and_wales_organisation.rb
@@ -1,4 +1,4 @@
-class RemoveAppointedPersonForEnglandAndWalesOrganisation < ActiveRecord::Migration
+class RemoveAppointedPersonForEnglandAndWalesOrganisation < ActiveRecord::Migration[4.2]
   def up
     organistion = Organisation.find_by(slug: '')
     if organistion.present?

--- a/db/migrate/20170216105512_add_retired_to_applications.rb
+++ b/db/migrate/20170216105512_add_retired_to_applications.rb
@@ -1,4 +1,4 @@
-class AddRetiredToApplications < ActiveRecord::Migration
+class AddRetiredToApplications < ActiveRecord::Migration[4.2]
   def change
     add_column :oauth_applications, :retired, :boolean, default: false
   end

--- a/db/migrate/20170816153804_add_bulk_grant_permission_sets.rb
+++ b/db/migrate/20170816153804_add_bulk_grant_permission_sets.rb
@@ -1,4 +1,4 @@
-class AddBulkGrantPermissionSets < ActiveRecord::Migration
+class AddBulkGrantPermissionSets < ActiveRecord::Migration[4.2]
   def change
     create_table :bulk_grant_permission_sets do |t|
       t.belongs_to :user, null: false

--- a/db/migrate/20170818134716_add_default_flag_to_supported_permissions.rb
+++ b/db/migrate/20170818134716_add_default_flag_to_supported_permissions.rb
@@ -1,4 +1,4 @@
-class AddDefaultFlagToSupportedPermissions < ActiveRecord::Migration
+class AddDefaultFlagToSupportedPermissions < ActiveRecord::Migration[4.2]
   def change
     add_column :supported_permissions, :default, :boolean, default: false, null: false
   end

--- a/db/migrate/20170905111153_create_user_agents.rb
+++ b/db/migrate/20170905111153_create_user_agents.rb
@@ -1,4 +1,4 @@
-class CreateUserAgents < ActiveRecord::Migration
+class CreateUserAgents < ActiveRecord::Migration[4.2]
   def change
     create_table :user_agents do |t|
       t.string :user_agent_string, null: false, :limit => 1000

--- a/db/migrate/20170908160100_add_ip_address_and_user_agent_id_to_event_logs.rb
+++ b/db/migrate/20170908160100_add_ip_address_and_user_agent_id_to_event_logs.rb
@@ -1,6 +1,6 @@
 require 'lhm'
 
-class AddIpAddressAndUserAgentIdToEventLogs < ActiveRecord::Migration
+class AddIpAddressAndUserAgentIdToEventLogs < ActiveRecord::Migration[4.2]
   def self.up
     Lhm.cleanup(:run)
     Lhm.change_table :event_logs do |m|

--- a/db/migrate/20170926101024_model_hmcts_org_structure.rb
+++ b/db/migrate/20170926101024_model_hmcts_org_structure.rb
@@ -1,4 +1,4 @@
-class ModelHmctsOrgStructure < ActiveRecord::Migration
+class ModelHmctsOrgStructure < ActiveRecord::Migration[4.2]
   def up
     # Make sure parent of HMCTS is MOJ
 

--- a/db/migrate/20170927105747_model_cabinet_office_org_structure.rb
+++ b/db/migrate/20170927105747_model_cabinet_office_org_structure.rb
@@ -1,4 +1,4 @@
-class ModelCabinetOfficeOrgStructure < ActiveRecord::Migration
+class ModelCabinetOfficeOrgStructure < ActiveRecord::Migration[4.2]
   def up
     cabinet_office = Organisation.find_by(name: "Cabinet Office")
     downing_street = Organisation.find_by(name: "Prime Minister's Office, 10 Downing Street")

--- a/db/migrate/20171002120204_model_defra_org_structure.rb
+++ b/db/migrate/20171002120204_model_defra_org_structure.rb
@@ -1,4 +1,4 @@
-class ModelDefraOrgStructure < ActiveRecord::Migration
+class ModelDefraOrgStructure < ActiveRecord::Migration[4.2]
   def up
     defra = Organisation.find_by(name: "Department for Environment, Food & Rural Affairs")
     fera = Organisation.find_by(name: "The Food and Environment Research Agency")

--- a/db/migrate/20171005140101_assign_apha_org_to_new_parent.rb
+++ b/db/migrate/20171005140101_assign_apha_org_to_new_parent.rb
@@ -1,4 +1,4 @@
-class AssignAphaOrgToNewParent < ActiveRecord::Migration
+class AssignAphaOrgToNewParent < ActiveRecord::Migration[4.2]
   def up
     defra = Organisation.find_by(name: "Department for Environment, Food & Rural Affairs")
 

--- a/db/migrate/20171006133438_cleanup_lhm_tables.rb
+++ b/db/migrate/20171006133438_cleanup_lhm_tables.rb
@@ -1,4 +1,4 @@
-class CleanupLhmTables < ActiveRecord::Migration
+class CleanupLhmTables < ActiveRecord::Migration[4.2]
   def up
     Lhm.cleanup(:run)
   end

--- a/db/migrate/20171006135205_cleanup_old_table.rb
+++ b/db/migrate/20171006135205_cleanup_old_table.rb
@@ -1,4 +1,4 @@
-class CleanupOldTable < ActiveRecord::Migration
+class CleanupOldTable < ActiveRecord::Migration[4.2][4.2]
   def up
     drop_table "_event_logs_old"
   end

--- a/db/migrate/20171017152038_add_short_url_manager_permission.rb
+++ b/db/migrate/20171017152038_add_short_url_manager_permission.rb
@@ -1,4 +1,4 @@
-class AddShortUrlManagerPermission < ActiveRecord::Migration
+class AddShortUrlManagerPermission < ActiveRecord::Migration[4.2]
   def up
     app = Doorkeeper::Application.find_by(name: "Short URL Manager")
     manage_short_urls = SupportedPermission.find_by(application: app, name: "manage_short_urls")

--- a/db/migrate/20171020125018_model_dclg_org_structure.rb
+++ b/db/migrate/20171020125018_model_dclg_org_structure.rb
@@ -1,4 +1,4 @@
-class ModelDclgOrgStructure < ActiveRecord::Migration
+class ModelDclgOrgStructure < ActiveRecord::Migration[4.2]
   def up
     dclg = Organisation.find_by(name: "Department for Communities and Local Government")
 

--- a/db/migrate/20171020132253_model_dft_org_structure.rb
+++ b/db/migrate/20171020132253_model_dft_org_structure.rb
@@ -1,4 +1,4 @@
-class ModelDftOrgStructure < ActiveRecord::Migration
+class ModelDftOrgStructure < ActiveRecord::Migration[4.2]
   def up
     dft = Organisation.find_by(name: "Department for Transport")
 

--- a/db/migrate/20171023161055_remove_soft_delete_correctly.rb
+++ b/db/migrate/20171023161055_remove_soft_delete_correctly.rb
@@ -1,4 +1,4 @@
-class RemoveSoftDeleteCorrectly < ActiveRecord::Migration
+class RemoveSoftDeleteCorrectly < ActiveRecord::Migration[4.2]
   def up
     remove_index :oauth_applications, :deleted_at if index_exists?(:oauth_applications, :deleted_at)
     remove_column :oauth_applications, :deleted_at if column_exists?(:oauth_applications, :deleted_at)

--- a/db/migrate/20171026164712_model_dh_org_structure.rb
+++ b/db/migrate/20171026164712_model_dh_org_structure.rb
@@ -1,4 +1,4 @@
-class ModelDhOrgStructure < ActiveRecord::Migration
+class ModelDhOrgStructure < ActiveRecord::Migration[4.2]
   def up
     dh = Organisation.find_by(name: "Department of Health")
 

--- a/db/migrate/20171027112449_model_dwp_org_structure.rb
+++ b/db/migrate/20171027112449_model_dwp_org_structure.rb
@@ -1,4 +1,4 @@
-class ModelDwpOrgStructure < ActiveRecord::Migration
+class ModelDwpOrgStructure < ActiveRecord::Migration[4.2]
   def up
     dwp = Organisation.find_by(name: "Department for Work and Pensions")
 

--- a/db/migrate/20171027112810_model_cabinet_office_org_shared_children_structure.rb
+++ b/db/migrate/20171027112810_model_cabinet_office_org_shared_children_structure.rb
@@ -1,4 +1,4 @@
-class ModelCabinetOfficeOrgSharedChildrenStructure < ActiveRecord::Migration
+class ModelCabinetOfficeOrgSharedChildrenStructure < ActiveRecord::Migration[4.2]
   def up
     cabinet_office = Organisation.find_by(name: "Cabinet Office")
 

--- a/db/migrate/20171027141009_model_home_office_org_structure.rb
+++ b/db/migrate/20171027141009_model_home_office_org_structure.rb
@@ -1,4 +1,4 @@
-class ModelHomeOfficeOrgStructure < ActiveRecord::Migration
+class ModelHomeOfficeOrgStructure < ActiveRecord::Migration[4.2]
   def up
     ho = Organisation.find_by(name: "Home Office")
 

--- a/db/migrate/20171103111953_model_mod_org_structure.rb
+++ b/db/migrate/20171103111953_model_mod_org_structure.rb
@@ -1,4 +1,4 @@
-class ModelModOrgStructure < ActiveRecord::Migration
+class ModelModOrgStructure < ActiveRecord::Migration[4.2]
   def up
     mod = Organisation.find_by(name: 'Ministry of Defence')
     dstl = Organisation.find_by(name: 'Defence Science and Technology Laboratory')

--- a/db/migrate/20171103145613_model_ago_org_structure.rb
+++ b/db/migrate/20171103145613_model_ago_org_structure.rb
@@ -1,4 +1,4 @@
-class ModelAgoOrgStructure < ActiveRecord::Migration
+class ModelAgoOrgStructure < ActiveRecord::Migration[4.2]
   def up
     ago = Organisation.find_by(name: "Attorney General's Office")
     tsd = Organisation.find_by(name: "Treasury Solicitor’s Department")

--- a/db/migrate/20171103151119_model_dfe_org_structure.rb
+++ b/db/migrate/20171103151119_model_dfe_org_structure.rb
@@ -1,4 +1,4 @@
-class ModelDfeOrgStructure < ActiveRecord::Migration
+class ModelDfeOrgStructure < ActiveRecord::Migration[4.2]
   def up
     dfe = Organisation.find_by(name: "Department for Education")
 

--- a/db/migrate/20171107105233_model_beis_org_structure.rb
+++ b/db/migrate/20171107105233_model_beis_org_structure.rb
@@ -1,4 +1,4 @@
-class ModelBeisOrgStructure < ActiveRecord::Migration
+class ModelBeisOrgStructure < ActiveRecord::Migration[4.2]
   def up
     beis = Organisation.find_by(name: 'Department for Business, Energy & Industrial Strategy')
     brdo = Organisation.find_by(name: 'Better Regulation Delivery Office')

--- a/db/migrate/20171107122414_model_dcms_org_structure.rb
+++ b/db/migrate/20171107122414_model_dcms_org_structure.rb
@@ -1,4 +1,4 @@
-class ModelDcmsOrgStructure < ActiveRecord::Migration
+class ModelDcmsOrgStructure < ActiveRecord::Migration[4.2]
   def up
     dcms = Organisation.find_by(name: "Department for Digital, Culture, Media & Sport")
 

--- a/db/migrate/20171107131556_model_dfid_org_structure.rb
+++ b/db/migrate/20171107131556_model_dfid_org_structure.rb
@@ -1,4 +1,4 @@
-class ModelDfidOrgStructure < ActiveRecord::Migration
+class ModelDfidOrgStructure < ActiveRecord::Migration[4.2]
   def up
     dfid = Organisation.find_by(name: "Department for International Development")
 

--- a/db/migrate/20171107153427_add_default_permissions_and_bulk_grant_them_to_all_users.rb
+++ b/db/migrate/20171107153427_add_default_permissions_and_bulk_grant_them_to_all_users.rb
@@ -1,6 +1,6 @@
 require 'enhancements/application'
 
-class AddDefaultPermissionsAndBulkGrantThemToAllUsers < ActiveRecord::Migration
+class AddDefaultPermissionsAndBulkGrantThemToAllUsers < ActiveRecord::Migration[4.2]
   def up
     support_app = Doorkeeper::Application.find_by!(name: 'Support')
     content_preview_app = Doorkeeper::Application.find_by!(name: 'Content Preview')

--- a/db/migrate/20171108144303_model_dit_org_structure.rb
+++ b/db/migrate/20171108144303_model_dit_org_structure.rb
@@ -1,4 +1,4 @@
-class ModelDitOrgStructure < ActiveRecord::Migration
+class ModelDitOrgStructure < ActiveRecord::Migration[4.2]
   def up
     dit = Organisation.find_by(name: "Department for International Trade")
 

--- a/db/migrate/20171108144431_model_fco_org_structure.rb
+++ b/db/migrate/20171108144431_model_fco_org_structure.rb
@@ -1,4 +1,4 @@
-class ModelFcoOrgStructure < ActiveRecord::Migration
+class ModelFcoOrgStructure < ActiveRecord::Migration[4.2][4.2]
   def up
     fco = Organisation.find_by(name: "Foreign & Commonwealth Office")
     gch = Organisation.find_by(name: "Government Communications Headquarters")

--- a/db/migrate/20171108144458_model_fsa_org_structure.rb
+++ b/db/migrate/20171108144458_model_fsa_org_structure.rb
@@ -1,4 +1,4 @@
-class ModelFsaOrgStructure < ActiveRecord::Migration
+class ModelFsaOrgStructure < ActiveRecord::Migration[4.2]
   def up
     fsa = Organisation.find_by(name: "Food Standards Agency")
 

--- a/db/migrate/20171108144537_model_hmt_org_structure.rb
+++ b/db/migrate/20171108144537_model_hmt_org_structure.rb
@@ -1,4 +1,4 @@
-class ModelHmtOrgStructure < ActiveRecord::Migration
+class ModelHmtOrgStructure < ActiveRecord::Migration[4.2]
   def up
     hmt = Organisation.find_by(name: "HM Treasury")
     ukgi = Organisation.find_by(name: "UK Government Investments")

--- a/db/migrate/20171108144557_model_moj_org_structure.rb
+++ b/db/migrate/20171108144557_model_moj_org_structure.rb
@@ -1,4 +1,4 @@
-class ModelMojOrgStructure < ActiveRecord::Migration
+class ModelMojOrgStructure < ActiveRecord::Migration[4.2]
   def up
     moj = Organisation.find_by(name: "Ministry of Justice")
     hmcts = Organisation.find_by(name: "HM Courts & Tribunals Service")

--- a/db/migrate/20171108145415_model_nio_org_structure.rb
+++ b/db/migrate/20171108145415_model_nio_org_structure.rb
@@ -1,4 +1,4 @@
-class ModelNioOrgStructure < ActiveRecord::Migration
+class ModelNioOrgStructure < ActiveRecord::Migration[4.2]
   def up
     nio = Organisation.find_by(name: "Northern Ireland Office")
     so = Organisation.find_by(name: "Scotland Office")

--- a/db/migrate/20171108150320_model_ukti_org_structure.rb
+++ b/db/migrate/20171108150320_model_ukti_org_structure.rb
@@ -1,4 +1,4 @@
-class ModelUktiOrgStructure < ActiveRecord::Migration
+class ModelUktiOrgStructure < ActiveRecord::Migration[4.2]
   def up
     ukti = Organisation.find_by(name: "UK Trade & Investment")
 

--- a/db/migrate/20171108150355_model_welsh_gov_org_structure.rb
+++ b/db/migrate/20171108150355_model_welsh_gov_org_structure.rb
@@ -1,4 +1,4 @@
-class ModelWelshGovOrgStructure < ActiveRecord::Migration
+class ModelWelshGovOrgStructure < ActiveRecord::Migration[4.2]
   def up
     wg = Organisation.find_by(name: "Welsh Government")
 


### PR DESCRIPTION
For compatibility reasons, migrations now need to specify the version they
are run with.

Depends on #589 being merged first