### PR TITLE
Send user IP address to Splunk event monitoring

### DIFF
--- a/app/controllers/api_users_controller.rb
+++ b/app/controllers/api_users_controller.rb
@@ -26,7 +26,7 @@ class ApiUsersController < ApplicationController
     @api_user.api_user = true
 
     if @api_user.save
-      EventLog.record_event(@api_user, EventLog::API_USER_CREATED, initiator: current_user)
+      EventLog.record_event(@api_user, EventLog::API_USER_CREATED, initiator: current_user, ip_address: user_ip_address)
       redirect_to [:edit, @api_user], notice: "Successfully created API user"
     else
       render :new

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -29,6 +29,10 @@ class ApplicationController < ActionController::Base
 
 private
 
+  def user_ip_address
+    request.remote_ip
+  end
+
   def doorkeeper_authorize!
     original_return_value = super
     return original_return_value if api_user_via_token_has_signin_permission_on_app?

--- a/app/controllers/authorisations_controller.rb
+++ b/app/controllers/authorisations_controller.rb
@@ -16,7 +16,7 @@ class AuthorisationsController < ApplicationController
 
     if authorisation.save
       @api_user.grant_application_permission(authorisation.application, 'signin')
-      EventLog.record_event(@api_user, EventLog::ACCESS_TOKEN_GENERATED, initiator: current_user, application: authorisation.application)
+      EventLog.record_event(@api_user, EventLog::ACCESS_TOKEN_GENERATED, initiator: current_user, application: authorisation.application, ip_address: user_ip_address)
       flash[:authorisation] = { application_name: authorisation.application.name, token: authorisation.token }
     else
       flash[:error] = "There was an error while creating the access token"
@@ -31,11 +31,11 @@ class AuthorisationsController < ApplicationController
         regenerated_authorisation = @api_user.authorisations.create!(expires_in: ApiUser::DEFAULT_TOKEN_LIFE,
                                                                       application_id: authorisation.application_id)
 
-        EventLog.record_event(@api_user, EventLog::ACCESS_TOKEN_REGENERATED, initiator: current_user, application: authorisation.application)
+        EventLog.record_event(@api_user, EventLog::ACCESS_TOKEN_REGENERATED, initiator: current_user, application: authorisation.application, ip_address: user_ip_address)
         flash[:authorisation] = { application_name: regenerated_authorisation.application.name,
                                   token: regenerated_authorisation.token }
       else
-        EventLog.record_event(@api_user, EventLog::ACCESS_TOKEN_REVOKED, initiator: current_user, application: authorisation.application)
+        EventLog.record_event(@api_user, EventLog::ACCESS_TOKEN_REVOKED, initiator: current_user, application: authorisation.application, ip_address: user_ip_address)
         flash[:notice] = "Access for #{authorisation.application.name} was revoked"
       end
     else

--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -19,7 +19,7 @@ class ConfirmationsController < Devise::ConfirmationsController
       else
         self.resource = resource_class.confirm_by_token(params[:confirmation_token])
         if resource.errors.empty?
-          EventLog.record_event(resource, EventLog::EMAIL_CHANGE_CONFIRMED)
+          EventLog.record_event(resource, EventLog::EMAIL_CHANGE_CONFIRMED, ip_address: user_ip_address)
           set_flash_message(:notice, :confirmed) if is_navigational_format?
           sign_in(resource_name, resource)
           respond_with_navigational(resource) { redirect_to after_confirmation_path_for(resource_name, resource) }
@@ -41,7 +41,7 @@ class ConfirmationsController < Devise::ConfirmationsController
     if self.resource.valid_password?(params[:user][:password])
       self.resource = resource_class.confirm_by_token(params[:confirmation_token])
       if resource.errors.empty?
-        EventLog.record_event(resource, EventLog::EMAIL_CHANGE_CONFIRMED)
+        EventLog.record_event(resource, EventLog::EMAIL_CHANGE_CONFIRMED, ip_address: user_ip_address)
         set_flash_message(:notice, :confirmed) if is_navigational_format?
         sign_in(resource_name, resource)
         respond_with_navigational(resource) { redirect_to after_confirmation_path_for(resource_name, resource) }

