### PR TITLE
Allow admins to upload users with organisations

### DIFF
--- a/app/policies/batch_invitation_policy.rb
+++ b/app/policies/batch_invitation_policy.rb
@@ -8,6 +8,6 @@ class BatchInvitationPolicy < BasePolicy
   alias_method :show?, :new?
 
   def assign_organisation_from_csv?
-    current_user.superadmin?
+    current_user.superadmin? || current_user.admin?
   end
 end

--- a/spec/policies/batch_invitation_policy_spec.rb
+++ b/spec/policies/batch_invitation_policy_spec.rb
@@ -35,8 +35,8 @@ describe BatchInvitationPolicy do
       expect(subject).to permit(create(:superadmin_user), BatchInvitation.new)
     end
 
-    it 'is forbidden for admins' do
-      expect(subject).not_to permit(create(:admin_user), BatchInvitation.new)
+    it 'is allowed for admins' do
+      expect(subject).to permit(create(:admin_user), BatchInvitation.new)
     end
 
     it 'is forbidden for super organisation admins' do

--- a/test/controllers/batch_invitations_controller_test.rb
+++ b/test/controllers/batch_invitations_controller_test.rb
@@ -63,7 +63,8 @@ class BatchInvitationsControllerTest < ActionController::TestCase
       assert_equal 3, bi.organisation_id
     end
 
-    should "ignore organisation info in the uploaded CSV when logged in as an admin" do
+    should "store organisation info from the uploaded CSV when logged in as an admin" do
+      @user.update_attributes(role: 'admin')
       post :create, params: { user: { supported_permission_ids: [] },
         batch_invitation: { user_names_and_emails: users_csv('users_with_orgs.csv'), organisation_id: 3 } }
 
@@ -71,9 +72,9 @@ class BatchInvitationsControllerTest < ActionController::TestCase
 
       assert_not_nil bi
       assert_equal 3, bi.organisation_id
-      bi.batch_invitation_users.each do |biu|
-        assert_nil biu.organisation_slug
-      end
+      assert_equal 'department-of-hats', bi.batch_invitation_users[0].organisation_slug
+      assert_nil bi.batch_invitation_users[1].organisation_slug
+      assert_equal 'cabinet-office', bi.batch_invitation_users[2].organisation_slug
     end
 
     should "store organisation info from the uploaded CSV when logged in as a superadmin" do

--- a/test/integration/batch_inviting_users_test.rb
+++ b/test/integration/batch_inviting_users_test.rb
@@ -37,11 +37,11 @@ class BatchInvitingUsersTest < ActionDispatch::IntegrationTest
       assert_user_created_and_invited('fred@example.com', @application, organisation: @cabinet_office)
     end
 
-    should "ignore org details specified in a CSV file, creating all the users assigned to one org" do
+    should "allow creating users with org details specified in a CSV file, overriding the org selected in the form" do
       perform_batch_invite_with_user(@user, @application, fixture_file: 'users_with_orgs.csv', user_count: 3, organisation: @cabinet_office)
-      assert_user_created_and_invited('fred@example.com', @application, organisation: @cabinet_office)
+      assert_user_created_and_invited('fred@example.com', @application, organisation: @department_of_hats)
       assert_user_created_and_invited('lara@example.com', @application, organisation: @cabinet_office)
-      assert_user_created_and_invited('emma@example.com', @application, organisation: @cabinet_office)
+      assert_user_not_created('emma@example.com')
     end
   end
 


### PR DESCRIPTION
Content designers often need to upload multiple users from multiple organisations and currently only super admins can do that.

Typically super admin role is reserved for developers, and other content designers can be admins. Users in departments other than GDS are usually not admins or super admins.

I can't figure out why it was decided that only super admins would get this permission in https://github.com/alphagov/signon/pull/649.

[Trello Card](https://trello.com/c/TTgmuzzt/329-batch-upload-of-users-incorrectly-assigning-organisations)