### PR TITLE
Use a fixed version of alphabetical_paginate

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,11 @@ gem 'rails', '~> 5'
 
 gem 'activejob-retry'
 gem 'addressable', '~> 2'
-gem 'alphabetical_paginate', '~> 2'
+gem(
+  'alphabetical_paginate',
+  git: 'https://github.com/cbaines/alphabetical_paginate',
+  branch: 'wrap-sql-in-arel-sql'
+)
 gem 'ancestry', '~> 3'
 gem 'bootsnap'
 gem 'bootstrap-kaminari-views', '0.0.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,10 @@
+GIT
+  remote: https://github.com/cbaines/alphabetical_paginate
+  revision: 26015e94c64f4feaeac756ab7c3512b0707e96be
+  branch: wrap-sql-in-arel-sql
+  specs:
+    alphabetical_paginate (2.3.3)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -47,7 +54,6 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
-    alphabetical_paginate (2.3.3)
     ancestry (3.0.5)
       activerecord (>= 3.2.0)
     arel (9.0.0)
@@ -423,7 +429,7 @@ PLATFORMS
 DEPENDENCIES
   activejob-retry
   addressable (~> 2)
-  alphabetical_paginate (~> 2)
+  alphabetical_paginate!
   ancestry (~> 3)
   better_errors (= 2.5.0)
   binding_of_caller (= 0.8.0)


### PR DESCRIPTION
That doesn't show a deprecation warning. This change hasn't been
released yet but has been pushed upstream here [1].

1: https://github.com/lingz/alphabetical_paginate/pull/55

The patch changes alphabetical_paginate to work with Rails 6, where
non-attribute arguments will be disallowed.

Below is an example of a deprecation warning that shows up without
this:

```
DEPRECATION WARNING: Dangerous query method (method whose arguments
are used as raw SQL) called with non-attribute argument(s): "substr(
users.name, 1 , 1)". Non-attribute arguments will be disallowed in
Rails 6.0. This method should not be called with user-provided values,
such as request parameters or model attributes. Known-safe values can
be passed by wrapping them in Arel.sql().
```