### PR TITLE
Copy changes for 2 step verification guidance

### DIFF
--- a/app/views/devise/two_step_verification/_make_your_account_more_secure.html.erb
+++ b/app/views/devise/two_step_verification/_make_your_account_more_secure.html.erb
@@ -1,5 +1,5 @@
 <div class="govuk-body">
-  <p>Make your account more secure by setting up 2&#8209;step verification. You’ll need to install an app on your phone which will generate a security code to enter when you sign in.</p>
+  <p>Make your account more secure by setting up 2&#8209;step verification. You’ll need to install an app on your phone which will generate a verification code to enter when you sign in.</p>
   <p>Set up takes about 5 minutes.</p>
 </div>
 

--- a/app/views/devise/two_step_verification/show.html.erb
+++ b/app/views/devise/two_step_verification/show.html.erb
@@ -10,34 +10,20 @@
         <p>Setting up a new phone will replace your existing one. You will only be able to sign in with your new phone.</p>
       </div>
     <% end %>
-    <p class="lead">Make your signon account more secure by setting up 2-step verification. You’ll need to install an app on your phone which will generate a security code to enter when you sign in.</p>
+    <p class="lead">Make your Signon account more secure by setting up 2-step verification. You’ll need to install an app on your phone which will generate a verification code to enter when you sign in.</p>
 
     <div class="panel-group" id="setup-steps" role="tablist" aria-multiselectable="true">
       <div class="panel panel-part">
         <div class="panel-heading" role="tab" id="step-one-heading">
           <h4 class="panel-title">
             <a role="button" data-toggle="collapse" data-parent="#setup-steps" href="#step-one" aria-expanded="true" aria-controls="step-one">
-              Install a verification app on your phone
+              1. Install a verification app on your phone
             </a>
           </h4>
         </div>
         <div id="step-one" class="panel-collapse collapse <% unless invalid_code_entered %>in<% end %>" role="tabpanel" aria-labelledby="step-one-heading">
           <div class="panel-body">
-            <p class="lead">Install one of the following apps from the app store on your phone.</p>
-            <ul class="list-group">
-              <li class="list-group-item">
-                <h4 class="list-group-item-heading">Google Authenticator</h4>
-                For iPhone, iPad, Android and Blackberry
-              </li>
-              <li class="list-group-item">
-                <h4 class="list-group-item-heading">Duo Mobile</h4>
-                For iPhone, iPad and Android
-              </li>
-              <li class="list-group-item">
-                <h4 class="list-group-item-heading">Windows Authenticator</h4>
-                For Windows phone
-              </li>
-            </ul>
+            <p class="lead">Install a verification app from the app store on your phone - for example, Google Authenticator or Microsoft Authenticator.</p>
             <a class="collapsed btn btn-lg btn-success" role="button" data-toggle="collapse" data-parent="#setup-steps" href="#step-two" aria-expanded="false" aria-controls="step-two">
               Next
             </a>
@@ -48,7 +34,7 @@
         <div class="panel-heading" role="tab" id="step-two-heading">
           <h4 class="panel-title">
             <a class="collapsed" role="button" data-toggle="collapse" data-parent="#setup-steps" href="#step-two" aria-expanded="false" aria-controls="step-two">
-              Scan the barcode using your app
+              2. Scan the barcode using your app
             </a>
           </h4>
         </div>
@@ -60,7 +46,7 @@
                 <%= image_tag(qr_code_data_uri, width: 180) %>
               </li>
             </ul>
-            <p class="add-bottom-margin">Can’t use a barcode? Enter the code manually: <%= @otp_secret_key%></p>
+            <p class="add-bottom-margin">If you cannot use a barcode, you can enter a code instead. This is sometimes called a set-up key, a secret key, or an activation key. Enter this code when asked: <%= @otp_secret_key%></p>
             <a class="collapsed btn btn-lg btn-success" role="button" data-toggle="collapse" data-parent="#setup-steps" href="#step-three" aria-expanded="false" aria-controls="step-three">
               Next
             </a>
@@ -71,7 +57,7 @@
         <div class="panel-heading" role="tab" id="step-three-heading">
           <h4 class="panel-title">
             <a class="collapsed" role="button" data-toggle="collapse" data-parent="#setup-steps" href="#step-three" aria-expanded="false" aria-controls="step-three">
