### PR TITLE
Remove non-robust DB migration

### DIFF
--- a/db/migrate/20200805142418_update_apha_parent.rb
+++ b/db/migrate/20200805142418_update_apha_parent.rb
@@ -1,9 +1,0 @@
-class UpdateAphaParent < ActiveRecord::Migration[6.0]
-  def up
-    apha = Organisation.find_by(abbreviation: "APHA")
-    defra = Organisation.find_by(abbreviation: "DEFRA")
-    apha.update!(parent: defra)
-  end
-
-  def down; end
-end


### PR DESCRIPTION
This db migration will fail if the Organisations do not exist in the Signon database.