### PR TITLE
Add API for bearer token creation and rotation

### DIFF
--- a/app/controllers/api/v1/authorisations_controller.rb
+++ b/app/controllers/api/v1/authorisations_controller.rb
@@ -1,0 +1,95 @@
+class Api::V1::AuthorisationsController < ApplicationController
+  before_action :authenticate
+  before_action :validate_create_params, only: %w[create]
+  before_action :validate_test_params, only: %w[test]
+  before_action :api_user
+
+  skip_after_action :verify_authorized
+  protect_from_forgery with: :null_session
+
+  rescue_from ActionController::ParameterMissing, with: :missing_params_error
+  rescue_from ActiveRecord::RecordNotFound, with: :not_found_error
+
+  respond_to :json
+
+  def create
+    authorisation = api_user.authorisations.build(expires_in: ApiUser::DEFAULT_TOKEN_LIFE)
+    authorisation.application_id = application.id
+    ActiveRecord::Base.transaction do
+      authorisation.save!
+      grant_app_permissions!(authorisation, params.fetch(:permissions, []))
+    end
+    EventLog.record_event(
+      api_user,
+      EventLog::ACCESS_TOKEN_GENERATED,
+      initiator: api_user,
+      application: authorisation.application,
+      ip_address: request.remote_ip,
+    )
+    render json: { application_name: authorisation.application.name, token: authorisation.token }
+  end
+
+  def test
+    authorisation = api_user.authorisations
+      .find_by!(
+        application: application,
+        token: params.require(:token),
+      )
+
+    render json: { application_name: authorisation.application.name }
+  end
+
+private
+
+  BEARER_TOKEN_VAR = "SIGNON_ADMIN_PASSWORD".freeze
+
+  def authenticate
+    authenticate_or_request_with_http_token do |token, _options|
+      if ENV.key? BEARER_TOKEN_VAR
+        ActiveSupport::SecurityUtils.secure_compare(token, ENV.fetch(BEARER_TOKEN_VAR))
+      end
+    end
+  end
+
+  def api_user
+    @api_user ||= begin
+      ApiUser.find_by!(email: params.require(:api_user_email))
+    end
+  end
+
+  def application
+    @application ||= Doorkeeper::Application.find_by!(name: params.require(:application_name))
+  end
+
+  def grant_app_permissions!(authorisation, permissions)
+    all_permissions = %w[signin] + permissions
+    @api_user.grant_application_permissions(authorisation.application, all_permissions)
+  end
+
+  def missing_params_error(exception)
+    render json: { error: exception.message }, status: :bad_request
+  end
+
+  def not_found_error(_exception)
+    render json: { error: "Not found" }, status: :not_found
+  end
+
+  def assert_no_missing_params(required_params)
+    missing = required_params
+                .index_with { |key| params[key] }
+                .select { |_k, v| v.blank? }
+                .keys
+
+    return if missing.empty?
+
+    raise ActionController::ParameterMissing, missing.to_sentence
+  end
+
+  def validate_create_params
+    assert_no_missing_params(%i[application_name api_user_email])
+  end
+
+  def validate_test_params
+    assert_no_missing_params(%i[application_name api_user_email token])
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,6 +65,13 @@ Rails.application.routes.draw do
     end
   end
 
+  namespace :api do
+    namespace :v1 do
+      post "authorisations/test", to: "authorisations#test"
+      post "authorisations", to: "authorisations#create"
+    end
+  end
+
   # Gracefully handle GET on page (e.g. hit refresh) reached by a render to a POST
   match "/users/:id" => redirect("/users/%{id}/edit"), via: :get
   match "/suspensions/:id" => redirect("/users/%{id}/edit"), via: :get

