### PR TITLE
Remove mailer queue listening

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -7,5 +7,4 @@
 :logfile: ./log/sidekiq.log
 :queues:
   - default
-  - mailer # Remove this once using `mailers` only.
   - mailers


### PR DESCRIPTION
ActiveMailer uses the `mailers` queue exclusively for sending emails, so remove the now defunct `mailer` queue after nearly 4 years.

<img width="1196" alt="Screen Shot 2019-04-29 at 10 20 54" src="https://user-images.githubusercontent.com/444232/56887151-b528be00-6a68-11e9-85f3-dac038a66b38.png">