### PR TITLE
Add /healthcheck endpoint

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,9 @@
 Rails.application.routes.draw do
+  get "/healthcheck", to: GovukHealthcheck.rack_response(
+    GovukHealthcheck::SidekiqRedis,
+    GovukHealthcheck::ActiveRecord,
+  )
+
   use_doorkeeper do
     controllers authorizations: 'signin_required_authorizations'
   end


### PR DESCRIPTION
Once enabled in puppet, this will make sure we have a more valuable healthcheck than currently.

https://github.com/alphagov/govuk-puppet/blob/master/modules/govuk/manifests/apps/signon.pp#L90