### PR TITLE
Fix deprecated usage of factories

### DIFF
--- a/test/factories/batch_invitation_user.rb
+++ b/test/factories/batch_invitation_user.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :batch_invitation_user do
-    name "Mark France"
+    name { "Mark France" }
     sequence(:email) { |n| "user#{n}@example.com" }
   end
 end

--- a/test/factories/oauth_access_tokens.rb
+++ b/test/factories/oauth_access_tokens.rb
@@ -2,6 +2,6 @@ FactoryBot.define do
   factory :access_token, class: Doorkeeper::AccessToken do
     sequence(:resource_owner_id) { |n| n }
     application
-    expires_in 2.hours
+    expires_in { 2.hours }
   end
 end

--- a/test/factories/oauth_applications.rb
+++ b/test/factories/oauth_applications.rb
@@ -1,16 +1,16 @@
 FactoryBot.define do
   factory :application, class: Doorkeeper::Application do
     transient do
-      with_supported_permissions []
-      with_supported_permissions_not_grantable_from_ui []
-      with_delegatable_supported_permissions []
+      with_supported_permissions { [] }
+      with_supported_permissions_not_grantable_from_ui { [] }
+      with_delegatable_supported_permissions { [] }
     end
 
     sequence(:name) { |n| "Application #{n}" }
-    redirect_uri "https://app.com/callback"
-    home_uri "https://app.com/"
-    description "Important information about this app"
-    supports_push_updates false
+    redirect_uri { "https://app.com/callback" }
+    home_uri { "https://app.com/" }
+    description { "Important information about this app" }
+    supports_push_updates { false }
 
     after(:create) do |app, evaluator|
       evaluator.with_supported_permissions.each do |permission_name|

--- a/test/factories/organisation.rb
+++ b/test/factories/organisation.rb
@@ -3,6 +3,6 @@ FactoryBot.define do
     sequence(:slug) { |n| "ministry-of-funk-#{n}000" }
     sequence(:name) { |n| "Ministry of Funk #{n}000" }
     content_id { SecureRandom.uuid }
-    organisation_type "Ministerial Department"
+    organisation_type { "Ministerial Department" }
   end
 end

--- a/test/factories/supported_permission.rb
+++ b/test/factories/supported_permission.rb
@@ -5,6 +5,6 @@ FactoryBot.define do
   end
 
   factory :delegatable_supported_permission, parent: :supported_permission do
-    delegatable true
+    delegatable { true }
   end
 end

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -1,15 +1,15 @@
 FactoryBot.define do
   factory :user do
     transient do
-      with_permissions {}
-      with_signin_permissions_for []
+      with_permissions { {} }
+      with_signin_permissions_for { [] }
     end
 
     sequence(:email) { |n| "user#{n}@example.com" }
-    password "this 1s 4 v3333ry s3cur3 p4ssw0rd.!Z"
-    confirmed_at 1.day.ago
+    password { "this 1s 4 v3333ry s3cur3 p4ssw0rd.!Z" }
+    confirmed_at { 1.day.ago }
     name { "A name is now required" }
-    role "normal"
+    role { "normal" }
 
     after(:create) do |user, evaluator|
       if evaluator.with_permissions
@@ -35,41 +35,41 @@ FactoryBot.define do
   end
 
   factory :two_step_enabled_user, parent: :user do
-    otp_secret_key "Sssshh"
+    otp_secret_key { "Sssshh" }
   end
 
   factory :two_step_flagged_user, parent: :superadmin_user do
-    require_2sv true
+    require_2sv { true }
   end
 
   factory :user_with_pending_email_change, parent: :user do
-    email "old@email.com"
-    unconfirmed_email "new@email.com"
+    email { "old@email.com" }
+    unconfirmed_email { "new@email.com" }
     sequence(:confirmation_token) { |n| "#{n}a1s2d3"} # see `token_sent_to` in ConfirmationTokenHelper
-    confirmation_sent_at Time.zone.now
+    confirmation_sent_at { Time.zone.now }
   end
 
   factory :superadmin_user, parent: :user do
     sequence(:email) { |n| "superadmin#{n}@example.com" }
-    role "superadmin"
+    role { "superadmin" }
   end
 
   factory :admin_user, parent: :user do
     sequence(:email) { |n| "admin#{n}@example.com" }
-    role "admin"
+    role { "admin" }
   end
 
   factory :super_org_admin, parent: :user_in_organisation do
-    role "super_organisation_admin"
+    role { "super_organisation_admin" }
   end
 
   factory :organisation_admin, parent: :user_in_organisation do
-    role "organisation_admin"
+    role { "organisation_admin" }
   end
 
   factory :suspended_user, parent: :user do
-    suspended_at Time.zone.now
-    reason_for_suspension "Testing"
+    suspended_at { Time.zone.now }
+    reason_for_suspension { "Testing" }
   end
 
   factory :user_in_organisation, parent: :user do
@@ -78,15 +78,15 @@ FactoryBot.define do
 
   factory :api_user do
     transient do
-      with_permissions {}
+      with_permissions { {} }
     end
 
     sequence(:email) { |n| "api-#{n}@example.com" }
-    password "this 1s 4 v3333ry s3cur3 p4ssw0rd.!Z"
-    confirmed_at 1.day.ago
+    password { "this 1s 4 v3333ry s3cur3 p4ssw0rd.!Z" }
+    confirmed_at { 1.day.ago }
     name { "API User" }
 
-    api_user true
+    api_user { true }
 
     after(:create) do |user, evaluator|
       if evaluator.with_permissions


### PR DESCRIPTION
FactoryBot has deprecated the usage of "static" factory values:

```
name "user"
```

should become:

```
name { "user" }
```

https://trello.com/c/05wMNlxg
