### PR TITLE
Add ApiUsers API endpoint

### DIFF
--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -1,0 +1,14 @@
+class Api::V1::ApiController < ApplicationController
+  include AdminApiHelper
+
+  before_action :authenticate
+
+  skip_after_action :verify_authorized
+  protect_from_forgery with: :null_session
+
+  rescue_from ActionController::ParameterMissing, with: :missing_params_error
+  rescue_from ActiveRecord::RecordInvalid, with: :not_valid_error
+  rescue_from ActiveRecord::RecordNotFound, with: :not_found_error
+
+  respond_to :json
+end

--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -9,6 +9,7 @@ class Api::V1::ApiController < ApplicationController
   rescue_from ActionController::ParameterMissing, with: :missing_params_error
   rescue_from ActiveRecord::RecordInvalid, with: :not_valid_error
   rescue_from ActiveRecord::RecordNotFound, with: :not_found_error
+  rescue_from ActiveRecord::RecordNotUnique, with: :already_created_error
 
   respond_to :json
 end

--- a/app/controllers/api/v1/api_users_controller.rb
+++ b/app/controllers/api/v1/api_users_controller.rb
@@ -20,6 +20,11 @@ private
                            password: password, password_confirmation: password)
     api_user.skip_confirmation!
     api_user.api_user = true
+
+    if api_user.invalid? && api_user.errors.where(:email, :taken).any?
+      raise ActiveRecord::RecordNotUnique
+    end
+
     api_user.save!
     api_user
   end

--- a/app/controllers/api/v1/api_users_controller.rb
+++ b/app/controllers/api/v1/api_users_controller.rb
@@ -1,0 +1,36 @@
+class Api::V1::ApiUsersController < Api::V1::ApiController
+  before_action :validate_create_params, only: %w[create]
+  before_action :validate_show_params, only: %w[show]
+
+  def create
+    api_user = create_api_user(name: params.fetch(:name), email: params.fetch(:email))
+    render json: { id: api_user.id }
+  end
+
+  def show
+    api_user = ApiUser.find_by!(email: params.fetch(:email))
+    render json: { id: api_user.id }
+  end
+
+private
+
+  def create_api_user(name:, email:)
+    password = SecureRandom.urlsafe_base64
+    api_user = ApiUser.new(name: name, email: email,
+                           password: password, password_confirmation: password)
+    api_user.skip_confirmation!
+    api_user.api_user = true
+    api_user.save!
+    api_user
+  end
+
+  def validate_create_params
+    assert_no_missing_params(%i[
+      name email
+    ])
+  end
+
+  def validate_show_params
+    assert_no_missing_params(%i[email])
+  end
+end

--- a/app/controllers/api/v1/applications_controller.rb
+++ b/app/controllers/api/v1/applications_controller.rb
@@ -1,18 +1,6 @@
-class Api::V1::ApplicationsController < ApplicationController
-  include AdminApiHelper
-
-  before_action :authenticate
+class Api::V1::ApplicationsController < Api::V1::ApiController
   before_action :validate_create_params, only: %w[create]
   before_action :validate_show_params, only: %w[show]
-
-  skip_after_action :verify_authorized
-  protect_from_forgery with: :null_session
-
-  rescue_from ActionController::ParameterMissing, with: :missing_params_error
-  rescue_from ActiveRecord::RecordInvalid, with: :not_valid_error
-  rescue_from ActiveRecord::RecordNotFound, with: :not_found_error
-
-  respond_to :json
 
   def create
     application = create_application(

--- a/app/controllers/api/v1/applications_controller.rb
+++ b/app/controllers/api/v1/applications_controller.rb
@@ -22,14 +22,14 @@ class Api::V1::ApplicationsController < ApplicationController
       home_uri: params.fetch(:home_uri),
       permissions: params.fetch(:permissions, []),
     )
-    render json: { oauth_id: application.uid, oauth_secret: application.secret }
+    render json: { id: application.id, oauth_id: application.uid, oauth_secret: application.secret }
   rescue ActiveRecord::RecordNotUnique
     render json: { error: "ApplicationAlreadyCreated" }, status: :conflict
   end
 
   def show
     application = Doorkeeper::Application.find_by!(name: params.fetch(:name))
-    render json: { oauth_id: application.uid, oauth_secret: application.secret }
+    render json: { id: application.id, oauth_id: application.uid, oauth_secret: application.secret }
   end
 
 private

