### PR TITLE
Bulk change organisation

### DIFF
--- a/lib/data_hygiene/bulk_organisation_updater.rb
+++ b/lib/data_hygiene/bulk_organisation_updater.rb
@@ -1,0 +1,64 @@
+require "csv"
+
+module DataHygiene
+  class BulkOrganisationUpdater
+    def initialize(filename)
+      @filename = filename
+    end
+
+    def call
+      CSV.foreach(filename, **CSV_OPTIONS) do |row|
+        process_row(row)
+      end
+    end
+
+    def self.call(*args)
+      new(*args).call
+    end
+
+  private
+
+    attr_reader :filename
+
+    CSV_OPTIONS = {
+      headers: true,
+    }.freeze
+
+    def process_row(row)
+      user = find_user(row)
+      new_email_address = find_new_email_address(row)
+      new_organisation = find_new_organisation(row)
+
+      update_user(user, new_email_address, new_organisation)
+    end
+
+    def find_user(row)
+      User.find_by!(email: row.fetch("Old email"))
+    end
+
+    def find_new_email_address(row)
+      row.fetch("New email")
+    end
+
+    def find_new_organisation(row)
+      Organisation.find_by!(slug: row.fetch("New organisation"))
+    end
+
+    def update_user(user, new_email_address, new_organisation)
+      puts "#{user.email}: #{new_email_address} #{new_organisation.slug}"
+
+      current_email_address = user.email
+
+      user.skip_confirmation_notification!
+
+      user.update!(
+        email: new_email_address,
+        organisation: new_organisation,
+      )
+
+      user.confirm # we trust the email addresses in the CSV spreadsheet
+
+      EventLog.record_email_change(user, current_email_address, new_email_address)
+    end
+  end
+end

--- a/lib/tasks/data_hygiene.rake
+++ b/lib/tasks/data_hygiene.rake
@@ -1,0 +1,6 @@
+namespace :data_hygiene do
+  desc "Bulk update the organisations associated with users."
+  task :bulk_update_organisation, %i(csv_filename) => :environment do |_, args|
+    DataHygiene::BulkOrganisationUpdater.call(args[:csv_filename])
+  end
+end

--- a/test/lib/data_hygiene/bulk_organisation_updater_test.rb
+++ b/test/lib/data_hygiene/bulk_organisation_updater_test.rb
@@ -1,0 +1,65 @@
+require "test_helper"
+
+class DataHygiene::BulkOrganisationUpdaterTest < ActiveSupport::TestCase
+  def process(csv_file)
+    file = Tempfile.new("bulk_update_organisation")
+    file.write(csv_file)
+    file.close
+
+    begin
+      DataHygiene::BulkOrganisationUpdater.call(file.path)
+    ensure
+      file.unlink
+    end
+  end
+
+  test "it fails with invalid CSV data" do
+    csv_file = <<~CSV
+      old email,New email address,replacement organisation
+      a@b.com,d@c.com,new-organisation
+    CSV
+
+    assert_raises KeyError do
+      process(csv_file)
+    end
+  end
+
+  test "it fails if the user doesn't exist" do
+    csv_file = <<~CSV
+      Old email,New email,New organisation
+      a@b.com,b@c.com,new-organisation
+    CSV
+
+    assert_raises ActiveRecord::RecordNotFound do
+      process(csv_file)
+    end
+  end
+
+  test "it changes the email address" do
+    csv_file = <<~CSV
+      Old email,New email,New organisation
+      a@b.com,c@d.com,organisation
+    CSV
+
+    organisation = create(:organisation, slug: "organisation")
+    user = create(:user, email: "a@b.com", organisation: organisation)
+
+    process(csv_file)
+
+    assert_equal user.reload.email, "c@d.com"
+  end
+
+  test "it changes the organisation" do
+    csv_file = <<~CSV
+      Old email,New email,New organisation
+      a@b.com,a@b.com,new-organisation
+    CSV
+
+    new_organisation = create(:organisation, slug: "new-organisation")
+    user = create(:user, email: "a@b.com")
+
+    process(csv_file)
+
+    assert_equal user.reload.organisation, new_organisation
+  end
+end


### PR DESCRIPTION
This class takes a path to a CSV file and performs a bulk update of the email address and organisation associated with users. This is useful during machinery of government changes.

The CSV file must contain at least the following columns:
 - 'Old email'
 - 'New email'
 - 'New organisation' (which must be a slug)

[Trello Card](https://trello.com/c/tDJ5oeIu/1702-add-rake-tasks-to-handle-machinery-of-government-changes)