### PR TITLE
Use Redis.new rather than Redis.current

### DIFF
--- a/lib/volatile_lock.rb
+++ b/lib/volatile_lock.rb
@@ -43,7 +43,7 @@ private
   end
 
   def redis
-    Redis.current
+    Redis.new
   end
 
   def hostname

--- a/test/integration/volatile_lock_test.rb
+++ b/test/integration/volatile_lock_test.rb
@@ -6,7 +6,7 @@ class VolatileLockTest < ActiveSupport::TestCase
   end
 
   def redis
-    Redis.current
+    Redis.new
   end
 
   def volatile_lock(key, expiration_time = 1.second)


### PR DESCRIPTION
Redis.current will be deprecated in Redis 5.0.

As Redis.current ultimately calls Redis.new we can migrate this method now to pave the way for future upgrades.

From Redis changelog from [5.0][1]:

‘Removed Redis.current. You shouldn't assume there is a single global Redis connection, use a connection pool instead, and libaries using Redis should accept a Redis instance (or connection pool) as a config. E.g. MyLibrary.redis = Redis.new(…).’

[Redis.current][2] just calls Redis.new so should just be able to swap methods.

[trello](https://trello.com/c/oGFWhrCO/1551-migrate-away-from-deprecated-redis-method)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
