### PR TITLE
Add links to the support app to relevant signon emails

### DIFF
--- a/app/views/user_mailer/notify_reset_password_disallowed_due_to_suspension.html.erb
+++ b/app/views/user_mailer/notify_reset_password_disallowed_due_to_suspension.html.erb
@@ -4,4 +4,4 @@
 <p><%= account_name.humanize %> suspensions do not suspend production accounts.</p>
 <% end %>
 
-<p>If you believe your account has been suspended in error, please contact a managing <%= link_to t('department.name'), t('department.url') %> editor in your organisation (or your parent organisation). They can use the support form to get help from the <%= link_to t('department.name'), t('department.url') %> team.</p>
+<p>If you believe your account has been suspended in error, please contact a managing <%= link_to t('department.name'), t('department.url') %> editor in your organisation (or your parent organisation). They can use the <%= link_to "support form", "https://www.gov.uk/support/internal" %> to get help from the <%= link_to t('department.name'), t('department.url') %> team.</p>

--- a/app/views/user_mailer/notify_reset_password_disallowed_due_to_suspension.text.erb
+++ b/app/views/user_mailer/notify_reset_password_disallowed_due_to_suspension.text.erb
@@ -5,4 +5,4 @@ Your <%= t('department.name') %> Signon <%= account_name %>, for <%= @user.email
 <%= account_name.humanize %> suspensions do not suspend production accounts.
 <% end %>
 
