### PR TITLE
Improve splunk logging of unsuccessful login attempts

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -29,7 +29,9 @@ private
     else
       # Call to_s to flatten out any unexpected params (eg a hash).
       user = User.find_by_email(params[:user][:email].to_s)
-      EventLog.record_event(user, EventLog::UNSUCCESSFUL_LOGIN, ip_address: user_ip_address) if user
+      EventLog.record_event(user, EventLog::UNSUCCESSFUL_LOGIN,
+                            ip_address: user_ip_address,
+                            user_agent_string: user_agent) if user
     end
   end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -28,10 +28,18 @@ private
                             user_agent_id: user_agent_record_id)
     else
       # Call to_s to flatten out any unexpected params (eg a hash).
-      user = User.find_by_email(params[:user][:email].to_s)
-      EventLog.record_event(user, EventLog::UNSUCCESSFUL_LOGIN,
-                            ip_address: user_ip_address,
-                            user_agent_string: user_agent) if user
+      email = params[:user][:email].to_s
+      user = User.find_by_email(email)
+      if user
+        EventLog.record_event(user, EventLog::UNSUCCESSFUL_LOGIN,
+                              ip_address: user_ip_address,
+                              user_agent_string: user_agent)
+      else
+        EventLog.record_event(nil, EventLog::NO_SUCH_ACCOUNT_LOGIN,
+                              ip_address: user_ip_address,
+                              user_agent_string: user_agent,
+                              user_email_string: email)
+      end
     end
   end
 

