### PR TITLE
Remove deprecated_columns gem and code

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,6 @@ gem "whenever"
 gem "zeroclipboard-rails"
 
 # GDS Gems
-gem "deprecated_columns"
 gem "gds-api-adapters"
 gem "govuk_admin_template"
 gem "govuk_app_config"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,8 +118,6 @@ GEM
       rexml
     crass (1.0.6)
     debug_inspector (1.1.0)
-    deprecated_columns (0.1.1)
-      rails (>= 4.0)
     devise (4.8.1)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -490,7 +488,6 @@ DEPENDENCIES
   browser
   capybara
   capybara-email
-  deprecated_columns
   devise
   devise-encryptable
   devise_invitable

--- a/app/models/event_log.rb
+++ b/app/models/event_log.rb
@@ -1,8 +1,6 @@
 require "ipaddr"
 
 class EventLog < ApplicationRecord
-  deprecated_columns :event
-
   LOCKED_DURATION = "#{Devise.unlock_in / 1.hour} #{'hour'.pluralize(Devise.unlock_in / 1.hour)}".freeze
 
   EVENTS = [


### PR DESCRIPTION
This functionality hasn't been used since the events column was removed
way back in 2015 [1]. This gem is seriously old and has likely been
superseded by ignore_columns added to Rails 5.

[1]: https://github.com/alphagov/signon/commit/2528879bd4314027c3216773007c4f166f1c0a4b