### PR TITLE
Stop password reset for unaccepted invitations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ gem 'zeroclipboard-rails', '>= 0.1.2'
 
 # GDS Gems
 gem 'deprecated_columns', '0.1.1'
-gem 'gds-api-adapters', '~> 55.0'
+gem 'gds-api-adapters', '~> 57.0'
 gem 'govuk_admin_template', '~> 6.6'
 gem 'govuk_app_config', '~> 1.11'
 gem 'govuk_publishing_components', '~> 13.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,7 +121,7 @@ GEM
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
     ffi (1.10.0)
-    gds-api-adapters (55.0.2)
+    gds-api-adapters (57.0.0)
       addressable
       link_header
       null_logger
@@ -428,7 +428,7 @@ DEPENDENCIES
   devise_zxcvbn (= 1.1.1)
   doorkeeper (~> 5.0.2)
   factory_bot_rails (~> 4.11)
-  gds-api-adapters (~> 55.0)
+  gds-api-adapters (~> 57.0)
   govuk-lint (~> 3.10)
   govuk_admin_template (~> 6.6)
   govuk_app_config (~> 1.11)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,7 +120,7 @@ GEM
       railties (>= 3.0.0)
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
-    ffi (1.9.25)
+    ffi (1.10.0)
     gds-api-adapters (55.0.2)
       addressable
       link_header
@@ -159,7 +159,7 @@ GEM
     govuk_frontend_toolkit (8.1.0)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_publishing_components (13.5.3)
+    govuk_publishing_components (13.5.4)
       govspeak (>= 5.0.3)
       govuk_app_config
       govuk_frontend_toolkit
@@ -338,7 +338,7 @@ GEM
       crass (~> 1.0.2)
       nokogiri (>= 1.4.4)
       nokogumbo (~> 1.4)
-    sass (3.7.2)
+    sass (3.7.3)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -43,6 +43,11 @@ class UserMailer < Devise::Mailer
     mail(to: @user.email, subject: suspension_notification_subject)
   end
 
+  def notify_reset_password_disallowed_due_to_unaccepted_invitation(user)
+    @user = user
+    mail(to: @user.email, subject: "Your #{app_name} account has not been activated")
+  end
+
   def email_changed_by_admin_notification(user, email_was, to_address)
     @user = user
     @email_was = email_was

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -160,6 +160,9 @@ class User < ActiveRecord::Base
     if user.present? && user.suspended?
       UserMailer.notify_reset_password_disallowed_due_to_suspension(user).deliver_later
       user
+    elsif user.present? && user.invited_to_sign_up? && !user.invitation_accepted?
+      UserMailer.notify_reset_password_disallowed_due_to_unaccepted_invitation(user).deliver_later
+      user
     else
       super
     end

--- a/app/views/user_mailer/notify_reset_password_disallowed_due_to_unaccepted_invitation.html.erb
+++ b/app/views/user_mailer/notify_reset_password_disallowed_due_to_unaccepted_invitation.html.erb
@@ -1,0 +1,3 @@
+<p>Your <%= link_to t('department.name'), t('department.url') %> Signon <%= account_name %>, for <%= @user.email %>, has not been activated. You can't request a password reset on an inactive account.</p>
+
+<p>If you want a new invitation, please contact a managing <%= link_to t('department.name'), t('department.url') %> editor in your organisation (or your parent organisation). They can use the support form to get help from the <%= link_to t('department.name'), t('department.url') %> team.</p>

--- a/app/views/user_mailer/notify_reset_password_disallowed_due_to_unaccepted_invitation.text.erb
+++ b/app/views/user_mailer/notify_reset_password_disallowed_due_to_unaccepted_invitation.text.erb
@@ -1,0 +1,4 @@
+
+Your <%= link_to t('department.name'), t('department.url') %> Signon <%= account_name %>, for <%= @user.email %>, has not been activated. You can't request a password reset on an inactive account.
+
+If you want a new invitation, please contact a managing <%= link_to t('department.name'), t('department.url') %> editor in your organisation (or your parent organisation). They can use the support form to get help from the <%= link_to t('department.name'), t('department.url') %> team.


### PR DESCRIPTION
https://trello.com/c/HXSZikzB/38-improve-signon

Previously a user could request a password reset against an invitation that had not been accepted, even if it has expired. This ensures we only send password reset links to users with active accounts (no invitation, or invitation accepted).