### PR TITLE
Give APHA the parent of DEFRA

### DIFF
--- a/db/migrate/20200805142418_update_apha_parent.rb
+++ b/db/migrate/20200805142418_update_apha_parent.rb
@@ -1,0 +1,9 @@
+class UpdateAphaParent < ActiveRecord::Migration[6.0]
+  def up
+    apha = Organisation.find_by(abbreviation: "APHA")
+    defra = Organisation.find_by(abbreviation: "DEFRA")
+    apha.update!(parent: defra)
+  end
+
+  def down; end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_20_161244) do
+ActiveRecord::Schema.define(version: 2020_08_05_142418) do
 
   create_table "batch_invitation_application_permissions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "batch_invitation_id", null: false


### PR DESCRIPTION
What
----

We received a zendesk ticket(linked below) from Defra which noted that they did not have access to the accounts under the Animal and Plant Health Agency(APHA) in signon, despite being their parent department. 

A look in the database confirmed that APHA is currently listed under the Welsh Government, this is incorrect. This change makes it so the APHA is now listed under Defra. 

How to review
-------------

We can deploy this branch to integration and see if the migration works. If it is properly formatted we can then deploy to production and close the ticket. 

Links
-----

[Zendesk ticket](https://govuk.zendesk.com/agent/tickets/4182860)
