### PR TITLE
Change to granting access to all users in an organisation

### DIFF
--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -120,7 +120,7 @@ namespace :users do
     raise "Couldn't find organisation (by slug): '#{args.org}'" unless organisation
 
     SigninPermissionGranter.call(
-      users: organisation.users.web_users.not_suspended.find_each,
+      users: organisation.users.web_users.find_each,
       application: application
     )
   end


### PR DESCRIPTION
In the users:grant_application_access_for_org Rake task. This means
that suspended users will be given access as well. Accounts are often
suspended, and then reactivated, so this better ensures that all users
in the organisation will be given access.