### PR TITLE
Don't show an error when signing in

### DIFF
--- a/app/views/layouts/admin_layout.html.erb
+++ b/app/views/layouts/admin_layout.html.erb
@@ -25,7 +25,7 @@
         } %>
       <% end %>
 
-      <% if flash["alert"] %>
+      <% if flash["alert"].present? %>
         <%= render "govuk_publishing_components/components/error_alert", {
           message: flash["alert"]
         } %>

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -15,7 +15,7 @@ en:
   devise:
     failure:
       already_authenticated: 'You are already signed in.'
-      unauthenticated: 'You need to sign in before continuing.'
+      unauthenticated: ""
       unconfirmed: 'You have to confirm your account before continuing.'
       locked: 'Invalid email or passphrase. Entering an incorrect passphrase 6 times will lock your account and you will be sent an email to reset it.'
       invalid: 'Invalid email or passphrase. Entering an incorrect passphrase 6 times will lock your account and you will be sent an email to reset it.'

--- a/test/integration/authorise_application_test.rb
+++ b/test/integration/authorise_application_test.rb
@@ -22,7 +22,6 @@ class AuthoriseApplicationTest < ActionDispatch::IntegrationTest
 
   should "not confirm the authorisation until the user signs in" do
     visit "/oauth/authorize?response_type=code&client_id=#{@app.uid}&redirect_uri=#{@app.redirect_uri}"
-    assert_response_contains("You need to sign in")
     refute Doorkeeper::AccessGrant.find_by(resource_owner_id: @user.id)
 
     ignoring_spurious_error do

--- a/test/integration/sign_in_test.rb
+++ b/test/integration/sign_in_test.rb
@@ -273,6 +273,6 @@ class SignInTest < ActionDispatch::IntegrationTest
   should "not be able to access the 2SV login page before logging in" do
     signout
     visit new_two_step_verification_session_path
-    assert_response_contains("You need to sign in before continuing.")
+    assert_equal "/users/sign_in", page.current_path
   end
 end


### PR DESCRIPTION
Currently, a user who visits `signon.publishing.service.gov.uk` will be confronted with a red flash alert message telling them "You need to sign in before continuing".

This commit removes the message, because the fact that they've arrived at a login page should be enough of a hint. The red message makes it look like something went wrong, but this scenario happens 99.9% of the time, so there's no need to alarm users.

## Before

![screen shot 2018-10-01 at 14 49 41](https://user-images.githubusercontent.com/233676/46292607-45615c00-c589-11e8-9c04-109a0b7b8311.png)

## After

![screen shot 2018-10-01 at 14 49 18](https://user-images.githubusercontent.com/233676/46292619-498d7980-c589-11e8-85f8-8da08795485b.png)

https://trello.com/c/05wMNlxg