### PR TITLE
Randomise a user's password when unsuspending their account

### DIFF
--- a/app/controllers/suspensions_controller.rb
+++ b/app/controllers/suspensions_controller.rb
@@ -3,7 +3,7 @@ class SuspensionsController < ApplicationController
   respond_to :html
 
   def update
-    if params[:user][:suspended] == "1"
+    if params[:user] && params[:user][:suspended] == "1"
       succeeded = @user.suspend(params[:user][:reason_for_suspension])
       action = EventLog::ACCOUNT_SUSPENDED
     else

--- a/app/views/suspensions/edit.html.erb
+++ b/app/views/suspensions/edit.html.erb
@@ -8,17 +8,17 @@
 <h1 class="page-title">Suspend &ldquo;<%= @user.name %>&rdquo;</h1>
 
 <%= form_tag suspension_path(@user), method: "put", :class => 'well remove-top-padding' do %>
-  <div class="checkbox add-top-margin">
-    <label>
-      <%= check_box_tag "user[suspended]", "1", @user.suspended? %>
-      Suspended?
-    </label>
-  </div>
-  <div class="form-group">
-    <label for="user_reason_for_suspension">Reason for suspension</label>
-    <%= text_field_tag "user[reason_for_suspension]", @user.reason_for_suspension, class: 'form-control input-md-6' %>
-  </div>
-  <hr />
-  <%= submit_tag "Save", class: "btn btn-primary add-right-margin" %>
+  <% if @user.suspended? %>
+    <p>After the user has been unsuspended, they will need to reset their password.</p>
+    <%= submit_tag "Unsuspend user", class: "btn btn-primary add-right-margin" %>
+  <% else %>
+    <input type="hidden" name="user[suspended]" value="1">
+    <div class="form-group">
+      <label for="user_reason_for_suspension">Reason for suspension</label>
+      <%= text_field_tag "user[reason_for_suspension]", @user.reason_for_suspension, class: 'form-control input-md-6' %>
+    </div>
+    <hr />
+    <%= submit_tag "Suspend user", class: "btn btn-primary add-right-margin" %>
+  <% end %>
   <%= link_to "Cancel", user_path(@user), class: "btn btn-default" %>
 <% end %>

--- a/lib/devise/models/suspendable.rb
+++ b/lib/devise/models/suspendable.rb
@@ -40,6 +40,7 @@ module Devise
         self.reason_for_suspension = nil
         self.suspended_at = nil
         self.unsuspended_at = Time.zone.now
+        self.password = SecureRandom.hex
         save
       end
 

--- a/test/integration/event_log_creation_test.rb
+++ b/test/integration/event_log_creation_test.rb
@@ -139,9 +139,8 @@ class EventLogCreationIntegrationTest < ActionDispatch::IntegrationTest
     visit users_path(letter: first_letter_of_name)
     click_on @user.name.to_s
     click_on 'Suspend user'
-    check 'Suspended?'
     fill_in 'Reason for suspension', with: 'Assaulting superior officer'
-    click_on 'Save'
+    click_on 'Suspend user'
 
     visit event_logs_user_path(@user)
     assert page.has_content?(EventLog::ACCOUNT_SUSPENDED.description + ' by ' + @admin.name)
@@ -165,8 +164,7 @@ class EventLogCreationIntegrationTest < ActionDispatch::IntegrationTest
     visit users_path(letter: first_letter_of_name)
     click_on @user.name.to_s
     click_on 'Unsuspend user'
-    uncheck 'Suspended?'
-    click_on 'Save'
+    click_on 'Unsuspend user'
 
     visit event_logs_user_path(@user)
     assert page.has_content?(EventLog::ACCOUNT_UNSUSPENDED.description + ' by ' + @admin.name)

--- a/test/integration/manage_api_users_test.rb
+++ b/test/integration/manage_api_users_test.rb
@@ -99,15 +99,13 @@ class ManageApiUsersTest < ActionDispatch::IntegrationTest
       click_link @api_user.name
       click_link "Suspend user"
 
-      check "Suspended?"
       fill_in "Reason for suspension", with: "Stole data"
-      click_button "Save"
+      click_button "Suspend user"
 
       assert page.has_selector?("p.alert-warning", text: "User suspended: Stole data")
 
       click_link "Unsuspend user"
-      uncheck "Suspended?"
-      click_button "Save"
+      click_button "Unsuspend user"
 
       assert page.has_selector?(".alert-success", text: "#{@api_user.email} is now active.")
     end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -288,6 +288,16 @@ class UserTest < ActiveSupport::TestCase
     assert_not_empty u.errors[:password]
   end
 
+  test "unlocking an account should randomise the password" do
+    original_password = "sherlock holmes baker street"
+    u = build(:user, email: "sleuth@gmail.com", password: original_password)
+
+    u.suspend "suspended for shenanigans"
+    u.unsuspend
+
+    refute u.valid_password?(original_password)
+  end
+
   test "it requires a reason for suspension to suspend a user" do
     u = create(:user)
     u.suspended_at = 1.minute.ago


### PR DESCRIPTION
If a suspended account is unsuspended, we want to force the user to reset their password (confirming that they have access to the registered email address), so set it to a random string.

This is using `SecureRandom.hex`, which has a limited character set in its output, but I think our current brute-force mitigation makes that fine.  I'm open to other suggestions though.

I've also changed the suspensions form to make it clear that the user needs to reset their password after being unsuspended.