### PR TITLE
Add govuk_editor permission to all Publisher users

### DIFF
--- a/lib/tasks/govuk_editor.rake
+++ b/lib/tasks/govuk_editor.rake
@@ -1,0 +1,18 @@
+namespace :govuk_editor do
+  desc "Assign govuk_editor permission to everyone who has access to Publisher."
+  task assign: :environment do
+    application = Doorkeeper::Application.find_by!(name: "Publisher")
+    permission = SupportedPermission.find_by!(application: application, name: "govuk_editor")
+
+    users = User
+      .with_status(User::USER_STATUS_ACTIVE)
+      .joins(:supported_permissions)
+      .where(supported_permissions: { application: application })
+      .distinct
+
+    users.find_each do |user|
+      puts "#{user.name} #{user.email}"
+      user.application_permissions.create!(supported_permission: permission)
+    end
+  end
+end


### PR DESCRIPTION
This adds a task which when run adds the `govuk_editor` permission to all users who currently have access to the Publisher application. This is a necessary step towards adding a new permission later which will only give permission to edit Welsh content in Publisher.

Publisher will be updated to recognise the `govuk_editor` permission as granting the ability to perform every action on an edition. The upcoming `welsh_editor` permission will only grant access to editing Welsh language editions.

Once run the task can be deleted.

[Trello Card](https://trello.com/c/Hq2qgwiI/2155-give-permission-in-publisher-for-welsh-teams-in-departments-to-update-only-welsh-content)