### PR TITLE
Rename Licence reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ bundle exec rake
 - [Mass password reset]
 - [Troubleshooting]
 
-## License
+## Licence
 
 [MIT License](LICENCE)
 


### PR DESCRIPTION
We want to make the reference to the licence in the README consistent with the GDS Way.

Trello card: [https://trello.com/c/P0DpFcwW/260-stan](https://trello.com/c/P0DpFcwW/260-standardise-all-license-files-names-to-licence)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
