### PR TITLE
Add button to reinvite a user to the user page

### DIFF
--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -8,6 +8,17 @@
   <%= link_to "#{@user.suspended? ? "Uns" : "S"}uspend user", edit_suspension_path(@user) %>
 </p>
 
+<% if @user.invited_but_not_accepted %>
+  <div class="alert alert-warning">
+    <strong>Invitation not accepted yet</strong>.<br/>
+    This user hasn't clicked on the link in their signup mail yet.
+
+    <%= form_tag resend_user_invitation_path(@user) do %>
+      <%= submit_tag "Resend signup email", class: "btn btn-default add-top-margin" %>
+    <% end %>
+  </div>
+<% end %>
+
 <% if @user.access_locked? %>
   <div class="alert alert-warning">
     <strong>Account has been locked after too many unsuccessful login attempts.</strong><br/>

--- a/test/integration/inviting_users_test.rb
+++ b/test/integration/inviting_users_test.rb
@@ -45,6 +45,24 @@ class InvitingUsersTest < ActionDispatch::IntegrationTest
       end
     end
 
+    should "resend the invite" do
+      perform_enqueued_jobs do
+        visit new_user_invitation_path
+        fill_in "Name", with: "Fred Bloggs"
+        fill_in "Email", with: "fred@example.com"
+        click_button "Create user and send email"
+
+        user = User.find_by(email: 'fred@example.com')
+        visit edit_user_path(user)
+
+        click_button "Resend signup email"
+
+        assert page.has_content?("Resent account signup email")
+        emails_received = all_emails.count { |email| email.subject == "Please confirm your account" }
+        assert_equal 2, emails_received
+      end
+    end
+
     should "grant the permissions selected" do
       application_one = create(:application)
       create(:supported_permission, application: application_one, name: 'editor')


### PR DESCRIPTION
This will allow us to remove the button from the index page in https://github.com/alphagov/signon/pull/961, which makes the UI cleaner. Also adds a missing test.

https://trello.com/c/HXSZikzB