### PR TITLE
Add nta font

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,5 +1,9 @@
 @import "govuk_publishing_components/all_components";
 
+// TODO: remove the font-face include when govuk_publishing_components doesn't
+// rely on govuk_template and has $govuk-compatibility-govuktemplate set to false
+@include _govuk-font-face-nta;
+
 // TODO: move into component
 .gem-c-success-alert,
 .gem-c-error-alert {


### PR DESCRIPTION
This fixes a bug where the font isn't loading. Font loading is disabled since govuk-frontend v2.9.0 to ensure font file is not required twice for projects that rely on govuk_template. The typeface comes disabled from govuk_publishing_component and needs to be enabled in repos that don't rely govuk_template.