### PR TITLE
Ensure path exists before creating usage report

### DIFF
--- a/app/presenters/usage_presenter.rb
+++ b/app/presenters/usage_presenter.rb
@@ -1,17 +1,22 @@
 require 'csv'
+require 'fileutils'
 
 class UsagePresenter
   include UsersHelper
 
-  attr_reader :start_date, :end_date
+  attr_reader :start_date, :end_date, :file_system, :file_utils
 
-  def initialize(start_date, end_date)
+  def initialize(start_date, end_date, file_system = File, file_utils = FileUtils)
     @start_date = start_date.beginning_of_day
     @end_date = end_date.end_of_day
+    @file_system = file_system
+    @file_utils = file_utils
   end
 
   def write_csv(path)
-    CSV.open(File.join(path, "usage_report_#{start_date.to_date}_#{end_date.to_date}.csv"), "wb") do |csv|
+    file_utils.mkdir_p(path) unless file_system.directory?(path)
+
+    CSV.open(file_system.join(path, "usage_report_#{start_date.to_date}_#{end_date.to_date}.csv"), "wb") do |csv|
       build_csv(csv)
     end
   end

--- a/test/presenters/usage_presenter_test.rb
+++ b/test/presenters/usage_presenter_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+class UsagePresenterTest < ActiveSupport::TestCase
+  should 'create the directory if it does not exist' do
+    fake_fs = Object.new
+    fake_file_utils = mock
+
+    dir = "/my/fancy/directory"
+    report_file = Tempfile.new("report.csv")
+
+    start_date = Date.parse('2018-01-01')
+    end_date = Date.parse('2018-10-01')
+    usage_presenter = UsagePresenter.new(start_date, end_date, fake_fs, fake_file_utils)
+
+    fake_fs.stubs(:directory?).returns(false)
+    fake_fs.stubs(:join).returns(report_file)
+
+    fake_file_utils.expects(:mkdir_p).once
+
+    usage_presenter.write_csv(dir)
+
+    report_file.unlink
+  end
+end


### PR DESCRIPTION
When we create the usage report csv, we should ensure the path exists
before creating the csv. The current behaviour will error if the
path does not exist and as such, the report will not be created.

Although the actual fix is only a one-line, refactor the code
to inject File and FileUtils to the constructor of UsagePresenter
so we can more easily test interactions with the file system.

I did explore using FakeFS as well as Minitest::Filesystem, but
decided to avoid introducing extra dependencies.