-              Enter the code from your phone
+              3. Enter the verification code shown in the app
             </a>
           </h4>
         </div>
@@ -86,7 +72,7 @@
               <%= form_tag two_step_verification_path, method: :put do %>
                 <%= hidden_field_tag :otp_secret_key, @otp_secret_key%>
                 <div class="form-group <% if invalid_code_entered %>has-error text-danger<% end %>">
-                  <%= label_tag :code, 'Code from your phone' %>
+                  <%= label_tag :code, 'Code from app' %>
                   <%= text_field_tag :code, nil,
                     class: 'form-control input-md-4 input-lg',
                     placeholder: 'Enter 6-digit code',

--- a/app/views/devise/two_step_verification_session/new.html.erb
+++ b/app/views/devise/two_step_verification_session/new.html.erb
@@ -12,7 +12,7 @@
         autofocus: true,
         tabindex: 0,
         autocomplete: "off",
-        hint: "Use the 6-digit verification app on your phone to get your code. You won’t need to do this again for 30 days."
+        hint: "Use the app on your phone to get your 6-digit verification code. You will not need to do this again for 30 days"
       } %>
 
       <%= render "govuk_publishing_components/components/button", {
@@ -23,9 +23,8 @@
 </div>
 
 <%= render "govuk_publishing_components/components/details", {
-  title: "Can’t get your verification code?"
+  title: "If you cannot get your verification code"
 } do %>
-  <p>If you can’t get your verification code, you’ll need to ask <%= link_to t('department.name'), t('department.url') %> to reset 2-step verification on your Signon account.</p>
-  <p>If you can’t do this yourself, you’ll need to contact a managing <%= link_to t('department.name'), t('department.url') %> editor in your organisation (or your parent organisation). They can raise a <%= link_to "support ticket", "#{t('department.url')}support/internal/" %> on your behalf.</p>
-  <p><%= link_to t('department.name'), t('department.url') %> is only able to respond to these requests 9am to 5pm, Monday to Friday.</p>
+  <p>If you cannot get your verification code, GDS can reset your 2-step verification. Ask a GOV.UK lead or managing editor in your organisation (or your parent organisation) to submit a support request for you.</p>
+  <p>GDS support is available from 9am to 5pm, Monday to Friday.</p>
 <% end %>

--- a/test/integration/authorise_application_test.rb
+++ b/test/integration/authorise_application_test.rb
@@ -41,7 +41,7 @@ class AuthoriseApplicationTest < ActionDispatch::IntegrationTest
     ignoring_spurious_error do
       visit "/oauth/authorize?response_type=code&client_id=#{@app.uid}&redirect_uri=#{@app.redirect_uri}"
     end
-    assert_response_contains("get your code")
+    assert_response_contains("get your 6-digit verification code")
     assert_not Doorkeeper::AccessGrant.find_by(resource_owner_id: @user.id)
   end
 

--- a/test/integration/sign_in_test.rb
+++ b/test/integration/sign_in_test.rb
@@ -116,7 +116,7 @@ class SignInTest < ActionDispatch::IntegrationTest
     should "prompt for a verification code" do
       visit root_path
       signin_with(email: "email@example.com", password: "some password with various $ymb0l$", second_step: false)
-      assert_response_contains "get your code"
+      assert_response_contains "get your 6-digit verification code"
       assert_selector "input[name=code]"
     end
 
@@ -145,7 +145,7 @@ class SignInTest < ActionDispatch::IntegrationTest
       visit root_path
       signin_with(email: "email@example.com", password: "some password with various $ymb0l$", second_step: false)
       visit root_path
-      assert_response_contains "get your code"
+      assert_response_contains "get your 6-digit verification code"
       assert_selector "input[name=code]"
     end
 
@@ -160,7 +160,7 @@ class SignInTest < ActionDispatch::IntegrationTest
       visit root_path
       signin_with(email: "email@example.com", password: "some password with various $ymb0l$", second_step: "")
 
-      assert_response_contains "get your code"
+      assert_response_contains "get your 6-digit verification code"
       assert_equal 1, EventLog.where(event_id: EventLog::TWO_STEP_VERIFICATION_FAILED.id, uid: @user.uid).count
     end
 
@@ -170,7 +170,7 @@ class SignInTest < ActionDispatch::IntegrationTest
       visit root_path
       signin_with(email: "email@example.com", password: "some password with various $ymb0l$", second_step: old_code)
 
-      assert_response_contains "get your code"
+      assert_response_contains "get your 6-digit verification code"
       assert_equal 1, EventLog.where(event_id: EventLog::TWO_STEP_VERIFICATION_FAILED.id, uid: @user.uid).count
     end
 
@@ -178,7 +178,7 @@ class SignInTest < ActionDispatch::IntegrationTest
       visit root_path
       signin_with(email: "email@example.com", password: "some password with various $ymb0l$", second_step: "abcdef")
 
-      assert_response_contains "get your code"
+      assert_response_contains "get your 6-digit verification code"
       assert_equal 1, EventLog.where(event_id: EventLog::TWO_STEP_VERIFICATION_FAILED.id, uid: @user.uid).count
     end
 
@@ -211,7 +211,7 @@ class SignInTest < ActionDispatch::IntegrationTest
 
         visit root_path
         signin_with(email: "email@example.com", password: "some password with various $ymb0l$", second_step: false)
-        assert_response_contains "get your code"
+        assert_response_contains "get your 6-digit verification code"
         assert_selector "input[name=code]"
       end
     end
@@ -229,7 +229,7 @@ class SignInTest < ActionDispatch::IntegrationTest
       signin_with(email: "email@example.com", password: "some password with various $ymb0l$", second_step: false)
       Capybara.current_session.driver.request.cookies["remember_2sv_session"] = remember_2sv_session
       visit root_path
-      assert_response_contains "get your code"
+      assert_response_contains "get your 6-digit verification code"
       assert_selector "input[name=code]"
     end
 
@@ -244,7 +244,7 @@ class SignInTest < ActionDispatch::IntegrationTest
       @user.update!(otp_secret_key: ROTP::Base32.random_base32)
       signin_with(email: "email@example.com", password: "some password with various $ymb0l$", second_step: false)
 
-      assert_response_contains "get your code"
+      assert_response_contains "get your 6-digit verification code"
       assert_selector "input[name=code]"
     end
 

--- a/test/integration/two_step_verification_test.rb
+++ b/test/integration/two_step_verification_test.rb
@@ -19,7 +19,7 @@ class TwoStepVerificationTest < ActionDispatch::IntegrationTest
       end
 
       should "show the TOTP secret and a warning" do
-        assert_response_contains "Enter the code manually: #{@new_secret}"
+        assert_response_contains "Enter this code when asked: #{@new_secret}"
         assert_response_contains "Setting up a new phone will replace your existing one. You will only be able to sign in with your new phone."
       end
 
@@ -28,7 +28,7 @@ class TwoStepVerificationTest < ActionDispatch::IntegrationTest
         click_button "submit_code"
 
         assert_response_contains "Sorry that code didn’t work. Please try again."
-        assert_response_contains "Enter the code manually: #{@new_secret}"
+        assert_response_contains "Enter this code when asked: #{@new_secret}"
         assert_equal 1, EventLog.where(event_id: EventLog::TWO_STEP_CHANGE_FAILED.id, uid: @user.uid).count
       end
 
@@ -63,7 +63,7 @@ class TwoStepVerificationTest < ActionDispatch::IntegrationTest
       end
 
       should "show the TOTP secret" do
-        assert_response_contains "Enter the code manually: #{@new_secret}"
+        assert_response_contains "Enter this code when asked: #{@new_secret}"
       end
 
       should "reject an invalid code, reuse the secret and log the rejection" do
@@ -71,7 +71,7 @@ class TwoStepVerificationTest < ActionDispatch::IntegrationTest
         click_button "submit_code"
 
         assert_response_contains "Sorry that code didn’t work. Please try again."
-        assert_response_contains "Enter the code manually: #{@new_secret}"
+        assert_response_contains "Enter this code when asked: #{@new_secret}"
         assert_equal 1, EventLog.where(event_id: EventLog::TWO_STEP_ENABLE_FAILED.id, uid: @user.uid).count
       end
 


### PR DESCRIPTION
These were requested ahead of a broader roll-out of 2SV for signon.

[Trello](https://trello.com/c/70fcYJqm/229-2-update-publisher-facing-guidance-and-current-in-app-sign-up-text)