### PR TITLE
Disallow unencrypted otp_secret_keys

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -26,9 +26,6 @@ module Signon
 
     config.active_record.belongs_to_required_by_default = false
 
-    # TODO: remove this config once all otp_secret_keys have been encrypted
-    config.active_record.encryption.support_unencrypted_data = true
-
     config.active_record.encryption.key_derivation_salt = Rails.application.secrets.active_record_encryption[:key_derivation_salt]
     config.active_record.encryption.primary_key = Rails.application.secrets.active_record_encryption[:primary_key]
 


### PR DESCRIPTION
These keys are not encrypted at the application level by activerecord and all unencrypted keys have been successfully migrated over, so this config is no longer needed.

Trello: https://trello.com/c/cikBzyF1/246-encrypt-2fa-secret-keys-in-sign-on

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
