### PR TITLE
Implement new design for dashboard

### DIFF
--- a/app/assets/stylesheets/new_admin_layout.scss
+++ b/app/assets/stylesheets/new_admin_layout.scss
@@ -8,3 +8,13 @@
 .gem-c-error-alert__message {
   margin: 0;
 }
+
+.app-application-list__item {
+  border-top: 1px solid #ccc;
+  padding-top: 20px;
+}
+
+.app-dashboard-side {
+  border-top: 2px solid #005ea5;
+  padding-top: 20px;
+}

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -1,4 +1,6 @@
 class RootController < ApplicationController
+  layout 'admin_layout'
+
   include UserPermissionsControllerMethods
   before_action :authenticate_user!
   skip_after_action :verify_authorized

--- a/app/helpers/component_helper.rb
+++ b/app/helpers/component_helper.rb
@@ -1,0 +1,36 @@
+module ComponentHelper
+  def navigation_items
+    return [] unless current_user
+
+    items = []
+
+    items << { text: 'Dashboard', href: root_path, active: is_current?(root_path) }
+
+    if policy(User).index?
+      items << { text: 'Users', href: users_path, active: is_current?(users_path) }
+    end
+
+    if policy(ApiUser).index?
+      items << { text: 'API Users', href: api_users_path, active: is_current?(users_path) }
+    end
+
+    if policy(Doorkeeper::Application).index?
+      items << { text: 'Apps', href: doorkeeper_applications_path, active: is_current?(users_path) }
+    end
+
+    if policy(Organisation).index?
+      items << { text: 'Organisations', href: organisations_path, active: is_current?(users_path) }
+    end
+
+    items << { text: current_user.name, href: user_link_target }
+    items << { text: "Sign out", href: destroy_user_session_path }
+
+    items
+  end
+
+  def is_current?(link)
+    recognized = Rails.application.routes.recognize_path(link)
+    recognized[:controller] == params[:controller] &&
+      recognized[:action] == params[:action]
+  end
+end

--- a/app/views/layouts/admin_layout.html.erb
+++ b/app/views/layouts/admin_layout.html.erb
@@ -10,7 +10,7 @@
 
   <%= render "govuk_publishing_components/components/layout_header", {
     environment: Rails.application.config.govuk_environment,
-    navigation_items: [], # TODO: add these
+    navigation_items: navigation_items,
   }%>
 
   <div class="govuk-width-container">

--- a/app/views/layouts/admin_layout.html.erb
+++ b/app/views/layouts/admin_layout.html.erb
@@ -43,4 +43,21 @@
 
   <%= render "govuk_publishing_components/components/layout_footer" %>
   <%= javascript_include_tag "new_admin_layout" %>
+
+  <%# TODO: replace with component %>
+  <script class="analytics">
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+    ga('create', 'UA-26179049-6', '<%= ENV['GOVUK_APP_DOMAIN'] %>');
+    ga('set', 'anonymizeIp', true);
+
+    <% if current_user %>
+      ga('set', 'dimension8', "<%= current_user.organisation ? current_user.organisation.slug : '(not set)' %>");
+    <% end %>
+
+    ga('send', 'pageview');
+  </script>
 <% end %>

--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -32,8 +32,6 @@
       <% else %>
         <li><%= link_to "Make your account more secure", two_step_verification_path, class: "js-track" %></li>
       <% end %>
-
-      <li><%= link_to "Sign out", destroy_user_session_path %></li>
     </ul>
   </div>
 </div>

--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -1,48 +1,39 @@
-<% content_for :title, "Dashboard" %>
-<div class="page-title">
-  <h1>Welcome to <%= t('department.name') %></h1>
-</div>
-<div class="well">
-<div class="row">
-  <div class="col-md-4">
-  <h2 class="remove-top-margin add-bottom-margin">Your account</h2>
-  <ul data-module="track-click">
-    <li><%= link_to "Change your email or password", edit_email_or_password_user_path(current_user) %></li>
-    <% if current_user.has_2sv? %>
-      <li><%= link_to "Change your 2-step verification phone", two_step_verification_path, class: "js-track" %></li>
-    <% else %>
-      <li><%= link_to "Make your account more secure", two_step_verification_path, class: "js-track" %></li>
+<% content_for :title, "Your applications" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <% if @applications_and_permissions.empty? %>
+      <p class="govuk-body">
+        You haven’t been assigned to any applications yet
+      </p>
     <% end %>