--- a/app/models/event_log.rb
+++ b/app/models/event_log.rb
@@ -6,53 +6,54 @@ class EventLog < ActiveRecord::Base
   LOCKED_DURATION = "#{Devise.unlock_in / 1.hour} #{'hour'.pluralize(Devise.unlock_in / 1.hour)}".freeze
 
   EVENTS = [
-    ACCOUNT_LOCKED = LogEntry.new(id: 1, description: "Password verification failed too many times, account locked for #{LOCKED_DURATION}"),
-    ACCOUNT_SUSPENDED = LogEntry.new(id: 2, description: "Account suspended", require_initiator: true),
-    ACCOUNT_UNSUSPENDED = LogEntry.new(id: 3, description: "Account unsuspended", require_initiator: true),
-    ACCOUNT_AUTOSUSPENDED = LogEntry.new(id: 4, description: "Account auto-suspended"),
-    MANUAL_ACCOUNT_UNLOCK = LogEntry.new(id: 5, description: "Manual account unlock", require_initiator: true),
-    PASSWORD_RESET_REQUEST = LogEntry.new(id: 7, description: "Password reset request"),
-    PASSWORD_RESET_LOADED = LogEntry.new(id: 8, description: "Password reset page loaded"),
-    PASSWORD_RESET_FAILURE = LogEntry.new(id: 9, description: "Password reset attempt failure"),
-    SUCCESSFUL_PASSWORD_CHANGE = LogEntry.new(id: 10, description: "Successful password change"),
-    SUCCESSFUL_LOGIN = LogEntry.new(id: 11, description: "Successful login"),
-    UNSUCCESSFUL_LOGIN = LogEntry.new(id: 12, description: "Unsuccessful login"),
-    SUSPENDED_ACCOUNT_AUTHENTICATED_LOGIN = LogEntry.new(id: 13, description: "Unsuccessful login attempt to a suspended account, with the correct username and password"),
-    UNSUCCESSFUL_PASSWORD_CHANGE = LogEntry.new(id: 14, description: "Unsuccessful password change"),
-    EMAIL_CHANGED = LogEntry.new(id: 15, description: "Email changed", require_initiator: true),
-    EMAIL_CHANGE_INITIATED = LogEntry.new(id: 16, description: "Email change initiated"),
-    EMAIL_CHANGE_CONFIRMED = LogEntry.new(id: 17, description: "Email change confirmed"),
-    TWO_STEP_ENABLED = LogEntry.new(id: 18, description: "2-step verification enabled"),
-    TWO_STEP_RESET = LogEntry.new(id: 19, description: "2-step verification reset"),
-    TWO_STEP_ENABLE_FAILED = LogEntry.new(id: 20, description: "2-step verification setup failed"),
-    TWO_STEP_VERIFIED = LogEntry.new(id: 21, description: "2-step verification successful"),
-    TWO_STEP_VERIFICATION_FAILED = LogEntry.new(id: 22, description: "2-step verification failed"),
-    TWO_STEP_LOCKED = LogEntry.new(id: 23, description: "2-step verification failed too many times, account locked for #{LOCKED_DURATION}"),
-    TWO_STEP_CHANGED = LogEntry.new(id: 24, description: "2-step verification phone changed"),
-    TWO_STEP_CHANGE_FAILED = LogEntry.new(id: 25, description: "2-step verification phone change failed"),
-    TWO_STEP_PROMPT_DEFERRED = LogEntry.new(id: 26, description: "2-step prompt deferred"),
-    API_USER_CREATED = LogEntry.new(id: 27, description: "Account created", require_initiator: true),
-    ACCESS_TOKEN_REGENERATED = LogEntry.new(id: 28, description: "Access token re-generated", require_application: true),
-    ACCESS_TOKEN_GENERATED = LogEntry.new(id: 29, description: "Access token generated", require_application: true, require_initiator: true),
-    ACCESS_TOKEN_REVOKED = LogEntry.new(id: 30, description: "Access token revoked", require_application: true, require_initiator: true),
-    PASSWORD_RESET_LOADED_BUT_TOKEN_EXPIRED = LogEntry.new(id: 31, description: "Password reset page loaded but the token has expired"),
-    SUCCESSFUL_PASSWORD_RESET = LogEntry.new(id: 32, description: "Password reset successfully"),
-    ROLE_CHANGED = LogEntry.new(id: 33, description: "Role changed", require_initiator: true),
-    ACCOUNT_UPDATED = LogEntry.new(id: 34, description: "Account updated", require_initiator: true),
-    PERMISSIONS_ADDED = LogEntry.new(id: 35, description: "Permissions added", require_initiator: true),
-    PERMISSIONS_REMOVED = LogEntry.new(id: 36, description: "Permissions removed", require_initiator: true),
-    ACCOUNT_INVITED = LogEntry.new(id: 37, description: "Account was invited", require_initiator: true),
+    ACCOUNT_LOCKED = LogEntry.new(id: 1, description: "Password verification failed too many times, account locked for #{LOCKED_DURATION}", require_uid: true),
+    ACCOUNT_SUSPENDED = LogEntry.new(id: 2, description: "Account suspended", require_uid: true, require_initiator: true),
+    ACCOUNT_UNSUSPENDED = LogEntry.new(id: 3, description: "Account unsuspended", require_uid: true, require_initiator: true),
+    ACCOUNT_AUTOSUSPENDED = LogEntry.new(id: 4, description: "Account auto-suspended", require_uid: true),
+    MANUAL_ACCOUNT_UNLOCK = LogEntry.new(id: 5, description: "Manual account unlock", require_uid: true, require_initiator: true),
+    PASSWORD_RESET_REQUEST = LogEntry.new(id: 7, description: "Password reset request", require_uid: true),
+    PASSWORD_RESET_LOADED = LogEntry.new(id: 8, description: "Password reset page loaded", require_uid: true),
+    PASSWORD_RESET_FAILURE = LogEntry.new(id: 9, description: "Password reset attempt failure", require_uid: true),
+    SUCCESSFUL_PASSWORD_CHANGE = LogEntry.new(id: 10, description: "Successful password change", require_uid: true),
+    SUCCESSFUL_LOGIN = LogEntry.new(id: 11, description: "Successful login", require_uid: true),
+    UNSUCCESSFUL_LOGIN = LogEntry.new(id: 12, description: "Unsuccessful login", require_uid: true),
+    SUSPENDED_ACCOUNT_AUTHENTICATED_LOGIN = LogEntry.new(id: 13, description: "Unsuccessful login attempt to a suspended account, with the correct username and password", require_uid: true),
+    UNSUCCESSFUL_PASSWORD_CHANGE = LogEntry.new(id: 14, description: "Unsuccessful password change", require_uid: true),
+    EMAIL_CHANGED = LogEntry.new(id: 15, description: "Email changed", require_uid: true, require_initiator: true),
+    EMAIL_CHANGE_INITIATED = LogEntry.new(id: 16, description: "Email change initiated", require_uid: true),
+    EMAIL_CHANGE_CONFIRMED = LogEntry.new(id: 17, description: "Email change confirmed", require_uid: true),
+    TWO_STEP_ENABLED = LogEntry.new(id: 18, description: "2-step verification enabled", require_uid: true),
+    TWO_STEP_RESET = LogEntry.new(id: 19, description: "2-step verification reset", require_uid: true),
+    TWO_STEP_ENABLE_FAILED = LogEntry.new(id: 20, description: "2-step verification setup failed", require_uid: true),
+    TWO_STEP_VERIFIED = LogEntry.new(id: 21, description: "2-step verification successful", require_uid: true),
+    TWO_STEP_VERIFICATION_FAILED = LogEntry.new(id: 22, description: "2-step verification failed", require_uid: true),
+    TWO_STEP_LOCKED = LogEntry.new(id: 23, description: "2-step verification failed too many times, account locked for #{LOCKED_DURATION}", require_uid: true),
+    TWO_STEP_CHANGED = LogEntry.new(id: 24, description: "2-step verification phone changed", require_uid: true),
+    TWO_STEP_CHANGE_FAILED = LogEntry.new(id: 25, description: "2-step verification phone change failed", require_uid: true),
+    TWO_STEP_PROMPT_DEFERRED = LogEntry.new(id: 26, description: "2-step prompt deferred", require_uid: true),
+    API_USER_CREATED = LogEntry.new(id: 27, description: "Account created", require_uid: true, require_initiator: true),
+    ACCESS_TOKEN_REGENERATED = LogEntry.new(id: 28, description: "Access token re-generated", require_uid: true, require_application: true),
+    ACCESS_TOKEN_GENERATED = LogEntry.new(id: 29, description: "Access token generated", require_uid: true, require_application: true, require_initiator: true),
+    ACCESS_TOKEN_REVOKED = LogEntry.new(id: 30, description: "Access token revoked", require_uid: true, require_application: true, require_initiator: true),
+    PASSWORD_RESET_LOADED_BUT_TOKEN_EXPIRED = LogEntry.new(id: 31, description: "Password reset page loaded but the token has expired", require_uid: true),
+    SUCCESSFUL_PASSWORD_RESET = LogEntry.new(id: 32, description: "Password reset successfully", require_uid: true),
+    ROLE_CHANGED = LogEntry.new(id: 33, description: "Role changed", require_uid: true, require_initiator: true),
+    ACCOUNT_UPDATED = LogEntry.new(id: 34, description: "Account updated", require_uid: true, require_initiator: true),
+    PERMISSIONS_ADDED = LogEntry.new(id: 35, description: "Permissions added", require_uid: true, require_initiator: true),
+    PERMISSIONS_REMOVED = LogEntry.new(id: 36, description: "Permissions removed", require_uid: true, require_initiator: true),
+    ACCOUNT_INVITED = LogEntry.new(id: 37, description: "Account was invited", require_uid: true, require_initiator: true),
 
     # We no longer expire passwords, but we keep this event for history purposes
     PASSWORD_EXPIRED = LogEntry.new(id: 6, description: "Password expired"),
   ].freeze
 
