### PR TITLE
Expire bearer tokens in 60 days

### DIFF
--- a/app/controllers/api/v1/authorisations_controller.rb
+++ b/app/controllers/api/v1/authorisations_controller.rb
@@ -15,7 +15,7 @@ class Api::V1::AuthorisationsController < ApplicationController
   respond_to :json
 
   def create
-    authorisation = api_user.authorisations.build(expires_in: ApiUser::DEFAULT_TOKEN_LIFE)
+    authorisation = api_user.authorisations.build(expires_in: ApiUser::AUTOROTATABLE_TOKEN_LIFE)
     authorisation.application_id = application.id
     ActiveRecord::Base.transaction do
       authorisation.save!

--- a/app/models/api_user.rb
+++ b/app/models/api_user.rb
@@ -2,4 +2,5 @@ class ApiUser < User
   default_scope { where(api_user: true).order(:name) }
 
   DEFAULT_TOKEN_LIFE = 2.years.to_i
+  AUTOROTATABLE_TOKEN_LIFE = 60.days.to_i
 end


### PR DESCRIPTION
This changes the bearer token expiry time from 2 years to 60 days for tokens that are created via the API.

The expectation is that tokens created via the API will be automatically rotated every 30 days. This is currently the case for bearer tokens created for the platform in ECS.

If a rotation fails, it retries daily for a few days - we should be able to fix the issue within the 30 days after a rotation fails.

This does _not_ change anything in the EC2 platform - we'll still have long-lived tokens for apps there, since we must rotate tokens in that platform manually.