### PR TITLE
Update layout for password reset error

### DIFF
--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -9,7 +9,7 @@ class PasswordsController < Devise::PasswordsController
     user = user_from_params
     unless user && user.reset_password_period_valid?
       record_reset_page_loaded_token_expired
-      render 'devise/passwords/reset_error'
+      render 'devise/passwords/reset_error', layout: "admin_layout"
     end
   end
 

--- a/app/views/devise/passwords/reset_error.html.erb
+++ b/app/views/devise/passwords/reset_error.html.erb
@@ -1,11 +1,16 @@
-<% content_for :title, "Password reset" %>
+<% content_for :title, "Sorry, this link doesn't work" %>
+<% content_for :back_link, new_session_path(resource_name) %>
 
-<div class="page-title">
-  <h1>Password reset</h1>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <p class="govuk-body">
+      This link to set a new password doesn't work. It may be that the link you
+      were using has expired or was invalid.
+    </p>
+
+    <%= render "govuk_publishing_components/components/button", {
+      text: "Try again",
+      href: new_user_password_path
+    } %>
+  </div>
 </div>
-
-<% info_message = 'That password reset didn’t work. It may be that the link you were using has expired or was invalid.' %>
-<%= content_tag :div, class: "alert alert-warning", data: track_analytics_data(:danger, info_message) do %>
-  <p><%= info_message %></p>
-  <p class="add-top-margin"><%= link_to 'Try again', new_user_password_path, class: 'btn btn-default' %></p>
-<% end %>

--- a/test/integration/password_reset_test.rb
+++ b/test/integration/password_reset_test.rb
@@ -73,7 +73,7 @@ class PasswordResetTest < ActionDispatch::IntegrationTest
 
       current_email.click_link("Change my password")
 
-      assert_response_contains("That password reset didn’t work.")
+      assert_response_contains("Sorry, this link doesn't work")
     end
   end
 


### PR DESCRIPTION
This updates the page the user sees when they click on an expired or incorrect password reset link.

https://trello.com/c/05wMNlxg