### PR TITLE
Encapsulate Splunk event payload

### DIFF
--- a/app/models/event_log.rb
+++ b/app/models/event_log.rb
@@ -95,7 +95,7 @@ class EventLog < ActiveRecord::Base
     conn.post do |request|
       request.headers['Content-Type'] = 'application/json'
       request.headers['Authorization'] = "Splunk #{ENV['SPLUNK_EVENT_LOG_ENDPOINT_HEC_TOKEN']}"
-      request.body = event.to_json
+      request.body = { event: event }.to_json
     end
   end
 


### PR DESCRIPTION
This commit wraps the Splunk event payload inside an `event` block as required by the Splunk HTTP event collector.