### PR TITLE
Allow granting same permission multiples times for batch invitations

### DIFF
--- a/app/controllers/batch_invitations_controller.rb
+++ b/app/controllers/batch_invitations_controller.rb
@@ -83,7 +83,7 @@ class BatchInvitationsController < ApplicationController
 
   def grant_default_permissions(batch_invitation)
     SupportedPermission.default.each do |default_permission|
-      batch_invitation.supported_permissions << default_permission
+      batch_invitation.grant_permission(default_permission)
     end
   end
 end

--- a/app/models/batch_invitation.rb
+++ b/app/models/batch_invitation.rb
@@ -37,4 +37,8 @@ class BatchInvitation < ActiveRecord::Base
     self.update_column(:outcome, "fail")
     raise
   end
+
+  def grant_permission(supported_permission)
+    supported_permissions << supported_permission unless supported_permissions.include?(supported_permission)
+  end
 end

--- a/test/models/batch_invitation_test.rb
+++ b/test/models/batch_invitation_test.rb
@@ -20,6 +20,12 @@ class BatchInvitationTest < ActiveSupport::TestCase
     assert_equal bi.organisation, organisation
   end
 
+  should "allow multiple supported permissions of the same to be added" do
+    @bi.grant_permission(@app.signin_permission)
+    @bi.grant_permission(@app.signin_permission)
+    @bi.save!
+  end
+
   context "perform" do
     should "create the users and assign them permissions" do
       @bi.reload.perform


### PR DESCRIPTION
We should check that the batch invitation doesn't already have said permission before adding it to prevent a Rails validation error when saving the batch invitation. This copies the same `grant_permission` and `grant_default_permissions` methods that already exist for the `User` model.

This solves a problem where the user interface for creating batch users doesn't show the default permissions which are implicitly granted to new users. Therefore it was possible to create a batch user configuration with the same supported permission declared twice which would fail Rails validation with the unhelpful error of "The change you wanted was rejected".

[Trello Card](https://trello.com/c/bUCRuBSv/140-batch-upload-of-users-broken-on-sign-on-2)