### PR TITLE
Make sure we default to 'A' when listing users

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -155,8 +155,8 @@ class UsersController < ApplicationController
       end
     else
       @users, @sorting_params = @users.alpha_paginate(
-        params[:letter],
-        ALPHABETICAL_PAGINATE_CONFIG,
+        params.fetch(:letter, 'A'),
+        ALPHABETICAL_PAGINATE_CONFIG.dup,
         &:name
       )
     end


### PR DESCRIPTION
If no letter is supplied, the new version of alphabetical_paginate will
list users that start with punctuation rather than 'A' if there are any
users whose name starts with punctuation instead of a letter.  It turns
out that we have a handful of users whose name starts with a space
character and so we need to force 'A' as the default letter if it's not
specified as otherwise it looks like we've paginated a weird list.

We also pass a duplicated version of `ALPHABETICAL_PAGINATE_CONFIG` into
the `alpha_paginate` call because the new version will mutate the supplied
hash, and we probably don't want that.