### PR TITLE
Remove obsolete troubleshooting documentation

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -4,12 +4,6 @@ This is a place to record workarounds to some common problems.
 
 ## User didn't receive password reset email
 
-Signon currently uses Amazon Simple Email Service (SES) to send emails to users. Amazon SES emails don’t pass strict [DMARC](https://dmarc.org/) setups. This means that some mail servers block Signon emails because they can't tell them apart from phishing or spoof emails.
-
-The proper fix to this is to move Signon to use GOV.UK Notify, but until that happens we need to find a way to allow users to reset the passwords.
-
-### Finding the reset password link
-
 All the emails do is send users a link to reset their password. We can find this link and give it to them directly.
 
 First, open a Rails console (Signon is on the backend box in Carrenza).


### PR DESCRIPTION
This refers specifically to an error which was fixed by the Notify migration