### PR TITLE
Add build/test instructions to README + minor improvements.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,40 +1,79 @@
 # Signon
 
-Signon is a centralised OAuth2 based single sign-on provider for GDS services that provides username/password and 2-Factor authentication.
+Signon is a centralised, OAuth2-based single sign-on (SSO) provider for GDS services that provides username/password and 2-factor authentication.
 
-## Technical documentation
+Signon uses [Devise] for username/password sign-in, and [Doorkeeper] as an OAuth 2 provider. Details of our interpretation of OAuth are provided in [an accompanying document](docs/oauth.md).
 
-[Devise] is used to provide username password sign-in, and [Doorkeeper] as an OAuth 2 provider. Details of our interpretation of OAuth are provided in [an accompanying document][auth].
+Signon is a Ruby on Rails app and should follow [our Rails app conventions][conventions].
 
-This is a Ruby on Rails app, and should follow [our Rails app conventions][conventions].
+[Devise]: https://github.com/heartcombo/devise
+[Doorkeeper]: https://github.com/doorkeeper-gem/doorkeeper
+[conventions]: https://docs.publishing.service.gov.uk/manual/conventions-for-rails-applications.html
 
-You can use the [GOV.UK Docker environment][govuk-docker] to run the application and its tests with all the necessary dependencies. Follow the [usage instructions][docker-usage] to get started.
 
-**Use GOV.UK Docker to run any commands that follow.**
+## Running the test suite using GOV.UK Docker
 
-### Running the test suite
+You can use the [GOV.UK Docker environment][govuk-docker] to run the application, its tests and all its dependencies. Follow the [govuk-docker installation instructions][govuk-docker-install] to get started.
+
+The first build with GOV.UK Docker typically takes 5-20 minutes, depending on your computer and network connection.
+
+```sh
+cd govuk-docker
+make signon  # This step can take a few minutes, especially the first time.
+govuk-docker run signon-lite bundle exec rake  # Run all tests.
+```
+
+[govuk-docker]: https://github.com/alphagov/govuk-docker
+[govuk-docker-install]: https://github.com/alphagov/govuk-docker#usage
+
+
+## Running the test suite without Docker
+
+You may find it more convenient to run the tests without Docker, for example if your machine has limited Internet connectivity or less than 16 GB RAM, or if you just want to run some subset of the tests.
+
+The tests require Redis, MySQL and Chromedriver. On macOS you can install and run these using [Homebrew](https://brew.sh/).
+
+```sh
+brew install chromedriver mysql redis
+brew services start mysql
+brew services start redis
+```
+
+Build Signon and create the database test fixtures.
+
+```sh
+export TEST_DATABASE_URL='mysql2://root:root@127.0.0.1/signon'
+export DATABASE_URL="$TEST_DATABASE_URL"
+bundle install -j12
+bundle exec rails db:reset
+```
+
+Run all the tests.
 
 ```sh
 bundle exec rake
 ```
 
+Run only the tests in a specific file which match a regex.
+
+```sh
+bundle exec rake test TEST=test/lib/kubernetes/client_test.rb TESTOPTS='-n "/should call apply secret/"'
+```
+
+When finished, you may want to shut down the MySQL and Redis servers.
+
+```sh
+brew services stop redis
+brew services stop mysql
+```
+
 ## Further documentation
 
-- [Usage documentation]
-- [Mass password reset]
-- [Troubleshooting]
+- [Usage documentation](docs/usage.md)
+- [Mass password reset](docs/mass_password_reset.md)
+- [Troubleshooting](docs/troubleshooting.md)
 
-## License
 
-[MIT License](LICENCE)
+## Licence
 
-[integration]: https://signon.integration.publishing.service.gov.uk
-[conventions]: https://docs.publishing.service.gov.uk/manual/conventions-for-rails-applications.html
-[govuk-docker]: https://github.com/alphagov/govuk-docker
-[docker-usage]: https://github.com/alphagov/govuk-docker#usage
-[Devise]: https://github.com/plataformatec/devise
-[Doorkeeper]: https://github.com/applicake/doorkeeper
-[auth]: docs/oauth.md
-[Usage documentation]: docs/usage.md
-[Mass password reset]: docs/mass_password_reset.md
-[Troubleshooting]: docs/troubleshooting.md
+[MIT Licence](LICENCE)


### PR DESCRIPTION
Improve instructions for first-time contributors and bring the document more into line with the [GDS Way] and [readme template].

- List the actual commands necessary to run the testsuite under GOV.UK Docker.
- Add copy/pasteable instructions for running the test suite without GOV.UK Docker. This lowers the barrier to entry for potential contributors (including me!), because setting up GOV.UK Docker requires a high-end machine, good Internet connectivity and significant time.
- Delete the _technical documentation_ heading, since the whole page is technical documentation and that heading wasn't adding anything.
- Update links to 3rd-party gems' websites.
- en-GB spelling for _licence_ (noun).
- Move the reference-style links underneath the sections where they're used. This makes it easier to read the document in plain text form.

[GDS Way]: https://gds-way.cloudapps.digital/manuals/readme-guidance.html
[readme template]: https://github.com/alphagov/readme-template/blob/main/README.md