### PR TITLE
Remove need for jQuery on design system layout

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,4 +1,4 @@
 //= require govuk_publishing_components/dependencies
 //= require govuk_publishing_components/all_components
 //= require password-strength-indicator
-//= require jquery_ujs
+//= require rails-ujs

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -42,32 +42,9 @@
   margin: 0;
 }
 
-.app-error-message--validation {
-  display: none;
-}
-
 .govuk-error-summary {
   li {
     color: #b10e1e;
     font-weight: bold;
   }
-}
-
-// stylelint-disable selector-max-id
-// TODO: replace IDs with `js-` prefixed classes as JavaScript selectors
-.not-strong-enough #password-guidance,
-.not-strong-enough #password-entropy,
-.password-too-short #password-guidance,
-.password-too-short #password-too-short,
-.parts-of-email #password-guidance,
-.parts-of-email #parts-of-email,
-.confirmation-not-matching #password-confirmation-guidance {
-  display: block;
-}
-
-#password-entropy,
-#password-too-short,
-#parts-of-email,
-#password-confirmation-guidance {
-  display: none;
 }

--- a/app/views/devise/passwords/_change_password_panel.html.erb
+++ b/app/views/devise/passwords/_change_password_panel.html.erb
@@ -1,4 +1,4 @@
-<div id="password-change-panel">
+<div id="password-change-panel" data-module="password-strength-indicator">
   <% if defined?(updating_password) && updating_password %>
     <%= render "govuk_publishing_components/components/input", {
       label: {
@@ -10,7 +10,7 @@
     } %>
   <% end %>
 
-  <div id="password-control-group">
+  <div id="password-control-group" class="password-control-group">
     <%= render "govuk_publishing_components/components/input", {
       label: {
         text: "New password"
@@ -20,19 +20,13 @@
       id: "user_password",
       type: "password",
       data: {
-        'weak-words': user_email_tokens(user).join(","),
+        'email-parts': user_email_tokens(user).join(","),
         'min-password-length': minimum_password_length
       }
     } %>
-    <div class="govuk-error-message app-error-message--validation" id="password-guidance">
-      <p id="password-too-short">Your password must be at least 10 characters</p>
-      <p id="parts-of-email">Your password shouldn’t include part or all of your email address</p>
-      <p id="password-entropy">Your password must be more complex</p>
-    </div>
-
   </div>
 
-  <div id="password-confirmation-control-group">
+  <div id="password-confirmation-control-group" class="password-confirmation-control-group">
     <%= render "govuk_publishing_components/components/input", {
       label: {
         text: "Confirm new password"
@@ -41,13 +35,10 @@
       id: "user_password_confirmation",
       type: "password",
     } %>
-    <div class="govuk-error-message app-error-message--validation" id="password-confirmation-guidance">
-      <p>The confirmation must match the new password</p>
-    </div>
-
   </div>
 
   <%= render "govuk_publishing_components/components/button", {
     text: t("users.edit.change"),
     margin_bottom: true
   } %>
+</div>

--- a/app/views/devise/passwords/_change_password_panel.html.erb
+++ b/app/views/devise/passwords/_change_password_panel.html.erb
@@ -1,23 +1,21 @@
-<div id="password-change-panel" data-module="password-strength-indicator">
+<div data-module="password-strength-indicator">
   <% if defined?(updating_password) && updating_password %>
     <%= render "govuk_publishing_components/components/input", {
       label: {
         text: "Current password"
       },
       name: "user[current_password]",
-      id: "user_current_password",
       type: "password"
     } %>
   <% end %>
 
-  <div id="password-control-group" class="password-control-group">
+  <div class="password-control-group">
     <%= render "govuk_publishing_components/components/input", {
       label: {
         text: "New password"
       },
       hint: "Passwords must be at least 10 characters, shouldn’t include part of your email address and must be complex. Consider using whole sentences (with spaces), lyrics or phrases to make your password more memorable.",
       name: "user[password]",
-      id: "user_password",
       type: "password",
       data: {
         'email-parts': user_email_tokens(user).join(","),
@@ -26,13 +24,12 @@
     } %>
   </div>
 
-  <div id="password-confirmation-control-group" class="password-confirmation-control-group">
+  <div class="password-confirmation-control-group">
     <%= render "govuk_publishing_components/components/input", {
       label: {
         text: "Confirm new password"
       },
       name: "user[password_confirmation]",
-      id: "user_password_confirmation",
       type: "password",
     } %>
   </div>


### PR DESCRIPTION
This PR will remove the need to delicately swap jQuery when govuk_publishing_components is released without it as per: https://github.com/alphagov/signon/pull/1813

Principally the work in this PR is to rewrite the password-strength-indicator script. Which was quite an old bit of jQuery we had with some interesting approaches to showing errors. This code is tested through a feature test: https://github.com/alphagov/signon/blob/3301f7028850afd389b9c42e4bef1636b8d326d0/test/integration/password_change_test.rb#L69-L104 which hasn't needed any changes. I looked into writing JS unit tests but that was complex because of the two different layouts JS files.

Here's a quick gif of how it looks for evidence:

![Mar-24-2022 12-37-20](https://user-images.githubusercontent.com/282717/159917732-b5ea4586-28f7-4313-b826-82ef8098cb64.gif)

