### PR TITLE
Ensure all users have signin permission for Asset Manager

### DIFF
--- a/db/migrate/20180131120100_set_signin_as_default_permission_for_asset_manager_and_grant_to_all_users.rb
+++ b/db/migrate/20180131120100_set_signin_as_default_permission_for_asset_manager_and_grant_to_all_users.rb
@@ -1,0 +1,31 @@
+require 'enhancements/application'
+
+class SetSigninAsDefaultPermissionForAssetManagerAndGrantToAllUsers < ActiveRecord::Migration[5.1]
+  def up
+    asset_manager_app = Doorkeeper::Application.find_by!(name: 'Asset Manager')
+
+    say_with_time 'Marking signin on Asset Manager as default permission' do
+      asset_manager_app.signin_permission.update_attributes(default: true)
+    end
+
+    say_with_time 'Enqueuing bulk grant permissions job as a super admin to make sure all existing users have the default permissions' do
+      superadmin = User.with_status('active').where(role: 'superadmin').first
+      bulk_grant = BulkGrantPermissionSet.create!(
+        user: superadmin,
+        supported_permission_ids: [asset_manager_app.signin_permission.id]
+      )
+      bulk_grant.enqueue
+    end
+  end
+
+  def down
+    # We can't undo the bulk grant because we don't know who had these
+    # permissions explicitly before we bulk granted them
+
+    asset_manager_app = Doorkeeper::Application.find_by!(name: 'Asset Manager')
+
+    say_with_time 'Removing default permission status from signin on Asset Manager' do
+      asset_manager_app.signin_permission.update_attributes(default: false)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180111145345) do
+ActiveRecord::Schema.define(version: 20180131120100) do
 
   create_table "batch_invitation_application_permissions", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "batch_invitation_id", null: false


### PR DESCRIPTION
This database migration is heavily based on [this one][1] which did the same thing for the Support and Content Preview apps.

The migration does two things:

1. Makes `signin` a default permission for the Asset Manager app. This means that new users will automatically be granted this permission.

2. Queues up jobs to grant the permission to all existing users.

We need this because we're using SSO in Asset Manager to protect draft assets. In the same way that all users are given `signin` permission for the Content Preview app in order to be able to view draft content, all users will need `signin` permission in order to be able to view draft assets.

Ideally we'd create a new Assets Preview app in Signon for this permission to mirror the Content Preview app. However, until we split Asset Manager into frontend & backend apps (or at least two instances of the same app with different configs), we're going to need use the existing Asset Manager `Doorkeeper::Application`.  This is because the `gds-sso` gem only supports authenticating against a single Signon app and the Asset Manager app is already using `gds-sso` to protect its API.

We're OK with this, because the API routes are not publicly accessible, even via the new `draft assets` host. However, it might be worth considering changing Asset Manager so it checks that the authenticated user for API access matches ones of the Signon API users for one of the publishing apps.

### Questions

1. As far as I can tell the `BulkGrantPermissionSet` only ever *adds* permissions, i.e. the fact that I've only listed the `signin` permission for the Asset Manager app shouldn't mean that the same permissions for Support & Content Preview apps are removed. But it would be good if someone could confirm that.

2. It looks as if the [`users: grant_content_preview_access Rake task`][5] scopes the users to update using [`web_users` & `not_suspended`][6]. This Rake task looks considerably older than the migration I based this PR on, but it would be good to be sure we don't need to do this.

3. I've moved the application lookup in the `down` method of the migration out of the `say_with_time` block to match the `up` method. It would be good to be sure that this isn't going to cause any problems.

4. Although not directly related to this PR, I notice [`script/prepare_training_environment`][2] hard-codes the [`home_uri`][3] and the [`redirect_uri`][4] for the Asset Manager app. We will be changing the bottom-level domain for these URIs from `asset-manager` to `draft-assets` soon, but I believe the changes to integration, staging & production will be made manually. I'm unsure whether/when I should update the values in this script.

**Note that this PR should not be merged until we're happy that the Asset Manager authentication for draft assets is working correctly**

[1]:
https://github.com/alphagov/signon/blob/c4b928af9ac85069362f7e332f0285fae1086467/db/migrate/20171107153427_add_default_permissions_and_bulk_grant_them_to_all_users.rb
[2]: https://github.com/alphagov/signon/blob/c4b928af9ac85069362f7e332f0285fae1086467/script/prepare_training_environment
[3]: https://github.com/alphagov/signon/blob/c4b928af9ac85069362f7e332f0285fae1086467/script/prepare_training_environment#L25
[4]: https://github.com/alphagov/signon/blob/c4b928af9ac85069362f7e332f0285fae1086467/script/prepare_training_environment#L24
[5]: https://github.com/alphagov/signon/blob/c4b928af9ac85069362f7e332f0285fae1086467/lib/tasks/users.rake#L73-L90
[6]: https://github.com/alphagov/signon/blob/c4b928af9ac85069362f7e332f0285fae1086467/lib/tasks/users.rake#L76
