### PR TITLE
Bugfix: new MFA device can be created without current MFA token

### DIFF
--- a/app/controllers/devise/two_step_verification_controller.rb
+++ b/app/controllers/devise/two_step_verification_controller.rb
@@ -1,7 +1,6 @@
 class Devise::TwoStepVerificationController < DeviseController
   before_action -> { authenticate_user!(force: true) }, only: :prompt
   before_action :prepare_and_validate, except: :prompt
-  skip_before_action :handle_two_step_verification
   layout "admin_layout", only: %w[prompt]
 
   attr_reader :otp_secret_key

--- a/app/helpers/two_step_verification_helper.rb
+++ b/app/helpers/two_step_verification_helper.rb
@@ -2,12 +2,14 @@ module TwoStepVerificationHelper
 private
 
   def handle_two_step_verification
-    if signed_in?(:user)
-      if warden.session(:user)["need_two_step_verification"]
-        handle_failed_second_step
-      elsif current_user.prompt_for_2sv?
-        redirect_to prompt_two_step_verification_path
-      end
+    # TODO: Should raise error if this helper is reached and not already signed in.
+    return unless signed_in?(:user)
+
+    if warden.session(:user)["need_two_step_verification"]
+      handle_failed_second_step
+    elsif current_user.prompt_for_2sv? && !on_2sv_setup_journey
+      # NOTE: 'Prompt' means prompt the user to _set up_ 2SV.
+      redirect_to prompt_two_step_verification_path
     end
   end
 
@@ -18,5 +20,9 @@ private
     else
       render nothing: true, status: :unauthorized
     end
+  end
+
+  def on_2sv_setup_journey
+    controller_path == Devise::TwoStepVerificationController.controller_path
   end
 end

--- a/test/controllers/two_step_verification_controller_test.rb
+++ b/test/controllers/two_step_verification_controller_test.rb
@@ -9,13 +9,26 @@ class TwoStepVerificationControllerTest < ActionController::TestCase
     sign_in @user
   end
 
-  context "when unauthenticated" do
+  context "when user is not logged in" do
     setup { sign_out @user }
 
     should "redirect to login upon attempted prompt" do
       get :prompt
 
       assert_redirected_to new_user_session_path
+    end
+  end
+
+  context "when MFA code is required by login journey" do
+    setup do
+      sign_out @user
+      sign_in @user, passed_mfa: false
+    end
+
+    should "redirect to login upon attempted prompt" do
+      get :prompt
+
+      assert_redirected_to new_two_step_verification_session_path
     end
   end
 


### PR DESCRIPTION
Note: This fix has already been deployed via the private repo deployment method.

A user could access the paths handled by `Devise::TwoStepVerificationController` without entering their current MFA token if it existed. This enabled a user to bypass the MFA flow. Commit 0ecdf332938239f6243ac86e02c820b8c34d4c49 seems to have introduced this.

Steps to reproduce provided by in-house pentester:

1. Enter username and password: https://signon.staging.publishing.service.gov.uk/
2. You're presented with the MFA form
3. Go directly to https://signon.staging.publishing.service.gov.uk/users/two_step_verification in your browser
4. You can now replace MFA for the account without needing theirs

Fix:

By removing the `skip_before_action: :handle_two_step_verification` we require a user to have entered their existing MFA token before changing their MFA device.