### PR TITLE
Handle Notify BadRequestError

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,6 +14,7 @@ class ApplicationController < ActionController::Base
   end
 
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
+  rescue_from Notifications::Client::BadRequestError, with: :notify_bad_request
 
   def after_sign_out_path_for(_resource_or_scope)
     new_user_session_path
@@ -59,6 +60,10 @@ private
   def user_not_authorized(_exception)
     flash[:alert] = "You do not have permission to perform this action."
     redirect_to root_path
+  end
+
+  def notify_bad_request(_exception)
+    render plain: "Error: One or more recipients not in GOV.UK Notify team (code: 400)", status: :bad_request
   end
 
   def redirect_to_prior_flow(args = {})

--- a/test/integration/inviting_users_test.rb
+++ b/test/integration/inviting_users_test.rb
@@ -188,4 +188,32 @@ class InvitingUsersTest < ActionDispatch::IntegrationTest
       assert_equal %w[editor], u.permissions_for(application_one)
     end
   end
+
+  context "Notify service is using an allowlist or is in trial mode" do
+    setup do
+      admin = create(:user, role: "admin")
+      visit root_path
+      signin_with(admin)
+    end
+
+    should "raise an error if email address is not in Notify team" do
+      raises_exception = lambda do |_request, _params|
+        response = MiniTest::Mock.new
+        response.expect :code, 400
+        response.expect :body, "Can't send to this recipient using a team-only API key"
+        raise Notifications::Client::BadRequestError, response
+      end
+
+      User.stub(:invite!, raises_exception) do
+        perform_enqueued_jobs do
+          visit new_user_invitation_path
+          fill_in "Name", with: "Fred Bloggs"
+          fill_in "Email", with: "fred@example.com"
+          click_button "Create user and send email"
+
+          assert_response_contains "Error: One or more recipients not in GOV.UK Notify team (code: 400)"
+        end
+      end
+    end
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,6 +8,7 @@ require File.expand_path("../config/environment", __dir__)
 require "rails/test_help"
 require "shoulda/context"
 require "webmock/minitest"
+require "minitest/autorun"
 require "mocha/minitest"
 
 class ActiveSupport::TestCase


### PR DESCRIPTION
When using a Notify service with an e-mail address allow list, or in trial mode, submitting an email-addresses that is not included in the team will trigger a `Notifications::Client::BadRequestError` with the message `Can't send to this recipient using a team-only API key`.

This PR will allow Signon to gracefully handle this error.

[Trello](https://trello.com/c/FEGnSfFP/2161-3-handle-not-in-team-notify-error-in-signon)