### PR TITLE
Update to govuk frontend v3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ gem 'deprecated_columns', '0.1.1'
 gem 'gds-api-adapters', '~> 60'
 gem 'govuk_admin_template', '~> 6'
 gem 'govuk_app_config', '~> 2'
-gem 'govuk_publishing_components', '~> 17'
+gem 'govuk_publishing_components', '~> 21'
 gem 'govuk_sidekiq', '~> 3'
 gem 'plek', '~> 3'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,13 +147,9 @@ GEM
       sentry-raven (>= 2.7.1, < 2.12.0)
       statsd-ruby (~> 1.4.0)
       unicorn (>= 5.4, < 5.6)
-    govuk_frontend_toolkit (8.2.0)
-      railties (>= 3.1.0)
-      sass (>= 3.2.0)
-    govuk_publishing_components (17.21.0)
+    govuk_publishing_components (21.3.0)
       gds-api-adapters
       govuk_app_config
-      govuk_frontend_toolkit
       kramdown
       plek
       rails (>= 5.0.0.1)
@@ -311,7 +307,7 @@ GEM
       netrc (~> 0.8)
     rotp (5.1.0)
       addressable (~> 2.5)
-    rouge (3.7.0)
+    rouge (3.11.0)
     rqrcode (1.1.1)
       chunky_png (~> 1.0)
       rqrcode_core (~> 0.1.0)
@@ -437,7 +433,7 @@ DEPENDENCIES
   govuk-lint (~> 4)
   govuk_admin_template (~> 6)
   govuk_app_config (~> 2)
-  govuk_publishing_components (~> 17)
+  govuk_publishing_components (~> 21)
   govuk_sidekiq (~> 3)
   jasmine (~> 3)
   json (~> 2)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,9 +1,5 @@
 @import "govuk_publishing_components/all_components";
 
-// TODO: remove the font-face include when govuk_publishing_components doesn't
-// rely on govuk_template and has $govuk-compatibility-govuktemplate set to false
-@include _govuk-font-face-nta;
-
 // TODO: move into component
 .gem-c-success-alert,
 .gem-c-error-alert {


### PR DESCRIPTION
Signon still uses `govuk_admin_template`, but this bump still brings in some new things from GOV.UK Frontend 3.

## Screenshot

![signon dev gov uk_ (1)](https://user-images.githubusercontent.com/424772/66208173-6385fe80-e6ac-11e9-8765-8ec43e3369a5.png)