--- a/app/controllers/api/v1/applications_controller.rb
+++ b/app/controllers/api/v1/applications_controller.rb
@@ -11,8 +11,6 @@ class Api::V1::ApplicationsController < Api::V1::ApiController
       permissions: params.fetch(:permissions, []),
     )
     render json: { id: application.id, oauth_id: application.uid, oauth_secret: application.secret }
-  rescue ActiveRecord::RecordNotUnique
-    render json: { error: "ApplicationAlreadyCreated" }, status: :conflict
   end
 
   def show

--- a/app/controllers/api/v1/authorisations_controller.rb
+++ b/app/controllers/api/v1/authorisations_controller.rb
@@ -1,19 +1,8 @@
-class Api::V1::AuthorisationsController < ApplicationController
-  include AdminApiHelper
-
-  before_action :authenticate
+class Api::V1::AuthorisationsController < Api::V1::ApiController
   before_action :validate_create_params, only: %w[create]
   before_action :validate_application, only: %w[create]
   before_action :validate_test_params, only: %w[test]
   before_action :api_user
-
-  skip_after_action :verify_authorized
-  protect_from_forgery with: :null_session
-
-  rescue_from ActionController::ParameterMissing, with: :missing_params_error
-  rescue_from ActiveRecord::RecordNotFound, with: :not_found_error
-
-  respond_to :json
 
   def create
     authorisation = api_user.authorisations.build(

--- a/app/controllers/api/v1/authorisations_controller.rb
+++ b/app/controllers/api/v1/authorisations_controller.rb
@@ -3,6 +3,7 @@ class Api::V1::AuthorisationsController < ApplicationController
 
   before_action :authenticate
   before_action :validate_create_params, only: %w[create]
+  before_action :validate_application, only: %w[create]
   before_action :validate_test_params, only: %w[test]
   before_action :api_user
 
@@ -15,8 +16,10 @@ class Api::V1::AuthorisationsController < ApplicationController
   respond_to :json
 
   def create
-    authorisation = api_user.authorisations.build(expires_in: ApiUser::AUTOROTATABLE_TOKEN_LIFE)
-    authorisation.application_id = application.id
+    authorisation = api_user.authorisations.build(
+      expires_in: ApiUser::AUTOROTATABLE_TOKEN_LIFE,
+      application_id: params.fetch(:application_id),
+    )
     ActiveRecord::Base.transaction do
       authorisation.save!
       grant_app_permissions!(authorisation, params.fetch(:permissions, []))
@@ -34,7 +37,7 @@ class Api::V1::AuthorisationsController < ApplicationController
   def test
     authorisation = api_user.authorisations
       .find_by!(
-        application: application,
+        application_id: params.require(:application_id),
         token: params.require(:token),
       )
 
@@ -44,23 +47,26 @@ class Api::V1::AuthorisationsController < ApplicationController
 private
 
   def api_user
-    @api_user ||= ApiUser.find_by!(email: params.require(:api_user_email))
+    @api_user ||= ApiUser.find(params.require(:id))
   end
 
-  def application
-    @application ||= Doorkeeper::Application.find_by!(name: params.require(:application_name))
+  def validate_application
+    # Doorkeeper doesn't validate application_ids, so we must
+    unless Doorkeeper::Application.exists?(params.fetch(:application_id))
+      raise ActiveRecord::RecordNotFound
+    end
   end
 
   def grant_app_permissions!(authorisation, permissions)
     all_permissions = %w[signin] + permissions
-    @api_user.grant_application_permissions(authorisation.application, all_permissions)
+    api_user.grant_application_permissions(authorisation.application, all_permissions)
   end
 
   def validate_create_params
-    assert_no_missing_params(%i[application_name api_user_email])
+    assert_no_missing_params(%i[application_id])
   end
 
   def validate_test_params
-    assert_no_missing_params(%i[application_name api_user_email token])
+    assert_no_missing_params(%i[application_id token])
   end
 end

--- a/app/helpers/admin_api_helper.rb
+++ b/app/helpers/admin_api_helper.rb
@@ -19,8 +19,8 @@ private
     render json: { error: "Not found" }, status: :not_found
   end
 
-  def not_valid_error(_exception)
-    render json: { error: "Not valid" }, status: :bad_request
+  def not_valid_error(exception)
+    render json: { error: exception.message }, status: :bad_request
   end
 
   def already_exists_error(_exception)

--- a/app/helpers/admin_api_helper.rb
+++ b/app/helpers/admin_api_helper.rb
@@ -11,12 +11,16 @@ private
     end
   end
 
+  def already_created_error(_exception)
+    render json: { error: "Record not unique" }, status: :conflict
+  end
+
   def missing_params_error(exception)
     render json: { error: exception.message }, status: :bad_request
   end
 
   def not_found_error(_exception)
-    render json: { error: "Not found" }, status: :not_found
+    render json: { error: "Record not found" }, status: :not_found
   end
 
   def not_valid_error(exception)

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -61,4 +61,7 @@ Rails.application.configure do
 
   # Annotate rendered view with file names.
   config.action_view.annotate_rendered_view_with_filenames = true
+
+  config.logger = Logger.new($stdout)
+  config.log_level = :fatal
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,10 +68,10 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v1 do
-      post "authorisations/test", to: "authorisations#test"
-      post "authorisations", to: "authorisations#create"
       get "applications", to: "applications#show"
       post "applications", to: "applications#create"
+      post "api-users/:id/authorisations", to: "authorisations#create"
+      post "api-users/:id/authorisations/test", to: "authorisations#test"
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -70,6 +70,8 @@ Rails.application.routes.draw do
     namespace :v1 do
       get "applications", to: "applications#show"
       post "applications", to: "applications#create"
+      get "api-users", to: "api_users#show"
+      post "api-users", to: "api_users#create"
       post "api-users/:id/authorisations", to: "authorisations#create"
       post "api-users/:id/authorisations/test", to: "authorisations#test"
     end

--- a/lib/data_hygiene/bulk_organisation_updater.rb
+++ b/lib/data_hygiene/bulk_organisation_updater.rb
@@ -2,8 +2,9 @@ require "csv"
 
 module DataHygiene
   class BulkOrganisationUpdater
-    def initialize(filename)
+    def initialize(filename, logger: Rails.logger)
       @filename = filename
+      @logger = logger
     end
 
     def call
@@ -22,7 +23,7 @@ module DataHygiene
 
   private
 
-    attr_reader :filename
+    attr_reader :filename, :logger
 
     CSV_OPTIONS = {
       headers: true,
@@ -33,11 +34,11 @@ module DataHygiene
 
       if user.nil?
         if User.exists?(email: row.fetch("New email"))
-          puts "warning: #{row.fetch('Old email')} looks to have already been updated"
+          logger.warn "#{row.fetch('Old email')} looks to have already been updated"
 
           return true
         else
-          puts "error: couldn't find user #{row.fetch('Old email')}"
+          logger.error "couldn't find user #{row.fetch('Old email')}"
 
           return false
         end
@@ -64,7 +65,7 @@ module DataHygiene
     end
 
     def update_user(user, new_email_address, new_organisation)
-      puts "#{user.email}: #{new_email_address} #{new_organisation.slug}"
+      logger.info "#{user.email}: #{new_email_address} #{new_organisation.slug}"
 
       current_email_address = user.email
 

--- a/test/integration/api/api_users_test.rb
+++ b/test/integration/api/api_users_test.rb
@@ -1,0 +1,107 @@
+require "test_helper"
+
+class ApiUsersTest < ActionDispatch::IntegrationTest
+  name = "example-name"
+  email = "example-name@example.org"
+  endpoint = "/api/v1/api-users"
+  create_params = { "name" => name, "email" => email }
+
+  test "#show responds with a 401 error when an invalid token is given" do
+    ENV["SIGNON_ADMIN_PASSWORD"] = SecureRandom.uuid
+    get endpoint, headers: { "HTTP_AUTHORIZATION" => "Bearer invalid-token" }
+    assert_unauthorized(response)
+  end
+
+  test "#show responds with a 401 error when SIGNON_ADMIN_PASSWORD env var is unset" do
+    ENV["SIGNON_ADMIN_PASSWORD"] = nil
+    get endpoint
+    assert_unauthorized(response)
+  end
+
+  test "#show responds with a 400 when required params are missing" do
+    get_req(endpoint, params: {})
+    assert_equal JSON.generate({ error: "param is missing or the value is empty: email" }), response.body
+    assert_equal 400, response.status
+  end
+
+  test "#show responds with a 404 when the api user doesn't exist" do
+    create(:api_user, name: name, email: email)
+    get_req(endpoint, params: { email: "invalid@example.org" })
+    assert_equal JSON.generate({ error: "Not found" }), response.body
+    assert_equal 404, response.status
+  end
+
+  test "#show returns the api_user" do
+    create(:api_user, name: "Alternate 1", email: "alt-1@example.org")
+    create(:api_user, name: name, email: email)
+    create(:api_user, name: "Alternate 2", email: "alt-2@example.org")
+    get_req(endpoint, params: { email: email })
+    assert_success_body(response)
+    assert_equal 200, response.status
+  end
+
+  test "#create responds with a 401 error when an invalid token is given" do
+    ENV["SIGNON_ADMIN_PASSWORD"] = SecureRandom.uuid
+    post endpoint, headers: { "HTTP_AUTHORIZATION" => "Bearer invalid-token" }
+    assert_unauthorized(response)
+  end
+
+  test "#create responds with a 401 error when SIGNON_ADMIN_PASSWORD env var is unset" do
+    ENV["SIGNON_ADMIN_PASSWORD"] = nil
+    post endpoint
+    assert_unauthorized(response)
+  end
+
+  test "#create responds with a 400 when required params are missing" do
+    post_req(endpoint, params: create_params.except("name", "email"))
+    assert_equal JSON.generate({ error: "param is missing or the value is empty: name and email" }), response.body
+    assert_equal 400, response.status
+  end
+
+  test "#create provided email is invalid" do
+    post_req(endpoint, params: { "name" => name, "email" => "an invalid email address" })
+    assert_equal JSON.generate({ error: "Validation failed: Email is invalid" }), response.body
+    assert_equal 400, response.status
+  end
+
+  test "#create when api_user email is already taken" do
+    create(:api_user, email: email, name: name)
+    post_req(endpoint, params: create_params)
+    assert_equal JSON.generate({ error: "Validation failed: Email has already been taken" }), response.body
+    assert_equal 400, response.status
+  end
+
+  test "#create adds an api user" do
+    post_req(endpoint, params: create_params)
+    assert_equal 200, response.status
+    assert_success_body(response)
+  end
+
+  #
+  # Helpers
+  #
+
+  def assert_success_body(response)
+    body = JSON.parse(response.body)
+    assert_equal Integer, body.fetch("id").class
+  end
+
+  def assert_unauthorized(response)
+    assert_equal "HTTP Token: Access denied.\n", response.body
+    assert_equal 401, response.status
+  end
+
+  def get_req(endpoint, params: {})
+    get endpoint, params: params, headers: headers
+  end
+
+  def post_req(endpoint, params: {})
+    post endpoint, params: params.to_json, headers: headers
+  end
+
+  def headers
+    token = SecureRandom.uuid
+    ENV["SIGNON_ADMIN_PASSWORD"] = token
+    { "HTTP_AUTHORIZATION" => "Bearer #{token}", "CONTENT_TYPE" => "application/json" }
+  end
+end

--- a/test/integration/api/api_users_test.rb
+++ b/test/integration/api/api_users_test.rb
@@ -27,7 +27,7 @@ class ApiUsersTest < ActionDispatch::IntegrationTest
   test "#show responds with a 404 when the api user doesn't exist" do
     create(:api_user, name: name, email: email)
     get_req(endpoint, params: { email: "invalid@example.org" })
-    assert_equal JSON.generate({ error: "Not found" }), response.body
+    assert_equal JSON.generate({ error: "Record not found" }), response.body
     assert_equal 404, response.status
   end
 
@@ -67,8 +67,8 @@ class ApiUsersTest < ActionDispatch::IntegrationTest
   test "#create when api_user email is already taken" do
     create(:api_user, email: email, name: name)
     post_req(endpoint, params: create_params)
-    assert_equal JSON.generate({ error: "Validation failed: Email has already been taken" }), response.body
-    assert_equal 400, response.status
+    assert_equal JSON.generate({ error: "Record not unique" }), response.body
+    assert_equal 409, response.status
   end
 
   test "#create adds an api user" do

--- a/test/integration/api/applications_test.rb
+++ b/test/integration/api/applications_test.rb
@@ -44,11 +44,7 @@ class ApplicationsTest < ActionDispatch::IntegrationTest
     create(:application, name: name)
     get_req(endpoint, params: { "name" => name })
     assert_equal 200, response.status
-    body = JSON.parse(response.body)
-    assert_equal 43, body.fetch("oauth_id").length
-    assert_match(/^[A-Za-z0-9_-]+$/, body.fetch("oauth_id"))
-    assert_equal 43, body.fetch("oauth_secret").length
-    assert_match(/^[A-Za-z0-9_-]+$/, body.fetch("oauth_secret"))
+    assert_success_body(response)
   end
 
   test "#create responds with a 401 error when an invalid token is given" do
@@ -85,26 +81,27 @@ class ApplicationsTest < ActionDispatch::IntegrationTest
   test "#create adds an application" do
     post_req(endpoint, params: create_params)
     assert_equal 200, response.status
-    body = JSON.parse(response.body)
-    assert_equal 43, body.fetch("oauth_id").length
-    assert_match(/^[A-Za-z0-9_-]+$/, body.fetch("oauth_id"))
-    assert_equal 43, body.fetch("oauth_secret").length
-    assert_match(/^[A-Za-z0-9_-]+$/, body.fetch("oauth_secret"))
+    assert_success_body(response)
   end
 
   test "#create with no permissions is successful" do
     post_req(endpoint, params: create_params.merge("permissions" => []))
     assert_equal 200, response.status
-    body = JSON.parse(response.body)
-    assert_equal 43, body.fetch("oauth_id").length
-    assert_match(/^[A-Za-z0-9_-]+$/, body.fetch("oauth_id"))
-    assert_equal 43, body.fetch("oauth_secret").length
-    assert_match(/^[A-Za-z0-9_-]+$/, body.fetch("oauth_secret"))
+    assert_success_body(response)
   end
 
   #
   # Helpers
   #
+
+  def assert_success_body(response)
+    body = JSON.parse(response.body)
+    assert_equal Integer, body.fetch("id").class
+    assert_equal 43, body.fetch("oauth_id").length
+    assert_match(/^[A-Za-z0-9_-]+$/, body.fetch("oauth_id"))
+    assert_equal 43, body.fetch("oauth_secret").length
+    assert_match(/^[A-Za-z0-9_-]+$/, body.fetch("oauth_secret"))
+  end
 
   def assert_unauthorized(response)
     assert_equal "HTTP Token: Access denied.\n", response.body

--- a/test/integration/api/applications_test.rb
+++ b/test/integration/api/applications_test.rb
@@ -68,7 +68,7 @@ class ApplicationsTest < ActionDispatch::IntegrationTest
   test "#create provided redirect_uri is invalid" do
     post_req(endpoint, params: create_params.merge("redirect_uri" => "a bad redirect_uri!!!!!"))
     assert_equal 400, response.status
-    assert_equal JSON.generate({ error: "Not valid" }), response.body
+    assert_equal JSON.generate({ error: "Validation failed: Redirect URI must be an absolute URI." }), response.body
   end
 
   test "#create when application already exists" do

--- a/test/integration/api/applications_test.rb
+++ b/test/integration/api/applications_test.rb
@@ -37,7 +37,7 @@ class ApplicationsTest < ActionDispatch::IntegrationTest
     create(:application, name: name)
     get_req(endpoint, params: { "name" => "doesnt exist" })
     assert_equal 404, response.status
-    assert_equal JSON.generate({ error: "Not found" }), response.body
+    assert_equal JSON.generate({ error: "Record not found" }), response.body
   end
 
   test "#show returns an application" do
@@ -75,7 +75,7 @@ class ApplicationsTest < ActionDispatch::IntegrationTest
     create(:application, name: name)
     post_req(endpoint, params: create_params.merge("name" => name))
     assert_equal 409, response.status
-    assert_equal JSON.generate({ error: "ApplicationAlreadyCreated" }), response.body
+    assert_equal JSON.generate({ error: "Record not unique" }), response.body
   end
 
   test "#create adds an application" do

--- a/test/integration/api/authorisations_test.rb
+++ b/test/integration/api/authorisations_test.rb
@@ -2,15 +2,17 @@ require "test_helper"
 
 class AuthorisationsTest < ActionDispatch::IntegrationTest
   setup do
-    @api_user = create(:api_user)
-    @application = create(:application)
+    @api_user = create(:api_user, id: 123)
+    @application = create(:application, id: 456)
   end
 
-  create_endpoint = "/api/v1/authorisations"
-  test_endpoint = "/api/v1/authorisations/test"
+  create_endpoint = "/api/v1/api-users/123/authorisations"
+  test_endpoint = "/api/v1/api-users/123/authorisations/test"
+  invalid_create_endpoint = "/api/v1/api-users/invalid/authorisations"
+  invalid_test_endpoint = "/api/v1/api-users/invalid/authorisations/test"
   endpoints_with_params = [create_endpoint, test_endpoint].zip([
-    %w[application_name api_user_email],
-    %w[application_name api_user_email token],
+    %w[application_id],
+    %w[application_id token],
   ])
 
   endpoints_with_params.each do |endpoint, required_params|
@@ -33,19 +35,17 @@ class AuthorisationsTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "#create provided api_user_email is invalid" do
-    request(create_endpoint, params: {
-      api_user_email: "invalid@example.org",
-      application_name: @application.name,
+  test "#create provided api user id is invalid" do
+    request(invalid_create_endpoint, params: {
+      application_id: @application.id,
     })
     assert_equal 404, response.status
     assert_equal JSON.generate({ error: "Not found" }), response.body
   end
 
-  test "#create provided application_name is invalid" do
+  test "#create provided application_id is invalid" do
     request(create_endpoint, params: {
-      api_user_email: @api_user.email,
-      application_name: "Invalid name",
+      application_id: "Invalid ID",
     })
     assert_equal JSON.generate({ error: "Not found" }), response.body
     assert_equal 404, response.status
@@ -53,8 +53,7 @@ class AuthorisationsTest < ActionDispatch::IntegrationTest
 
   test "#create adds an application auth token to an api_user" do
     request(create_endpoint, params: {
-      api_user_email: @api_user.email,
-      application_name: @application.name,
+      application_id: @application.id,
     })
     assert_equal 200, response.status
     body = JSON.parse(response.body)
@@ -65,18 +64,31 @@ class AuthorisationsTest < ActionDispatch::IntegrationTest
 
   test "#test confirms that a token has been created" do
     request(create_endpoint, params: {
-      api_user_email: @api_user.email,
-      application_name: @application.name,
+      application_id: @application.id,
     })
+
     assert_equal 200, response.status
     token = JSON.parse(response.body).fetch("token")
     request(test_endpoint, params: {
-      api_user_email: @api_user.email,
-      application_name: @application.name,
+      application_id: @application.id,
       token: token,
     })
     assert_equal 200, response.status
     assert_equal JSON.generate(application_name: @application.name), response.body
+  end
+
+  test "#test provided api user id is invalid" do
+    request(create_endpoint, params: {
+      application_id: @application.id,
+    })
+    token = JSON.parse(response.body).fetch("token")
+
+    request(invalid_test_endpoint, params: {
+      application_id: @application.id,
+      token: token,
+    })
+    assert_equal 404, response.status
+    assert_equal JSON.generate({ error: "Not found" }), response.body
   end
 
   #

--- a/test/integration/api/authorisations_test.rb
+++ b/test/integration/api/authorisations_test.rb
@@ -40,14 +40,14 @@ class AuthorisationsTest < ActionDispatch::IntegrationTest
       application_id: @application.id,
     })
     assert_equal 404, response.status
-    assert_equal JSON.generate({ error: "Not found" }), response.body
+    assert_equal JSON.generate({ error: "Record not found" }), response.body
   end
 
   test "#create provided application_id is invalid" do
     request(create_endpoint, params: {
       application_id: "Invalid ID",
     })
-    assert_equal JSON.generate({ error: "Not found" }), response.body
+    assert_equal JSON.generate({ error: "Record not found" }), response.body
     assert_equal 404, response.status
   end
 
@@ -88,7 +88,7 @@ class AuthorisationsTest < ActionDispatch::IntegrationTest
       token: token,
     })
     assert_equal 404, response.status
