### PR TITLE
Fix issues with the clone_trade_tariff_admin migration

### DIFF
--- a/db/migrate/20190417111131_clone_trade_tariff_admin.rb
+++ b/db/migrate/20190417111131_clone_trade_tariff_admin.rb
@@ -1,8 +1,12 @@
 class CloneTradeTariffAdmin < ActiveRecord::Migration[5.2]
+  class SupportedPermission < ActiveRecord::Base
+    belongs_to :application, class_name: 'Doorkeeper::Application'
+  end
+
   def up
     ActiveRecord::Base.transaction do
-      existing_trade_tariff_admin = Doorkeeper::Application.find(47)
-      cloned_trade_tariff_admin = Doorkeeper::Application.new
+      existing_trade_tariff_admin = ::Doorkeeper::Application.find_by_name("Trade Tariff Admin (PaaS)")
+      cloned_trade_tariff_admin = ::Doorkeeper::Application.new
       existing_trade_tariff_admin.attributes.each_pair do |key, value|
         if !%w(created_at updated_at id uid).include?(key)
           cloned_trade_tariff_admin[key] = value
@@ -11,7 +15,7 @@ class CloneTradeTariffAdmin < ActiveRecord::Migration[5.2]
       cloned_trade_tariff_admin.name = "New London: #{cloned_trade_tariff_admin.name}"
       cloned_trade_tariff_admin.save!
 
-      existing_trade_tariff_admin.supported_permissions.each do |existing_supported_permission|
+      SupportedPermission.where(application_id: existing_trade_tariff_admin.id).each do |existing_supported_permission|
         # Some are created by default and the index will complain if we try to duplicate them
         if !SupportedPermission.exists?(application_id: cloned_trade_tariff_admin.id, name: existing_supported_permission.name)
           cloned_supported_permission = SupportedPermission.new

--- a/db/migrate/20190417130540_clone_trade_tariff_backend.rb
+++ b/db/migrate/20190417130540_clone_trade_tariff_backend.rb
@@ -1,8 +1,12 @@
 class CloneTradeTariffBackend < ActiveRecord::Migration[5.2]
+  class SupportedPermission < ActiveRecord::Base
+    belongs_to :application, class_name: 'Doorkeeper::Application'
+  end
+
   def up
     ActiveRecord::Base.transaction do
-      existing_trade_tariff_admin = Doorkeeper::Application.find(48)
-      cloned_trade_tariff_admin = Doorkeeper::Application.new
+      existing_trade_tariff_admin = ::Doorkeeper::Application.find_by_name("Trade Tariff Backend (PaaS)")
+      cloned_trade_tariff_admin = ::Doorkeeper::Application.new
       existing_trade_tariff_admin.attributes.each_pair do |key, value|
         if !%w(created_at updated_at id uid).include?(key)
           cloned_trade_tariff_admin[key] = value
@@ -11,7 +15,7 @@ class CloneTradeTariffBackend < ActiveRecord::Migration[5.2]
       cloned_trade_tariff_admin.name = "New London: #{cloned_trade_tariff_admin.name}"
       cloned_trade_tariff_admin.save!
 
-      existing_trade_tariff_admin.supported_permissions.each do |existing_supported_permission|
+      SupportedPermission.where(application_id: existing_trade_tariff_admin.id).each do |existing_supported_permission|
         # Some are created by default and the index will complain if we try to duplicate them
         if !SupportedPermission.exists?(application_id: cloned_trade_tariff_admin.id, name: existing_supported_permission.name)
           cloned_supported_permission = SupportedPermission.new


### PR DESCRIPTION
This fixes some bugs in commit c81f453

The previous commit works in a rails console but not when deploying.
This is due to it not having a proper definition of
Doorkeeper::Application and it having the method
Doorkeeper::Application.supported_permissions. By adding the
definition and using a where command instead, this fixes the issue.
Zendesk: https://govuk.zendesk.com/agent/tickets/3634856