-    <li><%= link_to "Sign out", destroy_user_session_path %></li>
-  </ul>
+
+    <% @applications_and_permissions.each do |application, permissions| %>
+      <div class="app-application-list__item">
+        <h3 class="govuk-heading-m govuk-!-margin-bottom-1">
+          <%= link_to application.name, application.home_uri, class: "govuk-link" %>
+        </h3>
+
+        <p class="govuk-body">
+          <%= application.description || "No description" %>
+        </p>
+      </div>
+    <% end %>
   </div>
-  <div class="col-md-8">
-  <h2 class="remove-top-margin add-bottom-margin">Your Applications</h2>
-  <% if @applications_and_permissions.any? %>
-    <div class="list-group remove-bottom-margin">
-      <% @applications_and_permissions.each do |application, permissions| %>
-        <div class="list-group-item">
-          <h3 class="remove-top-margin add-label-margin">
-            <%= link_to_if application.home_uri, application.name, application.home_uri %>
-          </h3>
-          <div class="text-muted">
-          <% if application.description.present? %>
-            <%= application.description %>
-          <% end %>
-          <% if permissions.any? %>
-            <% if application.description.present? %>&bull; <% end %>
-            Roles: <em><%= current_user.permissions_for(application).map(&:humanize).to_sentence %></em>
-          <% end %>
-          </div>
-        </div>
+
+  <div class="govuk-grid-column-one-third">
+    <ul class="govuk-list app-dashboard-side">
+      <li>
+        <%= link_to "Change your email or password", edit_email_or_password_user_path(current_user) %>
+      </li>
+
+      <% if current_user.has_2sv? %>
+        <li><%= link_to "Change your 2-step verification phone", two_step_verification_path, class: "js-track" %></li>
+      <% else %>
+        <li><%= link_to "Make your account more secure", two_step_verification_path, class: "js-track" %></li>
       <% end %>
-    </div>
-  <% else %>
-    <p class="list-group-item no-content no-content-bordered">
-      You haven’t been assigned to<br />
-      any applications yet
-    </p>
-  <% end %>
+
+      <li><%= link_to "Sign out", destroy_user_session_path %></li>
+    </ul>
   </div>
-</div>
 </div>

--- a/test/controllers/root_controller_test.rb
+++ b/test/controllers/root_controller_test.rb
@@ -23,7 +23,7 @@ class RootControllerTest < ActionController::TestCase
     assert_equal "SAMEORIGIN", response.header['X-Frame-Options']
   end
 
-  test "Your Applications should include apps you have permission to signin to" do
+  test "Your applications should include apps you have permission to signin to" do
     exclusive_app = create(:application, name: "Exclusive app")
     everybody_app = create(:application, name: "Everybody app")
     user = create(:user, with_permissions: { exclusive_app => [], everybody_app => %w[signin] })

--- a/test/helpers/analytics_helpers.rb
+++ b/test/helpers/analytics_helpers.rb
@@ -15,8 +15,8 @@ module AnalyticsHelpers
   end
 
   def assert_dimension_is_set(dimension, with_value: nil)
