### PR TITLE
Handle missing users in the bulk organisation updater

### DIFF
--- a/lib/tasks/data_hygiene.rake
+++ b/lib/tasks/data_hygiene.rake
@@ -1,6 +1,8 @@
 namespace :data_hygiene do
   desc "Bulk update the organisations associated with users."
   task :bulk_update_organisation, %i[csv_filename] => :environment do |_, args|
-    DataHygiene::BulkOrganisationUpdater.call(args[:csv_filename])
+    unless DataHygiene::BulkOrganisationUpdater.call(args[:csv_filename])
+      abort "bulk updating organisations encountered errors"
+    end
   end
 end

--- a/test/lib/data_hygiene/bulk_organisation_updater_test.rb
+++ b/test/lib/data_hygiene/bulk_organisation_updater_test.rb
@@ -30,9 +30,7 @@ class DataHygiene::BulkOrganisationUpdaterTest < ActiveSupport::TestCase
       a@b.com,b@c.com,new-organisation
     CSV
 
-    assert_raises ActiveRecord::RecordNotFound do
-      process(csv_file)
-    end
+    assert_not process(csv_file)
   end
 
   test "it changes the email address" do


### PR DESCRIPTION
If a user can't be found, check if one exists with the new email
address, as they could have already been moved. If they have already
been moved, print a warning, otherwise, print an error.

Keep going regardless of warnings or errors, but make sure to fail at
the end if any errors were encountered along the way.