### PR TITLE
Return 409 status on failed recreate OAuth App call

### DIFF
--- a/app/controllers/api/v1/applications_controller.rb
+++ b/app/controllers/api/v1/applications_controller.rb
@@ -10,7 +10,6 @@ class Api::V1::ApplicationsController < ApplicationController
 
   rescue_from ActionController::ParameterMissing, with: :missing_params_error
   rescue_from ActiveRecord::RecordInvalid, with: :not_valid_error
-  rescue_from ActiveRecord::RecordNotUnique, with: :already_exists_error
   rescue_from ActiveRecord::RecordNotFound, with: :not_found_error
 
   respond_to :json
@@ -24,6 +23,8 @@ class Api::V1::ApplicationsController < ApplicationController
       permissions: params.fetch(:permissions, []),
     )
     render json: { oauth_id: application.uid, oauth_secret: application.secret }
+  rescue ActiveRecord::RecordNotUnique
+    render json: { error: "ApplicationAlreadyCreated" }, status: :conflict
   end
 
   def show

--- a/test/integration/api/applications_test.rb
+++ b/test/integration/api/applications_test.rb
@@ -78,8 +78,8 @@ class ApplicationsTest < ActionDispatch::IntegrationTest
   test "#create when application already exists" do
     create(:application, name: name)
     post_req(endpoint, params: create_params.merge("name" => name))
-    assert_equal 400, response.status
-    assert_equal JSON.generate({ error: "Record already exists" }), response.body
+    assert_equal 409, response.status
+    assert_equal JSON.generate({ error: "ApplicationAlreadyCreated" }), response.body
   end
 
   test "#create adds an application" do


### PR DESCRIPTION
We'll return a 409 Conflict status code and a more appropriate error message when we cannot create an application or its associated resources due to a RecordNotUnique error. This API's only client is the Concourse deploy pipeline, so it's an easy change.