### PR TITLE
Override the mail method so devise uses notify correctly

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -59,6 +59,11 @@ class UserMailer < Devise::Mailer
     view_mail(template_id, to: @user.email, subject: "Your #{app_name} email address is being changed")
   end
 
+  def unlock_instructions(user, _token, _opts = {})
+    @user = user
+    view_mail(template_id, to: @user.email, subject: sprintf(t("devise.mailer.unlock_instructions.subject"), app_name: app_name))
+  end
+
 private
 
   def suspension_time

--- a/app/views/user_mailer/unlock_instructions.text.erb
+++ b/app/views/user_mailer/unlock_instructions.text.erb
@@ -1,4 +1,4 @@
-Your <%= t('department.name') %> Signon <%= account_name %>, for <%= @resource.email %>, was locked at <%= locked_time %> because the wrong sign on details were entered too many times.
+Your <%= t('department.name') %> Signon <%= account_name %>, for <%= @user.email %>, was locked at <%= locked_time %> because the wrong sign on details were entered too many times.
 
 <% if instance_name.present? %>
   <%= account_name.humanize %> locks do not lock production accounts.


### PR DESCRIPTION
To use notify we rewrite mailer methods to call `view_mail` instead of    `mail`; however, the `unlock_instructions` email is defined by devise    and used `mail`. Overriding the mailer method so that it calls   `view_mail` with the correct parameters should address that.

https://trello.com/c/ZB29y9Y0/2050-signon-use-notify-instead-of-amazon-ses-%F0%9F%8D%90