-If you believe your account has been suspended in error, please contact a managing <%= t('department.name') %> editor in your organisation (or your parent organisation). They can use the support form to get help from the <%= t('department.name') %> team.
+If you believe your account has been suspended in error, please contact a managing <%= t('department.name') %> editor in your organisation (or your parent organisation). They can use the support form (https://www.gov.uk/support/internal) to get help from the <%= t('department.name') %> team.

--- a/app/views/user_mailer/notify_reset_password_disallowed_due_to_unaccepted_invitation.html.erb
+++ b/app/views/user_mailer/notify_reset_password_disallowed_due_to_unaccepted_invitation.html.erb
@@ -1,3 +1,3 @@
 <p>Your <%= link_to t('department.name'), t('department.url') %> Signon <%= account_name %>, for <%= @user.email %>, has not been activated. You can't request a password reset on an inactive account.</p>
 
-<p>If you want a new invitation, please contact a managing <%= link_to t('department.name'), t('department.url') %> editor in your organisation (or your parent organisation). They can use the support form to get help from the <%= link_to t('department.name'), t('department.url') %> team.</p>
+<p>If you want a new invitation, please contact a managing <%= link_to t('department.name'), t('department.url') %> editor in your organisation (or your parent organisation). They can use the <%= link_to "support form", "https://www.gov.uk/support/internal" %> to get help from the <%= link_to t('department.name'), t('department.url') %> team.</p>

--- a/app/views/user_mailer/notify_reset_password_disallowed_due_to_unaccepted_invitation.text.erb
+++ b/app/views/user_mailer/notify_reset_password_disallowed_due_to_unaccepted_invitation.text.erb
@@ -1,4 +1,4 @@
 
 Your <%= link_to t('department.name'), t('department.url') %> Signon <%= account_name %>, for <%= @user.email %>, has not been activated. You can't request a password reset on an inactive account.
 
-If you want a new invitation, please contact a managing <%= link_to t('department.name'), t('department.url') %> editor in your organisation (or your parent organisation). They can use the support form to get help from the <%= link_to t('department.name'), t('department.url') %> team.
+If you want a new invitation, please contact a managing <%= link_to t('department.name'), t('department.url') %> editor in your organisation (or your parent organisation). They can use the support form (https://www.gov.uk/support/internal) to get help from the <%= link_to t('department.name'), t('department.url') %> team.

--- a/app/views/user_mailer/suspension_notification.html.erb
+++ b/app/views/user_mailer/suspension_notification.html.erb
@@ -8,6 +8,6 @@
 
 <p>If you don't need the account you can ignore this email.</p>
 
-<p>If you do still need the account you will have to contact a managing <%= link_to t('department.name'), t('department.url') %> editor in your organisation (or your parent organisation). They can use the support form to get help from the <%= link_to t('department.name'), t('department.url') %> team.</p>
+<p>If you do still need the account you will have to contact a managing <%= link_to t('department.name'), t('department.url') %> editor in your organisation (or your parent organisation). They can use the <%= link_to "support form", "https://www.gov.uk/support/internal" %> to get help from the <%= link_to t('department.name'), t('department.url') %> team.</p>
 
 <p>Read our blog post about <%= link_to "suspending unused #{t('department.name')} accounts", 'https://insidegovuk.blog.gov.uk/2014/08/21/suspending-unused-gov-uk-accounts' %>.</p>

--- a/app/views/user_mailer/suspension_notification.text.erb
+++ b/app/views/user_mailer/suspension_notification.text.erb
@@ -8,7 +8,7 @@ Your <%= t('department.name') %> Signon <%= account_name %>, for <%= @user.email
 
 If you don't need the account you can ignore this email.
 
-If you do still need the account you will have to contact a managing <%= t('department.name') %> editor in your organisation (or your parent organisation). They can use the support form to get help from the <%= t('department.name') %> team.
+If you do still need the account you will have to contact a managing <%= t('department.name') %> editor in your organisation (or your parent organisation). They can use the support form (https://www.gov.uk/support/internal) to get help from the <%= t('department.name') %> team.
 
 Read our blog post about suspending unused <%= t('department.name') %> accounts:
 

--- a/app/views/user_mailer/two_step_changed.html.erb
+++ b/app/views/user_mailer/two_step_changed.html.erb
@@ -3,4 +3,4 @@ You’ll only be able to sign in with your new phone.</p>
 
 <p>If you didn’t make this change, please contact <%= t('department.name') %>. If you can’t do this
 yourself, please contact a managing <%= t('department.name') %> editor in your organisation (or your
-parent organisation). They can raise a support ticket on your behalf.</p>
+parent organisation). They can raise a <%= link_to "support ticket", "https://www.gov.uk/support/internal" %> on your behalf.</p>

--- a/app/views/user_mailer/two_step_changed.text.erb
+++ b/app/views/user_mailer/two_step_changed.text.erb
@@ -1,3 +1,3 @@
 You’ve successfully set up a new phone to use for 2-step verification. You’ll only be able to sign in with your new phone.
 
-If you didn’t make this change, please contact <%= t('department.name') %>. If you can’t do this yourself, please contact a managing <%= t('department.name') %> editor in your organisation (or your parent organisation). They can raise a support ticket on your behalf.
+If you didn’t make this change, please contact <%= t('department.name') %>. If you can’t do this yourself, please contact a managing <%= t('department.name') %> editor in your organisation (or your parent organisation). They can raise a support ticket (https://www.gov.uk/support/internal) on your behalf.

--- a/app/views/user_mailer/two_step_reset.html.erb
+++ b/app/views/user_mailer/two_step_reset.html.erb
@@ -3,4 +3,4 @@ again next time you sign in.</p>
 
 <p>If you didn’t make this request, please contact <%= t('department.name') %>. If you can’t do this
 yourself, please contact a managing <%= t('department.name') %> editor in your organisation (or your
-parent organisation). They can raise a support ticket on your behalf.</p>
+parent organisation). They can raise a <%= link_to "support ticket", "https://www.gov.uk/support/internal" %> on your behalf.</p>

--- a/app/views/user_mailer/two_step_reset.text.erb
+++ b/app/views/user_mailer/two_step_reset.text.erb
@@ -1,3 +1,3 @@
 Your 2-step verification has been reset. You’ll be asked to set this up again next time you sign in.
 
-If you didn’t make this request, please contact <%= t('department.name') %>. If you can’t do this yourself, please contact a managing <%= t('department.name') %> editor in your organisation (or your parent organisation). They can raise a support ticket on your behalf.
+If you didn’t make this request, please contact <%= t('department.name') %>. If you can’t do this yourself, please contact a managing <%= t('department.name') %> editor in your organisation (or your parent organisation). They can raise a support ticket (https://www.gov.uk/support/internal) on your behalf.

--- a/app/views/user_mailer/unlock_instructions.html.erb
+++ b/app/views/user_mailer/unlock_instructions.html.erb
@@ -4,4 +4,4 @@
 <p><%= account_name.humanize %> locks do not lock production accounts.</p>
 <% end %>
 
-<p>Your account will be unlocked at <%= unlock_time %>. If you need your account unlocked sooner, please contact a managing <%= link_to t('department.name'), t('department.url') %> editor in your organisation (or your parent organisation). They can use the support form to get help from the <%= link_to t('department.name'), t('department.url') %> team.</p>
+<p>Your account will be unlocked at <%= unlock_time %>. If you need your account unlocked sooner, please contact a managing <%= link_to t('department.name'), t('department.url') %> editor in your organisation (or your parent organisation). They can use the <%= link_to "support form", "https://www.gov.uk/support/internal" %> to get help from the <%= link_to t('department.name'), t('department.url') %> team.</p>

--- a/app/views/user_mailer/unlock_instructions.text.erb
+++ b/app/views/user_mailer/unlock_instructions.text.erb
@@ -4,4 +4,4 @@ Your <%= t('department.name') %> Signon <%= account_name %>, for <%= @resource.e
   <%= account_name.humanize %> locks do not lock production accounts.
 <% end %>
 
-Your account will be unlocked at <%= unlock_time %>. If you need your account unlocked sooner, please contact a managing <%= t('department.name') %> editor in your organisation (or your parent organisation). They can use the support form to get help from the <%= t('department.name') %> team.
+Your account will be unlocked at <%= unlock_time %>. If you need your account unlocked sooner, please contact a managing <%= t('department.name') %> editor in your organisation (or your parent organisation). They can use the support form (https://www.gov.uk/support/internal) to get help from the <%= t('department.name') %> team.


### PR DESCRIPTION
To make sure we redirect to the support app correctly from emails, we now ensure there are relevant links in emails that mention the key phrases "support form" or "support ticket."

In the case of text documents, the relevant link is included in brackets after the phrase.

Trello card: https://trello.com/c/B14NqZXp/1048-add-links-to-the-support-app-to-relevant-signon-emails