### PR TITLE
Remove mailer from the gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,6 @@ gem "faraday"
 gem "json"
 gem "kaminari"
 gem "kubeclient"
-gem "mail", "~> 2.8.0"  # TODO: remove once https://github.com/mikel/mail/issues/1489 is fixed.
 gem "mail-notify"
 gem "mysql2"
 gem "nokogiri"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -537,7 +537,6 @@ DEPENDENCIES
   kaminari
   kubeclient
   listen
-  mail (~> 2.8.0)
   mail-notify
   minitest
   mocha


### PR DESCRIPTION
Previously, there was an issue with the mailer gem in release 2.8.0 mikel/mail#1489.

To circumvent this we added it to the Gemfile and pinned it on the 2.7.0 release. Since this has been fixed we can remove it as a direct dependency.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
