### PR TITLE
Use source version of alphabetical_paginate

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,8 +6,8 @@ gem 'activejob-retry'
 gem 'addressable', '~> 2'
 gem(
   'alphabetical_paginate',
-  git: 'https://github.com/cbaines/alphabetical_paginate',
-  branch: 'wrap-sql-in-arel-sql'
+  git: 'https://github.com/lingz/alphabetical_paginate',
+  ref: 'b1a370d16acb9b9f0051ed8a2d325308da0d9af1'
 )
 gem 'ancestry', '~> 3'
 gem 'bootsnap'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
-  remote: https://github.com/cbaines/alphabetical_paginate
-  revision: 26015e94c64f4feaeac756ab7c3512b0707e96be
-  branch: wrap-sql-in-arel-sql
+  remote: https://github.com/lingz/alphabetical_paginate
+  revision: b1a370d16acb9b9f0051ed8a2d325308da0d9af1
+  ref: b1a370d16acb9b9f0051ed8a2d325308da0d9af1
   specs:
     alphabetical_paginate (2.3.3)
 


### PR DESCRIPTION
[Chris' PR](https://github.com/lingz/alphabetical_paginate/pull/55) was merged into master (and is the only change since v2.3.3 which was the previous version we used).  

We want to use the changes in his PR to ensure that we're ready for Rails 6.