### PR TITLE
Add task to set 2sv for all users within an organisation or email domain

### DIFF
--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -149,4 +149,25 @@ namespace :users do
 
     UserPermissionMigrator.migrate(source: source_application, target: target_application)
   end
+
+  desc "Sets 2sv on all users by organisation"
+  task :set_2sv_by_org, [:org] => :environment do |_t, args|
+    organisation = Organisation.find_by(name: args.org)
+    raise "Couldn't find organisation: '#{args.org}'" unless organisation
+
+    users_to_update = User.where(organisation_id: organisation.id, require_2sv: false)
+
+    puts "found #{users_to_update.size} users without 2sv in organsation #{args.org} to set require 2sv flag on"
+
+    users_to_update.each { |user| user.update(require_2sv: true) }
+  end
+
+  desc "Sets 2sv on all users by email domain"
+  task :set_2sv_by_email_domain, [:domain] => :environment do |_t, args|
+    users_to_update = User.where("email LIKE ?", "%#{args.domain}").where(require_2sv: false)
+
+    puts "found #{users_to_update.size} users without 2sv with email domain #{args.domain} to set require 2sv flag on"
+
+    users_to_update.each { |user| user.update(require_2sv: true) }
+  end
 end

--- a/test/lib/tasks/users_test.rb
+++ b/test/lib/tasks/users_test.rb
@@ -1,0 +1,37 @@
+require "test_helper"
+
+class UsersTaskTest < ActiveSupport::TestCase
+  setup do
+    Signon::Application.load_tasks if Rake::Task.tasks.empty?
+    $stdout.stubs(:write)
+
+    @user_types = %i[user superadmin_user admin_user organisation_admin super_org_admin]
+  end
+
+  context "#set_2sv_by_org" do
+    should "sets 2sv for all users within the specified org" do
+      organisation = create(:organisation, name: "Department of Health")
+      users_in_organisation = @user_types.map { |user_type| create(user_type, organisation:) }
+      users_in_different_organisation = @user_types.map { |user_type| create(user_type, organisation: create(:organisation)) }
+
+      Rake::Task["users:set_2sv_by_org"].invoke(organisation.name)
+
+      assert users_in_organisation.each(&:reload).all?(&:require_2sv)
+      assert(users_in_different_organisation.each(&:reload).all? { |user| !user.require_2sv })
+    end
+  end
+
+  context "#set_2sv_by_email_domain" do
+    should "sets 2sv for all users within the specified email domain" do
+      targeted_domain = "@some.domain.gov.uk"
+      other_domain = "@domain.gov.uk"
+      users_in_domain = @user_types.map { |user_type| create(user_type, email: user_type.to_s + targeted_domain) }
+      users_in_other_domain = @user_types.map { |user_type| create(user_type, email: user_type.to_s + other_domain) }
+
+      Rake::Task["users:set_2sv_by_email_domain"].invoke(targeted_domain)
+
+      assert users_in_domain.each(&:reload).all?(&:require_2sv)
+      assert(users_in_other_domain.each(&:reload).all? { |user| !user.require_2sv })
+    end
+  end
+end


### PR DESCRIPTION
We will soon be switching on 2sv for all users, and so having the ability to set this flag by domain means we will be able to turn it on incrementally for sets of users.

[Trello](https://trello.com/c/yZFT5Rak/434-write-a-rake-task-to-allow-developers-to-set-the-flag-on-groups-of-users-by-organisation-and-by-email-domain)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
