### PR TITLE
Hold back bad version 2.8.0 of the `mail` rubygem.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem "faraday"
 gem "json"
 gem "kaminari"
 gem "kubeclient"
+gem "mail", "~> 2.7.1"  # TODO: remove once https://github.com/mikel/mail/issues/1489 is fixed.
 gem "mail-notify"
 gem "mysql2"
 gem "nokogiri"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,6 +117,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
+    date (3.3.1)
     debug_inspector (1.1.0)
     devise (4.8.1)
       bcrypt (~> 3.0)
@@ -252,11 +253,8 @@ GEM
       nokogiri (>= 1.5.9)
     macaddr (1.7.2)
       systemu (~> 2.6.5)
-    mail (2.8.0)
+    mail (2.7.1)
       mini_mime (>= 0.1.1)
-      net-imap
-      net-pop
-      net-smtp
     mail-notify (1.1.0)
       actionmailer (>= 5.2.4.6)
       actionpack (>= 5.2.7.1)
@@ -278,11 +276,12 @@ GEM
     msgpack (1.6.0)
     multi_json (1.15.0)
     mysql2 (0.5.4)
-    net-imap (0.3.1)
+    net-imap (0.3.2)
+      date
       net-protocol
     net-pop (0.1.2)
       net-protocol
-    net-protocol (0.2.0)
+    net-protocol (0.2.1)
       timeout
     net-smtp (0.3.3)
       net-protocol
@@ -534,6 +533,7 @@ DEPENDENCIES
   kaminari
   kubeclient
   listen
+  mail (~> 2.7.1)
   mail-notify
   minitest
   mocha


### PR DESCRIPTION
Version 2.8.0 of the `mail` gem has the wrong filesystem permissions on a few of its .rb files (seems to be the generated tables?), which breaks the app when running as an unprivileged user. We therefore need to hold back this version of the gem until a new version is released that fixes the issue.

The upstream bug is mikel/mail#1489. We can remove this workaround once the bug is fixed.
