### PR TITLE
Improve security for 2SV cookies

### DIFF
--- a/app/controllers/devise/two_step_verification_session_controller.rb
+++ b/app/controllers/devise/two_step_verification_session_controller.rb
@@ -16,6 +16,7 @@ class Devise::TwoStepVerificationSessionController < DeviseController
           valid_until: User::REMEMBER_2SV_SESSION_FOR.from_now,
           secret_hash: Digest::SHA256.hexdigest(current_user.otp_secret_key)
         },
+        secure: Rails.env.production?,
         expires: User::REMEMBER_2SV_SESSION_FOR.from_now
       }
 

--- a/app/controllers/devise/two_step_verification_session_controller.rb
+++ b/app/controllers/devise/two_step_verification_session_controller.rb
@@ -17,6 +17,7 @@ class Devise::TwoStepVerificationSessionController < DeviseController
           secret_hash: Digest::SHA256.hexdigest(current_user.otp_secret_key)
         },
         secure: Rails.env.production?,
+        httponly: true,
         expires: User::REMEMBER_2SV_SESSION_FOR.from_now
       }
 

--- a/app/controllers/devise/two_step_verification_session_controller.rb
+++ b/app/controllers/devise/two_step_verification_session_controller.rb
@@ -10,17 +10,15 @@ class Devise::TwoStepVerificationSessionController < DeviseController
     render(:show) && return if params[:code].nil?
 
     if current_user.authenticate_otp(params[:code])
-      expires_seconds = User::REMEMBER_2SV_SESSION_FOR
-      if expires_seconds && expires_seconds > 0
-        cookies.signed['remember_2sv_session'] = {
-          value: {
-            user_id: current_user.id,
-            valid_until: expires_seconds.from_now,
-            secret_hash: Digest::SHA256.hexdigest(current_user.otp_secret_key)
-          },
-          expires: expires_seconds.from_now
-        }
-      end
+      cookies.signed['remember_2sv_session'] = {
+        value: {
+          user_id: current_user.id,
+          valid_until: User::REMEMBER_2SV_SESSION_FOR.from_now,
+          secret_hash: Digest::SHA256.hexdigest(current_user.otp_secret_key)
+        },
+        expires: User::REMEMBER_2SV_SESSION_FOR.from_now
+      }
+
       warden.session(:user)['need_two_step_verification'] = false
       bypass_sign_in current_user
       set_flash_message :notice, :success


### PR DESCRIPTION
At present, the 2SV cookie (which determines whether or not the user needs to provide a 2FA code) is not marked as secure or httpOnly. I think we intended to do this in https://github.com/alphagov/signon/pull/507, but I think this was missed.

I've not found a way to actually test this in code. I've tried the `cookies` hash [as described in the Rails docs](https://guides.rubyonrails.org/testing.html#the-three-hashes-of-the-apocalypse), and I've tried to access this cookie via `Capybara.current_session.driver.response.headers["Set-Cookie"]`. Any ideas welcome.
 
https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#Secure_and_HttpOnly_cookies

https://trello.com/c/cDd3UUeg