### PR TITLE
Fix ArgumentError in Kubernetes::Client.new

### DIFF
--- a/lib/kubernetes/client.rb
+++ b/lib/kubernetes/client.rb
@@ -16,12 +16,8 @@ module Kubernetes
 
       @client = Kubeclient::Client.new(
         API_SERVER, API_VERSION,
-        {
-          auth_options: {
-            bearer_token_file: BEARER_TOKEN_FILE,
-          },
-          ssl_options:,
-        }
+        auth_options: { bearer_token_file: BEARER_TOKEN_FILE },
+        ssl_options:
       )
     end
 

--- a/test/lib/kubernetes/client_test.rb
+++ b/test/lib/kubernetes/client_test.rb
@@ -9,12 +9,8 @@ class Kubernetes::ClientTest < ActiveSupport::TestCase
       Kubeclient::Client.stubs(:new).with(
         Kubernetes::Client::API_SERVER,
         Kubernetes::Client::API_VERSION,
-        {
-          auth_options: {
-            bearer_token_file: Kubernetes::Client::BEARER_TOKEN_FILE,
-          },
-          ssl_options: {},
-        },
+        auth_options: { bearer_token_file: Kubernetes::Client::BEARER_TOKEN_FILE },
+        ssl_options: {},
       ).once
 
       Kubernetes::Client.new
@@ -27,12 +23,8 @@ class Kubernetes::ClientTest < ActiveSupport::TestCase
       Kubeclient::Client.stubs(:new).with(
         Kubernetes::Client::API_SERVER,
         Kubernetes::Client::API_VERSION,
-        {
-          auth_options: {
-            bearer_token_file: Kubernetes::Client::BEARER_TOKEN_FILE,
-          },
-          ssl_options: { ca_file: Kubernetes::Client::CA_FILE },
-        },
+        auth_options: { bearer_token_file: Kubernetes::Client::BEARER_TOKEN_FILE },
+        ssl_options: { ca_file: Kubernetes::Client::CA_FILE },
       ).once
 
       Kubernetes::Client.new


### PR DESCRIPTION
This broke with the Ruby 2 to 3 upgrade and we didn't notice because even though the broken constructor was covered by a test, the test still passes because the assertion is too permissive.

(This PR only fixes the implementation, not the test — I ran out of time trying to figure out a way to do that without rewriting the whole approach. The test still passes either way 😞)

https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

https://testing.googleblog.com/2013/05/testing-on-toilet-dont-overuse-mocks.html