### PR TITLE
Remove redundant config

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,8 +8,6 @@ node {
   govuk.setEnvar("DEVISE_SECRET_KEY", UUID.randomUUID().toString())
 
   govuk.buildProject(
-    beforeTest: { sh("yarn install") },
     brakeman: true,
-    sassLint: false,
   )
 }


### PR DESCRIPTION
The sassLint option was removed in https://github.com/alphagov/govuk-jenkinslib/pull/80
And the Yarn install step is unnecessary as of https://github.com/alphagov/govuk-jenkinslib/pull/82