### PR TITLE
Fix link appearance

### DIFF
--- a/app/views/root/signin_required.html.erb
+++ b/app/views/root/signin_required.html.erb
@@ -10,14 +10,14 @@
           Ask your organisation’s main GOV.UK contact if you need access.
         <% end %>
       </p>
-      <p class="govuk-body">If you think something is wrong, try <%= link_to "signing out", destroy_user_session_path %> and then
+      <p class="govuk-body">
+        If you think something is wrong, try <%= link_to "signing out", destroy_user_session_path, class: "govuk-link" %> and then
         <%- if @application.present? -%>
-          <%= link_to 'back in', @application.home_uri -%>
+          <%= link_to "back in", @application.home_uri, class: "govuk-link" -%>
         <%- else -%>
           back in
         <%- end %>.
       </p>
     <% end %>
-
-    </div>
+  </div>
 </div>


### PR DESCRIPTION
## What

Links on the "Sign in required" page needed `govuk-link` class added to be styled correctly.

## Why

To be visually consistent with the rest of the application.


## Visual differences

Before:
![image](https://user-images.githubusercontent.com/1732331/153861053-f46e7f7a-e2ca-4eaa-885d-27cfac48fb76.png)

After:
![image](https://user-images.githubusercontent.com/1732331/153861104-ad029f25-867f-44fc-a010-406eb2d99240.png)
