### PR TITLE
Manually set APHA parent to Defra 

### DIFF
--- a/lib/organisations_fetcher.rb
+++ b/lib/organisations_fetcher.rb
@@ -5,10 +5,9 @@ require "gds_api/organisations"
 # membership of organisations.
 class OrganisationsFetcher
   def call
-    organisation_relationships = {}
-    organisations.each do |organisation_data|
+    organisation_relationships = organisations.each_with_object({}) do |organisation_data, memo|
       update_or_create_organisation(organisation_data)
-      organisation_relationships[organisation_data["details"]["slug"]] = child_organisation_slugs(organisation_data)
+      memo[organisation_data["details"]["slug"]] = child_organisation_slugs(organisation_data)
     end
     # Now that any new organisations have been created and any slug changes
     # have been applied, we can safely tie together organisations
@@ -39,17 +38,18 @@ private
       abbreviation: organisation_data["details"]["abbreviation"],
       closed: organisation_data["details"]["govuk_status"] == "closed",
     }
+
     organisation.update!(update_data)
   end
 
   def child_organisation_slugs(organisation_data)
-    organisation_data["child_organisations"].collect { |child_organisation| child_organisation["id"].split("/").last }
+    organisation_data["child_organisations"].map { |child_organisation| child_organisation["id"].split("/").last }
   end
 
   def update_ancestry(organisation_relationships)
     organisation_relationships.each do |organisation_slug, child_organisation_slugs|
-      parent = Organisation.find_by(slug: organisation_slug)
-      Organisation.where(slug: child_organisation_slugs).map do |child_organisation|
+      parent = Organisation.find_by!(slug: organisation_slug)
+      Organisation.where(slug: child_organisation_slugs).find_each do |child_organisation|
         # TODO: this ignores that organisations can have multiple parents. I think organisations will
         # end up with the parent that appears last in the API response(s).
         #

--- a/lib/organisations_fetcher.rb
+++ b/lib/organisations_fetcher.rb
@@ -20,8 +20,7 @@ class OrganisationsFetcher
 private
 
   def organisations
-    base_uri = Plek.new.website_root
-    GdsApi::Organisations.new(base_uri).organisations.with_subsequent_pages
+    @organisations ||= GdsApi.organisations.organisations.with_subsequent_pages
   end
 
   def update_or_create_organisation(organisation_data)

--- a/test/lib/organisations_fetcher_test.rb
+++ b/test/lib/organisations_fetcher_test.rb
@@ -113,4 +113,17 @@ class OrganisationsFetcherTest < ActiveSupport::TestCase
       OrganisationsFetcher.new.call
     end
   end
+
+  OrganisationsFetcher::MANUAL_PARENT_FIXES.each do |child_slug, parent_slug|
+    test "it manually fixes #{child_slug}" do
+      child = create(:organisation, name: "Child", slug: child_slug)
+      parent = create(:organisation, name: "Parent", slug: parent_slug)
+
+      stub_organisations_api_has_organisations([child.slug, parent.slug])
+
+      OrganisationsFetcher.new.call
+
+      assert_equal child.reload.parent, parent
+    end
+  end
 end


### PR DESCRIPTION
This updates the organisation fetcher to manually fix APHA to set its parent to Defra. This introduces tech debt, but it was deemed to be the most practical option. Defra is a better parent for APHA than what it ends up being set to (The Welsh Government) as often editors in Defra will need access to content published by APHA.

It's worth noting, we've introduced a migration to make this change on three different occasions, but each time it's wiped when the fetcher runs:

- #574
- #1157
- #1481

At the moment the chosen parent will be the one that is last in the list ordered alphabetically. We wondered whether changing it to be the first in the list as stored in Whitehall was better, but although it fixes the parent for APHA, it introduces some different parents to other organisations that doesn't seem quite right. We felt that this wasn't a decision for us to make.

[Trello Card](https://trello.com/c/7koTf4OD/2293-investigate-prevent-parent-organisation-being-swapped-for-another-in-signon-timebox-2-days)