### PR TITLE
Add APHA as a child of Defra

### DIFF
--- a/db/migrate/20190712160951_add_apha_as_child_of_defra.rb
+++ b/db/migrate/20190712160951_add_apha_as_child_of_defra.rb
@@ -1,0 +1,16 @@
+class AddAphaAsChildOfDefra < ActiveRecord::Migration
+  def up
+    defra = Organisation.find_by_abbreviation("Defra")
+    puts "!! Couldn't find Defra" && return if defra.nil?
+    epha = Organisation.find_by_abbreviation("APHA")
+    puts "!! Couldn't find APHA" && return if epha.nil?
+    epha.update_attributes!(parent: defra)
+    puts "Updated parent for #{epha.name} to #{defra.name}"
+  rescue => error
+    puts "Parent re-assignment failed for: #{epha.name} with error '#{error.message}'"
+  end
+
+  def down
+    # This change cannot be reversed
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_29_105421) do
-
+ActiveRecord::Schema.define(version: 2019_07_12_160951) do
+  
   create_table "batch_invitation_application_permissions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "batch_invitation_id", null: false
     t.integer "supported_permission_id", null: false


### PR DESCRIPTION
This migration adds APHA to the list of children of Defra.

See Zendesk: https://govuk.zendesk.com/agent/tickets/3738715