### PR TITLE
Add `rake users:revoke_application_access[application]`

### DIFF
--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -111,6 +111,15 @@ namespace :users do
     )
   end
 
+  desc "Revoke all permissions for all users of an application"
+  task :revoke_application_access, [:application] => :environment do |_t, args|
+    application = Doorkeeper::Application.find_by(name: args.application)
+
+    raise "Couldn't find application: '#{args.application}'" unless application
+
+    UserApplicationPermission.where(application: application).destroy_all
+  end
+
   desc "Grant all active users in an organisation access to an application"
   task :grant_application_access_for_org, %i[application org] => :environment do |_t, args|
     application = Doorkeeper::Application.find_by(name: args.application)


### PR DESCRIPTION
Allows revocation of all access to a given application for all users.

This is helpful when an application is shutting down and the owners would like to prevent all access.

https://govuk.zendesk.com/agent/tickets/3674781