### PR TITLE
Update change of email address confirmation

### DIFF
--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -1,6 +1,8 @@
 # Copied from
 # https://github.com/plataformatec/devise/blob/v2.1.2/app/controllers/devise/confirmations_controller.rb#L19
 class ConfirmationsController < Devise::ConfirmationsController
+  layout "admin_layout"
+
   def new
     handle_new_token_needed
   end
@@ -9,7 +11,7 @@ class ConfirmationsController < Devise::ConfirmationsController
     handle_new_token_needed
   end
 
-  # GET /resource/confirmation?confirmation_token=abcdef
+  # GET /users/confirmation?confirmation_token=abcdef
   def show
     if user_signed_in?
       if confirmation_user.persisted? && (current_user.email != confirmation_user.email)

--- a/app/views/devise/confirmations/show.html.erb
+++ b/app/views/devise/confirmations/show.html.erb
@@ -1,28 +1,26 @@
-<% content_for :title, "Confirm account email changes" %>
+<% content_for :title, "Confirm change of email address" %>
 
-<h1>Confirm account email changes</h1>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <p class="govuk-body">
+      Please enter your password to confirm the change of email address from
+      <strong><%= resource.email %></strong> to <strong><%= resource.unconfirmed_email %></strong>.
+    </p>
 
-<div class="alert alert-info">
-  For security, we need you to enter your password before your account email can be changed.
+    <%= form_for resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :put, class: 'well'} do |f| %>
+      <%= hidden_field_tag :confirmation_token, params[:confirmation_token] %>
+
+      <%= render "govuk_publishing_components/components/input", {
+        label: {
+          text: "Your password"
+        },
+        name: "user[password]",
+        type: "password"
+      } %>
+
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Confirm change"
+      } %>
+    <% end %>
+  </div>
 </div>
-
-<%= form_for resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :put, class: 'well'} do |f| %>
-  <%= hidden_field_tag :confirmation_token, params[:confirmation_token] %>
-
-  <p>
-    <%= f.label :email, "Current email" %>
-    <%= f.text_field :email, disabled: "disabled", readonly: "readonly", class: 'form-control input-md-5' %>
-  </p>
-  <p>
-    <%= f.label :unconfirmed_email, "New email" %>
-    <%= f.text_field :unconfirmed_email, disabled: "disabled", readonly: "readonly", class: 'form-control input-md-5' %>
-  </p>
-  <p>
-    <%= f.label :password, "Password" %>
-    <%= f.password_field :password, required: "required", class: 'form-control input-md-5' %>
-  </p>
-
-  <hr>
-
-  <%= f.submit "Confirm email change", class: "btn btn-primary" %>
-<% end %>

--- a/test/controllers/confirmations_controller_test.rb
+++ b/test/controllers/confirmations_controller_test.rb
@@ -39,7 +39,7 @@ class ConfirmationsControllerTest < ActionController::TestCase
 
       should "render a form" do
         get :show, params: { confirmation_token: @confirmation_token }
-        assert_select "input#user_password"
+        assert_select "input[name='user[password]']"
         assert_select "input[type=hidden][name=confirmation_token][value=?]", @confirmation_token
       end
     end

--- a/test/helpers/user_account_operations.rb
+++ b/test/helpers/user_account_operations.rb
@@ -18,8 +18,8 @@ module UserAccountOperations
 
     signout
     visit user_confirmation_path(confirmation_token: options[:confirmation_token])
-    assert_response_contains("Confirm account email changes")
-    fill_in "Password", with: options[:password]
-    click_button "Confirm email change"
+    assert_response_contains("Confirm change of email address")
+    fill_in "Your password", with: options[:password]
+    click_button "Confirm change"
   end
 end


### PR DESCRIPTION
This commit updates the page that users see when they are not signed in and click on a link to confirm a change of email address.

## Before

![screen shot 2018-10-04 at 18 35 05](https://user-images.githubusercontent.com/233676/46492080-7bf6db00-c804-11e8-8912-1bed7a19c980.png)

## After

![screen shot 2018-10-04 at 18 34 36](https://user-images.githubusercontent.com/233676/46492086-80bb8f00-c804-11e8-89f7-5a24eb939cc4.png)

https://trello.com/c/05wMNlxg