### PR TITLE
Redo request password reset page

### DIFF
--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -1,4 +1,5 @@
 class PasswordsController < Devise::PasswordsController
+  layout 'admin_layout', only: %w(new)
   before_action :record_password_reset_request, only: :create
   before_action :record_reset_page_loaded, only: :edit
 

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,24 +1,20 @@
 <% content_for :title, "Request a passphrase reset" %>
-<% content_for :thin_form, true %>
+<% content_for :back_link, new_session_path(resource_name) %>
 
-<ol class="breadcrumb">
-  <li><%= render "links" %></li>
-  <li class="active">Request a passphrase reset</li>
-</ol>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-half">
+    <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+      <%= render "govuk_publishing_components/components/input", {
+        label: {
+          text: "Email"
+        },
+        name: "user[email]",
+        type: "email"
+      } %>
 
-<div class="page-title">
-  <h1>Request a passphrase reset</h1>
+      <%= render "govuk_publishing_components/components/button", {
+        text: t("devise.passwords.new.send_passphrase_reset")
+      } %>
+    <% end %>
+  </div>
 </div>
-
-<%= form_for(resource, :as => resource_name, :url => password_path(resource_name), :html => { :method => :post, :class => 'panel panel-default' }) do |f| %>
-  <div class="panel-body">
-    <%= devise_error_messages! %>
-    <div class="form-group">
-      <%= f.label :email %>
-      <%= f.email_field :email, autofocus: true, class: 'form-control input-lg' %>
-    </div>
-  </div>
-  <div class="panel-footer">
-    <%= f.submit t('.send_passphrase_reset'), :class => 'btn btn-success btn-lg btn-block' %>
-  </div>
-<% end %>


### PR DESCRIPTION
This redesigns the "request a password reset" page using the new patterns.

I've removed `devise_error_messages!` because there are no error messages that can be displayed.

## Before

![screen shot 2018-10-01 at 14 08 11](https://user-images.githubusercontent.com/233676/46290341-7b034680-c583-11e8-88b3-6566a07b352b.png)

## After

![screen shot 2018-10-01 at 14 07 52](https://user-images.githubusercontent.com/233676/46290346-7e96cd80-c583-11e8-8bc3-4779b14bd468.png)

https://trello.com/c/05wMNlxg