### PR TITLE
Encourage people to set up 2-step verification

### DIFF
--- a/app/assets/stylesheets/new_admin_layout.scss
+++ b/app/assets/stylesheets/new_admin_layout.scss
@@ -51,6 +51,10 @@
   }
 }
 
+a.gem-c-button.govuk-button {
+  color: #fff;
+}
+
 // TODO: replace IDs with `js-` prefixed classes as JavaScript selectors
 .not-strong-enough #password-guidance,
 .not-strong-enough #password-entropy,

--- a/app/assets/stylesheets/new_admin_layout.scss
+++ b/app/assets/stylesheets/new_admin_layout.scss
@@ -51,10 +51,6 @@
   }
 }
 
-a.gem-c-button.govuk-button {
-  color: #fff;
-}
-
 // TODO: replace IDs with `js-` prefixed classes as JavaScript selectors
 .not-strong-enough #password-guidance,
 .not-strong-enough #password-entropy,

--- a/app/controllers/devise/two_step_verification_controller.rb
+++ b/app/controllers/devise/two_step_verification_controller.rb
@@ -2,6 +2,7 @@ class Devise::TwoStepVerificationController < DeviseController
   before_action -> { authenticate_user!(force: true) }, only: :prompt
   before_action :prepare_and_validate, except: :prompt
   skip_before_action :handle_two_step_verification
+  layout "admin_layout", only: %w[prompt]
 
   attr_reader :otp_secret_key
 

--- a/app/views/devise/two_step_verification/_make_your_account_more_secure.html.erb
+++ b/app/views/devise/two_step_verification/_make_your_account_more_secure.html.erb
@@ -1,0 +1,9 @@
+<div class="govuk-body">
+  <p>Make your account more secure by setting up 2&#8209;step verification. You’ll need to install an app on your phone which will generate a security code to enter when you sign in.</p>
+  <p>Set up takes about 5 minutes.</p>
+
+  <%= render "govuk_publishing_components/components/button", {
+    text: "Start set up",
+    href: two_step_verification_path
+  } %>
+</div>

--- a/app/views/devise/two_step_verification/_make_your_account_more_secure.html.erb
+++ b/app/views/devise/two_step_verification/_make_your_account_more_secure.html.erb
@@ -1,9 +1,9 @@
 <div class="govuk-body">
   <p>Make your account more secure by setting up 2&#8209;step verification. You’ll need to install an app on your phone which will generate a security code to enter when you sign in.</p>
   <p>Set up takes about 5 minutes.</p>
-
-  <%= render "govuk_publishing_components/components/button", {
-    text: "Start set up",
-    href: two_step_verification_path
-  } %>
 </div>
+
+<%= render "govuk_publishing_components/components/button", {
+  text: "Start set up",
+  href: two_step_verification_path
+} %>

--- a/app/views/devise/two_step_verification/prompt.html.erb
+++ b/app/views/devise/two_step_verification/prompt.html.erb
@@ -1,17 +1,8 @@
 <% content_for :title, "Make your account more secure" %>
-<% content_for :thin_form, true %>
 <% content_for :suppress_navbar_items, true %>
 
-<div class="page-title">
-  <h1>Make your account more secure</h1>
-</div>
-
-<div class="panel panel-default">
-  <div class="panel-body">
-    <p class="lead">Make your signon account more secure by setting up 2&#8209;step verification. You’ll need to install an app on your phone which will generate a security code to enter when you sign in.</p>
-    <p class="lead remove-bottom-margin">Set up takes about 5 minutes.</p>
-  </div>
-  <div class="panel-footer" data-module="track-click">
-    <%= link_to 'Start set up', two_step_verification_path, class: 'btn btn-success btn-lg js-track', "data-track-label" => "setup" %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "make_your_account_more_secure" %>
   </div>
 </div>

--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -2,6 +2,15 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+
+    <% unless current_user.has_2sv? %>
+      <%= render "govuk_publishing_components/components/notice", {
+        title: "Make your account more secure"
+      } do %>
+        <%= render "devise/two_step_verification/make_your_account_more_secure" %>
+      <% end %>
+    <% end %>
+
     <% if @applications_and_permissions.empty? %>
       <p class="govuk-body">
         You haven’t been assigned to any applications yet
@@ -30,7 +39,7 @@
       <% if current_user.has_2sv? %>
         <li><%= link_to "Change your 2-step verification phone", two_step_verification_path, class: "govuk-link" %></li>
       <% else %>
-        <li><%= link_to "Make your account more secure", two_step_verification_path, class: "govuk-link" %></li>
+        <li><%= link_to "Set up 2-step verification", two_step_verification_path, class: "govuk-link" %></li>
       <% end %>
     </ul>
   </div>

--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -5,10 +5,9 @@
 
     <% unless current_user.has_2sv? %>
       <%= render "govuk_publishing_components/components/notice", {
-        title: "Make your account more secure"
-      } do %>
-        <%= render "devise/two_step_verification/make_your_account_more_secure" %>
-      <% end %>
+        title: "Make your account more secure",
+        description_text: (render "devise/two_step_verification/make_your_account_more_secure")
+      } %>
     <% end %>
 
     <% if @applications_and_permissions.empty? %>

--- a/test/integration/dashboard_test.rb
+++ b/test/integration/dashboard_test.rb
@@ -41,7 +41,8 @@ class DashboardTest < ActionDispatch::IntegrationTest
       visit root_path
       signin_with(user)
 
-      assert has_link?("Make your account more secure")
+      assert_response_contains("Make your account more secure")
+      assert has_link?("Set up 2-step verification")
     end
   end
 end


### PR DESCRIPTION
This updates the 2-step verification prompt page. This page is seen by user when they've been required to set up 2-step verification.

## Before

<img width="1154" alt="screen shot 2018-10-12 at 12 05 55" src="https://user-images.githubusercontent.com/233676/46865921-3b581c80-ce17-11e8-8222-df50c1314aa9.png">

## After

<img width="1154" alt="screen shot 2018-10-12 at 11 58 52" src="https://user-images.githubusercontent.com/233676/46865943-4f038300-ce17-11e8-953a-3d69d195a043.png">

Also adds a permanent warning to the dashboard if 2-step verification hasn't been set up:

<img width="1154" alt="screen shot 2018-10-12 at 12 03 50" src="https://user-images.githubusercontent.com/233676/46865935-4743de80-ce17-11e8-8ca3-ae46025e4465.png">
