### PR TITLE
Add get OAuth application API endpoint

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -70,6 +70,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       post "authorisations/test", to: "authorisations#test"
       post "authorisations", to: "authorisations#create"
+      get "applications", to: "applications#show"
       post "applications", to: "applications#create"
     end
   end

--- a/test/integration/api/applications_test.rb
+++ b/test/integration/api/applications_test.rb
@@ -7,13 +7,49 @@ class ApplicationsTest < ActionDispatch::IntegrationTest
   description = "Herds cats"
   permissions = %w[cat_herder herder_of_cats]
   endpoint = "/api/v1/applications"
-  params = {
+  create_params = {
     "name" => name,
     "home_uri" => home_uri,
     "redirect_uri" => redirect_uri,
     "description" => description,
     "permissions" => permissions,
   }
+
+  test "#show responds with a 401 error when an invalid token is given" do
+    ENV["SIGNON_ADMIN_PASSWORD"] = SecureRandom.uuid
+    get endpoint, headers: { "HTTP_AUTHORIZATION" => "Bearer invalid-token" }
+    assert_unauthorized(response)
+  end
+
+  test "#show responds with a 401 error when SIGNON_ADMIN_PASSWORD env var is unset" do
+    ENV["SIGNON_ADMIN_PASSWORD"] = nil
+    get endpoint
+    assert_unauthorized(response)
+  end
+
+  test "#show responds with a 400 when required params are missing" do
+    get_req(endpoint, params: {})
+    assert_equal 400, response.status
+    assert_equal JSON.generate({ error: "param is missing or the value is empty: name" }), response.body
+  end
+
+  test "#show responds with a 404 when the application doesn't exist" do
+    create(:application, name: name)
+    get_req(endpoint, params: { "name" => "doesnt exist" })
+    assert_equal 404, response.status
+    assert_equal JSON.generate({ error: "Not found" }), response.body
+  end
+
+  test "#show returns an application" do
+    create(:application, name: name)
+    get_req(endpoint, params: { "name" => name })
+    assert_equal 200, response.status
+    body = JSON.parse(response.body)
+    assert_equal 43, body.fetch("oauth_id").length
+    assert_match(/[A-Za-z0-9]\w+/, body.fetch("oauth_id"))
+    assert_equal 43, body.fetch("oauth_secret").length
+    assert_match(/[A-Za-z0-9]\w+/, body.fetch("oauth_secret"))
+  end
 
   test "#create responds with a 401 error when an invalid token is given" do
     ENV["SIGNON_ADMIN_PASSWORD"] = SecureRandom.uuid
@@ -28,26 +64,26 @@ class ApplicationsTest < ActionDispatch::IntegrationTest
   end
 
   test "#create responds with a 400 when required params are missing" do
-    request(endpoint, params: params.except("home_uri", "description"))
+    post_req(endpoint, params: create_params.except("home_uri", "description"))
     assert_equal 400, response.status
     assert_equal JSON.generate({ error: "param is missing or the value is empty: description and home_uri" }), response.body
   end
 
   test "#create provided redirect_uri is invalid" do
-    request(endpoint, params: params.merge("redirect_uri" => "a bad redirect_uri!!!!!"))
+    post_req(endpoint, params: create_params.merge("redirect_uri" => "a bad redirect_uri!!!!!"))
     assert_equal 400, response.status
     assert_equal JSON.generate({ error: "Not valid" }), response.body
   end
 
   test "#create when application already exists" do
     create(:application, name: name)
-    request(endpoint, params: params.merge("name" => name))
+    post_req(endpoint, params: create_params.merge("name" => name))
     assert_equal 400, response.status
     assert_equal JSON.generate({ error: "Record already exists" }), response.body
   end
 
   test "#create adds an application" do
-    request(endpoint, params: params)
+    post_req(endpoint, params: create_params)
     assert_equal 200, response.status
     body = JSON.parse(response.body)
     assert_equal 43, body.fetch("oauth_id").length
@@ -65,10 +101,17 @@ class ApplicationsTest < ActionDispatch::IntegrationTest
     assert_equal 401, response.status
   end
 
-  def request(endpoint, params: {})
+  def get_req(endpoint, params: {})
+    get endpoint, params: params, headers: auth_header
+  end
+
+  def post_req(endpoint, params: {})
+    post endpoint, params: params, headers: auth_header
+  end
+
+  def auth_header
     token = SecureRandom.uuid
     ENV["SIGNON_ADMIN_PASSWORD"] = token
-    auth_header = { "HTTP_AUTHORIZATION" => "Bearer #{token}" }
-    post endpoint, params: params, headers: auth_header
+    { "HTTP_AUTHORIZATION" => "Bearer #{token}" }
   end
 end


### PR DESCRIPTION
This adds the endpoint `GET /api/v1/applications?name=Publishing+API` which will return the OAuth ID and Secret for a Doorkeeper App.

The endpoint is IP-restricted and requires a bearer token.

This will be used by the Concourse deploy pipeline when deploying apps. It's not sufficient to provide only a create endpoint, since we can be in a state where an application has been created but the generated secrets don't yet exist in SecretsManager. This endpoint enables the deploy pipeline to recover from this state.

Trello: https://trello.com/c/elhnwnaf/454-bootstrapping-signon-oauth-app-secrets