### PR TITLE
Fix issue with Chromedriver not clicking a button off the viewport

### DIFF
--- a/test/integration/password_change_test.rb
+++ b/test/integration/password_change_test.rb
@@ -97,6 +97,7 @@ class PasswordChangeTest < ActionDispatch::IntegrationTest
       fill_in "Confirm new password", with: "stronger password purple monkey dishwasher"
       refute_response_contains("The confirmation must match the new password")
 
+      scroll_to page.find("button", text: "Save password", visible: false)
       click_button "Save password"
 
       assert_response_contains("Your password was changed successfully")


### PR DESCRIPTION
A recent upgrade to Chromedriver means that `click_button` only works
if the element is visible on the screen.  Which it's not in this test.
So fix the test by scrolling to the button first.