### PR TITLE
Only lint diffs for now

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,5 +9,5 @@ node("postgresql-9.3") {
   govuk.setEnvar("DEVISE_SECRET_KEY", UUID.randomUUID().toString())
 
   // FIXME: Re-enable sass lint and fix the issues
-  govuk.buildProject(sassLint: false, brakeman: true)
+  govuk.buildProject(sassLint: false, brakeman: true, rubyLintDiff: true)
 }


### PR DESCRIPTION
This is needed to maintain current behaviour since https://github.com/alphagov/govuk-jenkinslib/pull/35.