### PR TITLE
Fix setting permissions while inviting users

### DIFF
--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -84,7 +84,8 @@ class InvitationsController < Devise::InvitationsController
       :name, :email, :organisation_id,
       :invitation_token, :password,
       :password_confirmation, :require_2sv,
-      :role
+      :role,
+      supported_permission_ids: []
     ).to_h
   end
 

--- a/test/integration/inviting_users_test.rb
+++ b/test/integration/inviting_users_test.rb
@@ -15,23 +15,21 @@ class InvitingUsersTest < ActionDispatch::IntegrationTest
     assert_response_contains("You are now signed in")
   end
 
-  context "for non-superadmins" do
-    should "not display the 2SV flagging checkbox" do
-      admin = create(:admin_user)
-      visit root_path
-      signin_with(admin)
-
-      visit new_user_invitation_path
-
-      assert has_no_field?("Require 2-step verification")
-    end
-  end
-
-  context "for an end-user by an admin" do
+  context "as an admin" do
     setup do
       admin = create(:user, role: "admin")
       visit root_path
       signin_with(admin)
+    end
+
+    should "not present the role selector" do
+      visit new_user_invitation_path
+      assert has_no_select?("Role")
+    end
+
+    should "not display the 2SV flagging checkbox" do
+      visit new_user_invitation_path
+      assert has_no_field?("Ask user to set up 2-step verification")
     end
 
     should "create and notify the user" do
@@ -72,14 +70,24 @@ class InvitingUsersTest < ActionDispatch::IntegrationTest
     end
   end
 
-  context "for an admin by a superadmin" do
+  context "as a superadmin" do
     setup do
-      admin = create(:user, role: "superadmin")
+      superadmin = create(:user, role: "superadmin")
       visit root_path
-      signin_with(admin)
+      signin_with(superadmin)
     end
 
-    should "create and notify the admin" do
+    should "present the role selector" do
+      visit new_user_invitation_path
+      assert has_select?("Role")
+    end
+
+    should "display the 2SV flagging checkbox" do
+      visit new_user_invitation_path
+      assert has_field?("Ask user to set up 2-step verification")
+    end
+
+    should "create and notify the user" do
       perform_enqueued_jobs do
         visit new_user_invitation_path
         fill_in "Name", with: "Fred Bloggs"
@@ -94,44 +102,6 @@ class InvitingUsersTest < ActionDispatch::IntegrationTest
           require_2sv: true
         )
         assert_equal "fred_admin@example.com", last_email.to[0]
-        assert_match 'Please confirm your account', last_email.subject
-      end
-    end
-
-    should "grant the user any default permissions" do
-      application_one = create(:application)
-      create(:supported_permission, application: application_one, name: 'editor', default: true)
-      application_two = create(:application)
-      application_two.signin_permission.update_attributes(default: true)
-
-      visit new_user_invitation_path
-      fill_in "Name", with: "Alicia Smith"
-      fill_in "Email", with: "alicia@example.com"
-      click_button "Create user and send email"
-
-      u = User.find_by(email: 'alicia@example.com')
-      assert u.has_access_to? application_two
-      assert_equal ['editor'], u.permissions_for(application_one)
-    end
-  end
-
-  context "a normal user being invited by an admin" do
-    setup do
-      admin = create(:admin_user)
-      visit root_path
-      signin_with(admin)
-    end
-
-    should "create and notify the user" do
-      perform_enqueued_jobs do
-        visit new_user_invitation_path
-        assert has_no_select?("Role")
-        fill_in "Name", with: "Fred Bloggs"
-        fill_in "Email", with: "normal_fred@example.com"
-        click_button "Create user and send email"
-
-        assert_not_nil User.where(email: "normal_fred@example.com", role: "normal").first
-        assert_equal "normal_fred@example.com", last_email.to[0]
         assert_match 'Please confirm your account', last_email.subject
       end
     end

--- a/test/integration/inviting_users_test.rb
+++ b/test/integration/inviting_users_test.rb
@@ -45,6 +45,30 @@ class InvitingUsersTest < ActionDispatch::IntegrationTest
       end
     end
 
+    should "grant the permissions selected" do
+      application_one = create(:application)
+      create(:supported_permission, application: application_one, name: 'editor')
+      application_two = create(:application)
+      create(:supported_permission, application: application_two, name: 'gds-admin')
+
+      visit new_user_invitation_path
+      fill_in "Name", with: "Alicia Smith"
+      fill_in "Email", with: "alicia@example.com"
+
+      uncheck "Has access to #{application_one.name}?"
+      check "Has access to #{application_two.name}?"
+      select 'editor', from: "Permissions for #{application_one.name}"
+      unselect 'gds-admin', from: "Permissions for #{application_two.name}"
+
+      click_button "Create user and send email"
+
+      u = User.find_by(email: 'alicia@example.com')
+      refute u.has_access_to? application_one
+      assert_includes u.permissions_for(application_one), 'editor'
+      assert u.has_access_to? application_two
+      refute_includes u.permissions_for(application_two), 'gds-admin'
+    end
+
     should "grant the user any default permissions" do
       application_one = create(:application)
       create(:supported_permission, application: application_one, name: 'editor', default: true)
@@ -104,6 +128,30 @@ class InvitingUsersTest < ActionDispatch::IntegrationTest
         assert_equal "fred_admin@example.com", last_email.to[0]
         assert_match 'Please confirm your account', last_email.subject
       end
+    end
+
+    should "grant the permissions selected" do
+      application_one = create(:application)
+      create(:supported_permission, application: application_one, name: 'editor')
+      application_two = create(:application)
+      create(:supported_permission, application: application_two, name: 'gds-admin')
+
+      visit new_user_invitation_path
+      fill_in "Name", with: "Alicia Smith"
+      fill_in "Email", with: "alicia@example.com"
+
+      uncheck "Has access to #{application_one.name}?"
+      check "Has access to #{application_two.name}?"
+      select 'editor', from: "Permissions for #{application_one.name}"
+      unselect 'gds-admin', from: "Permissions for #{application_two.name}"
+
+      click_button "Create user and send email"
+
+      u = User.find_by(email: 'alicia@example.com')
+      refute u.has_access_to? application_one
+      assert_includes u.permissions_for(application_one), 'editor'
+      assert u.has_access_to? application_two
+      refute_includes u.permissions_for(application_two), 'gds-admin'
     end
 
     should "grant the user any default permissions" do


### PR DESCRIPTION
For: https://trello.com/c/6H9d5nNC/313-bug-signon-issue

We didn't have any tests around setting permissions (other than default ones) when inviting single users via the UI and so we didn't spot during the rails 5 upgrade that we'd broken this when we had to upgrade the code for permitting params.  It's not really the fault of the upgrade, we just have fairly spotty test coverage around all the possible functionality.

This PR fixes it and adds tests to that branch so we don't fall into the same trap again.