### PR TITLE
Add bootstrap rake task

### DIFF
--- a/config/api_users.json
+++ b/config/api_users.json
@@ -1,0 +1,26 @@
+[
+  {
+    "name": "Content Store",
+    "slug": "content-store"
+  },
+  {
+    "name": "Draft Content Store",
+    "slug": "draft-content-store"
+  },
+  {
+    "name": "Frontend App",
+    "slug": "frontend"
+  },
+  {
+    "name": "Publisher App",
+    "slug": "publisher"
+  },
+  {
+    "name": "Publishing API",
+    "slug": "publishing-api"
+  },
+  {
+    "name": "Static",
+    "slug": "static"
+  }
+]

--- a/config/applications.json
+++ b/config/applications.json
@@ -1,0 +1,66 @@
+[
+  {
+    "name": "Content Store",
+    "description": "Central store for current live content on GOV.UK",
+    "permissions": [
+      "signin",
+      "user_update_permission"
+    ],
+    "redirect_path": "/auth/gds/callback",
+    "subdomain_name": "content-store"
+  },
+  {
+    "name": "Draft Content Store",
+    "description": "Central store for current draft content on GOV.UK",
+    "permissions": [
+      "signin",
+      "user_update_permission"
+    ],
+    "redirect_path": "/auth/gds/callback",
+    "subdomain_name": "draft-content-store"
+  },
+  {
+    "name": "Draft Router API",
+    "description": "Manages the draft router database",
+    "permissions": [
+      "signin",
+      "user_update_permission"
+    ],
+    "redirect_path": "/auth/gds/callback",
+    "subdomain_name": "draft-router-api"
+  },
+  {
+    "name": "Publisher",
+    "description": "Publish mainstream content",
+    "permissions": [
+      "govuk_editor",
+      "signin",
+      "skip_review",
+      "user_update_permission",
+      "welsh_editor"
+    ],
+    "redirect_path": "/auth/gds/callback",
+    "subdomain_name": "publisher"
+  },
+  {
+    "name": "Publishing API",
+    "description": "Central store for all publishing content on GOV.UK",
+    "permissions": [
+      "signin",
+      "user_update_permission",
+      "view_all"
+    ],
+    "redirect_path": "/auth/gds/callback",
+    "subdomain_name": "publishing-api"
+  },
+  {
+    "name": "Router API",
+    "description": "Manages the router database",
+    "permissions": [
+      "signin",
+      "user_update_permission"
+    ],
+    "redirect_path": "/auth/gds/callback",
+    "subdomain_name": "router-api"
+  }
+]

--- a/lib/configure/api_users.rb
+++ b/lib/configure/api_users.rb
@@ -1,0 +1,33 @@
+module Configure
+  class ApiUsers
+    def initialize(namespace:, resource_name_prefix:)
+      @namespace = namespace
+      @name_prefix = resource_name_prefix
+    end
+
+    def configure!(api_users)
+      api_users.each do |api_user|
+        email = [namespace, "#{api_user.fetch('slug')}@digital.cabinet-office.gov.uk"].compact.join("-")
+        find_or_create_api_user(
+          name: [name_prefix, api_user.fetch("name")].join,
+          email: email,
+        )
+      end
+    end
+
+  private
+
+    attr_reader :namespace, :name_prefix
+
+    def find_or_create_api_user(name:, email:)
+      return if ApiUser.exists?(email: email)
+
+      password = SecureRandom.urlsafe_base64
+      api_user = ApiUser.new(name: name, email: email,
+                             password: password, password_confirmation: password)
+      api_user.skip_confirmation!
+      api_user.api_user = true
+      api_user.save!
+    end
+  end
+end

