### PR TITLE
Separate out API token healthcheck & add RFC 141 healthcheck endpoints

### DIFF
--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -1,0 +1,7 @@
+class HealthcheckController < ApplicationController
+  skip_after_action :verify_authorized
+
+  def api_tokens
+    render json: Healthcheck::ApiTokens.new.to_hash
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,12 @@ Rails.application.routes.draw do
         Healthcheck::ApiTokens,
       )
 
+  get "/healthcheck/live", to: proc { [200, {}, %w[OK]] }
+  get "/healthcheck/ready", to: GovukHealthcheck.rack_response(
+    GovukHealthcheck::ActiveRecord,
+    GovukHealthcheck::SidekiqRedis,
+  )
+
   get "/healthcheck/api-tokens", to: "healthcheck#api_tokens"
 
   use_doorkeeper do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,8 @@ Rails.application.routes.draw do
         Healthcheck::ApiTokens,
       )
 
+  get "/healthcheck/api-tokens", to: "healthcheck#api_tokens"
+
   use_doorkeeper do
     controllers authorizations: "signin_required_authorizations"
   end

--- a/lib/healthcheck/api_tokens.rb
+++ b/lib/healthcheck/api_tokens.rb
@@ -34,11 +34,18 @@ module Healthcheck
     end
 
     def status
-      return GovukHealthcheck::CRITICAL if expiring_tokens.any?(&:critical?)
+      return :critical if expiring_tokens.any?(&:critical?)
 
-      return GovukHealthcheck::WARNING if expiring_tokens.any?
+      return :warning if expiring_tokens.any?
 
-      GovukHealthcheck::OK
+      :ok
+    end
+
+    def to_hash
+      {
+        message: message,
+        status: status,
+      }
     end
 
   private

--- a/test/lib/healthcheck/api_tokens_test.rb
+++ b/test/lib/healthcheck/api_tokens_test.rb
@@ -4,32 +4,32 @@ class PermissionUpdaterTest < ActiveSupport::TestCase
   context "status" do
     should "return 'OK' when no tokens are expiring" do
       check = Healthcheck::ApiTokens.new
-      assert_equal GovukHealthcheck::OK, check.status
+      assert_equal :ok, check.status
     end
 
     should "return 'WARNING' when a token is getting old" do
       make_api_user_token(expires_in: Healthcheck::ApiTokens::WARNING_THRESHOLD)
       check = Healthcheck::ApiTokens.new
-      assert_equal GovukHealthcheck::WARNING, check.status
+      assert_equal :warning, check.status
     end
 
     should "return 'CRITICAL' when a token is almost expired" do
       make_api_user_token(expires_in: Healthcheck::ApiTokens::CRITICAL_THRESHOLD)
       check = Healthcheck::ApiTokens.new
-      assert_equal GovukHealthcheck::CRITICAL, check.status
+      assert_equal :critical, check.status
     end
 
     should "return 'CRITICAL' even when if we have a 'WARNING'" do
       make_api_user_token(expires_in: Healthcheck::ApiTokens::WARNING_THRESHOLD)
       make_api_user_token(expires_in: Healthcheck::ApiTokens::CRITICAL_THRESHOLD)
       check = Healthcheck::ApiTokens.new
-      assert_equal GovukHealthcheck::CRITICAL, check.status
+      assert_equal :critical, check.status
     end
 
     should "return 'OK' when the tokens are for normal users" do
       make_normal_user_token(expires_in: Healthcheck::ApiTokens::CRITICAL_THRESHOLD)
       check = Healthcheck::ApiTokens.new
-      assert_equal GovukHealthcheck::OK, check.status
+      assert_equal :ok, check.status
     end
   end
 


### PR DESCRIPTION
The API token check has value, but not as a readiness healthcheck.  So,
following a pattern from whitehall and a few other apps, I'm giving it
its own route, and it'll get its own Icinga alert.

Once govuk-puppet has been updated, the old endpoint can be removed.

See the RFC for more details.

---

[Trello card](https://trello.com/c/tl6RV1el/723-improve-govuk-healthchecks)