### PR TITLE
Add local jQuery

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,3 +1,4 @@
+//= require jquery/dist/jquery
 //= require govuk_publishing_components/dependencies
 //= require govuk_publishing_components/all_components
 //= require password-strength-indicator

--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
   "stylelint": {
     "extends": "stylelint-config-gds/scss"
   },
+  "dependencies": {
+    "jquery": "1.12.4"
+  },
   "devDependencies": {
     "jasmine-browser-runner": "^1.0.0",
     "jasmine-core": "^4.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1682,6 +1682,11 @@ jasmine-core@^4.0.1:
   resolved "https://registry.yarnpkg.com/jasmine-core/-/jasmine-core-4.0.1.tgz#ea4b0495d82155023bd56c25181d9f9b623f61b8"
   integrity sha512-w+JDABxQCkxbGGxg+a2hUVZyqUS2JKngvIyLGu/xiw2ZwgsoSB0iiecLQsQORSeaKQ6iGrCyWG86RfNDuoA7Lg==
 
+jquery@1.12.4:
+  version "1.12.4"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-1.12.4.tgz#01e1dfba290fe73deba77ceeacb0f9ba2fec9e0c"
+  integrity sha1-AeHfuikP5z3rp3zurLD5ui/sngw=
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"


### PR DESCRIPTION
## What
Adds jQuery as a local dependency, instead of relying on the jQuery that comes from the components gem.

**This PR should be deployed immediately prior to the removal of jQuery from GOV.UK** in order to minimise the time when this application will effectively contain two copies of jQuery. This shouldn't cause any errors, but it will lead to an increased asset size.

Note that I've only been able to test the first sign in screen in this application to check it works - not sure how to progress further locally.

## Why
jQuery is going to be removed from the components gem soon.

## Visual changes
None.

Trello card: https://trello.com/c/mAfQNVRG/745-investigate-which-apps-we-could-remove-jquery-from?filter=member:andysellick2