### PR TITLE
Add extra healthcheck for expiring API User tokens

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   get "/healthcheck", to: GovukHealthcheck.rack_response(
     GovukHealthcheck::SidekiqRedis,
     GovukHealthcheck::ActiveRecord,
+    Healthcheck::ApiTokens
   )
 
   use_doorkeeper do

--- a/lib/healthcheck/api_tokens.rb
+++ b/lib/healthcheck/api_tokens.rb
@@ -1,0 +1,47 @@
+module Healthcheck
+  class ApiTokens
+    WARNING_THRESHOLD = 1.year.to_i
+    CRITICAL_THRESHOLD = 1.month.to_i
+
+    QUERY = <<-SQL.freeze
+      SELECT users.name, oauth_applications.name FROM oauth_access_tokens
+      INNER JOIN users ON users.id = resource_owner_id
+      INNER JOIN oauth_applications ON oauth_applications.id = application_id
+      WHERE oauth_access_tokens.revoked_at IS NULL
+      AND users.api_user = TRUE
+      AND (oauth_access_tokens.expires_in -
+          (unix_timestamp(now()) -
+           unix_timestamp(oauth_access_tokens.created_at))) < %<threshold>s
+    SQL
+
+    def name
+      :api_tokens
+    end
+
+    def details
+      { warnings: warnings - criticals, criticals: criticals }
+    end
+
+    def status
+      return GovukHealthcheck::CRITICAL if criticals.any?
+
+      return GovukHealthcheck::WARNING if warnings.any?
+
+      GovukHealthcheck::OK
+    end
+
+  private
+
+    def warnings
+      @warnings ||= connection.execute(QUERY % { threshold: WARNING_THRESHOLD }).to_a
+    end
+
+    def criticals
+      @criticals ||= connection.execute(QUERY % { threshold: CRITICAL_THRESHOLD }).to_a
+    end
+
+    def connection
+      ActiveRecord::Base.connection
+    end
+  end
+end

--- a/lib/healthcheck/api_tokens.rb
+++ b/lib/healthcheck/api_tokens.rb
@@ -1,6 +1,6 @@
 module Healthcheck
   class ApiTokens
-    WARNING_THRESHOLD = 1.year.to_i
+    WARNING_THRESHOLD = 2.months.to_i
     CRITICAL_THRESHOLD = 1.month.to_i
 
     QUERY = <<-SQL.freeze

--- a/test/lib/healthcheck/api_tokens_test.rb
+++ b/test/lib/healthcheck/api_tokens_test.rb
@@ -1,0 +1,78 @@
+require 'test_helper'
+
+class PermissionUpdaterTest < ActiveSupport::TestCase
+  context "status" do
+    should "return 'OK' when no tokens are expiring" do
+      check = Healthcheck::ApiTokens.new
+      assert_equal GovukHealthcheck::OK, check.status
+    end
+
+    should "return 'WARNING' when a token is getting old" do
+      make_api_user_token(expires_in: Healthcheck::ApiTokens::WARNING_THRESHOLD)
+      check = Healthcheck::ApiTokens.new
+      assert_equal GovukHealthcheck::WARNING, check.status
+    end
+
+    should "return 'CRITICAL' when a token is almost expired" do
+      make_api_user_token(expires_in: Healthcheck::ApiTokens::CRITICAL_THRESHOLD)
+      check = Healthcheck::ApiTokens.new
+      assert_equal GovukHealthcheck::CRITICAL, check.status
+    end
+
+    should "return 'CRITICAL' even when if we have a 'WARNING'" do
+      make_api_user_token(expires_in: Healthcheck::ApiTokens::WARNING_THRESHOLD)
+      make_api_user_token(expires_in: Healthcheck::ApiTokens::CRITICAL_THRESHOLD)
+      check = Healthcheck::ApiTokens.new
+      assert_equal GovukHealthcheck::CRITICAL, check.status
+    end
+
+    should "return 'OK' when the tokens are for normal users" do
+      make_normal_user_token(expires_in: Healthcheck::ApiTokens::CRITICAL_THRESHOLD)
+      check = Healthcheck::ApiTokens.new
+      assert_equal GovukHealthcheck::OK, check.status
+    end
+  end
+
+  context "details" do
+    should "return which tokens are causing the check to fail" do
+      warning_user = create :api_user
+      critical_user = create :api_user
+
+      warning_token = make_api_user_token(
+        expires_in: Healthcheck::ApiTokens::WARNING_THRESHOLD,
+        user: warning_user,
+      )
+
+      critical_token = make_api_user_token(
+        expires_in: Healthcheck::ApiTokens::CRITICAL_THRESHOLD,
+        user: critical_user,
+      )
+
+      check = Healthcheck::ApiTokens.new
+
+      assert_equal(
+        {
+          warnings: [[warning_user.name, warning_token.application.name]],
+          criticals: [[critical_user.name, critical_token.application.name]],
+        },
+        check.details
+      )
+    end
+
+    should "not return expiring token details for normal users" do
+      make_normal_user_token(expires_in: Healthcheck::ApiTokens::CRITICAL_THRESHOLD)
+      check = Healthcheck::ApiTokens.new
+      assert_equal({ warnings: [], criticals: [] }, check.details)
+    end
+  end
+
+  def make_api_user_token(expires_in:, user: nil)
+    user ||= create :api_user
+    create :access_token, resource_owner_id: user.id, expires_in: expires_in - 1
+  end
+
+  def make_normal_user_token(expires_in:)
+    user ||= create :user
+    create :access_token, resource_owner_id: user.id, expires_in: expires_in - 1
+  end
+end


### PR DESCRIPTION
https://trello.com/c/pvSF3FTe/5-rotate-gds-sso-tokens

This will help us to proactively rotate tokens by alerting us as reach
their expiry. We can't currently automate cycling of tokens, so the
check includes details of each API User and Application pair that need
attention, which is enough to find them in the UI.