### PR TITLE
Make error messages more helpful

### DIFF
--- a/app/helpers/root_helper.rb
+++ b/app/helpers/root_helper.rb
@@ -1,9 +1,13 @@
 module RootHelper
-  def application_name
-    if @application.present?
-      @application.name
+  def gds_only_application_and_non_gds_user?
+    @application.gds_only? && !current_user.belongs_to_gds?
+  end
+
+  def title
+    if @application.blank? || gds_only_application_and_non_gds_user?
+      "You don’t have permission to use this app."
     else
-      "this application"
+      "You don’t have permission to sign in to #{@application.name}."
     end
   end
 end

--- a/app/models/enhancements/application.rb
+++ b/app/models/enhancements/application.rb
@@ -44,6 +44,14 @@ class ::Doorkeeper::Application < ActiveRecord::Base
     url_without_path = "#{parsed_url.scheme}://#{parsed_url.host}:#{parsed_url.port}"
   end
 
+  def gds_only?
+    [
+      "Collections Publisher",
+      "Publisher",
+      "Service Manual Publisher"
+    ].include?(name)
+  end
+
 private
 
   def create_signin_supported_permission

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -3,6 +3,8 @@
 class Organisation < ActiveRecord::Base
   include ActiveModel::ForbiddenAttributesProtection
 
+  GDS_ORG_CONTENT_ID = "af07d5a5-df63-4ddc-9383-6a666845ebe9".freeze
+
   has_ancestry
 
   has_many :users

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -294,6 +294,10 @@ class User < ActiveRecord::Base
     require_2sv? && two_step_flag_changed?
   end
 
+  def belongs_to_gds?
+    organisation.try(:content_id).to_s == Organisation::GDS_ORG_CONTENT_ID
+  end
+
 private
 
   def two_step_flag_changed?

--- a/app/views/root/signin_required.html.erb
+++ b/app/views/root/signin_required.html.erb
@@ -1,16 +1,23 @@
-<% content_for :title, "Sorry, you don't have permission to access " + application_name %>
+<% content_for :title, title %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <% unless gds_only_application_and_non_gds_user? %>
+      <p class="govuk-body">
+        <% if current_user.belongs_to_gds? %>
+          Ask your delivery manager if you need access.
+        <% else %>
+          Ask your organisation’s main GOV.UK contact if you need access.
+        <% end %>
+      </p>
+      <p class="govuk-body">If you think something is wrong, try <%= link_to "signing out", destroy_user_session_path %> and then
+        <%- if @application.present? -%>
+          <%= link_to 'back in', @application.home_uri -%>
+        <%- else -%>
+          back in
+        <%- end %>.
+      </p>
+    <% end %>
 
-    <p class="govuk-body">Please contact your Delivery Manager or main GDS contact if you need access.</p>
-
-    <p class="govuk-body">If you think something is wrong, try <%= link_to "signing out", destroy_user_session_path %> and then
-      <%- if @application.present? -%>
-        <%= link_to 'back in', @application.home_uri -%>
-      <%- else -%>
-        back in
-      <%- end %>.</p>
-
-  </div>
+    </div>
 </div>

--- a/test/controllers/root_controller_test.rb
+++ b/test/controllers/root_controller_test.rb
@@ -35,4 +35,33 @@ class RootControllerTest < ActionController::TestCase
     assert_select "h3", "Everybody app"
     assert_select "h3", count: 1
   end
+
+  test "GDS publishers should be told to ask their delivery manager when they don't have permission to use a publishing app" do
+    gds = create(:organisation, content_id: "af07d5a5-df63-4ddc-9383-6a666845ebe9")
+    gds_user = create(:user, organisation: gds)
+    session[:signin_missing_for_application] = create(:application, name: "Everybody app").id
+    sign_in gds_user
+    get :signin_required
+
+    assert_select "h1", "You don’t have permission to sign in to Everybody app."
+    assert_select "p", "Ask your delivery manager if you need access."
+  end
+
+  test "Departmental publishers should be told to ask their GOV.UK contact when they don't have permission to use a publishing app" do
+    session[:signin_missing_for_application] = create(:application, name: "Whitehall").id
+    sign_in create(:user_in_organisation)
+    get :signin_required
+
+    assert_select "h1", "You don’t have permission to sign in to Whitehall."
+    assert_select "p", "Ask your organisation’s main GOV.UK contact if you need access."
+  end
+
+  test "Departmental publishers should be told they don't have permissions to use GDS only applications" do
+    session[:signin_missing_for_application] = create(:application, name: "Publisher").id
+    sign_in create(:user_in_organisation)
+    get :signin_required
+
+    assert_select "h1", "You don’t have permission to use this app."
+    assert_select "p", count: 0
+  end
 end

--- a/test/integration/authorise_application_test.rb
+++ b/test/integration/authorise_application_test.rb
@@ -66,7 +66,7 @@ class AuthoriseApplicationTest < ActionDispatch::IntegrationTest
     ignoring_spurious_error do
       visit "/oauth/authorize?response_type=code&client_id=#{@app.uid}&redirect_uri=#{@app.redirect_uri}"
     end
-    assert_response_contains("you don't have permission to access #{@app.name}")
+    assert_response_contains("You don’t have permission to sign in to #{@app.name}.")
     refute Doorkeeper::AccessGrant.find_by(resource_owner_id: @user.id)
   end
 


### PR DESCRIPTION
Show who the publisher should contact if they can't access a publishing application.

https://trello.com/c/bOxIvf1L