### PR TITLE
Support IPv6 logging

### DIFF
--- a/db/migrate/20190429105421_change_event_logs_ip_address_to_numeric.rb
+++ b/db/migrate/20190429105421_change_event_logs_ip_address_to_numeric.rb
@@ -1,0 +1,21 @@
+require 'lhm'
+
+class ChangeEventLogsIpAddressToNumeric < ActiveRecord::Migration[5.2]
+  def self.up
+    remove_foreign_key :event_logs, name: :event_logs_user_agent_id_fk
+    Lhm.cleanup(:run)
+    Lhm.change_table :event_logs do |m|
+      m.change_column :ip_address, "DECIMAL(38,0)"
+      m.ddl("ALTER TABLE %s ADD CONSTRAINT event_logs_user_agent_id_fk FOREIGN KEY (user_agent_id) REFERENCES user_agents(id)" % m.name)
+    end
+  end
+
+  def self.down
+    remove_foreign_key :event_logs, name: :event_logs_user_agent_id_fk
+    Lhm.cleanup(:run)
+    Lhm.change_table :event_logs do |m|
+      m.change_column :ip_address, "BIGINT"
+      m.ddl("ALTER TABLE %s ADD CONSTRAINT event_logs_user_agent_id_fk FOREIGN KEY (user_agent_id) REFERENCES user_agents(id)" % m.name)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190417130540) do
+ActiveRecord::Schema.define(version: 2019_04_29_105421) do
 
-  create_table "batch_invitation_application_permissions", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "batch_invitation_application_permissions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "batch_invitation_id", null: false
     t.integer "supported_permission_id", null: false
     t.datetime "created_at", null: false
@@ -20,7 +20,7 @@ ActiveRecord::Schema.define(version: 20190417130540) do
     t.index ["batch_invitation_id", "supported_permission_id"], name: "index_batch_invite_app_perms_on_batch_invite_and_supported_perm", unique: true
   end
 
-  create_table "batch_invitation_users", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
+  create_table "batch_invitation_users", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
     t.integer "batch_invitation_id"
     t.string "name"
     t.string "email"
@@ -31,7 +31,7 @@ ActiveRecord::Schema.define(version: 20190417130540) do
     t.index ["batch_invitation_id"], name: "index_batch_invitation_users_on_batch_invitation_id"
   end
 
-  create_table "batch_invitations", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
+  create_table "batch_invitations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
     t.text "applications_and_permissions"
     t.string "outcome"
     t.datetime "created_at", null: false
@@ -41,7 +41,7 @@ ActiveRecord::Schema.define(version: 20190417130540) do
     t.index ["outcome"], name: "index_batch_invitations_on_outcome"
   end
 
-  create_table "bulk_grant_permission_set_application_permissions", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "bulk_grant_permission_set_application_permissions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "bulk_grant_permission_set_id", null: false
     t.integer "supported_permission_id", null: false
     t.datetime "created_at"
@@ -49,7 +49,7 @@ ActiveRecord::Schema.define(version: 20190417130540) do
     t.index ["bulk_grant_permission_set_id", "supported_permission_id"], name: "index_app_permissions_on_bulk_grant_permission_set", unique: true
   end
 
-  create_table "bulk_grant_permission_sets", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "bulk_grant_permission_sets", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "outcome"
     t.integer "processed_users", default: 0, null: false
@@ -58,7 +58,20 @@ ActiveRecord::Schema.define(version: 20190417130540) do
     t.datetime "updated_at"
   end
 
-  create_table "event_logs", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "event_logs", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "uid", null: false
+    t.datetime "created_at", null: false
+    t.integer "initiator_id"
+    t.integer "application_id"
+    t.string "trailing_message"
+    t.integer "event_id"
+    t.decimal "ip_address", precision: 38
+    t.integer "user_agent_id"
+    t.index ["uid", "created_at"], name: "index_event_logs_on_uid_and_created_at"
+    t.index ["user_agent_id"], name: "event_logs_user_agent_id_fk"
+  end
+
+  create_table "lhma_2019_04_29_13_15_20_064_event_logs", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "uid", null: false
     t.datetime "created_at", null: false
     t.integer "initiator_id"
@@ -71,7 +84,7 @@ ActiveRecord::Schema.define(version: 20190417130540) do
     t.index ["user_agent_id"], name: "event_logs_user_agent_id_fk"
   end
 
-  create_table "oauth_access_grants", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "oauth_access_grants", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "resource_owner_id", null: false
     t.integer "application_id", null: false
     t.string "token", null: false
