### PR TITLE
Ensure BatchInvitation gets saved

### DIFF
--- a/app/controllers/batch_invitations_controller.rb
+++ b/app/controllers/batch_invitations_controller.rb
@@ -41,7 +41,8 @@ class BatchInvitationsController < ApplicationController
       return
     end
 
-    @batch_invitation.save
+    @batch_invitation.save!
+
     csv.each do |row|
       batch_user_args = {
         batch_invitation: @batch_invitation,

--- a/test/controllers/suspensions_controller_test.rb
+++ b/test/controllers/suspensions_controller_test.rb
@@ -101,7 +101,7 @@ class SuspensionsControllerTest < ActionController::TestCase
       another_user.reload
 
       assert_equal false, another_user.suspended?
-      assert_equal nil, another_user.reason_for_suspension
+      assert_nil another_user.reason_for_suspension
     end
   end
 

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -135,8 +135,8 @@ class UsersControllerTest < ActionController::TestCase
       delete :cancel_email_change, params: { id: @user.id }
 
       @user.reload
-      assert_equal nil, @user.unconfirmed_email
-      assert_equal nil, @user.confirmation_token
+      assert_nil @user.unconfirmed_email
+      assert_nil @user.confirmation_token
     end
 
     should "redirect to the user edit email or passphrase page" do

--- a/test/integration/batch_inviting_users_test.rb
+++ b/test/integration/batch_inviting_users_test.rb
@@ -129,7 +129,7 @@ class BatchInvitingUsersTest < ActionDispatch::IntegrationTest
     invite_email = last_email_for(email)
     assert_not_nil invite_email
     assert_equal "noreply-signon-development@digital.cabinet-office.gov.uk", invite_email.from[0]
-    assert_equal nil, invite_email.reply_to[0]
+    assert_nil invite_email.reply_to[0]
 
     assert_match 'Please confirm your account', invite_email.subject
   end

--- a/test/integration/event_log_creation_test.rb
+++ b/test/integration/event_log_creation_test.rb
@@ -200,7 +200,7 @@ class EventLogCreationIntegrationTest < ActionDispatch::IntegrationTest
       signin_with(@user)
 
       ip_address = @user.event_logs.first.ip_address
-      assert_equal nil, ip_address
+      assert_nil ip_address
     end
   end
 

--- a/test/integration/passphrase_reset_test.rb
+++ b/test/integration/passphrase_reset_test.rb
@@ -46,7 +46,7 @@ class PassphraseResetTest < ActionDispatch::IntegrationTest
       open_email(user.email)
       assert current_email
       assert_equal "noreply-signon-development@digital.cabinet-office.gov.uk", current_email.from[0]
-      assert_equal nil, last_email.reply_to[0]
+      assert_nil last_email.reply_to[0]
       assert_equal "Reset passphrase instructions", current_email.subject
 
       # partially signed-in user should be able to reset passphrase using link in reset passphrase instructions


### PR DESCRIPTION
At the moment we call `save` which returns true or false depending on whether the save actually worked. In the case when it fails, we ignore that and then continue to use it as a foreign key of the `BatchInvitationUser` model, which then fails because the `BatchInvitation` isn't saved, and when that tries to save it fails again.

This doesn't solve the problem that we're seeing with CSV imports not working, but it should push the problem further up so we can identify what's going wrong and fix it.

I've also fixed a deprecation warning relating to use of `assert_equal nil`.

[Trello Card](https://trello.com/c/bUCRuBSv/140-batch-upload-of-users-broken-on-sign-on-2)