### PR TITLE
Encrypt opt secret keys

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -32,6 +32,8 @@ class User < ApplicationRecord
          :confirmable,
          :password_archivable # in signon/lib/devise/models/password_archivable.rb
 
+  encrypts :otp_secret_key
+
   validates :name, presence: true
   validates :reason_for_suspension, presence: true, if: proc { |u| u.suspended? }
   validate :organisation_admin_belongs_to_organisation

--- a/config/application.rb
+++ b/config/application.rb
@@ -26,6 +26,12 @@ module Signon
 
     config.active_record.belongs_to_required_by_default = false
 
+    # TODO: remove this config once all otp_secret_keys have been encrypted
+    config.active_record.encryption.support_unencrypted_data = true
+
+    config.active_record.encryption.key_derivation_salt = Rails.application.secrets.active_record_encryption[:key_derivation_salt]
+    config.active_record.encryption.primary_key = Rails.application.secrets.active_record_encryption[:primary_key]
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -1,7 +1,16 @@
 development:
+  active_record_encryption:
+    primary_key: 5iYPUMb6NWxlsyiRGyBrVgfY6ZPhm5ZA
+    key_derivation_salt: q8sHPMCYthvtuM5N7mv2438my5v4DPaP
   secret_key_base: 101615e3369d108c13f7182caf9bb988fc8f2d8d309ebd16d39b34bece4b4bd0944df576bfa2ff35984e7c447658cc25810540b50759c15c2b94f8ef26867a8a
 test:
+  active_record_encryption:
+    primary_key: 5iYPUMb6NWxlsyiRGyBrVgfY6ZPhm5ZA
+    key_derivation_salt: q8sHPMCYthvtuM5N7mv2438my5v4DPaP
   secret_key_base: 3fb6b8dc769442c5f268a1fc6d1238e80bd6cf07b240d02ae622bd635a79f19342363291f053c80ac5f0132fe773f73e561022a46324a1310d9f0d368414d369
 production:
+  active_record_encryption:
+    primary_key: <%= ENV["ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY"] %>
+    key_derivation_salt: <%= ENV["ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT"] %>
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
   notify_api_key: <%= ENV["GOVUK_NOTIFY_API_KEY"] %>

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -149,4 +149,11 @@ namespace :users do
 
     UserPermissionMigrator.migrate(source: source_application, target: target_application)
   end
+
+  desc "Encrypts user OTP keys, temporary task to migrate away from unencrypted keys"
+  task encrypt_otp_keys: :environment do
+    two_factor_users = User.where.not(otp_secret_key: nil)
+
+    two_factor_users.find_each(&:encrypt)
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -226,6 +226,11 @@ class UserTest < ActiveSupport::TestCase
       assert_equal 1, disabled_users.count
       assert_equal @user, disabled_users.first
     end
+
+    should "encrypt otp_secret_key" do
+      enabled_user = create(:two_step_enabled_user)
+      assert enabled_user.encrypted_attribute?(:otp_secret_key)
+    end
   end
 
   context "email validation" do


### PR DESCRIPTION
Encrypt otp_secret_keys in signon.

This change is being made as we noticed during some other work that the otp_secret_keys for users in signon were stored as plaintext, while this is not against the principle of RFC-6238, and not a huge vulnerability, it was still worth fixing. 

I've used the `encrypts` model attribute introduced in Rails 7 for this, with separate keys for each environment.

Relevant PR's for Puppet and Secrets and below:

Puppet: https://github.com/alphagov/govuk-puppet/pull/11830
Secrets: https://github.com/alphagov/govuk-secrets/pull/1363

Trello: https://trello.com/c/cikBzyF1/246-encrypt-2fa-secret-keys-in-sign-on

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
