### PR TITLE
Disable autocomplete for 2FA input when logging in

### DIFF
--- a/app/views/devise/two_step_verification_session/new.html.erb
+++ b/app/views/devise/two_step_verification_session/new.html.erb
@@ -11,7 +11,7 @@
         name: "code",
         autofocus: true,
         tabindex: 0,
-        # TODO: disable autocomplete
+        autocomplete: "off",
         hint: "Use the 6-digit verification app on your phone to get your code. You won’t need to do this again for 30 days."
       } %>
 


### PR DESCRIPTION
The 2FA code input permits autocompletion.  The code is different for each login, so the autocomplete is not useful.