### PR TITLE
Allow applications to be hidden from the dashboard

### DIFF
--- a/app/controllers/doorkeeper_applications_controller.rb
+++ b/app/controllers/doorkeeper_applications_controller.rb
@@ -41,6 +41,7 @@ private
       :retired,
       :home_uri,
       :supports_push_updates,
+      :show_on_dashboard,
     )
   end
 end

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -6,7 +6,7 @@ class RootController < ApplicationController
   skip_after_action :verify_authorized
 
   def index
-    applications = ::Doorkeeper::Application.can_signin(current_user)
+    applications = ::Doorkeeper::Application.where(show_on_dashboard: true).can_signin(current_user)
 
     @applications_and_permissions = zip_permissions(applications, current_user)
   end

--- a/app/views/doorkeeper_applications/edit.html.erb
+++ b/app/views/doorkeeper_applications/edit.html.erb
@@ -69,6 +69,12 @@
 
   <p class="checkbox">
     <label>
+      <%= f.check_box :show_on_dashboard %> Show on dashboard
+    </label>
+  </p>
+
+  <p class="checkbox">
+    <label>
       <%= f.check_box :retired %> This application is retired
     </label>
     <span class="help-block">

--- a/db/migrate/20181002104116_add_show_on_dashboard_to_applications.rb
+++ b/db/migrate/20181002104116_add_show_on_dashboard_to_applications.rb
@@ -1,0 +1,5 @@
+class AddShowOnDashboardToApplications < ActiveRecord::Migration[5.1]
+  def change
+    add_column :oauth_applications, :show_on_dashboard, :boolean, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180131120100) do
+ActiveRecord::Schema.define(version: 20181002104116) do
 
   create_table "batch_invitation_application_permissions", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "batch_invitation_id", null: false
@@ -108,6 +108,7 @@ ActiveRecord::Schema.define(version: 20180131120100) do
     t.string "description"
     t.boolean "supports_push_updates", default: true
     t.boolean "retired", default: false
+    t.boolean "show_on_dashboard", default: true, null: false
     t.index ["name"], name: "unique_application_name", unique: true
     t.index ["uid"], name: "index_oauth_applications_on_uid", unique: true
   end

--- a/test/integration/dashboard_test.rb
+++ b/test/integration/dashboard_test.rb
@@ -4,7 +4,9 @@ require 'test_helper'
 
 class DashboardTest < ActionDispatch::IntegrationTest
   should "notify the user if they've not been assigned any applications" do
-    user = create(:user)
+    app = create(:application, name: "MyApp", show_on_dashboard: false)
+    user = create(:user, with_signin_permissions_for: [app])
+
     visit root_path
     signin_with(user)
 


### PR DESCRIPTION
Some applications aren't interesting to users, and will not likely be accessed from the dashboard. This commit adds an option to the application page that will hide it from the dashboard.

https://trello.com/c/05wMNlxg