### PR TITLE
Update Signon API to enable updating permissions

### DIFF
--- a/app/controllers/api/v1/authorisations_controller.rb
+++ b/app/controllers/api/v1/authorisations_controller.rb
@@ -30,7 +30,10 @@ class Api::V1::AuthorisationsController < Api::V1::ApiController
         token: params.require(:token),
       )
 
-    render json: { application_name: authorisation.application.name }
+    render json: {
+      application_name: authorisation.application.name,
+      permissions: api_user.permissions_for(authorisation.application),
+    }
   end
 
 private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -70,6 +70,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       get "applications", to: "applications#show"
       post "applications", to: "applications#create"
+      patch "applications/:id", to: "applications#update"
       get "api-users", to: "api_users#show"
       post "api-users", to: "api_users#create"
       post "api-users/:id/authorisations", to: "authorisations#create"


### PR DESCRIPTION
This is required for the signon-bootstrap client to update permissions on apps and api-users.

Co-Authored-By @theseanything 

https://trello.com/c/7ZSzslmt/849-signon-bootstrap-improvements