### PR TITLE
Add task to promote all non-GDS managing editors to 'organisation admin' role

### DIFF
--- a/lib/tasks/permission_promoter.rake
+++ b/lib/tasks/permission_promoter.rake
@@ -1,0 +1,18 @@
+namespace :permissions_promoter do
+  desc "Update anyone with a managing editor permission and a normal role to an org admin role"
+  task promote_managing_editors_to_org_admins: :environment do
+    managing_editor_permissions = SupportedPermission.where("name REGEXP ?", "managing.*editor").pluck(:id)
+    user_application_permissions = UserApplicationPermission.where(supported_permission_id: managing_editor_permissions)
+    gds = Organisation.find_by(name: "Government Digital Service")
+    users_to_update = user_application_permissions
+                        .map { |user_application_permission| User.find(user_application_permission.user_id) }.uniq
+                        .filter { |user| user.role == "normal" && !user.suspended? && user.organisation != gds }
+
+    puts "found #{users_to_update.size} users with managing editor positions to be updated to organisation admins"
+    puts "user ids to update are #{users_to_update.map(&:id)}"
+
+    users_to_update.each do |user|
+      user.update(role: "organisation_admin")
+    end
+  end
+end

--- a/test/lib/tasks/permissions_promoter_test.rb
+++ b/test/lib/tasks/permissions_promoter_test.rb
@@ -1,0 +1,78 @@
+require "test_helper"
+
+class PermissionsPromoterTest < ActiveSupport::TestCase
+  setup do
+    Signon::Application.load_tasks if Rake::Task.tasks.empty?
+
+    @gds_org = create(:organisation, name: "Government Digital Service")
+    @org = create(:organisation, name: "Another Department")
+    @first_app = create(:application, name: "Cat Publisher", with_supported_permissions: ["Managing Editor", "other"])
+    @second_app = create(:application, name: "Dog Publisher", with_supported_permissions: %w[managing_editor other])
+    @task = Rake::Task["permissions_promoter:promote_managing_editors_to_org_admins"]
+    $stdout.stubs(:write)
+  end
+
+  teardown do
+    @task.reenable # without this, calling `invoke` does nothing after first test
+  end
+
+  context "#promote_managing_editors_to_org_admins" do
+    should "update any non-GDS user with a managing editor permission who is not suspended and has a 'normal' role" do
+      first_non_gds_user = user_with_permissions(:user, @org, { @first_app => ["Managing Editor"], @second_app => %w[managing_editor other] })
+      second_non_gds_user = user_with_permissions(:user, @org, { @second_app => %w[managing_editor other] })
+
+      @task.invoke
+
+      users = [first_non_gds_user, second_non_gds_user].each(&:reload)
+
+      assert users.all? do |user|
+        user.role == "organisation_admin"
+      end
+    end
+  end
+
+  should "not update a non-GDS user without a managing editor permission" do
+    non_gds_user = user_with_permissions(:user, @org, { @first_app => %w[other], @second_app => %w[other] })
+
+    @task.invoke
+
+    assert non_gds_user.reload.role == "normal"
+  end
+
+  should "not update a non-GDS user who already has an admin role" do
+    admin_user = user_with_permissions(:admin_user, @org, { @first_app => ["Managing Editor"] })
+
+    @task.invoke
+
+    assert admin_user.reload.role == "admin"
+  end
+
+  should "not update a non-GDS user who is suspended" do
+    user = user_with_permissions(:user, @org, { @first_app => ["Managing Editor"] })
+    user.update!(suspended_at: 1.day.ago, reason_for_suspension: "Dormant account")
+
+    @task.invoke
+
+    assert user.reload.role == "normal"
+  end
+
+  should "not update GDS users" do
+    gds_users = %i[user admin_user].map do |user_type|
+      user_with_permissions(user_type, @gds_org, { @first_app => ["Managing Editor"] })
+    end
+    original_roles = gds_users.map(&:role)
+
+    @task.invoke
+
+    gds_users.each(&:reload)
+    assert gds_users.map(&:role) == original_roles
+  end
+
+  def user_with_permissions(user_type, organisation, permissions_hash)
+    create(user_type, organisation:).tap do |user|
+      permissions_hash.to_a.each do |app, permissions|
+        user.grant_application_permissions(app, permissions)
+      end
+    end
+  end
+end


### PR DESCRIPTION
As part of turning on 2 step verification for all users, we would like any managing editors to have organisation admin roles (if they do not already have a higher level of admin rights), in order to ensure that the appropriate people in an organisation can manage their users.

We may remove this task in the future, but given the possibility of these permissions becoming out of sync, it may be useful to keep.

[Trello](https://trello.com/c/O8jeiIfc/432-give-organisation-admin-permission-to-the-non-gds-managing-editors-who-are-not-currently-organisation-admin)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
