### PR TITLE
Update migration

### DIFF
--- a/db/migrate/20171122121841_change_event_log_user_agent_id_to_integer.rb
+++ b/db/migrate/20171122121841_change_event_log_user_agent_id_to_integer.rb
@@ -1,9 +1,15 @@
 class ChangeEventLogUserAgentIdToInteger < ActiveRecord::Migration[5.1]
   def up
+    remove_foreign_key :event_logs, :user_agents
+    change_column :user_agents, :id, "BIGINT"
     change_column :event_logs, :user_agent_id, "BIGINT"
+    add_foreign_key :event_logs, :user_agents
   end
 
   def down
+    remove_foreign_key :event_logs, :user_agents
+    change_column :user_agents, :id, "INT"
     change_column :event_logs, :user_agent_id, "INT"
+    add_foreign_key :event_logs, :user_agents
   end
 end


### PR DESCRIPTION
This migration was introduced to fix an error when trying to load the
schema - but as it was done on foreign keys it didn't run correctly.