### PR TITLE
Fix healthcheck message being null when OK

### DIFF
--- a/lib/healthcheck/api_tokens.rb
+++ b/lib/healthcheck/api_tokens.rb
@@ -28,7 +28,7 @@ module Healthcheck
     end
 
     def message
-      return unless expiring_tokens.any?
+      return "" unless expiring_tokens.any?
 
       "\n\n" + expiring_tokens.join("\n") + "\n\n"
     end

--- a/test/lib/healthcheck/api_tokens_test.rb
+++ b/test/lib/healthcheck/api_tokens_test.rb
@@ -52,7 +52,7 @@ class PermissionUpdaterTest < ActiveSupport::TestCase
     should "not return expiring token details for normal users" do
       make_normal_user_token(expires_in: Healthcheck::ApiTokens::CRITICAL_THRESHOLD)
       check = Healthcheck::ApiTokens.new
-      assert_nil check.message
+      assert_match("", check.message)
     end
 
     should "cope when the token has already expired" do


### PR DESCRIPTION
Turns out nagios needs the message to always be a string.