### PR TITLE
Define mail methods on UserMailer to avoid using the default Devise methods

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -70,6 +70,28 @@ class UserMailer < Devise::Mailer
     view_mail(template_id, to: @user.email, subject: t("devise.mailer.reset_password_instructions.subject"))
   end
 
+  def confirmation_instructions(user, token, _opts = {})
+    @user = user
+    @token = token
+    view_mail(template_id, to: @user.unconfirmed_email, subject: t("devise.mailer.confirmation_instructions.subject"))
+  end
+
+  def email_changed(user, _opts = {})
+    @user = user
+    view_mail(template_id, to: @user.email, subject: t("devise.mailer.email_changed.subject"))
+  end
+
+  def password_change(user, _opts = {})
+    @user = user
+    view_mail(template_id, to: @user.email, subject: t("devise.mailer.password_change.subject"))
+  end
+
+  def invitation_instructions(user, token, _opts = {})
+    @user = user
+    @token = token
+    view_mail(template_id, to: @user.email, subject: t("devise.mailer.invitation_instructions.subject"))
+  end
+
 private
 
   def suspension_time

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -157,10 +157,6 @@ class User < ApplicationRecord
     elsif user.present? && user.invited_but_not_yet_accepted?
       UserMailer.notify_reset_password_disallowed_due_to_unaccepted_invitation(user).deliver_later
       user
-    elsif user.present?
-      token = user.send(:set_reset_password_token)
-      UserMailer.reset_password_instructions(user, token).deliver_later
-      user
     else
       super
     end

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,7 +1,0 @@
-<p>You can confirm the email change through the link below:</p>
-
-<p><%= link_to 'Confirm my account', confirmation_url(@resource, :confirmation_token => @token) %></p>
-
-<p>If you believe this has reached you in error, please ignore this email.<br />
-<p>Until you follow the link above, your registered address will be unchanged.</p>
-<p>The link will be valid for two weeks.</p>

--- a/app/views/devise/mailer/invitation_instructions.html.erb
+++ b/app/views/devise/mailer/invitation_instructions.html.erb
@@ -1,7 +1,0 @@
-<p>Someone has invited you to <%= t('department.name') %> Signon, you can accept it through the link below.</p>
-
-<p><%= link_to 'Accept invitation', accept_invitation_url(@resource, :invitation_token => @token) %></p>
-
-<p>If you don't want to accept the invitation, please ignore this email.<br />
-Your account won't be created until you access the link above and set your password.</p>
-<p>If you do not access the link within two weeks, it will expire.</p>

--- a/app/views/user_mailer/confirmation_instructions.text.erb
+++ b/app/views/user_mailer/confirmation_instructions.text.erb
@@ -1,7 +1,9 @@
-You can confirm your email change by copying-and-pasting the link below into your browser's URL bar:
+You can confirm the email change through the link below:
 
-<%= confirmation_url(@resource, :confirmation_token => @token) %>
+<%= confirmation_url(@user, :confirmation_token => @token) %>
 
 If you believe this has reached you in error, please ignore this email.
+
 Until you follow the link above, your registered address will be unchanged.
+
 The link will be valid for two weeks.

--- a/app/views/user_mailer/invitation_instructions.text.erb
+++ b/app/views/user_mailer/invitation_instructions.text.erb
@@ -1,6 +1,6 @@
-Someone has invited you to <%= t('department.name') %> Signon, you can accept it copying-and-pasting the link below into your browser's URL bar:
+Someone has invited you to <%= t('department.name') %> Signon, you can accept it through the link below.
 
-<%= accept_invitation_url(@resource, :invitation_token => @token) %>
+<%= accept_invitation_url(@user, invitation_token: @token) %>
 
 If you don't want to accept the invitation, please ignore this email.
 

--- a/test/integration/batch_inviting_users_test.rb
+++ b/test/integration/batch_inviting_users_test.rb
@@ -129,7 +129,7 @@ class BatchInvitingUsersTest < ActionDispatch::IntegrationTest
     invite_email = last_email_for(email)
     assert_not_nil invite_email
     assert_equal "noreply-signon-development@digital.cabinet-office.gov.uk", invite_email.from[0]
-    assert_nil invite_email.reply_to[0]
+    assert_nil invite_email.reply_to
 
     assert_match "Please confirm your account", invite_email.subject
   end

--- a/test/integration/email_change_test.rb
+++ b/test/integration/email_change_test.rb
@@ -64,7 +64,7 @@ class EmailChangeTest < ActionDispatch::IntegrationTest
 
           email = emails_sent_to("new@email.com").detect { |mail| mail.subject == "Please confirm your account" }
           assert email
-          assert email.body.include?("Accept invitation")
+          assert email.body.include?("/users/invitation/accept?invitation_token=")
           assert user.accept_invitation!
         end
       end
@@ -123,7 +123,7 @@ class EmailChangeTest < ActionDispatch::IntegrationTest
         fill_in "Email", with: "new@email.com"
         click_button "Change email"
 
-        first_email_sent_to("new@email.com").click_link("Confirm my account")
+        first_email_sent_to("new@email.com").find_link(href: false).click
 
         signout
         signin_with(create(:admin_user))


### PR DESCRIPTION
The default mailer methods defined by Devise will not use the correct methods to interface with Notify: we need to call `view_mail` and pass `template_id`, and overriding the `mail` method itself at a lower level doesn't work.

This involves creating one method for each type of mail sent by Devise (and `devise_invitable`) as well as templates for them — some of these can simply be moved, because we previously overrode the templates but not the methods. (However, rather than simply moving the plaintext template, I've converted the slightly-different HTML template to plaintext, as Notify will be converting it _back_ into HTML when it's sent).

This also partially reverts #1482, because that PR [overrode](https://github.com/alphagov/signon/pull/1482/files#diff-4676c008b11a5480d73d4a6de01e45b9R160) a method unnecessarily. (For reference: `super` there calls `devise_mailer` and `devise_mailer` is set to `UserMailer`, so calling `UserMailer` explicitly is unnecessary.)

https://trello.com/c/ZB29y9Y0/2050-signon-use-notify-instead-of-amazon-ses-%F0%9F%8D%90