### PR TITLE
Redesign the signin page

### DIFF
--- a/app/assets/javascripts/new_admin_layout.js
+++ b/app/assets/javascripts/new_admin_layout.js
@@ -1,0 +1,1 @@
+//= require jquery

--- a/app/assets/stylesheets/new_admin_layout.scss
+++ b/app/assets/stylesheets/new_admin_layout.scss
@@ -1,0 +1,10 @@
+// TODO: move into component
+.gem-c-success-alert,
+.gem-c-error-alert {
+  margin: 0 0 30px 0;
+}
+
+.gem-c-success-alert__message,
+.gem-c-error-alert__message {
+  margin: 0;
+}

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,4 +1,6 @@
 class SessionsController < Devise::SessionsController
+  layout 'admin_layout'
+
   skip_before_action :handle_two_step_verification
 
   def destroy

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,37 +1,31 @@
-<% content_for :title, "Sign in" %>
-<% content_for :thin_form, true %>
+<% content_for :title, "Sign in to GOV.UK" %>
 
-<div class="page-title">
-  <h1>Sign in</h1>
-</div>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-half">
+    <%= form_for(resource, as: resource_name, url: session_path(resource_name), html: { autocomplete: 'on' }) do |f| %>
+      <%= render "govuk_publishing_components/components/input", {
+        label: {
+          text: "Email"
+        },
+        name: "user[email]",
+        type: "email"
+      } %>
 
-<!--[if lte IE 7]>
-  <div class="alert alert-warning add-bottom-margin">
-    <h4>Your browser is not supported</h4>
-    <p>Pages might not work as expected. You should <a href="https://www.gov.uk/help/browsers" class="link-inherit">upgrade your browser</a> – you might need to ask your IT administrator to do this for you.</p>
-  </div>
-<![endif]-->
-<%= form_for(resource, as: resource_name, url: session_path(resource_name), html: { class: 'panel panel-default', autocomplete: 'on' }) do |f| %>
-  <div class="panel-body">
-    <div class="form-group">
-      <%= f.label :email %>
-      <%= f.email_field :email, class: 'form-control input-lg', tabindex: 1, autofocus: 'autofocus' %>
-    </div>
+      <%= render "govuk_publishing_components/components/input", {
+        label: {
+          text: "Passphrase"
+        },
+        name: "user[password]",
+        type: "password"
+      } %>
 
-    <div class="form-group">
-      <%= f.label :password, "Passphrase" %>
-      <%= f.password_field :password, tabindex: 2, class: 'form-control input-lg' %>
-    </div>
-
-    <%= render "links" %>
-
-    <% if devise_mapping.rememberable? %>
-      <label class="checkbox" for="remember_me">Remember me?
-        <%= f.check_box :remember_me, class: 'checkbox' %>
-      </label>
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Sign in"
+      } %>
     <% end %>
+
+    <p class="govuk-body govuk-!-margin-top-5">
+      <%= link_to t('devise.links.forgot_passphrase'), new_password_path(resource_name), class: "govuk-link" %>
+    </p>
   </div>
-  <div class="panel-footer">
-    <%= f.submit "Sign in", tabindex: 3, class: 'btn btn-success btn-lg btn-block' %>
-  </div>
-<% end %>
+</div>

--- a/app/views/layouts/admin_layout.html.erb
+++ b/app/views/layouts/admin_layout.html.erb
@@ -1,0 +1,46 @@
+<% content_for :head do %>
+  <%= stylesheet_link_tag "new_admin_layout" %>
+<% end %>
+
+<%= render 'govuk_publishing_components/components/layout_for_admin',
+  environment: Rails.application.config.govuk_environment,
+  browser_title: yield(:title) + " - GOV.UK" do %>
+
+  <%= render "govuk_publishing_components/components/skip_link" %>
+
+  <%= render "govuk_publishing_components/components/layout_header", {
+    environment: Rails.application.config.govuk_environment,
+    navigation_items: [], # TODO: add these
+  }%>
+
+  <div class="govuk-width-container">
+    <% if yield(:back_link).present? %>
+      <%= render "govuk_publishing_components/components/back_link", href: yield(:back_link) %>
+    <% end %>
+
+    <main class="govuk-main-wrapper" id="main-content" role="main">
+      <% if flash["notice"] %>
+        <%= render "govuk_publishing_components/components/success_alert", {
+          message: flash["notice"]
+        } %>
+      <% end %>
+
+      <% if flash["alert"] %>
+        <%= render "govuk_publishing_components/components/error_alert", {
+          message: flash["alert"]
+        } %>
+      <% end %>
+
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <span class="govuk-caption-l"><%= yield(:context) %></span>
+          <h1 class="govuk-heading-l"><%= yield(:title) %></h1>
+        </div>
+      </div>
+      <%= yield %>
+    </main>
+  </div>
+
+  <%= render "govuk_publishing_components/components/layout_footer" %>
+  <%= javascript_include_tag "new_admin_layout" %>
+<% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -55,7 +55,7 @@ module Signon
     config.action_dispatch.ip_spoofing_check = false
 
     # Precompile additional assets (application.js, application.css, and all non-JS/CSS are already added)
-    config.assets.precompile += %w(password-strength-indicator.js)
+    config.assets.precompile += %w(new_admin_layout.css new_admin_layout.js password-strength-indicator.js)
 
     config.to_prepare do
       Doorkeeper::ApplicationController.layout "application"
@@ -66,5 +66,18 @@ module Signon
     config.active_job.queue_adapter = :sidekiq
 
     config.middleware.insert_before 0, SameSiteSecurity::Middleware
+
+    # TODO: replace by https://github.com/alphagov/govuk_publishing_components/pull/548
+    #
+    # The "acceptance environment" we're in - not the same as Rails env.
+    # Can be production, staging, integration, or development
+    govuk_environments = {
+      "production" => "production",
+      "staging" => "staging",
+      "integration-blue-aws" => "integration",
+    }
+
+    config.govuk_environment = govuk_environments.fetch(ENV["ERRBIT_ENVIRONMENT_NAME"], "development")
+    config.govuk_environment = "production"
   end
 end


### PR DESCRIPTION
This uses the new design for the sign in page.

- Most of the things in the layout come from content publisher
- We've had to include jQuery (from jquery-rails, a dependency of govuk_admin_template) to get the current functionality to work.
- The header & footer will be updated to reflect new designs, I've not copied over these from content publisher
- This also removes a bunch of code that will never be run, but is part of Devise - specifically `if devise_mapping.rememberable?` and the other things in the links.

## Before

![screen shot 2018-10-01 at 11 43 07](https://user-images.githubusercontent.com/233676/46285582-d7f70080-c573-11e8-9760-cfeb6deab100.png)

## After

![screen shot 2018-10-01 at 11 42 53](https://user-images.githubusercontent.com/233676/46285589-e3e2c280-c573-11e8-9345-b8df2b1f3d40.png)

https://trello.com/c/05wMNlxg