### PR TITLE
Log the names of the k8s secrets in the app/token sync tasks.

### DIFF
--- a/lib/tasks/sync_kubernetes_secrets.rake
+++ b/lib/tasks/sync_kubernetes_secrets.rake
@@ -14,6 +14,7 @@ namespace :kubernetes do
         name = "signon-token-#{api_user.name}-#{token.application.name}".parameterize
         data = { bearer_token: token.token }
 
+        Rails.logger.info(name)
         client.apply_secret(name, data)
       end
     end
@@ -37,6 +38,7 @@ namespace :kubernetes do
       name = "signon-app-#{app.name}".parameterize
       data = { oauth_id: app.uid, oauth_secret: app.secret }
 
+      Rails.logger.info(name)
       client.apply_secret(name, data)
     end
 


### PR DESCRIPTION
This makes it easier to figure out what's wrong when a name doesn't match.

This PR shouldn't affect anything outside of Kubernetes.

Tested: ran in staging with a locally-built image; produces expected log output.