### PR TITLE
Fix use of incorrect variable in email template

### DIFF
--- a/app/views/user_mailer/email_changed_notification.text.erb
+++ b/app/views/user_mailer/email_changed_notification.text.erb
@@ -1,5 +1,5 @@
 Your <%= t('department.name') %> Signon <%= account_name %> email address is being changed from <%= @user.email %> to <%= @user.unconfirmed_email %>.
 
-You should follow the instructions sent to your new email address: <%= @user.email %> to confirm this change.
+You should follow the instructions sent to your new email address: <%= @user.unconfirmed_email %> to confirm this change.
 
 If your email address shouldn't have changed you should contact a managing <%= t('department.name') %> editor in your organisation or your parent organisation.


### PR DESCRIPTION
The "Confirm your email change" email template was using the wrong variable. When referring to the user's "new email address", it was displaying the user's old email address.

Thanks to @ChrisBAshton for tipping us off about this bug.