### PR TITLE
Allow super admins to batch create users for multiple orgs

### DIFF
--- a/app/controllers/batch_invitations_controller.rb
+++ b/app/controllers/batch_invitations_controller.rb
@@ -43,7 +43,15 @@ class BatchInvitationsController < ApplicationController
 
     @batch_invitation.save
     csv.each do |row|
-      BatchInvitationUser.create(batch_invitation: @batch_invitation, name: row["Name"], email: row["Email"])
+      batch_user_args = {
+        batch_invitation: @batch_invitation,
+        name: row["Name"],
+        email: row["Email"]
+      }
+      if policy(@batch_invitation).assign_organisation_from_csv?
+        batch_user_args[:organisation_slug] = row["Organisation"]
+      end
+      BatchInvitationUser.create(batch_user_args)
     end
     @batch_invitation.enqueue
     flash[:notice] = "Scheduled invitation of #{@batch_invitation.batch_invitation_users.count} users"

--- a/app/models/batch_invitation_user.rb
+++ b/app/models/batch_invitation_user.rb
@@ -14,13 +14,15 @@ class BatchInvitationUser < ActiveRecord::Base
       {
         name: self.name,
         email: self.email,
-        organisation_id: batch_invitation.organisation_id,
+        organisation_id: organisation_id,
         supported_permission_ids: supported_permission_ids,
       },
       inviting_user,
     )
 
     invite_user_with_attributes(sanitised_attributes, inviting_user)
+  rescue InvalidOrganisationSlug
+    self.update_column(:outcome, 'failed')
   end
 
   def humanized_outcome
@@ -32,6 +34,28 @@ class BatchInvitationUser < ActiveRecord::Base
       outcome
     end
   end
+
+  def organisation_id
+    organisation_from_slug&.id || batch_invitation.organisation_id
+  end
+
+  def organisation_from_slug
+    # allow memoizing nil with a defined? check instead of ||=
+    if defined? @organisation_from_slug
+      @organisation_from_slug
+    elsif organisation_slug?
+      org = Organisation.find_by(slug: organisation_slug)
+      if org.nil?
+        raise InvalidOrganisationSlug, organisation_slug
+      else
+        @organisation_from_slug = org
+      end
+    else
+      @organisation_from_slug = nil
+    end
+  end
+
+  class InvalidOrganisationSlug < StandardError; end
 
 private
   def invite_user_with_attributes(sanitised_attributes, inviting_user)

--- a/app/policies/batch_invitation_policy.rb
+++ b/app/policies/batch_invitation_policy.rb
@@ -6,4 +6,8 @@ class BatchInvitationPolicy < BasePolicy
   end
   alias_method :create?, :new?
   alias_method :show?, :new?
+
+  def assign_organisation_from_csv?
+    current_user.superadmin?
+  end
 end

--- a/app/views/batch_invitations/new.html.erb
+++ b/app/views/batch_invitations/new.html.erb
@@ -38,18 +38,33 @@
       </div>
       <div class="col-md-5 pull-right">
         <p>The format of the CSV should be as follows:</p>
-        <pre>
+        <% if policy(f.object).assign_organisation_from_csv? %>
+          <pre>
+Name,Email,Organisation
+Jane Smith,jane@example.com,government-digital-service
+Winston Churchill,winston@example.com,cabinet-office
+          </pre>
+          <p class="help-block">The values in the Organisation column should be the slug of the organisation the user will be assigned to.  If the value is blank, the user will be assigned to the Organisation selected in the drop-down below.  If the value is provided, but is not a valid slug, the user will not be invited.</p>
+        <% else %>
+          <pre>
 Name,Email
 Jane Smith,jane@example.com
 Winston Churchill,winston@example.com
-        </pre>
+          </pre>
+        <% end %>
+        <p class="help-block">Any fields in the CSV other than those shown above will be ignored.</p>
       </div>
     </div>
 
-    <p>
+    <div class="form-group">
       <%= f.label :organisation_id, "Organisation" %>
       <%= f.select :organisation_id, organisation_options(f), organisation_select_options, { class: "chosen-select", 'data-module' => 'chosen' } %>
-    </p>
+      <% if policy(f.object).assign_organisation_from_csv? %>
+        <p class="help-block">If the uploaded CSV doesn't contain an Organisation column, or the value is blank for a row, the user will be assigned to this organisation instead.</p>
+      <% else %>
+        <p class="help-block">All users in the CSV will be assigned to the organisation selected here.</p>
+      <% end %>
+    </div>
 
     <h2>Permissions for the users</h2>
 

