### PR TITLE
Upgrade Ruby in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.2.3-slim
+FROM ruby:2.4.2-slim
 MAINTAINER "govuk-role-platform-accounts-members@digital.cabinet-office.gov.uk"
 
 RUN apt-get update && \


### PR DESCRIPTION
This matches the version specified in `.ruby-version`.