--- a/app/controllers/devise/two_step_verification_controller.rb
+++ b/app/controllers/devise/two_step_verification_controller.rb
@@ -15,11 +15,11 @@ class Devise::TwoStepVerificationController < DeviseController
   def update
     mode = current_user.has_2sv? ? :change : :setup
     if verify_code_and_update
-      EventLog.record_event(current_user, success_event_for(mode))
+      EventLog.record_event(current_user, success_event_for(mode), ip_address: user_ip_address)
       send_notification(current_user, mode)
       redirect_to_prior_flow notice: I18n.t("devise.two_step_verification.messages.success.#{mode}")
     else
-      EventLog.record_event(current_user, failure_event_for(mode))
+      EventLog.record_event(current_user, failure_event_for(mode), ip_address: user_ip_address)
       flash.now[:invalid_code] = "Sorry that code didn’t work. Please try again."
       render :show, status: :unprocessable_entity
     end

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -27,25 +27,25 @@ private
 
   def record_password_reset_request
     user = User.find_by_email(params[:user][:email]) if params[:user].present?
-    EventLog.record_event(user, EventLog::PASSWORD_RESET_REQUEST) if user
+    EventLog.record_event(user, EventLog::PASSWORD_RESET_REQUEST, ip_address: user_ip_address) if user
     GovukStatsd.increment("users.password_reset_request")
   end
 
   def record_reset_page_loaded
-    EventLog.record_event(user_from_params, EventLog::PASSWORD_RESET_LOADED) if user_from_params
+    EventLog.record_event(user_from_params, EventLog::PASSWORD_RESET_LOADED, ip_address: user_ip_address) if user_from_params
   end
 
   def record_password_reset_success(user)
-    EventLog.record_event(user, EventLog::SUCCESSFUL_PASSWORD_RESET)
+    EventLog.record_event(user, EventLog::SUCCESSFUL_PASSWORD_RESET, ip_address: user_ip_address)
   end
 
   def record_reset_page_loaded_token_expired
-    EventLog.record_event(user_from_params, EventLog::PASSWORD_RESET_LOADED_BUT_TOKEN_EXPIRED) if user_from_params
+    EventLog.record_event(user_from_params, EventLog::PASSWORD_RESET_LOADED_BUT_TOKEN_EXPIRED, ip_address: user_ip_address) if user_from_params
   end
 
   def record_password_reset_failure(user)
     message = "(errors: #{user.errors.full_messages.join(', ')})".truncate(255)
-    EventLog.record_event(user, EventLog::PASSWORD_RESET_FAILURE, trailing_message: message)
+    EventLog.record_event(user, EventLog::PASSWORD_RESET_FAILURE, trailing_message: message, ip_address: user_ip_address)
   end
 
   def user_from_params

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -29,12 +29,8 @@ private
     else
       # Call to_s to flatten out any unexpected params (eg a hash).
       user = User.find_by_email(params[:user][:email].to_s)
-      EventLog.record_event(user, EventLog::UNSUCCESSFUL_LOGIN) if user
+      EventLog.record_event(user, EventLog::UNSUCCESSFUL_LOGIN, ip_address: user_ip_address) if user
     end
-  end
-
-  def user_ip_address
-    request.remote_ip
   end
 
   def user_agent

--- a/app/controllers/suspensions_controller.rb
+++ b/app/controllers/suspensions_controller.rb
@@ -12,7 +12,7 @@ class SuspensionsController < ApplicationController
     end
 
     if succeeded
-      EventLog.record_event(@user, action, initiator: current_user)
+      EventLog.record_event(@user, action, initiator: current_user, ip_address: user_ip_address)
       PermissionUpdater.perform_on(@user)
       ReauthEnforcer.perform_on(@user)
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -57,7 +57,7 @@ class UsersController < ApplicationController
   end
 
   def unlock
-    EventLog.record_event(@user, EventLog::MANUAL_ACCOUNT_UNLOCK, initiator: current_user)
+    EventLog.record_event(@user, EventLog::MANUAL_ACCOUNT_UNLOCK, initiator: current_user, ip_address: user_ip_address)
     @user.unlock_access!
     flash[:notice] = "Unlocked #{@user.email}"
     redirect_back(fallback_location: root_path)
@@ -106,12 +106,12 @@ class UsersController < ApplicationController
 
   def update_password
     if @user.update_with_password(password_params)