@@ -83,7 +96,7 @@ ActiveRecord::Schema.define(version: 20190417130540) do
     t.index ["token"], name: "index_oauth_access_grants_on_token", unique: true
   end
 
-  create_table "oauth_access_tokens", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "oauth_access_tokens", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "resource_owner_id", null: false
     t.integer "application_id", null: false
     t.string "token", null: false
@@ -97,7 +110,7 @@ ActiveRecord::Schema.define(version: 20190417130540) do
     t.index ["token"], name: "index_oauth_access_tokens_on_token", unique: true
   end
 
-  create_table "oauth_applications", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
+  create_table "oauth_applications", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
     t.string "name"
     t.string "uid", null: false
     t.string "secret", null: false
@@ -114,7 +127,7 @@ ActiveRecord::Schema.define(version: 20190417130540) do
     t.index ["uid"], name: "index_oauth_applications_on_uid", unique: true
   end
 
-  create_table "old_passwords", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "old_passwords", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "encrypted_password", null: false
     t.string "password_salt"
     t.integer "password_archivable_id", null: false
@@ -123,7 +136,7 @@ ActiveRecord::Schema.define(version: 20190417130540) do
     t.index ["password_archivable_type", "password_archivable_id"], name: "index_password_archivable"
   end
 
-  create_table "organisations", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
+  create_table "organisations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
     t.string "slug", null: false
     t.string "name", null: false
     t.string "organisation_type", null: false
@@ -138,7 +151,7 @@ ActiveRecord::Schema.define(version: 20190417130540) do
     t.index ["slug"], name: "index_organisations_on_slug", unique: true
   end
 
-  create_table "supported_permissions", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "supported_permissions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "application_id"
     t.string "name"
     t.datetime "created_at"
@@ -150,12 +163,12 @@ ActiveRecord::Schema.define(version: 20190417130540) do
     t.index ["application_id"], name: "index_supported_permissions_on_application_id"
   end
 
-  create_table "user_agents", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "user_agents", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "user_agent_string", limit: 1000, null: false
-    t.index ["user_agent_string"], name: "index_user_agents_on_user_agent_string", length: { user_agent_string: 255 }
+    t.index ["user_agent_string"], name: "index_user_agents_on_user_agent_string", length: 255
   end
 
-  create_table "user_application_permissions", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "user_application_permissions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "application_id", null: false
     t.integer "supported_permission_id", null: false
@@ -165,7 +178,7 @@ ActiveRecord::Schema.define(version: 20190417130540) do
     t.index ["user_id", "application_id", "supported_permission_id"], name: "index_app_permissions_on_user_and_app_and_supported_permission", unique: true
   end
 
-  create_table "users", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "users", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: ""
@@ -213,4 +226,5 @@ ActiveRecord::Schema.define(version: 20190417130540) do
     t.index ["unlock_token"], name: "index_users_on_unlock_token", unique: true
   end
 
+  add_foreign_key "event_logs", "user_agents", name: "event_logs_user_agent_id_fk"
 end

--- a/test/integration/event_log_creation_test.rb
+++ b/test/integration/event_log_creation_test.rb
@@ -173,7 +173,7 @@ class EventLogCreationIntegrationTest < ActionDispatch::IntegrationTest
   end
 
   context "recording user's ip address" do
-    should "record user's ip address on login" do
+    should "record user's IPv4 address on login" do
       page.driver.options[:headers] = { 'REMOTE_ADDR' => '1.2.3.4' }
       visit root_path
       signin_with(@user)
@@ -182,14 +182,13 @@ class EventLogCreationIntegrationTest < ActionDispatch::IntegrationTest
       assert_equal '1.2.3.4', ip_address
     end
 
-    should "call alert error service for ipv6 addresses" do
+    should "record user's IPv6 address on login" do
       page.driver.options[:headers] = { 'REMOTE_ADDR' => '2001:0db8:0000:0000:0008:0800:200c:417a' }
-      GovukError.expects(:notify)
       visit root_path
       signin_with(@user)
 
-      ip_address = @user.event_logs.first.ip_address
-      assert_nil ip_address
+      ip_address = @user.event_logs.first.ip_address_string
+      assert_equal '2001:db8::8:800:200c:417a', ip_address
     end
   end
 


### PR DESCRIPTION
This commit replaces hand-written IPv4-to-integer code with the `IPAddr` Ruby built-in. This also has the side-effect of adding support for IPv6 addresses.