### PR TITLE
Remove jQuery from design-system layout JS

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,4 +1,3 @@
-//= require jquery/dist/jquery
 //= require govuk_publishing_components/dependencies
 //= require govuk_publishing_components/all_components
 //= require password-strength-indicator

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -5,6 +5,3 @@ Rails.application.config.assets.version = "1.0"
 
 # Enable the asset pipeline
 Rails.application.config.assets.enabled = true
-
-# Add node_modules folder to the asset load path.
-Rails.application.config.assets.paths << Rails.root.join("node_modules")

--- a/package.json
+++ b/package.json
@@ -32,9 +32,6 @@
   "stylelint": {
     "extends": "stylelint-config-gds/scss"
   },
-  "dependencies": {
-    "jquery": "1.12.4"
-  },
   "devDependencies": {
     "jasmine-browser-runner": "^1.0.0",
     "jasmine-core": "^4.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1324,11 +1324,6 @@ jasmine-core@^4.0.1:
   resolved "https://registry.yarnpkg.com/jasmine-core/-/jasmine-core-4.0.1.tgz#ea4b0495d82155023bd56c25181d9f9b623f61b8"
   integrity sha512-w+JDABxQCkxbGGxg+a2hUVZyqUS2JKngvIyLGu/xiw2ZwgsoSB0iiecLQsQORSeaKQ6iGrCyWG86RfNDuoA7Lg==
 
-jquery@1.12.4:
-  version "1.12.4"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-1.12.4.tgz#01e1dfba290fe73deba77ceeacb0f9ba2fec9e0c"
-  integrity sha1-AeHfuikP5z3rp3zurLD5ui/sngw=
-
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"


### PR DESCRIPTION
We no longer need jQuery as a dependency for the design system aspects
of signon. This need was removed in: https://github.com/alphagov/signon/pull/1818