-      EventLog.record_event(@user, EventLog::SUCCESSFUL_PASSWORD_CHANGE)
+      EventLog.record_event(@user, EventLog::SUCCESSFUL_PASSWORD_CHANGE, ip_address: user_ip_address)
       flash[:notice] = t(:updated, scope: 'devise.passwords')
       bypass_sign_in(@user)
       redirect_to root_path
     else
-      EventLog.record_event(@user, EventLog::UNSUCCESSFUL_PASSWORD_CHANGE)
+      EventLog.record_event(@user, EventLog::UNSUCCESSFUL_PASSWORD_CHANGE, ip_address: user_ip_address)
       render :edit_email_or_password, layout: "admin_layout"
     end
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -48,7 +48,7 @@ class UsersController < ApplicationController
   def update
     raise Pundit::NotAuthorizedError if params[:user][:organisation_id].present? && !policy(@user).assign_organisations?
 
-    updater = UserUpdate.new(@user, user_params, current_user)
+    updater = UserUpdate.new(@user, user_params, current_user, user_ip_address)
     if updater.update
       redirect_to users_path, notice: "Updated user #{@user.email} successfully"
     else

--- a/app/models/event_log.rb
+++ b/app/models/event_log.rb
@@ -80,7 +80,7 @@ class EventLog < ActiveRecord::Base
     return unless ENV['SPLUNK_EVENT_LOG_ENDPOINT_URL'] && ENV['SPLUNK_EVENT_LOG_ENDPOINT_HEC_TOKEN']
 
     event = {
-      timestamp: self.created_at,
+      timestamp: self.created_at.utc,
       app: self.application&.name,
       object_id: self.id,
       user: self.initiator&.name,

--- a/app/services/user_update.rb
+++ b/app/services/user_update.rb
@@ -1,10 +1,11 @@
 class UserUpdate
-  attr_reader :user, :user_params, :current_user
+  attr_reader :user, :user_params, :current_user, :user_ip
 
-  def initialize(user, user_params, current_user)
+  def initialize(user, user_params, current_user, user_ip)
     @user = user
     @user_params = user_params
     @current_user = current_user
+    @user_ip = user_ip
   end
 
   def update
@@ -47,6 +48,7 @@ private
         initiator: current_user,
         application_id: application_id,
         trailing_message: "(#{permissions.map(&:name).join(', ')})",
+        ip_address: user_ip
       )
     end
 
@@ -56,7 +58,8 @@ private
         EventLog::PERMISSIONS_REMOVED,
         initiator: current_user,
         application_id: application_id,
-        trailing_message: "(#{permissions.map(&:name).join(', ')})"
+        trailing_message: "(#{permissions.map(&:name).join(', ')})",
+        ip_address: user_ip
       )
     end
   end
@@ -66,6 +69,7 @@ private
       user,
       EventLog::ACCOUNT_UPDATED,
       initiator: current_user,
+      ip_address: user_ip
     )
   end
 

--- a/test/controllers/api_users_controller_test.rb
+++ b/test/controllers/api_users_controller_test.rb
@@ -51,8 +51,7 @@ class ApiUsersControllerTest < ActionController::TestCase
 
       should "log API user created event in the api users event log" do
         EventLog.stubs(:record_event) # to ignore logs being created, other than the one under test
-        EventLog.expects(:record_event).with(instance_of(ApiUser), EventLog::API_USER_CREATED, initiator: @superadmin)
-
+        EventLog.expects(:record_event).with(instance_of(ApiUser), EventLog::API_USER_CREATED, initiator: @superadmin, ip_address: request.remote_ip)
         post :create, params: { api_user: { name: "Content Store Application", email: "content.store@gov.uk" } }
       end
 

--- a/test/integration/event_log_creation_test.rb
+++ b/test/integration/event_log_creation_test.rb
@@ -173,7 +173,7 @@ class EventLogCreationIntegrationTest < ActionDispatch::IntegrationTest
   end
 
   context "recording user's ip address" do
-    should "record user's IPv4 address on login" do
+    should "record user's IPv4 address for successful login" do
       page.driver.options[:headers] = { 'REMOTE_ADDR' => '1.2.3.4' }
       visit root_path
       signin_with(@user)
@@ -182,7 +182,16 @@ class EventLogCreationIntegrationTest < ActionDispatch::IntegrationTest
       assert_equal '1.2.3.4', ip_address
     end
 
