### PR TITLE
Allow OAuth apps to have no special permissions

### DIFF
--- a/app/controllers/api/v1/applications_controller.rb
+++ b/app/controllers/api/v1/applications_controller.rb
@@ -53,7 +53,7 @@ private
 
   def validate_create_params
     assert_no_missing_params(%i[
-      name description redirect_uri home_uri permissions
+      name description redirect_uri home_uri
     ])
   end
 

--- a/test/integration/api/applications_test.rb
+++ b/test/integration/api/applications_test.rb
@@ -46,9 +46,9 @@ class ApplicationsTest < ActionDispatch::IntegrationTest
     assert_equal 200, response.status
     body = JSON.parse(response.body)
     assert_equal 43, body.fetch("oauth_id").length
-    assert_match(/[A-Za-z0-9]\w+/, body.fetch("oauth_id"))
+    assert_match(/[a-zA-Z0-9\-_]/, body.fetch("oauth_id"))
     assert_equal 43, body.fetch("oauth_secret").length
-    assert_match(/[A-Za-z0-9]\w+/, body.fetch("oauth_secret"))
+    assert_match(/[a-zA-Z0-9\-_]/, body.fetch("oauth_secret"))
   end
 
   test "#create responds with a 401 error when an invalid token is given" do
@@ -87,9 +87,9 @@ class ApplicationsTest < ActionDispatch::IntegrationTest
     assert_equal 200, response.status
     body = JSON.parse(response.body)
     assert_equal 43, body.fetch("oauth_id").length
-    assert_match(/[A-Za-z0-9]\w+/, body.fetch("oauth_id"))
+    assert_match(/[a-zA-Z0-9\-_]/, body.fetch("oauth_id"))
     assert_equal 43, body.fetch("oauth_secret").length
-    assert_match(/[A-Za-z0-9]\w+/, body.fetch("oauth_secret"))
+    assert_match(/[a-zA-Z0-9\-_]/, body.fetch("oauth_secret"))
   end
 
   test "#create with no permissions is successful" do
@@ -97,9 +97,9 @@ class ApplicationsTest < ActionDispatch::IntegrationTest
     assert_equal 200, response.status
     body = JSON.parse(response.body)
     assert_equal 43, body.fetch("oauth_id").length
-    assert_match(/[A-Za-z0-9]\w+/, body.fetch("oauth_id"))
+    assert_match(/[a-zA-Z0-9\-_]/, body.fetch("oauth_id"))
     assert_equal 43, body.fetch("oauth_secret").length
-    assert_match(/[A-Za-z0-9]\w+/, body.fetch("oauth_secret"))
+    assert_match(/[a-zA-Z0-9\-_]/, body.fetch("oauth_secret"))
   end
 
   #

--- a/test/integration/api/applications_test.rb
+++ b/test/integration/api/applications_test.rb
@@ -92,6 +92,16 @@ class ApplicationsTest < ActionDispatch::IntegrationTest
     assert_match(/[A-Za-z0-9]\w+/, body.fetch("oauth_secret"))
   end
 
+  test "#create with no permissions is successful" do
+    post_req(endpoint, params: create_params.merge("permissions" => []))
+    assert_equal 200, response.status
+    body = JSON.parse(response.body)
+    assert_equal 43, body.fetch("oauth_id").length
+    assert_match(/[A-Za-z0-9]\w+/, body.fetch("oauth_id"))
+    assert_equal 43, body.fetch("oauth_secret").length
+    assert_match(/[A-Za-z0-9]\w+/, body.fetch("oauth_secret"))
+  end
+
   #
   # Helpers
   #
@@ -102,16 +112,16 @@ class ApplicationsTest < ActionDispatch::IntegrationTest
   end
 
   def get_req(endpoint, params: {})
-    get endpoint, params: params, headers: auth_header
+    get endpoint, params: params, headers: headers
   end
 
   def post_req(endpoint, params: {})
-    post endpoint, params: params, headers: auth_header
+    post endpoint, params: params.to_json, headers: headers
   end
 
-  def auth_header
+  def headers
     token = SecureRandom.uuid
     ENV["SIGNON_ADMIN_PASSWORD"] = token
-    { "HTTP_AUTHORIZATION" => "Bearer #{token}" }
+    { "HTTP_AUTHORIZATION" => "Bearer #{token}", "CONTENT_TYPE" => "application/json" }
   end
 end

--- a/test/integration/api/authorisations_test.rb
+++ b/test/integration/api/authorisations_test.rb
@@ -62,7 +62,7 @@ class AuthorisationsTest < ActionDispatch::IntegrationTest
     body = JSON.parse(response.body)
     assert_equal @application.name, body.fetch("application_name")
     assert_equal body.fetch("token").length, 43
-    assert_match(/[A-Za-z0-9]\w+/, body.fetch("token"))
+    assert_match(/[a-zA-Z0-9\-_]/, body.fetch("token"))
   end
 
   test "#test confirms that a token has been created" do


### PR DESCRIPTION
When creating an OAuth app one can specify the permissions that the app has. However, some apps don't have any permissions - this change adds support for those apps.