+  EVENTS_REQUIRING_UID = EVENTS.select(&:require_uid?)
   EVENTS_REQUIRING_INITIATOR = EVENTS.select(&:require_initiator?)
   EVENTS_REQUIRING_APPLICATION = EVENTS.select(&:require_application?)
 
   VALID_OPTIONS = %i[initiator application application_id trailing_message ip_address user_agent_id user_agent_string].freeze
 
-  validates :uid, presence: true
+  validates_presence_of :uid, if: Proc.new { |event_log| EVENTS_REQUIRING_UID.include? event_log.entry }
   validates_presence_of :event_id
   validate :validate_event_mappable
   validates_presence_of :initiator_id,   if: Proc.new { |event_log| EVENTS_REQUIRING_INITIATOR.include? event_log.entry }
@@ -106,7 +107,7 @@ class EventLog < ActiveRecord::Base
       options[:ip_address] = convert_ip_address_to_integer(options[:ip_address])
     end
     attributes = {
-      uid: user.uid,
+      uid: user&.uid,
       event_id: event.id
     }.merge!(options.slice(*VALID_OPTIONS))
 

--- a/app/models/log_entry.rb
+++ b/app/models/log_entry.rb
@@ -1,11 +1,16 @@
 class LogEntry
   attr_reader :id, :description
 
-  def initialize(id:, description:, require_initiator: false, require_application: false)
+  def initialize(id:, description:, require_uid: false, require_initiator: false, require_application: false)
     @id = id
     @description = description
+    @require_uid = require_uid
     @require_initiator = require_initiator
     @require_application = require_application
+  end
+
+  def require_uid?
+    @require_uid
   end
 
   def require_initiator?

--- a/app/views/users/event_logs.html.erb
+++ b/app/views/users/event_logs.html.erb
@@ -37,7 +37,7 @@
               <%= log.ip_address_string %>
             <% end %>
             <% if log.user_agent_id %>
-                <% browser = Browser.new(log.user_agent_string) %>
+                <% browser = Browser.new(log.user_agent_as_string) %>
                 <%= browser.name + ' ' + browser.version %>
             <% end %>
           </td>

--- a/db/migrate/20190903085745_add_string_user_agent_to_event_log.rb
+++ b/db/migrate/20190903085745_add_string_user_agent_to_event_log.rb
@@ -1,0 +1,5 @@
+class AddStringUserAgentToEventLog < ActiveRecord::Migration[5.2]
+  def change
+    add_column :event_logs, :user_agent_string, :string
+  end
+end

