### PR TITLE
Ensure @user.locked_at is set before displaying

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -111,11 +111,11 @@ private
   end
 
   def locked_time
-    @user.locked_at.to_s(:govuk_date)
+    @user.locked_at.present? ? @user.locked_at.to_s(:govuk_date) : "unknown"
   end
 
   def unlock_time
-    (@user.locked_at + 1.hour).to_s(:govuk_date)
+    @user.locked_at.present? ? (@user.locked_at + 1.hour).to_s(:govuk_date) : "unknown"
   end
 
   def account_name


### PR DESCRIPTION
If `@user` is nil then `to_s` is called as expected, but `NoneType#to_s` does not accept parameters, so instead of a `NoMethodError` it returns an `ArgumentError` which obscures the actual problem.