### PR TITLE
Change `user_agent_string` column type to text

### DIFF
--- a/db/migrate/20220419100040_change_event_logs_user_agent_string_to_text.rb
+++ b/db/migrate/20220419100040_change_event_logs_user_agent_string_to_text.rb
@@ -1,0 +1,9 @@
+class ChangeEventLogsUserAgentStringToText < ActiveRecord::Migration[7.0]
+  def up
+    change_column :event_logs, :user_agent_string, :text
+  end
+
+  def down
+    change_column :event_logs, :user_agent_string, :string
+  end
+end


### PR DESCRIPTION
This column currently has a limit of 255 characters. Changing to text to remove this limit as we have found some user agents can exceed this.

The update to `db/schema.rb` was accidentally committed already in https://github.com/alphagov/signon/pull/1842.