--- a/app/views/batch_invitations/new.html.erb
+++ b/app/views/batch_invitations/new.html.erb
@@ -44,7 +44,7 @@ Name,Email,Organisation
 Jane Smith,jane@example.com,government-digital-service
 Winston Churchill,winston@example.com,cabinet-office
           </pre>
-          <p class="help-block">The values in the Organisation column should be the slug of the organisation the user will be assigned to.  If the value is blank, the user will be assigned to the Organisation selected in the drop-down below.  If the value is provided, but is not a valid slug, the user will not be invited.</p>
+          <p class="help-block">The values in the Organisation column should be the slug of the organisation the user will be assigned to.  If the value is blank, the user will be assigned to the Organisation selected in the drop-down below.  If the value is provided, but is not a valid slug, the user will not be invited.  You can find the slug for an organisation on <%= link_to 'the list of organisations', organisations_path %>.</p>
         <% else %>
           <pre>
 Name,Email

--- a/app/views/organisations/index.html.erb
+++ b/app/views/organisations/index.html.erb
@@ -6,6 +6,7 @@
       <th>Name</th>
       <th>Abbreviation</th>
       <th>Organisation Type</th>
+      <th>Slug</th>
     </tr>
   </thead>
   <tbody>
@@ -14,6 +15,7 @@
         <td><%= organisation.name %></td>
         <td><%= organisation.abbreviation %></td>
         <td><%= organisation.organisation_type %></td>
+        <td><%= organisation.slug %></td>
       </tr>
     <% end %>
   </tbody>

--- a/db/migrate/20180111145345_add_organisation_slug_to_batch_invitation_user.rb
+++ b/db/migrate/20180111145345_add_organisation_slug_to_batch_invitation_user.rb
@@ -1,0 +1,7 @@
+class AddOrganisationSlugToBatchInvitationUser < ActiveRecord::Migration[5.1]
+  def change
+    change_table :batch_invitation_users do |t|
+      t.string :organisation_slug, null: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171108150355) do
+ActiveRecord::Schema.define(version: 20180111145345) do
 
   create_table "batch_invitation_application_permissions", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "batch_invitation_id", null: false
@@ -27,6 +27,7 @@ ActiveRecord::Schema.define(version: 20171108150355) do
     t.string "outcome"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "organisation_slug"
     t.index ["batch_invitation_id"], name: "index_batch_invitation_users_on_batch_invitation_id"
   end
 

--- a/spec/policies/batch_invitation_policy_spec.rb
+++ b/spec/policies/batch_invitation_policy_spec.rb
@@ -5,12 +5,12 @@ describe BatchInvitationPolicy do
 
   permissions :new? do
     it 'allows superadmins and admins to create new batch uploads' do
-      expect(subject).to permit(create(:user_in_organisation, role: 'superadmin'), BatchInvitation.new)
-      expect(subject).to permit(create(:user_in_organisation, role: 'admin'), BatchInvitation.new)
+      expect(subject).to permit(create(:superadmin_user), BatchInvitation.new)
+      expect(subject).to permit(create(:admin_user), BatchInvitation.new)
     end
 
     it 'is forbidden for organisation admins to create new batch uploads even within their organisation subtree' do
-      organisation_admin = create(:user_in_organisation, role: 'organisation_admin')
+      organisation_admin = create(:organisation_admin)
 
       expect(subject).not_to permit(organisation_admin, BatchInvitation.new)
       expect(subject).not_to permit(organisation_admin, BatchInvitation.new(organisation_id: create(:organisation).id))
@@ -18,11 +18,33 @@ describe BatchInvitationPolicy do
     end
 
     it 'is forbidden for super organisation admins to create new batch uploads even within their organisation subtree' do
-      super_org_admin = create(:user_in_organisation, role: 'super_organisation_admin')
+      super_org_admin = create(:super_org_admin)
 
       expect(subject).not_to permit(super_org_admin, BatchInvitation.new)
       expect(subject).not_to permit(super_org_admin, BatchInvitation.new(organisation_id: create(:organisation).id))
       expect(subject).not_to permit(super_org_admin, BatchInvitation.new(organisation_id: super_org_admin.organisation_id))