--- a/test/integration/api/authorisations_test.rb
+++ b/test/integration/api/authorisations_test.rb
@@ -1,0 +1,99 @@
+require "test_helper"
+
+class AuthorisationsTest < ActionDispatch::IntegrationTest
+  setup do
+    @api_user = create(:api_user)
+    @application = create(:application)
+  end
+
+  create_endpoint = "/api/v1/authorisations"
+  test_endpoint = "/api/v1/authorisations/test"
+  endpoints_with_params = [create_endpoint, test_endpoint].zip([
+    %w[application_name api_user_email],
+    %w[application_name api_user_email token],
+  ])
+
+  endpoints_with_params.each do |endpoint, _required_params|
+    test "endpoint #{endpoint} responds with a 401 error when an invalid token is given" do
+      ENV["SIGNON_ADMIN_PASSWORD"] = SecureRandom.uuid
+      post endpoint, headers: { "HTTP_AUTHORIZATION" => "Bearer invalid-token" }
+      assert_unauthorized(response)
+    end
+
+    test "endpoint #{endpoint} responds with a 401 error when SIGNON_ADMIN_PASSWORD env var is unset" do
+      ENV["SIGNON_ADMIN_PASSWORD"] = nil
+      post endpoint
+      assert_unauthorized(response)
+    end
+  end
+
+  endpoints_with_params.each do |endpoint, required_params|
+    test "endpoint #{endpoint} responds with a 400 when required params are missing" do
+      request(endpoint)
+      assert_equal 400, response.status
+      assert_equal JSON.generate({ error: "param is missing or the value is empty: #{required_params.to_sentence}" }), response.body
+    end
+  end
+
+  test "#create provided api_user_email is invalid" do
+    request(create_endpoint, params: {
+      api_user_email: "invalid@example.org",
+      application_name: @application.name,
+    })
+    assert_equal 404, response.status
+    assert_equal JSON.generate({ error: "Not found" }), response.body
+  end
+
+  test "#create provided application_name is invalid" do
+    request(create_endpoint, params: {
+      api_user_email: @api_user.email,
+      application_name: "Invalid name",
+    })
+    assert_equal JSON.generate({ error: "Not found" }), response.body
+    assert_equal 404, response.status
+  end
+
+  test "#create adds an application auth token to an api_user" do
+    request(create_endpoint, params: {
+      api_user_email: @api_user.email,
+      application_name: @application.name,
+    })
+    assert_equal 200, response.status
+    body = JSON.parse(response.body)
+    assert_equal @application.name, body.fetch("application_name")
+    assert_equal body.fetch("token").length, 43
+    assert_match(/[A-Za-z0-9]\w+/, body.fetch("token"))
+  end
+
+  test "#test confirms that a token has been created" do
+    request(create_endpoint, params: {
+      api_user_email: @api_user.email,
+      application_name: @application.name,
+    })
+    assert_equal 200, response.status
+    token = JSON.parse(response.body).fetch("token")
+    request(test_endpoint, params: {
+      api_user_email: @api_user.email,
+      application_name: @application.name,
+      token: token,
+    })
+    assert_equal 200, response.status
+    assert_equal JSON.generate(application_name: @application.name), response.body
+  end
+
+  #
+  # Helpers
+  #
+
+  def assert_unauthorized(response)
+    assert_equal "HTTP Token: Access denied.\n", response.body
+    assert_equal 401, response.status
+  end
+
+  def request(endpoint, params: {})
+    token = SecureRandom.uuid
+    ENV["SIGNON_ADMIN_PASSWORD"] = token
+    auth_header = { "HTTP_AUTHORIZATION" => "Bearer #{token}" }
+    post endpoint, params: params, headers: auth_header
+  end
+end


### PR DESCRIPTION
This commit adds an API for the automated creation and rotation of ApiUser bearer tokens

## Motivation

**We don't rotate secrets generated by Signon often**. It is a manual process to generate a new bearer token, add it to our secrets store (hiera-eyaml), deploy Puppet, and then delete the old token.

However, we will soon be moving GOV.UK from EC2 to [ECS](https://aws.amazon.com/ecs/) (the replatforming team's goal).

As a side effect of the migration, we will change our secret store from the git-based hiera-eyaml (puppet/govuk-secrets) to AWS SecretsManager.

This gives us an opportunity to automate the rotation of Signon credentials, since AWS supports rotation of SecretsManager credentials natively.

## Implementation

Use a [SecretsManager Rotation Lambda](https://docs.aws.amazon.com/secretsmanager/latest/userguide/rotating-secrets-lambda-function-overview.html) to create and rotate the bearer tokens (using the API added in this PR) for the cluster. The API is not enabled in the EC2 environment, and uses bearer token auth and IP-restriction in ECS.

We considered implementing a Terraform provider for Signon. However, Terraform would likely store the secret in its statefile so this was a blocker to this approach.

## Benefit

This enables us to rotate bearer tokens automatically.

## Further work

* Implement a rotation Lambda for creation and rotation of bearer tokens in ECS (https://github.com/alphagov/govuk-infrastructure/pull/202)
* Automate deletion of old unused bearer tokens (only those created by the new platform in ECS)
* Implement rotation of OAuth application secret keys using a Lambda
* Remove UI for Applications and ApiUsers, and move all config into code (after replatforming).