### PR TITLE
Replace phantom js

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,8 +51,9 @@ group :development do
 end
 
 group :development, :test do
+  gem "govuk_test"
   gem "jasmine"
-  gem "phantomjs", require: "phantomjs/poltergeist"
+  gem "jasmine_selenium_runner"
   gem "pry-byebug"
   gem "rubocop-govuk"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,6 +82,7 @@ GEM
     bootstrap-sass (3.4.1)
       autoprefixer-rails (>= 5.2.1)
       sassc (>= 2.0.0)
+    brakeman (4.10.0)
     browser (4.2.0)
     builder (3.2.4)
     byebug (11.1.3)
@@ -96,6 +97,7 @@ GEM
     capybara-email (3.0.2)
       capybara (>= 2.4, < 4.0)
       mail
+    childprocess (3.0.0)
     chronic (0.10.2)
     chunky_png (1.3.12)
     cliver (0.3.2)
@@ -168,6 +170,12 @@ GEM
       sidekiq (>= 5, < 6)
       sidekiq-logging-json (~> 0.0)
       sidekiq-statsd (>= 2.1)
+    govuk_test (2.0.0)
+      brakeman (~> 4.6)
+      capybara
+      puma
+      selenium-webdriver (>= 3.142)
+      webdrivers (>= 4)
     hashdiff (1.0.1)
     http-accept (1.7.0)
     http-cookie (1.0.3)
@@ -180,6 +188,9 @@ GEM
       rack (>= 1.2.1)
       rake
     jasmine-core (3.6.0)
+    jasmine_selenium_runner (3.0.0)
+      jasmine (~> 3.0)
+      selenium-webdriver (~> 3.8)
     jquery-rails (4.3.5)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -260,6 +271,8 @@ GEM
       byebug (~> 11.0)
       pry (~> 0.13.0)
     public_suffix (4.0.6)
+    puma (5.0.2)
+      nio4r (~> 2.0)
     pundit (2.1.0)
       activesupport (>= 3.0.0)
     rack (2.0.9)
@@ -349,6 +362,7 @@ GEM
     rubocop-rspec (1.42.0)
       rubocop (>= 0.87.0)
     ruby-progressbar (1.10.1)
+    rubyzip (2.3.0)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
     sassc (2.4.0)
@@ -359,6 +373,9 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
+    selenium-webdriver (3.142.7)
+      childprocess (>= 0.5, < 4.0)
+      rubyzip (>= 1.2.2)
     sentry-raven (3.0.4)
       faraday (>= 1.0)
     shoulda-context (2.0.0)
@@ -404,6 +421,10 @@ GEM
       macaddr (~> 1.0)
     warden (1.2.9)
       rack (>= 2.0.9)
+    webdrivers (4.4.1)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (>= 3.0, < 4.0)
     webmock (3.9.1)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -448,7 +469,9 @@ DEPENDENCIES
   govuk_app_config
   govuk_publishing_components
   govuk_sidekiq
+  govuk_test
   jasmine
+  jasmine_selenium_runner
   json
   kaminari
   lhm
@@ -459,7 +482,6 @@ DEPENDENCIES
   mysql2
   nokogiri
   pg
-  phantomjs
   plek
   poltergeist
   pry-byebug

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,3 @@
-#!/usr/bin/env rake
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 

--- a/spec/javascripts/support/jasmine_helper.rb
+++ b/spec/javascripts/support/jasmine_helper.rb
@@ -1,0 +1,7 @@
+require "jasmine_selenium_runner/configure_jasmine"
+
+class HeadlessChromeJasmineConfigurer < JasmineSeleniumRunner::ConfigureJasmine
+  def selenium_options
+    { options: GovukTest.headless_chrome_selenium_options }
+  end
+end

--- a/spec/javascripts/support/jasmine_selenium_runner.yml
+++ b/spec/javascripts/support/jasmine_selenium_runner.yml
@@ -1,0 +1,2 @@
+browser: chrome
+configuration_class: HeadlessChromeJasmineConfigurer

--- a/test/integration/super_admin_reset_two_step_verification_test.rb
+++ b/test/integration/super_admin_reset_two_step_verification_test.rb
@@ -34,7 +34,9 @@ class SuperAdminResetTwoStepVerificationTest < ActionDispatch::IntegrationTest
       perform_enqueued_jobs do
         assert_response_contains "2-step verification enabled"
 
-        click_link "Reset 2-step verification"
+        accept_alert do
+          click_link "Reset 2-step verification"
+        end
 
         assert_response_contains "Reset 2-step verification for #{@user.email}"
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,6 +11,8 @@ require "webmock/minitest"
 require "minitest/autorun"
 require "mocha/minitest"
 
+GovukTest.configure
+
 class ActiveSupport::TestCase
   include FactoryBot::Syntax::Methods
 
@@ -40,24 +42,24 @@ class ActionController::TestCase
   end
 end
 
-Capybara.server = :webrick
-
-require "capybara/rails"
-
-Capybara.register_driver :rack_test do |app|
-  # capybara/rails sets up the rack-test driver to respect data-method attributes.
-  # https://github.com/jnicklas/capybara/blob/2.2_stable/lib/capybara/rails.rb#L18-L20
-  #
-  # This is problematic because it's not a javascript driver, and therefore isn't running
-  # the javascript that would use these, and insert the CSRF token.
-  #
-  # It's better to not respect these attributes in this driver, because it then behaves like
-  # a normal browser with javascript disabled.
-  Capybara::RackTest::Driver.new(app)
-end
-
-require "capybara/poltergeist"
-Capybara.javascript_driver = :poltergeist
+# Capybara.server = :webrick
+#
+# require "capybara/rails"
+#
+# Capybara.register_driver :rack_test do |app|
+#   # capybara/rails sets up the rack-test driver to respect data-method attributes.
+#   # https://github.com/jnicklas/capybara/blob/2.2_stable/lib/capybara/rails.rb#L18-L20
+#   #
+#   # This is problematic because it's not a javascript driver, and therefore isn't running
+#   # the javascript that would use these, and insert the CSRF token.
+#   #
+#   # It's better to not respect these attributes in this driver, because it then behaves like
+#   # a normal browser with javascript disabled.
+#   Capybara::RackTest::Driver.new(app)
+# end
+#
+# require "capybara/poltergeist"
+# Capybara.javascript_driver = :poltergeist
 
 require "support/user_helpers"
 require "support/email_helpers"
@@ -70,6 +72,8 @@ class ActiveRecord::Base
     @@shared_connection || retrieve_connection
   end
 end
+
+require "capybara/rails"
 
 # Forces all threads to share the same connection. This works on
 # Capybara because it starts the web server in a thread.


### PR DESCRIPTION
Trello: https://trello.com/c/PlDX9ps8/180-run-govuk-docker-containers-as-root-to-allow-application-specific-mounts

This commit changes this repo to use the govuk_test gem which provides
a Chrome headless Selenium configuration for Capybara. It then uses
the govuk_test to configure Jasmine for selenium to use the same Chrome
headless configuration.

This has been done to reflect that GOV.UK convention is to use Chrome
Headless over PhantomJS - PhantomJS development has paused. The use of
govuk_test prepares this repo for an upcoming govuk-docker update [1].

[1]: https://github.com/alphagov/govuk-docker/pull/394
