### PR TITLE
Use provided domain for ApiUser emails

### DIFF
--- a/lib/configure/api_users.rb
+++ b/lib/configure/api_users.rb
@@ -1,13 +1,14 @@
 module Configure
   class ApiUsers
-    def initialize(namespace:, resource_name_prefix:)
+    def initialize(namespace:, public_domain:, resource_name_prefix:)
       @namespace = namespace
       @name_prefix = resource_name_prefix
+      @public_domain = public_domain
     end
 
     def configure!(api_users)
       api_users.each do |api_user|
-        email = [namespace, "#{api_user.fetch('slug')}@digital.cabinet-office.gov.uk"].compact.join("-")
+        email = [namespace, "#{api_user.fetch('slug')}@#{public_domain}"].compact.join("-")
         find_or_create_api_user(
           name: [name_prefix, api_user.fetch("name")].join,
           email: email,
@@ -17,7 +18,7 @@ module Configure
 
   private
 
-    attr_reader :namespace, :name_prefix
+    attr_reader :namespace, :name_prefix, :public_domain
 
     def find_or_create_api_user(name:, email:)
       return if ApiUser.exists?(email: email)

--- a/lib/tasks/bootstrap.rake
+++ b/lib/tasks/bootstrap.rake
@@ -16,6 +16,7 @@ namespace :bootstrap do
       resource_name_prefix: resource_name_prefix(args.resource_prefix),
     ).configure!(applications)
     Configure::ApiUsers.new(
+      public_domain: public_domain,
       namespace: args.resource_prefix,
       resource_name_prefix: resource_name_prefix(args.resource_prefix),
     ).configure!(api_users)

--- a/test/lib/configure/api_users_test.rb
+++ b/test/lib/configure/api_users_test.rb
@@ -1,14 +1,18 @@
 require "test_helper"
 
 class ConfigureApiUsersTest < ActiveSupport::TestCase
+  public_domain = "example.gov.uk"
+
   test "creates required api users" do
     Configure::ApiUsers.new(
-      namespace: nil, resource_name_prefix: nil,
+      namespace: nil,
+      resource_name_prefix: nil,
+      public_domain: public_domain,
     ).configure!(api_users)
 
     api_users.each do |api_user|
       assert ApiUser.exists?(
-        email: "#{api_user.fetch('slug')}@digital.cabinet-office.gov.uk",
+        email: "#{api_user.fetch('slug')}@#{public_domain}",
         name: api_user.fetch("name"),
       )
     end
@@ -18,23 +22,26 @@ class ConfigureApiUsersTest < ActiveSupport::TestCase
     namespace = "test"
     prefix = "[Test!] "
     Configure::ApiUsers.new(
-      namespace: namespace, resource_name_prefix: prefix,
+      namespace: namespace,
+      public_domain: public_domain,
+      resource_name_prefix: prefix,
     ).configure!(api_users)
 
     api_users.each do |api_user|
       assert ApiUser.exists?(
-        email: "#{namespace}-#{api_user.fetch('slug')}@digital.cabinet-office.gov.uk",
+        email: "#{namespace}-#{api_user.fetch('slug')}@#{public_domain}",
         name: prefix + api_user.fetch("name"),
       )
     end
   end
 
   test "#configure! is idempotent and non-destructive" do
-    email = "#{api_users.first.fetch('slug')}@digital.cabinet-office.gov.uk"
+    email = "#{api_users.first.fetch('slug')}@#{public_domain}"
     name = "Pre-existing api_user"
     create(:api_user, email: email, name: name)
 
     Configure::ApiUsers.new(
+      public_domain: public_domain,
       namespace: nil,
       resource_name_prefix: nil,
     ).configure!(api_users)
@@ -44,7 +51,7 @@ class ConfigureApiUsersTest < ActiveSupport::TestCase
 
     api_users[1..].each do |api_user|
       assert ApiUser.exists?(
-        email: "#{api_user.fetch('slug')}@digital.cabinet-office.gov.uk",
+        email: "#{api_user.fetch('slug')}@#{public_domain}",
         name: api_user.fetch("name"),
       )
     end


### PR DESCRIPTION
The domain `digital.cabinet-office.gov.uk` isn't owned by us, and GDS IT run email on it so there is a chance of a conflict.

This enables us to use workspace/environment specific domains in emails, such as test.govuk.digital where a conflict is less likely.