### PR TITLE
Use the errors #add method to fix deprecation messages

### DIFF
--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -49,7 +49,7 @@ class ConfirmationsController < Devise::ConfirmationsController
         respond_with_navigational(resource.errors, status: :unprocessable_entity) { handle_new_token_needed }
       end
     else
-      resource.errors[:password] << "was incorrect"
+      resource.errors.add(:password, "was incorrect")
       render :show
     end
   end


### PR DESCRIPTION
We're currently getting some deprecation messages as `errors[:key] << value` has been deprecated.

![image](https://user-images.githubusercontent.com/42515961/144821026-f024939d-9148-44da-bff7-9af4f31456bf.png)

This PR uses the errors#add method instead.