### PR TITLE
Add a rake task to grant permission "2i reviewer" in Collections Publisher

### DIFF
--- a/lib/tasks/user_application_permissions.rake
+++ b/lib/tasks/user_application_permissions.rake
@@ -1,0 +1,51 @@
+namespace :users do
+  desc "Grant 2i reviewer permission in Collections Publisher"
+  task grant_2i_reviewer_permission: :environment do
+    application = Doorkeeper::Application.find_by(name: "Collections Publisher")
+    users = User.where(email: user_emails)
+
+    users.each do |user|
+      puts "-- Adding 2i reviewer permission for #{user.name} in #{application.name}"
+      user.grant_application_permission(application, "2i reviewer")
+
+      if application.supports_push_updates?
+        PermissionUpdater.perform_later(user.uid, application.id)
+      end
+    end
+  end
+
+  def user_emails
+    %w(
+      abigail.waraker@digital.cabinet-office.gov.uk
+      ale.delcueto@digital.cabinet-office.gov.uk
+      alistair.smith@digital.cabinet-office.gov.uk
+      andrew.harsant@digital.cabinet-office.gov.uk
+      andy.keen@digital.cabinet-office.gov.uk
+      dave.standen@digital.cabinet-office.gov.uk
+      gavan.curley@digital.cabinet-office.gov.uk
+      george.mcdonald@digital.cabinet-office.gov.uk
+      graeme.claridge@digital.cabinet-office.gov.uk
+      hannah.mackay@digital.cabinet-office.gov.uk
+      hannah.whittaker@digital.cabinet-office.gov.uk
+      helen.nickols@digital.cabinet-office.gov.uk
+      joe.harrison@digital.cabinet-office.gov.uk
+      jon.sanger@digital.cabinet-office.gov.uk
+      katherine.dunn@digital.cabinet-office.gov.uk
+      kati.tirbhowan@digital.cabinet-office.gov.uk
+      lucy.hartley@digital.cabinet-office.gov.uk
+      lucy.musselwhite@digital.cabinet-office.gov.uk
+      marian.foley@digital.cabinet-office.gov.uk
+      matt.clear@digital.cabinet-office.gov.uk
+      patricia.turk@digital.cabinet-office.gov.uk
+      paula.stephenson@digital.cabinet-office.gov.uk
+      polly.green@digital.cabinet-office.gov.uk
+      richard.furlong@digital.cabinet-office.gov.uk
+      sean.walsh@digital.cabinet-office.gov.uk
+      sharon.giles@digital.cabinet-office.gov.uk
+      sheryll.sulit@digital.cabinet-office.gov.uk
+      stefan.nicolaou@digital.cabinet-office.gov.uk
+      stephen.gill@digital.cabinet-office.gov.uk
+      tom.hughes@digital.cabinet-office.gov.uk
+    )
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/lPYBEJzc

This list is limited to content designers who have completed 2i training.

It gives users the permission, even if they don't have access to Collections Publisher.
This is so that when they are ready to start using Collections Publisher, they don't
need to remember to add this special permission.

Follows the same pattern of using PermissionUpdater, established in:
https://github.com/alphagov/signon/blob/master/lib/signin_permission_granter.rb

Integration test results: https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/80979/console

This rake task will be removed once the user permissions have been updated in all environments.