### PR TITLE
Add Rubygem platforms for GOV.UK environments

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -287,6 +287,12 @@ GEM
     nokogiri (1.13.8)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
+    nokogiri (1.13.8-aarch64-linux)
+      racc (~> 1.4)
+    nokogiri (1.13.8-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.13.8-x86_64-linux)
+      racc (~> 1.4)
     notifications-ruby-client (5.3.0)
       jwt (>= 1.5, < 3)
     null_logger (0.0.1)
@@ -490,7 +496,10 @@ GEM
     zxcvbn-ruby (1.2.0)
 
 PLATFORMS
+  aarch64-linux
+  arm64-darwin
   ruby
+  x86_64-linux
 
 DEPENDENCIES
   activejob-retry


### PR DESCRIPTION
This adds Linux, Arm Linux and Arm MacOS platforms for bundler and allows precompiled gems to be installed. This allows faster installation on these platforms and resolves an issue on production where Rubygems can get confused as to which gem to use [1]

[1]: https://github.com/alphagov/publisher/pull/1699/commits/cee149a469376ec9f3ef1577e207de285101783b

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
