### PR TITLE
Override reset_password_instructions mailer method for devise to use Notify

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -64,6 +64,12 @@ class UserMailer < Devise::Mailer
     view_mail(template_id, to: @user.email, subject: sprintf(t("devise.mailer.unlock_instructions.subject"), app_name: app_name))
   end
 
+  def reset_password_instructions(user, token, _opts = {})
+    @user = user
+    @token = token
+    view_mail(template_id, to: @user.email, subject: t("devise.mailer.reset_password_instructions.subject"))
+  end
+
 private
 
   def suspension_time

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -157,6 +157,10 @@ class User < ApplicationRecord
     elsif user.present? && user.invited_but_not_yet_accepted?
       UserMailer.notify_reset_password_disallowed_due_to_unaccepted_invitation(user).deliver_later
       user
+    elsif user.present?
+      token = user.send(:set_reset_password_token)
+      UserMailer.reset_password_instructions(user, token).deliver_later
+      user
     else
       super
     end

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,7 +1,0 @@
-<p>Someone has requested a link to change your password, and you can do this through the link below.</p>
-
-<p><%= link_to 'Change my password', edit_password_url(@resource, :reset_password_token => @token) %></p>
-
-<p>If you didn't request this, please ignore this email.</p>
-<p>Your password won't change until you access the link above and create a new one.</p>
-<p>The link will be valid for 6 hours and will only work once.</p>

--- a/app/views/devise/mailer/reset_password_instructions.text.erb
+++ b/app/views/devise/mailer/reset_password_instructions.text.erb
@@ -1,7 +1,0 @@
-Someone has requested a link to change your password, and you can do this copying-and-pasting the link below into your browser's URL bar:
-
-<%= edit_password_url(@resource, :reset_password_token => @token) %>
-
-If you didn't request this, please ignore this email.
-Your password won't change until you access the link above and create a new one.
-The link will be valid for 6 hours and will only work once.

--- a/app/views/user_mailer/reset_password_instructions.text.erb
+++ b/app/views/user_mailer/reset_password_instructions.text.erb
@@ -1,0 +1,11 @@
+Hello <%= @user.email %>!
+
+Someone has requested a link to change your password. You can do this through the link below.
+
+<%= edit_password_url(@user, :reset_password_token => @token) %>
+
+If you didn't request this, please ignore this email.
+
+Your password won't change until you access the link above and create a new one.
+
+The link will be valid for 6 hours and will only work once.

--- a/test/integration/password_reset_test.rb
+++ b/test/integration/password_reset_test.rb
@@ -74,7 +74,7 @@ class PasswordResetTest < ActionDispatch::IntegrationTest
 
       signout
 
-      current_email.click_link("Change my password")
+      current_email.find_link(href: false).click
 
       assert_response_contains("Sorry, this link doesn't work")
     end
@@ -97,7 +97,7 @@ class PasswordResetTest < ActionDispatch::IntegrationTest
       assert_equal "Reset password instructions", current_email.subject
 
       # simulate something following the link in the email.
-      current_email.click_link("Change my password")
+      current_email.find_link(href: false).click
 
       complete_password_reset(current_email, new_password: new_password)
       assert_response_contains("Your password was changed successfully")
@@ -111,7 +111,7 @@ class PasswordResetTest < ActionDispatch::IntegrationTest
 
       open_email(user.email)
 
-      current_email.click_link("Change my password")
+      current_email.find_link(href: false).click
       fill_in "New password", with: "A Password"
       fill_in "Confirm new password", with: "Not That Password"
       click_button "Save password"

--- a/test/support/password_helpers.rb
+++ b/test/support/password_helpers.rb
@@ -16,7 +16,7 @@ module PasswordHelpers
   end
 
   def complete_password_reset(email, options)
-    email.click_link("Change my password")
+    email.find_link(href: false).click
     fill_in "New password", with: options[:new_password]
     fill_in "Confirm new password", with: options[:new_password]
     click_button "Save password"


### PR DESCRIPTION
https://trello.com/c/ZB29y9Y0/2050-signon-use-notify-instead-of-amazon-ses-%F0%9F%8D%90