### PR TITLE
Revert "Bump govuk_publishing_components from 29.14.0 to 29.15.0"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -174,7 +174,7 @@ GEM
     govuk_personalisation (0.12.0)
       plek (>= 1.9.0)
       rails (>= 6, < 8)
-    govuk_publishing_components (29.15.0)
+    govuk_publishing_components (29.14.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown
@@ -198,7 +198,7 @@ GEM
     http-accept (1.7.0)
     http-cookie (1.0.5)
       domain_name (~> 0.5)
-    i18n (1.12.0)
+    i18n (1.11.0)
       concurrent-ruby (~> 1.0)
     jquery-rails (4.4.0)
       rails-dom-testing (>= 1, < 3)


### PR DESCRIPTION
Reverts alphagov/signon#1895

Bug in 29.15.0: https://github.com/alphagov/govuk_publishing_components/issues/2861