+    end
+
+    it 'is forbidden for normal users' do
+      expect(subject).not_to permit(create(:user), BatchInvitation.new)
+    end
+  end
+
+  permissions :assign_organisation_from_csv? do
+    it 'is allowed for super admins' do
+      expect(subject).to permit(create(:superadmin_user), BatchInvitation.new)
+    end
+
+    it 'is forbidden for admins' do
+      expect(subject).not_to permit(create(:admin_user), BatchInvitation.new)
+    end
+
+    it 'is forbidden for super organisation admins' do
+      expect(subject).not_to permit(create(:super_org_admin), BatchInvitation.new)
+    end
+
+    it 'is forbidden for organisation admins' do
+      expect(subject).not_to permit(create(:organisation_admin), BatchInvitation.new)
     end
 
     it 'is forbidden for normal users' do

--- a/test/controllers/batch_invitations_controller_test.rb
+++ b/test/controllers/batch_invitations_controller_test.rb
@@ -63,6 +63,33 @@ class BatchInvitationsControllerTest < ActionController::TestCase
       assert_equal 3, bi.organisation_id
     end
 
+    should "ignore organisation info in the uploaded CSV when logged in as an admin" do
+      post :create, params: { user: { supported_permission_ids: [] },
+        batch_invitation: { user_names_and_emails: users_csv('users_with_orgs.csv'), organisation_id: 3 } }
+
+      bi = BatchInvitation.last
+
+      assert_not_nil bi
+      assert_equal 3, bi.organisation_id
+      bi.batch_invitation_users.each do |biu|
+        assert_nil biu.organisation_slug
+      end
+    end
+
+    should "store organisation info from the uploaded CSV when logged in as a superadmin" do
+      @user.update_attributes(role: 'superadmin')
+      post :create, params: { user: { supported_permission_ids: [] },
+        batch_invitation: { user_names_and_emails: users_csv('users_with_orgs.csv'), organisation_id: 3 } }
+
+      bi = BatchInvitation.last
+
+      assert_not_nil bi
+      assert_equal 3, bi.organisation_id
+      assert_equal 'department-of-hats', bi.batch_invitation_users[0].organisation_slug
+      assert_nil bi.batch_invitation_users[1].organisation_slug
+      assert_equal 'cabinet-office', bi.batch_invitation_users[2].organisation_slug
+    end
+
     should "queue a job to do the processing" do
       assert_enqueued_jobs 2 do
         post :create, params: { batch_invitation: { user_names_and_emails: users_csv }, user: { supported_permission_ids: [] } }

--- a/test/controllers/fixtures/users_with_orgs.csv
+++ b/test/controllers/fixtures/users_with_orgs.csv
@@ -1,0 +1,4 @@
+Name,Email,Organisation
+Arthur Dent,a@hhg.com,department-of-hats
+Tricia McMillan,t@hhg.com,
+Zaphod Beeblebrox,z@hhg.com,cabinet-office

--- a/test/fixtures/users_with_orgs.csv
+++ b/test/fixtures/users_with_orgs.csv
@@ -1,0 +1,4 @@
+Name,Email,Organisation
+Fred,fred@example.com,department-of-hats
+Lara,lara@example.com,
+Emma,emma@example.com,a-missing-org

--- a/test/helpers/email_helpers.rb
+++ b/test/helpers/email_helpers.rb
@@ -6,4 +6,8 @@ module EmailHelpers
   def last_email
     all_emails.last
   end
+
+  def last_email_for(email_address)
+    all_emails.reverse.find { |email| email.to.include? email_address }
+  end
 end

--- a/test/integration/batch_inviting_users_test.rb
+++ b/test/integration/batch_inviting_users_test.rb
@@ -3,50 +3,83 @@ require 'test_helper'
 class BatchInvitingUsersTest < ActionDispatch::IntegrationTest
   include ActiveJob::TestHelper
 
-  should "superadmin user can create users whose details are specified in a CSV file" do
-    application = create(:application)
-    user = create(:superadmin_user)
-
-    perform_batch_invite_with_user(user, application)
+  setup do
+    @cabinet_office = create(:organisation, slug: 'cabinet-office', name: 'Cabinet Office')
+    @department_of_hats = create(:organisation, slug: 'department-of-hats', name: 'Department of Hats')
+    @application = create(:application)
   end
 
-  should "admin user can create users whose details are specified in a CSV file" do
-    application = create(:application)
-    user = create(:admin_user)
+  context 'for superadmin users' do
+    setup do
+      @user = create(:superadmin_user)
+    end
 
