### PR TITLE
Rewrite redirect and home URIs for OAuth Applications

### DIFF
--- a/app/models/doorkeeper/application.rb
+++ b/app/models/doorkeeper/application.rb
@@ -56,7 +56,26 @@ class ::Doorkeeper::Application < ActiveRecord::Base
     ].include?(name)
   end
 
+  def redirect_uri
+    substituted_uri(self[:redirect_uri])
+  end
+
+  def home_uri
+    substituted_uri(self[:home_uri])
+  end
+
 private
+
+  def substituted_uri(uri)
+    uri_pattern = Rails.configuration.oauth_apps_uri_sub_pattern
+    uri_sub = Rails.configuration.oauth_apps_uri_sub_replacement
+
+    if uri_pattern.present? && uri_sub.present?
+      uri.sub(uri_pattern, uri_sub)
+    else
+      uri
+    end
+  end
 
   def create_signin_supported_permission
     supported_permissions.create!(name: "signin", delegatable: true)

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+Rails.configuration.oauth_apps_uri_sub_pattern = ENV["SIGNON_APPS_URI_SUB_PATTERN"]
+Rails.configuration.oauth_apps_uri_sub_replacement = ENV["SIGNON_APPS_URI_SUB_REPLACEMENT"]
+
 Doorkeeper.configure do
   # Change the ORM that doorkeeper will use (requires ORM extensions installed).
   # Check the list of supported ORMs here: https://github.com/doorkeeper-gem/doorkeeper#orms

--- a/test/models/doorkeeper_application_test.rb
+++ b/test/models/doorkeeper_application_test.rb
@@ -63,6 +63,58 @@ class ::Doorkeeper::ApplicationTest < ActiveSupport::TestCase
     end
   end
 
+  context "redirect_uri" do
+    should "return application redirect uri" do
+      application = create(:application)
+
+      assert_equal "https://app.com/callback", application.redirect_uri
+    end
+
+    should "return application substituted redirect uri if match" do
+      Rails.application.config.stubs(oauth_apps_uri_sub_pattern: "replace.me")
+      Rails.application.config.stubs(oauth_apps_uri_sub_replacement: "new.domain")
+
+      application = create(:application, redirect_uri: "https://app.replace.me/callback")
+
+      assert_equal "https://app.new.domain/callback", application.redirect_uri
+    end
+
+    should "return application original redirect uri if not matched" do
+      Rails.application.config.stubs(oauth_apps_uri_sub_pattern: "replace.me")
+      Rails.application.config.stubs(oauth_apps_uri_sub_replacement: "new.domain")
+
+      application = create(:application, redirect_uri: "https://app.keep.me/callback")
+
+      assert_equal "https://app.keep.me/callback", application.redirect_uri
+    end
+  end
+
+  context "home_uri" do
+    should "return application home uri" do
+      application = create(:application)
+
+      assert_equal "https://app.com/", application.home_uri
+    end
+
+    should "return application substituted home uri if match" do
+      Rails.application.config.stubs(oauth_apps_uri_sub_pattern: "replace.me")
+      Rails.application.config.stubs(oauth_apps_uri_sub_replacement: "new.domain")
+
+      application = create(:application, home_uri: "https://app.replace.me/")
+
+      assert_equal "https://app.new.domain/", application.home_uri
+    end
+
+    should "return application original home uri if not matched" do
+      Rails.application.config.stubs(oauth_apps_uri_sub_pattern: "replace.me")
+      Rails.application.config.stubs(oauth_apps_uri_sub_replacement: "new.domain")
+
+      application = create(:application, home_uri: "https://app.keep.me/")
+
+      assert_equal "https://app.keep.me/", application.home_uri
+    end
+  end
+
   context "scopes" do
     should "return applications that the user can signin into" do
       user = create(:user)


### PR DESCRIPTION
This adds the ability to rewrite parts of the redirect and home URIs for OAuth Applications. This allows us to run Signon in our new infrastructure alongside the existing instance of Signon and redirect users to the correct domains for applications running in the new infrastructure. This will remove the need to create separate OAuth Applications for instances of applications in the new infrastructure.

You can use the following env vars to configure the URI string substitution:
SIGNON_APPS_URI_SUB_PATTERN: the pattern within URI to match and rewrite (e.g. "integration.publishing.service.gov.uk")
SIGNON_APPS_URI_SUB_REPLACEMENT: the string to replace the matching pattern (e.g. "integration.eks.govuk.digital")
