### PR TITLE
Add organisation info to the show page for batch invites

### DIFF
--- a/app/helpers/batch_invitations_helper.rb
+++ b/app/helpers/batch_invitations_helper.rb
@@ -13,4 +13,10 @@ module BatchInvitationsHelper
         "users processed."
     end
   end
+
+  def batch_invite_organisation_for_user(batch_invitation_user)
+    Organisation.find(batch_invitation_user.organisation_id).name
+  rescue BatchInvitationUser::InvalidOrganisationSlug, ActiveRecord::RecordNotFound
+    ''
+  end
 end

--- a/app/views/batch_invitations/show.html.erb
+++ b/app/views/batch_invitations/show.html.erb
@@ -29,6 +29,7 @@
     <tr class="table-header">
       <th>Name</th>
       <th>Email</th>
+      <th>Organisation</th>
       <th>Outcome</th>
     </tr>
   </thead>
@@ -37,6 +38,7 @@
       <tr class="<%= user.outcome == "failed" ? "error" : "" %>">
         <td><%= user.name %></td>
         <td><%= user.email %></td>
+        <td><%= batch_invite_organisation_for_user(user) %></td>
         <td><%= user.humanized_outcome %></td>
       </tr>
     <% end %>

--- a/test/units/helpers/batch_invitations_helper_test.rb
+++ b/test/units/helpers/batch_invitations_helper_test.rb
@@ -1,0 +1,49 @@
+require 'test_helper'
+
+class BatchInvitationsHelperTest < ActionView::TestCase
+  context '#batch_invite_organisation_for_user' do
+    context 'when the batch invitation user raises an invalid slug error when asked for organisation_id' do
+      setup do
+        @user = FactoryBot.create(:batch_invitation_user, organisation_slug: 'department-of-hats')
+      end
+
+      should 'return the empty string' do
+        assert_equal '', batch_invite_organisation_for_user(@user)
+      end
+    end
+
+    context 'when the batch invitation user raises an active record not found error when asked for organisation_id' do
+      setup do
+        @invite = FactoryBot.create(:batch_invitation, organisation_id: -1)
+        @user = FactoryBot.create(:batch_invitation_user, organisation_slug: nil, batch_invitation: @invite)
+      end
+
+      should 'return the empty string' do
+        assert_equal '', batch_invite_organisation_for_user(@user)
+      end
+    end
+
+    context 'when the batch invitation user has a valid organisation_slug' do
+      setup do
+        @org = FactoryBot.create(:organisation, name: 'Department of Hats', slug: 'department-of-hats')
+        @user = FactoryBot.create(:batch_invitation_user, organisation_slug: @org.slug)
+      end
+
+      should 'return the name of the organisation' do
+        assert_equal 'Department of Hats', batch_invite_organisation_for_user(@user)
+      end
+    end
+
+    context 'when the batch invitation user has a valid organisation from the batch invite' do
+      setup do
+        @org = FactoryBot.create(:organisation, name: 'Department of Hats', slug: 'department-of-hats')
+        @invite = FactoryBot.create(:batch_invitation, organisation: @org)
+        @user = FactoryBot.create(:batch_invitation_user, organisation_slug: nil, batch_invitation: @invite)
+      end
+
+      should 'return the name of the organisation' do
+        assert_equal 'Department of Hats', batch_invite_organisation_for_user(@user)
+      end
+    end
+  end
+end


### PR DESCRIPTION
For: https://trello.com/c/62ShH5HQ/18-batch-creation-of-new-signon-accounts

We always show the org info so we don't have to worry about checking the
policy and we have a simpler upgrade path if we decide to let admins
specify org details in the CSV as well as superadmins.