-    perform_batch_invite_with_user(user, application)
+    should "allow creating users whose details are specified in a CSV file, assigning them all to one org" do
+      perform_batch_invite_with_user(@user, @application, organisation: @cabinet_office)
+      assert_user_created_and_invited('fred@example.com', @application, organisation: @cabinet_office)
+    end
+
+    should "allow creating users with org details specified in a CSV file, overriding the org selected in the form" do
+      perform_batch_invite_with_user(@user, @application, fixture_file: 'users_with_orgs.csv', user_count: 3, organisation: @cabinet_office)
+      assert_user_created_and_invited('fred@example.com', @application, organisation: @department_of_hats)
+      assert_user_created_and_invited('lara@example.com', @application, organisation: @cabinet_office)
+      assert_user_not_created('emma@example.com')
+    end
   end
 
-  should "not allow organisation admin user to create users whose details are specified in a CSV file" do
-    application = create(:application)
-    user = create(:user_in_organisation, role: 'organisation_admin')
-    user.grant_application_permission(application, ['signin'])
+  context 'for admin users' do
+    setup do
+      @user = create(:admin_user)
+    end
 
-    visit root_path
-    signin_with(user)
+    should "allow creating users whose details are specified in a CSV file, assigning them all to one org" do
+      perform_batch_invite_with_user(@user, @application, organisation: @cabinet_office)
+      assert_user_created_and_invited('fred@example.com', @application, organisation: @cabinet_office)
+    end
 
-    visit new_batch_invitation_path
-    assert_equal root_path, current_path
+    should "ignore org details specified in a CSV file, creating all the users assigned to one org" do
+      perform_batch_invite_with_user(@user, @application, fixture_file: 'users_with_orgs.csv', user_count: 3, organisation: @cabinet_office)
+      assert_user_created_and_invited('fred@example.com', @application, organisation: @cabinet_office)
+      assert_user_created_and_invited('lara@example.com', @application, organisation: @cabinet_office)
+      assert_user_created_and_invited('emma@example.com', @application, organisation: @cabinet_office)
+    end
   end
 
-  should "not allow super organisation admin user to create users whose details are specified in a CSV file" do
-    application = create(:application)
-    user = create(:user_in_organisation, role: 'super_organisation_admin')
-    user.grant_application_permission(application, ['signin'])
+  context 'for organisation admins' do
+    setup do
+      @user = create(:organisation_admin)
+      @user.grant_application_permission(@application, ['signin'])
+    end
 
-    visit root_path
-    signin_with(user)
+    should "not allow batch inviting users" do
+      visit root_path
+      signin_with(@user)
 
-    visit new_batch_invitation_path
-    assert_equal root_path, current_path
+      visit new_batch_invitation_path
+      assert_equal root_path, current_path
+    end
   end
 
-  should "batch invited users get default permissions even when not checked in UI" do
-    application = create(:application)
-    create(:supported_permission, application: application, name: 'reader', default: true)
+  context 'for super organisation admins' do
+    setup do
+      @user = create(:super_org_admin)
+      @user.grant_application_permission(@application, ['signin'])
+    end
+
+    should "not allow batch inviting users" do
+      visit root_path
+      signin_with(@user)
+
+      visit new_batch_invitation_path
+      assert_equal root_path, current_path
+    end
+  end
+
+  should "ensure that batch invited users get default permissions even when not checked in UI" do
+    create(:supported_permission, application: @application, name: 'reader', default: true)
     support_app = create(:application, name: 'support', with_supported_permissions: ['signin'])
     support_app.signin_permission.update_attributes(default: true)
-    user = create(:user_in_organisation, role: 'admin')
+    user = create(:admin_user)
 
     visit root_path
     signin_with(user)
@@ -56,38 +89,56 @@ class BatchInvitingUsersTest < ActionDispatch::IntegrationTest
       path = File.join(::Rails.root, "test", "fixtures", "users.csv")
       attach_file("Choose a CSV file of users with names and email addresses", path)
       uncheck "Has access to #{support_app.name}?"
-      check "Has access to #{application.name}?"
-      unselect 'reader', from: "Permissions for #{application.name}"
+      check "Has access to #{@application.name}?"
+      unselect 'reader', from: "Permissions for #{@application.name}"
       click_button "Create users and send emails"
 
       invited_user = User.find_by_email("fred@example.com")
       assert invited_user.has_access_to?(support_app)
-      assert invited_user.permissions_for(application).include? 'reader'
+      assert invited_user.permissions_for(@application).include? 'reader'
     end
   end
 
-  def perform_batch_invite_with_user(user, application)
+  def perform_batch_invite_with_user(user, application, fixture_file: 'users.csv', user_count: 1, organisation:)
     perform_enqueued_jobs do
       visit root_path
       signin_with(user)
 
       visit new_batch_invitation_path