--- a/lib/configure/applications.rb
+++ b/lib/configure/applications.rb
@@ -1,0 +1,37 @@
+module Configure
+  class Applications
+    def initialize(public_domain:, resource_name_prefix:)
+      @public_domain = public_domain
+      @name_prefix = resource_name_prefix
+    end
+
+    def configure!(applications = [])
+      applications.each do |application|
+        home_uri = "https://#{application.fetch('subdomain_name')}.#{public_domain}"
+        redirect_url = URI.join(home_uri, application.fetch("redirect_path")).to_s
+        find_or_create_application(
+          name: [name_prefix, application.fetch("name")].join,
+          redirect_uri: redirect_url,
+          description: application.fetch("description"),
+          home_uri: home_uri,
+          supported_permissions: application.fetch("permissions"),
+        )
+      end
+    end
+
+  private
+
+    attr_reader :public_domain, :name_prefix
+
+    def find_or_create_application(name:, redirect_uri:, description:, home_uri:, supported_permissions:)
+      application = Doorkeeper::Application.find_or_create_by!(name: name) do |app|
+        app.redirect_uri = redirect_uri
+        app.description = description
+        app.home_uri = home_uri
+      end
+      supported_permissions.each do |permission|
+        SupportedPermission.find_or_create_by!(application_id: application.id, name: permission)
+      end
+    end
+  end
+end

--- a/lib/tasks/bootstrap.rake
+++ b/lib/tasks/bootstrap.rake
@@ -1,0 +1,28 @@
+namespace :bootstrap do
+  desc "Create all resources for bootrapping an environment
+    Usage:
+      boostrap:all[my-test.publishing.service.gov.uk,my-test-env]
+      boostrap:all[integration.publishing.service.gov.uk]
+  "
+  task :all, %i[public_domain resource_prefix] => :environment do |_, args|
+    public_domain = args.public_domain
+    raise ArgumentError, "Provide a public_domain!" if public_domain.blank?
+
+    applications = JSON.parse(File.read("config/applications.json"))
+    api_users = JSON.parse(File.read("config/api_users.json"))
+
+    Configure::Applications.new(
+      public_domain: public_domain,
+      resource_name_prefix: resource_name_prefix(args.resource_prefix),
+    ).configure!(applications)
+    Configure::ApiUsers.new(
+      namespace: args.resource_prefix,
+      resource_name_prefix: resource_name_prefix(args.resource_prefix),
+    ).configure!(api_users)
+  end
+end
+
+def resource_name_prefix(resource_prefix)
+  given_prefix = resource_prefix.to_s.strip
+  given_prefix.present? ? "[#{given_prefix}] " : nil
+end

--- a/test/lib/configure/api_users_test.rb
+++ b/test/lib/configure/api_users_test.rb
@@ -1,0 +1,65 @@
+require "test_helper"
+
+class ConfigureApiUsersTest < ActiveSupport::TestCase
+  test "creates required api users" do
+    Configure::ApiUsers.new(
+      namespace: nil, resource_name_prefix: nil,
+    ).configure!(api_users)
+
+    api_users.each do |api_user|
+      assert ApiUser.exists?(
+        email: "#{api_user.fetch('slug')}@digital.cabinet-office.gov.uk",
+        name: api_user.fetch("name"),
+      )
+    end
+  end
+
+  test "namespaces api user name and emails" do
+    namespace = "test"
+    prefix = "[Test!] "
+    Configure::ApiUsers.new(
+      namespace: namespace, resource_name_prefix: prefix,
+    ).configure!(api_users)
+
+    api_users.each do |api_user|
+      assert ApiUser.exists?(
+        email: "#{namespace}-#{api_user.fetch('slug')}@digital.cabinet-office.gov.uk",
+        name: prefix + api_user.fetch("name"),
+      )
+    end
+  end
+
+  test "#configure! is idempotent and non-destructive" do
+    email = "#{api_users.first.fetch('slug')}@digital.cabinet-office.gov.uk"
+    name = "Pre-existing api_user"
+    create(:api_user, email: email, name: name)
+
+    Configure::ApiUsers.new(
+      namespace: nil,
+      resource_name_prefix: nil,
+    ).configure!(api_users)
+
+    assert ApiUser.exists?(email: email, name: name)
+    assert_not ApiUser.exists?(email: email, name: api_users.first.fetch("name"))
+
+    api_users[1..].each do |api_user|
+      assert ApiUser.exists?(
+        email: "#{api_user.fetch('slug')}@digital.cabinet-office.gov.uk",
+        name: api_user.fetch("name"),
+      )
+    end
+  end
+
+  def api_users
+    @api_users ||= [
+      {
+        "name" => "Business Support Finder App",
+        "slug" => "businesssupportfinder",
+      },
+      {
+        "name" => "Calculators App",
+        "slug" => "calculators",
+      },
+    ]
+  end
+end

