### PR TITLE
Ignore expiring tokens alert for tokens created by Lambda

### DIFF
--- a/lib/healthcheck/api_tokens.rb
+++ b/lib/healthcheck/api_tokens.rb
@@ -19,6 +19,7 @@ module Healthcheck
         ) tokens
       INNER JOIN users ON users.id = tokens.resource_owner_id
       WHERE tokens.revoked_at IS NULL
+      AND users.email NOT LIKE '%@#{ENV['GOVUK_ENVIRONMENT_NAME']}.publishing.service.gov.uk'
       AND users.api_user = TRUE
       AND tokens.expires_in < #{WARNING_THRESHOLD}
     SQL

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,5 @@
 ENV["RAILS_ENV"] = "test"
+ENV["GOVUK_ENVIRONMENT_NAME"] = "test"
 
 require "simplecov"
 SimpleCov.start "rails"


### PR DESCRIPTION
This modifies the expiring tokens alert to ignore the expiration
of tokens that are managed by the Lambda rotation process. We're
taking advantage of the difference in email domain to filter the
alert (alphagov is typically used in production, while the Lambda
uses the environment's public domain).

It is OK for these tokens to expire, since the Lambda will create
new tokens, and leave the old tokens to expire without deleting them.

In future we'll create a new alert for monitoring Lambda rotation
failures.

https://trello.com/c/QbkAqyQW/570-signon-resolve-ux-alerting-issue