-    dimension_set_js_code = "GOVUKAdmin.setDimension(#{dimension}"
-    dimension_set_js_code += ", \"#{with_value}\")" if with_value.present?
+    dimension_set_js_code = "ga('set', 'dimension#{dimension}"
+    dimension_set_js_code += "', \"#{with_value}\")" if with_value.present?
     assert_match(/#{Regexp.escape(dimension_set_js_code)}/, page.body)
   end
 end

--- a/test/integration/dashboard_test.rb
+++ b/test/integration/dashboard_test.rb
@@ -8,7 +8,7 @@ class DashboardTest < ActionDispatch::IntegrationTest
     visit root_path
     signin_with(user)
 
-    assert_response_contains("Your Applications")
+    assert_response_contains("Your applications")
     assert_response_contains("You haven’t been assigned to any applications yet")
   end
 

--- a/test/integration/manage_api_users_test.rb
+++ b/test/integration/manage_api_users_test.rb
@@ -12,9 +12,7 @@ class ManageApiUsersTest < ActionDispatch::IntegrationTest
       @api_user = create(:api_user, with_permissions: { @application => %w[write] })
       create(:access_token, resource_owner_id: @api_user.id, application_id: @application.id)
 
-      within("ul.nav") do
-        click_link "API Users"
-      end
+      click_link "API Users"
     end
 
     should "be able to view a list of API users alongwith their authorised applications" do

--- a/test/integration/sign_in_test.rb
+++ b/test/integration/sign_in_test.rb
@@ -116,13 +116,13 @@ class SignInTest < ActionDispatch::IntegrationTest
     should "not prompt for a verification code twice per browser in 30 days" do
       visit root_path
       signin_with(email: "email@example.com", password: "some password with various $ymb0l$")
-      assert_response_contains "Welcome to"
+      assert_response_contains "Your applications"
 
       signout
       visit root_path
 
       signin_with(email: "email@example.com", password: "some password with various $ymb0l$", second_step: false)
-      assert_response_contains "Welcome to"
+      assert_response_contains "Your applications"
 
       signout
       visit root_path
@@ -130,7 +130,7 @@ class SignInTest < ActionDispatch::IntegrationTest
       Timecop.travel(30.days.from_now + 1) do
         visit root_path
         signin_with(email: "email@example.com", password: "some password with various $ymb0l$")
-        assert_response_contains "Welcome to"
+        assert_response_contains "Your applications"
       end
     end
 
@@ -145,7 +145,7 @@ class SignInTest < ActionDispatch::IntegrationTest
     should "allow access with a correctly-generated code" do
       visit root_path
       signin_with(email: "email@example.com", password: "some password with various $ymb0l$")
-      assert_response_contains "Welcome to"
+      assert_response_contains "Your applications"
       assert_response_contains "Signed in successfully"
       assert_equal 1, EventLog.where(event_id: EventLog::TWO_STEP_VERIFIED.id, uid: @user.uid).count
     end
@@ -230,7 +230,7 @@ class SignInTest < ActionDispatch::IntegrationTest
     should "not remember a user's 2SV session if they've changed 2SV secret" do
       visit root_path
       signin_with(email: "email@example.com", password: "some password with various $ymb0l$")
-      assert_response_contains "Welcome to"
+      assert_response_contains "Your applications"
 
       signout
       visit root_path
@@ -245,7 +245,7 @@ class SignInTest < ActionDispatch::IntegrationTest
     should "not prevent login if 2SV is disabled for user with a remembered session" do
       visit root_path
       signin_with(email: "email@example.com", password: "some password with various $ymb0l$")
-      assert_response_contains "Welcome to"
+      assert_response_contains "Your applications"
 
       signout
       visit root_path

--- a/test/integration/sign_out_test.rb
+++ b/test/integration/sign_out_test.rb
@@ -10,9 +10,8 @@ class SignOutTest < ActionDispatch::IntegrationTest
     signin_with(@user)
     ReauthEnforcer.expects(:perform_on).with(@user).once
 
-    within("main") do
-      click_link "Sign out"
-    end
+    click_link "Sign out"
+
     assert_response_contains("Signed out successfully.")
   end
 

--- a/test/integration/superadmin_application_edit_test.rb
+++ b/test/integration/superadmin_application_edit_test.rb
@@ -10,9 +10,7 @@ class SuperAdminApplicationEditTest < ActionDispatch::IntegrationTest
       @superadmin = create(:superadmin_user)
       visit new_user_session_path
       signin_with(@superadmin)
-      within("ul.nav") do
-        click_link "Applications"
-      end
+      click_link "Apps"
 
       # normal user who's authorised to use app
       @user = create(:user)

--- a/test/integration/superadmin_application_users_test.rb
+++ b/test/integration/superadmin_application_users_test.rb
@@ -12,9 +12,7 @@ class SuperAdminApplicationUsersTest < ActionDispatch::IntegrationTest
     end
 
     should "see all the users with access" do
-      within("ul.nav") do
-        click_link "Applications"
-      end
+      click_link "Apps"
 
       # Create a user that's authorized to use our app
       user = create(:user, name: "My Test User")

--- a/test/integration/two_step_verification_test.rb
+++ b/test/integration/two_step_verification_test.rb
@@ -51,9 +51,7 @@ class TwoStepVerificationTest < ActionDispatch::IntegrationTest
       should "require the code again on next login" do
         enter_2sv_code(@new_secret)
 
-        within("main") do
-          click_link "Sign out"
-        end
+        click_link "Sign out"
 
         signin_with(@user)
       end


### PR DESCRIPTION
This is a implementation of the dashboard redesign by Sonia. The functionality is mostly the same as before.

I've removed the roles of the user, because I think this doesn't tell the user anything at the moment. Users that care about the roles of a user are probably all admins, and will have access to their own profile, which also lists the roles.

Also implements the navigation items in the header, as this is the first logged-in page that we've redesigned. We had to change "Applications" to "Apps" because we're running out of space in the header.

## Before

![screen shot 2018-10-02 at 09 59 28](https://user-images.githubusercontent.com/233676/46339126-e869b280-c629-11e8-8628-c2ac68b2d30b.png)

## After

![screen shot 2018-10-02 at 09 59 14](https://user-images.githubusercontent.com/233676/46339137-ec95d000-c629-11e8-87de-4637dfbb0c59.png)

https://trello.com/c/05wMNlxg