--- a/test/lib/configure/applications_test.rb
+++ b/test/lib/configure/applications_test.rb
@@ -1,0 +1,70 @@
+require "test_helper"
+
+class ConfigureApplicationsTest < ActiveSupport::TestCase
+  domain = "test.gov.example.org"
+  name = "Cat herder"
+  subdomain_name = "cats"
+  description = "Herds cats"
+  redirect_path = "/auth/gds/callback"
+  permissions = %w[signin cat_herder]
+  cats_app = {
+    "name" => name,
+    "description" => description,
+    "permissions" => permissions,
+    "redirect_path" => redirect_path,
+    "subdomain_name" => subdomain_name,
+  }
+
+  test "creates required apps" do
+    Configure::Applications.new(
+      public_domain: domain, resource_name_prefix: nil,
+    ).configure!([cats_app])
+
+    created = Doorkeeper::Application.find_by(name: name)
+
+    assert_equal created.name, name
+    assert_equal created.redirect_uri, "https://#{subdomain_name}.#{domain}#{redirect_path}"
+    assert_equal created.description, description
+    assert_equal created.home_uri, "https://#{subdomain_name}.#{domain}"
+  end
+
+  test "creates associated permissions" do
+    Configure::Applications.new(
+      public_domain: domain, resource_name_prefix: nil,
+    ).configure!([cats_app])
+
+    created = Doorkeeper::Application.find_by(name: name)
+
+    created_permissions = created.supported_permissions.pluck(:name)
+    permissions.each do |permission|
+      assert_contains created_permissions, permission
+    end
+  end
+
+  test "namespaces api user name and emails" do
+    prefix = "[Test!] "
+    Configure::Applications.new(
+      public_domain: domain, resource_name_prefix: prefix,
+    ).configure!([cats_app])
+
+    created = Doorkeeper::Application.find_by(name: prefix + name)
+
+    assert_equal created.redirect_uri, "https://#{subdomain_name}.#{domain}#{redirect_path}"
+    assert_equal created.redirect_uri, "https://#{subdomain_name}.#{domain}#{redirect_path}"
+    assert_equal created.description, description
+    assert_equal created.home_uri, "https://#{subdomain_name}.#{domain}"
+  end
+
+  test "#configure! is idempotent and non-destructive" do
+    create(:application, name: name)
+
+    Configure::Applications.new(
+      public_domain: domain,
+      resource_name_prefix: "[just testing] ",
+    ).configure!([cats_app])
+
+    application = Doorkeeper::Application.find_by(name: name)
+    assert_not_equal application.description, description
+    assert_not_includes application.home_uri, domain
+  end
+end


### PR DESCRIPTION
This adds a rake task `bootstrap:all` which will enable us to configure signon with the OAuth applications and api users required to run in a GOV.UK cluster.

For now I've only added the apps required for the core GOV.UK cluster - that are currently running in ECS. We'll add others as needed.

Motivation
----

**Bootstrapping Signon is slow**. Currently when bringing up GOV.UK in a new environment, one must either copy an existing database to the new environment (making appropriate changes to application URLs, creating new tokens) or manually create all of the configuration required.

We want to automate Signon's bootstrapping process (the creation of Signon resources).

Implementation
----

We will run a new rake task `bootstrap:all[integration.publishing.service.gov.uk]` when deploying Signon to a new environment/namespace. This will create the ApiUsers and Applications necessary for the cluster.

Since the task is safe to re run, we can run it during deploy.

Not handled here is deletion of secrets - it might be preferable in future to expose the application/api_user models through a CRUD api. For now we'll need to continue manually deleting secrets.

This implementation supports creating resources for a namespace, which is useful for running multiple clusters of govuk that use the same Signon database - as will be the case in the ECS test environment.

It might make sense to move the JSON config over to govuk-infrastructure, and provide that as input, but I've included it here for now.