### PR TITLE
Use table component for organisations page

### DIFF
--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -1,4 +1,6 @@
 class OrganisationsController < ApplicationController
+  layout "admin_layout"
+
   before_action :authenticate_user!
 
   respond_to :html

--- a/app/views/organisations/index.html.erb
+++ b/app/views/organisations/index.html.erb
@@ -1,22 +1,19 @@
 <% content_for :title, "Organisations" %>
-<h1 class="page-title">Organisations</h1>
-<table class="table table-striped table-bordered">
-  <thead>
-    <tr class="table-header">
-      <th>Name</th>
-      <th>Abbreviation</th>
-      <th>Organisation Type</th>
-      <th>Slug</th>
-    </tr>
-  </thead>
-  <tbody>
+
+<%= GovukPublishingComponents::AppHelpers::TableHelper.helper(self, "Applications", { caption_classes: "govuk-visually-hidden" }) do |t| %>
+  <%= t.head do %>
+    <%= t.header "Name" %>
+    <%= t.header "Organisation Type" %>
+    <%= t.header "Slug" %>
+  <% end %>
+
+  <%= t.body do %>
     <% @organisations.each do |organisation| %>
-      <tr>
-        <td><%= organisation.name %></td>
-        <td><%= organisation.abbreviation %></td>
-        <td><%= organisation.organisation_type %></td>
-        <td><%= organisation.slug %></td>
-      </tr>
+      <%= t.row do %>
+        <%= t.cell "#{organisation.name} (#{organisation.abbreviation})" %>
+        <%= t.cell organisation.organisation_type %>
+        <%= t.cell organisation.slug %>
+      <% end %>
     <% end %>
-  </tbody>
-</table>
+  <% end %>
+<% end %>

--- a/test/controllers/organisations_controller_test.rb
+++ b/test/controllers/organisations_controller_test.rb
@@ -8,13 +8,13 @@ class OrganisationsControllerTest < ActionController::TestCase
 
   context "GET index" do
     setup do
-      create(:organisation, name: "Ministry of Funk")
+      create(:organisation, name: "Ministry of Funk", abbreviation: "MoF")
     end
 
     should "list organisations" do
       get :index
       assert_response 200
-      assert_select "td", "Ministry of Funk"
+      assert_select "td", "Ministry of Funk (MoF)"
     end
   end
 end


### PR DESCRIPTION
I'm not sure what this page is for, but we're keeping it in order not to make too many changes to the app now. This converts the table to use a component.

https://trello.com/c/05wMNlxg