### PR TITLE
Remove link to make a support request when logged out

### DIFF
--- a/app/views/layouts/admin_layout.html.erb
+++ b/app/views/layouts/admin_layout.html.erb
@@ -44,15 +44,17 @@
       {
         title: "Support and feedback",
         items: [
-          {
-            href: Plek.new.external_url_for("support"),
-            text: "Raise a support request"
-          },
+          (
+            {
+              href: Plek.new.external_url_for("support"),
+              text: "Raise a support request"
+            } if user_signed_in?
+          ),
           {
             href: "https://www.gov.uk/government/content-publishing",
-            text: "How to write, publish, and improve content"
+            text: "How to write, publish, and improve content",
           }
-        ]
+        ].compact
       }
     ]
   } %>

--- a/test/integration/dashboard_test.rb
+++ b/test/integration/dashboard_test.rb
@@ -23,6 +23,15 @@ class DashboardTest < ActionDispatch::IntegrationTest
     assert page.has_css?("a[href='#{app.home_uri}']")
   end
 
+  should "include a link to request support" do
+    user = create(:user)
+
+    visit root_path
+    signin_with(user)
+
+    assert_response_contains("Raise a support request")
+  end
+
   context "when the user has enrolled in 2SV" do
     should "display the 'change' link" do
       user = create(:two_step_enabled_user)

--- a/test/integration/sign_in_test.rb
+++ b/test/integration/sign_in_test.rb
@@ -8,6 +8,11 @@ class SignInTest < ActionDispatch::IntegrationTest
     @user = create(:user_in_organisation, email: @email, password: @password, organisation: @organisation)
   end
 
+  should "not include a link to request support" do
+    visit root_path
+    refute_response_contains("Raise a support request")
+  end
+
   should "display a confirmation for successful sign-ins" do
     visit root_path
     signin_with(email: "email@example.com", password: "some password with various $ymb0l$")


### PR DESCRIPTION
This link is rendered to users who are not logged in. However the support system is behind Signon, so requires a user to be logged in to make a request. This leads to them being sent back to the same login page.

Removing the link to remove the continuous loop.

When signed out:
![Screenshot showing the footer links when signed out.  The "raise support request" link does not appear.](https://user-images.githubusercontent.com/6329861/161753524-d5286e64-9f73-4a74-b9b0-55d7f9e23406.png)

When signed in:
![Screenshot showing the footer links when signed in.  The "raise support request" link appears.](https://user-images.githubusercontent.com/6329861/161753537-f8888d3c-90cd-403f-8975-3a2b6c7bea0d.png)

[Trello card](https://trello.com/c/A55SZgO4/346-remove-support-link-from-signon-homepage)