### PR TITLE
Ignore expiring EKS tokens in healthcheck

### DIFF
--- a/lib/healthcheck/api_tokens.rb
+++ b/lib/healthcheck/api_tokens.rb
@@ -20,6 +20,7 @@ module Healthcheck
       INNER JOIN users ON users.id = tokens.resource_owner_id
       WHERE tokens.revoked_at IS NULL
       AND users.email NOT LIKE '%@#{ENV['GOVUK_ENVIRONMENT_NAME']}.publishing.service.gov.uk'
+      AND users.name NOT LIKE '%[EKS]'
       AND users.api_user = TRUE
       AND tokens.expires_in < #{WARNING_THRESHOLD}
     SQL

--- a/test/lib/healthcheck/api_tokens_test.rb
+++ b/test/lib/healthcheck/api_tokens_test.rb
@@ -18,6 +18,17 @@ class PermissionUpdaterTest < ActiveSupport::TestCase
       assert_equal :ok, check.status
     end
 
+    should "return 'OK' when EKS tokens are expiring" do
+      user = create(:api_user, name: "Publisher [EKS]")
+
+      make_api_user_token(
+        expires_in: Healthcheck::ApiTokens::WARNING_THRESHOLD,
+        user: user,
+      )
+      check = Healthcheck::ApiTokens.new
+      assert_equal :ok, check.status
+    end
+
     should "return 'WARNING' when a token is getting old" do
       make_api_user_token(expires_in: Healthcheck::ApiTokens::WARNING_THRESHOLD)
       check = Healthcheck::ApiTokens.new


### PR DESCRIPTION
[Trello card](https://trello.com/c/j5cMUAJa/2954-split-expiring-signon-token-alert-into-individual-ones-3)

2nd line doesn't need to rotate expired EKS tokens - new tokens should automatically be issued for Replatforming's stuff.

Because this alert covers all tokens handled by signon, we can't just acknowledge/ignore the alert, as that would suppress genuine issues.

Instead we can take advantage of the fact that tokens for EKS apps have user names ending with `[EKS]`, and simply filter out those tokens from the alert.