--- a/db/migrate/20190903085803_add_string_user_email_to_event_log.rb
+++ b/db/migrate/20190903085803_add_string_user_email_to_event_log.rb
@@ -1,0 +1,5 @@
+class AddStringUserEmailToEventLog < ActiveRecord::Migration[5.2]
+  def change
+    add_column :event_logs, :user_email_string, :string
+  end
+end

--- a/db/migrate/20190903120837_set_default_event_log_uid.rb
+++ b/db/migrate/20190903120837_set_default_event_log_uid.rb
@@ -1,0 +1,6 @@
+class SetDefaultEventLogUid < ActiveRecord::Migration[5.2]
+  def change
+    change_column :event_logs, :uid, null: true
+    change_column_default :event_logs, :uid, nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_12_160951) do
-  
+ActiveRecord::Schema.define(version: 2019_09_03_085745) do
+
   create_table "batch_invitation_application_permissions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "batch_invitation_id", null: false
     t.integer "supported_permission_id", null: false
@@ -67,6 +67,7 @@ ActiveRecord::Schema.define(version: 2019_07_12_160951) do
     t.integer "event_id"
     t.decimal "ip_address", precision: 38
     t.integer "user_agent_id"
+    t.string "user_agent_string"
     t.index ["uid", "created_at"], name: "index_event_logs_on_uid_and_created_at"
     t.index ["user_agent_id"], name: "event_logs_user_agent_id_fk"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_03_085745) do
+ActiveRecord::Schema.define(version: 2019_09_03_085803) do
 
   create_table "batch_invitation_application_permissions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "batch_invitation_id", null: false
@@ -68,6 +68,7 @@ ActiveRecord::Schema.define(version: 2019_09_03_085745) do
     t.decimal "ip_address", precision: 38
     t.integer "user_agent_id"
     t.string "user_agent_string"
+    t.string "user_email_string"
     t.index ["uid", "created_at"], name: "index_event_logs_on_uid_and_created_at"
     t.index ["user_agent_id"], name: "event_logs_user_agent_id_fk"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_03_085803) do
+ActiveRecord::Schema.define(version: 2019_09_03_120837) do
 
   create_table "batch_invitation_application_permissions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "batch_invitation_id", null: false
@@ -59,7 +59,7 @@ ActiveRecord::Schema.define(version: 2019_09_03_085803) do
   end
 
   create_table "event_logs", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "uid", null: false
+    t.string "uid"
     t.datetime "created_at", null: false
     t.integer "initiator_id"
     t.integer "application_id"

--- a/test/integration/event_log_creation_test.rb
+++ b/test/integration/event_log_creation_test.rb
@@ -26,11 +26,12 @@ class EventLogCreationIntegrationTest < ActionDispatch::IntegrationTest
       assert_equal EventLog::UNSUCCESSFUL_LOGIN, @user.event_logs.last.entry
     end
 
-    should "log nothing for an invalid email" do
+    should "record an invalid email" do
       visit root_path
       signin_with(email: "nonexistent@example.com", password: "anything")
 
-      assert_equal 0, EventLog.count
+      assert_equal 1, EventLog.count
+      assert_equal EventLog::NO_SUCH_ACCOUNT_LOGIN, EventLog.last.entry
     end
 
     should "raise an error when missing CSRF token" do

--- a/test/integration/user_agent_test.rb
+++ b/test/integration/user_agent_test.rb
@@ -15,7 +15,7 @@ class UserAgentIntegrationTest < ActionDispatch::IntegrationTest
     signin_with(@user)
 
     assert_equal user_agent_test, UserAgent.last.user_agent_string
-    user_agent = @user.event_logs.first.user_agent_string
+    user_agent = @user.event_logs.first.user_agent_as_string
     assert_equal user_agent_test, user_agent
   end
 end


### PR DESCRIPTION
**Record user agent string on unsuccessful login:** done by adding a `user_agent_string` field to the `event_logs` table.  I'm not sure if this approach is better or worse than creating `UserAgent` models, I went for this because I figured it would be pretty straightforward to prune the event log if it grows too big.  If there are too many `UserAgent` values, then both `event_logs` and `user_agents` need pruning.

**Record email address when no such account exists:** done by making the `uid` field of `event_logs` optional (though it's required for all pre-existing event types), adding a `user_email_string` field, and adding a new event type.

The new event is type 38 and passes the email address in the `user` field.

---

https://govuk.zendesk.com/agent/tickets/3783119
https://govuk.zendesk.com/agent/tickets/3788622