### PR TITLE
Use rubygems version of alphabetical_paginate

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,11 +4,7 @@ gem 'rails', '~> 5'
 
 gem 'activejob-retry'
 gem 'addressable', '~> 2'
-gem(
-  'alphabetical_paginate',
-  git: 'https://github.com/lingz/alphabetical_paginate',
-  ref: 'b1a370d16acb9b9f0051ed8a2d325308da0d9af1'
-)
+gem 'alphabetical_paginate', '~> 2'
 gem 'ancestry', '~> 3'
 gem 'bootsnap'
 gem 'bootstrap-kaminari-views', '0.0.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,3 @@
-GIT
-  remote: https://github.com/lingz/alphabetical_paginate
-  revision: b1a370d16acb9b9f0051ed8a2d325308da0d9af1
-  ref: b1a370d16acb9b9f0051ed8a2d325308da0d9af1
-  specs:
-    alphabetical_paginate (2.3.3)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -54,6 +47,7 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
+    alphabetical_paginate (2.3.4)
     ancestry (3.0.7)
       activerecord (>= 3.2.0)
     arel (9.0.0)
@@ -422,7 +416,7 @@ PLATFORMS
 DEPENDENCIES
   activejob-retry
   addressable (~> 2)
-  alphabetical_paginate!
+  alphabetical_paginate (~> 2)
   ancestry (~> 3)
   better_errors (= 2.5.1)
   binding_of_caller (= 0.8.0)


### PR DESCRIPTION
@lingz has [released v2.3.4](https://github.com/lingz/alphabetical_paginate/pull/56) so we can get off using a commitish version from Github.  It's the same code as before, only with a patch version bump applied.