### PR TITLE
Symlink /app/tmp to /tmp in the Docker image & sync Bundler version.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ RUN apt-get update -qy
 RUN apt-get install -y --no-install-suggests --no-install-recommends \
     nodejs libmariadb-dev-compat
 
+RUN ln -fs /tmp /app/tmp
 WORKDIR /app
 COPY Gemfile Gemfile.lock .ruby-version /app/
 RUN echo 'install: --no-document' >> /etc/gemrc && bundle install
@@ -54,6 +55,7 @@ ENV BOOTSNAP_CACHE_DIR=/var/cache/bootsnap
 WORKDIR /app
 
 RUN echo 'IRB.conf[:HISTORY_FILE] = "/tmp/irb_history"' > irb.rc
+RUN ln -fs /tmp /app/tmp
 
 # TODO: include libmariadb3 in the base image and stop running apt-get install here.
 COPY --from=builder /var/lib/apt/lists/ /var/lib/apt/lists/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -536,4 +536,4 @@ DEPENDENCIES
   zeroclipboard-rails
 
 BUNDLED WITH
-   2.1.4
+   2.3.11


### PR DESCRIPTION
This covers the general case for Ruby gems wanting to write to what should be a read-only filesystem. We've configured most of the cache locations and whatnot already, but it seems there's no standard setting for Ruby/Rails to tell it where to write temporary files.

We create the symlink in the build stage as well as the final stage, because things like `rails assets:precompile` write stuff to `app/tmp` (which thankfully we don't need) and that would make it a pain to create the symlink later.

While we're there, update the version of Bundler to the one in the base image so that Bundler doesn't have to reinstall itself every time we build the image.

Tested: locally with `docker build -t signon .` / `docker run -it --rm signon bash`. Puma starts up ok, rails console works.