-    assert_equal JSON.generate({ error: "Not found" }), response.body
+    assert_equal JSON.generate({ error: "Record not found" }), response.body
   end
 
   #

--- a/test/lib/data_hygiene/bulk_organisation_updater_test.rb
+++ b/test/lib/data_hygiene/bulk_organisation_updater_test.rb
@@ -7,7 +7,7 @@ class DataHygiene::BulkOrganisationUpdaterTest < ActiveSupport::TestCase
     file.close
 
     begin
-      DataHygiene::BulkOrganisationUpdater.call(file.path)
+      DataHygiene::BulkOrganisationUpdater.call(file.path, logger: Rails.logger)
     ensure
       file.unlink
     end


### PR DESCRIPTION
This adds the `/api/v1/api-users` resource and changes the `/api/v1/authorisations` endpoint to be a sub-resource of api-users: `/api/v1/api-users/:id/authorisations`. This API is currently not in use so we are safe to break the API without modifying the version.

This addition enables the only client ([Signon bootstrap rake task](https://github.com/alphagov/govuk-infrastructure/pull/499)) to create all Signon resources necessary during cluster turnup. Previously ApiUsers were created using a Signon rake task.

Trello: https://trello.com/c/fUXJ6X1U/725-create-signon-resources-when-signon-is-deployed