-    should "record user's IPv6 address on login" do
+    should "record user's IPv4 address for unsuccessful login" do
+      page.driver.options[:headers] = { 'REMOTE_ADDR' => '4.5.6.7' }
+      visit root_path
+      signin_with(email: @user.email, password: :incorrect)
+
+      ip_address = @user.event_logs.last.ip_address_string
+      assert_equal '4.5.6.7', ip_address
+    end
+
+    should "record user's IPv6 address" do
       page.driver.options[:headers] = { 'REMOTE_ADDR' => '2001:0db8:0000:0000:0008:0800:200c:417a' }
       visit root_path
       signin_with(@user)

--- a/test/models/event_log_test.rb
+++ b/test/models/event_log_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'ipaddr'
 
 class EventLogTest < ActiveSupport::TestCase
   context "#event" do
@@ -79,6 +80,22 @@ class EventLogTest < ActiveSupport::TestCase
     EventLog.record_event(create(:user), EventLog::EMAIL_CHANGED, initiator: initiator)
 
     assert_equal initiator, EventLog.last.initiator
+  end
+
+  test "records the IPv6 address of the user passed as an option" do
+    raw_ip_address = '2001:0db8:0000:0000:0008:0800:200c:417a'
+    parsed_ip_address = IPAddr.new(raw_ip_address, Socket::AF_INET6).to_s
+    EventLog.record_event(create(:user), EventLog::SUCCESSFUL_LOGIN, ip_address: raw_ip_address)
+
+    assert_equal parsed_ip_address, EventLog.last.ip_address_string
+  end
+
+  test "records the IP address of the user passed as an option" do
+    raw_ip_address = '1.2.3.4'
+    parsed_ip_address = IPAddr.new(raw_ip_address, Socket::AF_INET).to_s
+    EventLog.record_event(create(:user), EventLog::SUCCESSFUL_LOGIN, ip_address: raw_ip_address)
+
+    assert_equal parsed_ip_address, EventLog.last.ip_address_string
   end
 
   test "records the application associated with the event passed as an option" do

--- a/test/services/user_update_test.rb
+++ b/test/services/user_update_test.rb
@@ -1,17 +1,21 @@
 require 'test_helper'
+require 'ipaddr'
 
 class UserUpdateTest < ActionView::TestCase
   should "record an event" do
     affected_user = create(:user)
     current_user = create(:superadmin_user)
+    ip_address = '1.2.3.4'
 
-    UserUpdate.new(affected_user, {}, current_user).update
+    UserUpdate.new(affected_user, {}, current_user, ip_address).update
 
     assert_equal 1, EventLog.where(event_id: EventLog::ACCOUNT_UPDATED.id).count
   end
 
   should "records permission changes" do
     current_user = create(:superadmin_user)
+    ip_address = '1.2.3.4'
+    parsed_ip_address = IPAddr.new(ip_address, Socket::AF_INET).to_s
 
     affected_user = create(:user)
     app = create(:application, name: "App", with_supported_permissions: ["Editor", "signin", "Something Else"])
@@ -19,16 +23,18 @@ class UserUpdateTest < ActionView::TestCase
 
     perms = app.supported_permissions.first(2).map(&:id)
     params = { supported_permission_ids: perms }
-    UserUpdate.new(affected_user, params, current_user).update
+    UserUpdate.new(affected_user, params, current_user, ip_address).update
 
     add_event = EventLog.where(event_id: EventLog::PERMISSIONS_ADDED.id).last
     assert ["(Editor, signin)", "(signin, Editor)"].include?(add_event.trailing_message)
     assert_equal current_user, add_event.initiator
     assert_equal app.id, add_event.application_id
+    assert_equal parsed_ip_address, add_event.ip_address_string
 
     add_event = EventLog.where(event_id: EventLog::PERMISSIONS_REMOVED.id).last
     assert_equal "(Something Else)", add_event.trailing_message
     assert_equal current_user, add_event.initiator
     assert_equal app.id, add_event.application_id
+    assert_equal parsed_ip_address, add_event.ip_address_string
   end
 end


### PR DESCRIPTION
IP addresses for Events were not being sent to Splunk. Including these will help with security monitoring.

This also changes the EventLog created at time stamp to be UTC.