### PR TITLE
Add Prometheus exporter for EKS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,7 @@ ENV BUNDLE_WITHOUT="development test"
 ENV GOVUK_APP_NAME=signon
 ENV ASSETS_PREFIX=/assets/signon
 ENV BOOTSNAP_CACHE_DIR=/var/cache/bootsnap
+ENV GOVUK_PROMETHEUS_EXPORTER=true
 
 WORKDIR /app
 

--- a/config/initializers/prometheus.rb
+++ b/config/initializers/prometheus.rb
@@ -1,0 +1,2 @@
+require "govuk_app_config/govuk_prometheus_exporter"
+GovukPrometheusExporter.configure


### PR DESCRIPTION
Enable Prometheus exporter for EKS by:
1. adding `GOVUK_PROMETHEUS_EXPORTER=true` to Dockerfile
2. adding Prometheus initializer