-      path = File.join(::Rails.root, "test", "fixtures", "users.csv")
+      path = File.join(::Rails.root, "test", "fixtures", fixture_file)
       attach_file("Choose a CSV file of users with names and email addresses", path)
       check "Has access to #{application.name}?"
+      if organisation
+        select organisation.name, from: 'Organisation'
+      end
+
       click_button "Create users and send emails"
 
       assert_response_contains("Creating a batch of users")
-      assert_response_contains("1 users processed")
-
-      invited_user = User.find_by_email("fred@example.com")
-      assert_not_nil invited_user
-      assert invited_user.has_access_to?(application)
-      assert_equal "noreply-signon-development@digital.cabinet-office.gov.uk", last_email.from[0]
-      assert_equal nil, last_email.reply_to[0]
-
-      assert_equal "fred@example.com", last_email.to[0]
-      assert_match 'Please confirm your account', last_email.subject
+      assert_response_contains("#{user_count} users processed")
     end
+  end
+
+  def assert_user_created_and_invited(email, application, organisation: nil)
+    invited_user = User.find_by_email(email)
+    assert_not_nil invited_user
+    assert invited_user.has_access_to?(application)
+    if organisation
+      assert_equal organisation.name, invited_user.organisation.name
+    end
+    invite_email = last_email_for(email)
+    assert_not_nil invite_email
+    assert_equal "noreply-signon-development@digital.cabinet-office.gov.uk", invite_email.from[0]
+    assert_equal nil, invite_email.reply_to[0]
+
+    assert_match 'Please confirm your account', invite_email.subject
+  end
+
+  def assert_user_not_created(email)
+    invited_user = User.find_by_email(email)
+    assert_nil invited_user
+
+    invite_email = last_email_for(email)
+    assert_nil invite_email
   end
 end

--- a/test/models/batch_invitation_user_test.rb
+++ b/test/models/batch_invitation_user_test.rb
@@ -15,7 +15,7 @@ class BatchInvitationUserTest < ActiveSupport::TestCase
       invitation_attributes = ActionController::Parameters.new({
         name: user.name,
         email: user.email,
-        organisation_id: @batch_invitation.organisation_id,
+        organisation_id: user.organisation_id,
         supported_permission_ids: [1, 2, 3]
       })
       User.expects(:invite!).with(invitation_attributes, @inviting_user)
@@ -49,6 +49,49 @@ class BatchInvitationUserTest < ActiveSupport::TestCase
 
         assert_equal "failed", user.reload.outcome
       end
+    end
+
+    context "organisation slug is invalid" do
+      should "record it as a failure" do
+        user = create(:batch_invitation_user, batch_invitation: @batch_invitation, email: 'foo@example.com', organisation_slug: 'not-a-real-slug')
+        user.invite(@inviting_user, [])
+
+        assert_equal "failed", user.reload.outcome
+      end
+    end
+  end
+
+  context "#organisation_id" do
+    setup do
+      @batch_invitation = create(:batch_invitation, :with_organisation)
+    end
+
+    should "use the organisation_id from the batch invitation if no slug is present" do
+      user = create(:batch_invitation_user, batch_invitation: @batch_invitation, organisation_slug: nil)
+
+      assert_equal @batch_invitation.organisation_id, user.organisation_id
+    end
+
+    should "use the organisation_id from the batch invitation if a blank slug is present" do
+      user = create(:batch_invitation_user, batch_invitation: @batch_invitation, organisation_slug: '')
+
+      assert_equal @batch_invitation.organisation_id, user.organisation_id
+    end
+
+    should "raise BatchInvitationUser::InvalidOrganisationSlug if the slug is present but doesn't refer to a real org" do
+      user = create(:batch_invitation_user, batch_invitation: @batch_invitation, organisation_slug: 'doesnt-exist-does-it?-eh?')
+
+      assert_raises(BatchInvitationUser::InvalidOrganisationSlug) {
+        user.organisation_id
+      }
+    end
+
+    should "use the id of the organisation refered to by the slug if present" do
+      local_organisation = create(:organisation, slug: 'local-slugs-for-local-organisations')
+
+      user = create(:batch_invitation_user, batch_invitation: @batch_invitation, organisation_slug: local_organisation.slug)
+
+      assert_equal local_organisation.id, user.organisation_id
     end
   end
 end


### PR DESCRIPTION
For: https://trello.com/c/62ShH5HQ/298-spike-batch-creation-of-new-signon-accounts

This PR allows super admins to upload a CSV of users for batch inviting that contains organisation slugs for each user, letting them invite a load of users who belong to different organisations all in one go.