### PR TITLE
Improve Dockerfile and allow running as non-root.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+*/log
+.dockerignore
+.git
+.gitignore
+CONTRIBUTING.md
+Dockerfile
+Jenkinsfile
+Procfile
+README.md
+docs
+spec
+test
+tmp

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,10 +1,11 @@
-# Sample configuration file for Sidekiq.
+# Configuration file for Sidekiq.
 # Options here can still be overridden by cmd line args.
-#   sidekiq -C config.yml
 ---
 :verbose: true
-:concurrency:  2
-:logfile: ./log/sidekiq.log
+:concurrency: 2
+<% if ENV.key?('SIDEKIQ_LOGFILE') %>
+:logfile: <%= ENV['SIDEKIQ_LOGFILE'] %>
+<% end %>
 :queues:
   - default
   - mailers


### PR DESCRIPTION
- Fix Sidekiq config to log to stdout by default but still log to `log/sidekiq.log` in the EC2 environments.
- Use debian-slim as base instead of the full version.
- Multi-stage build to separate out build dependencies from runtime dependencies.
- Add .dockerignore.
- Don't run as root by default.
- Populate the bootsnap cache at build time so it doesn't try to write to the read-only image filesystem.

Image shrinks from ~800M to ~500M.

https://trello.com/c/Jef1t4xU