### PR TITLE
Revert "Add temporary rake task to encrypt otp_secret_keys"

### DIFF
--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -149,11 +149,4 @@ namespace :users do
 
     UserPermissionMigrator.migrate(source: source_application, target: target_application)
   end
-
-  desc "Encrypts user OTP keys, temporary task to migrate away from unencrypted keys"
-  task encrypt_otp_keys: :environment do
-    two_factor_users = User.where.not(otp_secret_key: nil)
-
-    two_factor_users.find_each(&:encrypt)
-  end
 end


### PR DESCRIPTION
This reverts commit d7dffbd3cc79556534eb657b901ab3a47a4634c9.

All keys have been migrated to encrypted data so this task is no longer needed. 

Trello: https://trello.com/c/cikBzyF1/246-encrypt-2fa-secret-keys-in-sign-on

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
