### PR TITLE
Modify config to allow custom assets host and location

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ ENV DATABASE_URL mysql2://root:root@mysql/signon
 ENV GOVUK_APP_NAME signon
 ENV PORT 3016
 ENV TEST_DATABASE_URL mysql2://root:root@mysql/signon_test
+ENV ASSETS_PREFIX /assets/signon
 
 RUN mkdir $APP_HOME
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -63,6 +63,12 @@ module Signon
 
     config.action_dispatch.return_only_media_type_on_content_type = true
 
+    # allows another assets location to be specified if assets are stored in non-default path
+    config.assets.prefix = ENV.fetch("ASSETS_PREFIX", "/assets")
+
+    # allows another asset host to be specified if different from app host
+    config.asset_host = ENV.fetch("ASSET_HOST", nil)
+
     # Using a sass css compressor causes a scss file to be processed twice
     # (once to build, once to compress) which breaks the usage of "unquote"
     # to use CSS that has same function names as SCSS such as max.


### PR DESCRIPTION
Currently, assets are served by [nginx](https://github.com/alphagov/govuk-puppet/blob/9da822c3bb38e6565e7835e66ecadc43cb35f025/modules/govuk/manifests/apps/publisher.pp#L154)
in EC2 while in ECS we'll serve assets using the same [`CloudFront and S3`](alphagov/govuk-infrastructure#192)
infrastructure across all Backend Rails apps.

Being able to set `config.asset_host` will allow the Signon app to
point requests to its assets to the `CloudFront and S3` infrastructure.
While setting `config.assets.prefix`, will allow differentiation of assets
from different apps based on path in the same S3 bucket.

This change should be a no-op in the current platform because the
defaults for both of these config values is nil, and we won't set
these env vars with Puppet.

In addtiion, there is a need to build the docker images with the
ASSETS_PREFIX=/assets/signon so that signon directs client to this
prefix path for its assets which are stored in a S3 bucket.

Ref:
1. [trello card](https://trello.com/c/XwlrmXRJ/458-enable-other-rails-app-to-serve-assets-the-new-way-ie-cloudfront-s3)
2. [govuk-infrastructure pr](alphagov/govuk-infrastructure#221)