### PR TITLE
Explicitly use external URLs for Signon

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -15,7 +15,7 @@ Rails.application.configure do
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
-  config.action_mailer.default_url_options = { host: URI.parse(Plek.find('signon')).host }
+  config.action_mailer.default_url_options = { host: URI.parse(Plek.new.external_url_for('signon')).host }
 
   # Send emails to the local MailHog instance
   config.action_mailer.delivery_method = :smtp

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -73,7 +73,7 @@ Rails.application.configure do
   config.active_support.deprecation = :notify
 
   config.action_mailer.default_url_options = {
-    host: URI.parse(Plek.find('signon')).host,
+    host: URI.parse(Plek.new.external_url_for('signon')).host,
     protocol: 'https'
   }
   # Use default logging formatter so that PID and timestamp are not suppressed.

--- a/lib/user_creator.rb
+++ b/lib/user_creator.rb
@@ -20,7 +20,7 @@ class UserCreator
   end
 
   def invitation_url
-    "#{Plek.find('signon')}/users/invitation/accept?invitation_token=#{user.raw_invitation_token}"
+    "#{Plek.new.external_url_for('signon')}/users/invitation/accept?invitation_token=#{user.raw_invitation_token}"
   end
 
 private


### PR DESCRIPTION
With the new external_url_for method in Plek.