### PR TITLE
Enable Brakeman

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,5 +9,5 @@ node("postgresql-9.3") {
   govuk.setEnvar("DEVISE_SECRET_KEY", UUID.randomUUID().toString())
 
   // FIXME: Re-enable sass lint and fix the issues
-  govuk.buildProject(sassLint: false)
+  govuk.buildProject(sassLint: false, brakeman: true)
 }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,7 @@ require 'devise/hooks/two_step_verification'
 
 class ApplicationController < ActionController::Base
   include Pundit
-  protect_from_forgery
+  protect_from_forgery with: :exception
 
   include Devise::Helpers::PasswordExpirable
   include TwoStepVerificationHelper

--- a/app/controllers/batch_invitations_controller.rb
+++ b/app/controllers/batch_invitations_controller.rb
@@ -67,7 +67,7 @@ class BatchInvitationsController < ApplicationController
   private
 
   def recent_batch_invitations
-    @_recent_batch_invitations ||= BatchInvitation.where("created_at > '#{3.days.ago}'").order("created_at desc")
+    @_recent_batch_invitations ||= BatchInvitation.where("created_at > ?", 3.days.ago).order("created_at desc")
   end
 
   def file_uploaded?

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,0 +1,45 @@
+{
+  "ignored_warnings": [
+    {
+      "warning_type": "Cross-Site Scripting",
+      "warning_code": 4,
+      "fingerprint": "0b8f343234a3e8032ef58bff6dbad18fa3160c1f1983a132ba7044d86ee30631",
+      "check_name": "LinkToHref",
+      "message": "Potentially unsafe model attribute in link_to href",
+      "file": "app/views/root/signin_required.html.erb",
+      "line": 7,
+      "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
+      "code": "link_to(\"back in\", ::Doorkeeper::Application.find_by_id(session.delete(:signin_missing_for_application)).home_uri)",
+      "render_path": [{"type":"controller","class":"RootController","method":"signin_required","line":14,"file":"app/controllers/root_controller.rb"}],
+      "location": {
+        "type": "template",
+        "template": "root/signin_required"
+      },
+      "user_input": "::Doorkeeper::Application.find_by_id(session.delete(:signin_missing_for_application)).home_uri",
+      "confidence": "Weak",
+      "note": "This is not an issue as we control the database."
+    },
+    {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
+      "fingerprint": "6e625e6e38b22e2d8d17724f2fe2e1552bfefba31ae24b4c0d989a133dcb5211",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "lib/organisation_mappings/zendesk_to_signon.rb",
+      "line": 9,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "User.where(:organisation_id => nil).where(\"#{substring_function} IN (?)\", domain_names)",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "OrganisationMappings::ZendeskToSignon",
+        "method": "s(:self).apply"
+      },
+      "user_input": "substring_function",
+      "confidence": "Medium",
+      "note": "This isn't a SQL injection, we control the function and it simply returns a static string depending on whether we're on MySQL or PostgreSQL. No user inpurt."
+    }
+  ],
+  "updated": "2018-08-02 14:43:42 +0100",
+  "brakeman_version": "4.3.1"
+}

--- a/test/integration/event_log_creation_test.rb
+++ b/test/integration/event_log_creation_test.rb
@@ -33,12 +33,10 @@ class EventLogCreationIntegrationTest < ActionDispatch::IntegrationTest
       assert_equal 0, EventLog.count
     end
 
-    should "not blow up if not given a string for the email" do
-      # Assert we don't blow up when looking up the attempted user
-      # when people have been messing with the posted params.
-      post "/users/sign_in", params: { "user" => { "email" => { "foo" => "bar" }, :password => "anything" } }
-
-      assert response.success?
+    should "raise an error when missing CSRF token" do
+      assert_raises ActionController::InvalidAuthenticityToken do
+        post "/users/sign_in", params: { "user" => { "email" => { "foo" => "bar" }, :password => "anything" } }
+      end
     end
   end
 

--- a/test/integration/sign_in_test.rb
+++ b/test/integration/sign_in_test.rb
@@ -81,8 +81,10 @@ class SignInTest < ActionDispatch::IntegrationTest
 
     fill_in "Email", with: @user.email
     fill_in "Passphrase", with: @user.password
-    click_button "Sign in"
-    assert_response_contains("You need to sign in before continuing.")
+
+    assert_raises(ActionController::InvalidAuthenticityToken) do
+      click_button "Sign in"
+    end
   end
 
   should "not remotely sign out user when visiting with an expired session cookie" do


### PR DESCRIPTION
This allows us to find security vulnerabilities. I've also had to fix some false positives and ignore some others, details of which are available in the commits.

[Trello Card](https://trello.com/c/JyrOAef3/363-fix-sql-injection-vulnerabilities-in-govuk-applications)