### PR TITLE
Allow gds admins to exempt users from 2sv with reason

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,7 @@ end
 group :test do
   gem "capybara"
   gem "capybara-email"
+  gem "climate_control"
   gem "factory_bot_rails"
   gem "minitest"
   gem "mocha", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,6 +111,7 @@ GEM
     childprocess (4.1.0)
     chronic (0.10.2)
     chunky_png (1.4.0)
+    climate_control (1.2.0)
     coderay (1.1.3)
     concurrent-ruby (1.2.0)
     connection_pool (2.3.0)
@@ -520,6 +521,7 @@ DEPENDENCIES
   browser
   capybara
   capybara-email
+  climate_control
   devise
   devise-encryptable
   devise_invitable

--- a/app/controllers/two_step_verification_exemptions_controller.rb
+++ b/app/controllers/two_step_verification_exemptions_controller.rb
@@ -1,0 +1,16 @@
+class TwoStepVerificationExemptionsController < ApplicationController
+  before_action :authenticate_user!, :load_and_authorize_user
+
+  def update
+    @user.exempt_from_2sv(params[:user][:reason_for_2sv_exemption])
+
+    redirect_to @user.api_user? ? edit_api_user_path(@user) : edit_user_path(@user)
+  end
+
+private
+
+  def load_and_authorize_user
+    @user = User.find(params[:id])
+    authorize @user, :exempt_from_two_step_verification?
+  end
+end

--- a/app/controllers/two_step_verification_exemptions_controller.rb
+++ b/app/controllers/two_step_verification_exemptions_controller.rb
@@ -9,7 +9,7 @@ class TwoStepVerificationExemptionsController < ApplicationController
 
       redirect_to edit_two_step_verification_exemption_path(@user)
     else
-      @user.exempt_from_2sv(params[:user][:reason_for_2sv_exemption])
+      @user.exempt_from_2sv(params[:user][:reason_for_2sv_exemption], current_user)
 
       flash[:notice] = "User exempted from 2SV"
 

--- a/app/controllers/two_step_verification_exemptions_controller.rb
+++ b/app/controllers/two_step_verification_exemptions_controller.rb
@@ -1,10 +1,20 @@
 class TwoStepVerificationExemptionsController < ApplicationController
   before_action :authenticate_user!, :load_and_authorize_user
 
-  def update
-    @user.exempt_from_2sv(params[:user][:reason_for_2sv_exemption])
+  def edit; end
 
-    redirect_to @user.api_user? ? edit_api_user_path(@user) : edit_user_path(@user)
+  def update
+    if params[:user][:reason_for_2sv_exemption].empty?
+      flash[:alert] = "Reason for exemption must be provided"
+
+      redirect_to edit_two_step_verification_exemption_path(@user)
+    else
+      @user.exempt_from_2sv(params[:user][:reason_for_2sv_exemption])
+
+      flash[:notice] = "User exempted from 2SV"
+
+      redirect_to edit_user_path(@user)
+    end
   end
 
 private

--- a/app/helpers/user_filter_helper.rb
+++ b/app/helpers/user_filter_helper.rb
@@ -42,7 +42,7 @@ module UserFilterHelper
               end
             when :two_step_status
               # rubocop:disable Style/WordArray
-              [["true", "Enabled"], ["false", "Not set up"]]
+              [["true", "Enabled"], ["false", "Not set up"], ["exempt", "Exempted"]]
               # rubocop:enable Style/WordArray
             end
 

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,6 +1,12 @@
 module UsersHelper
   def two_step_status(user)
-    user.has_2sv? ? "Enabled" : "Not set up"
+    if user.has_2sv?
+      "Enabled"
+    elsif user.reason_for_2sv_exemption.present?
+      "Exempted"
+    else
+      "Not set up"
+    end
   end
 
   def organisation_options(form_builder)

--- a/app/models/event_log.rb
+++ b/app/models/event_log.rb
@@ -43,6 +43,7 @@ class EventLog < ApplicationRecord
     NO_SUCH_ACCOUNT_LOGIN = LogEntry.new(id: 38, description: "Attempted login to nonexistent account"),
     TWO_STEP_EXEMPTED = LogEntry.new(id: 39, description: "Exempted from 2-step verification", require_uid: true, require_initiator: true),
     TWO_STEP_EXEMPTION_REASON_UPDATED = LogEntry.new(id: 40, description: "Reason for 2-step verification exemption updated", require_uid: true, require_initiator: true),
+    TWO_STEP_EXEMPTION_REMOVED = LogEntry.new(id: 41, description: "Exemption from 2-step verification removed", require_uid: true, require_initiator: true),
 
     # We no longer expire passwords, but we keep this event for history purposes
     PASSWORD_EXPIRED = LogEntry.new(id: 6, description: "Password expired"),

--- a/app/models/event_log.rb
+++ b/app/models/event_log.rb
@@ -44,6 +44,7 @@ class EventLog < ApplicationRecord
     TWO_STEP_EXEMPTED = LogEntry.new(id: 39, description: "Exempted from 2-step verification", require_uid: true, require_initiator: true),
     TWO_STEP_EXEMPTION_REASON_UPDATED = LogEntry.new(id: 40, description: "Reason for 2-step verification exemption updated", require_uid: true, require_initiator: true),
     TWO_STEP_EXEMPTION_REMOVED = LogEntry.new(id: 41, description: "Exemption from 2-step verification removed", require_uid: true, require_initiator: true),
+    TWO_STEP_MANDATED = LogEntry.new(id: 42, description: "2-step verification setup mandated at next login", require_uid: true, require_initiator: true),
 
     # We no longer expire passwords, but we keep this event for history purposes
     PASSWORD_EXPIRED = LogEntry.new(id: 6, description: "Password expired"),

--- a/app/models/event_log.rb
+++ b/app/models/event_log.rb
@@ -41,6 +41,7 @@ class EventLog < ApplicationRecord
     PERMISSIONS_REMOVED = LogEntry.new(id: 36, description: "Permissions removed", require_uid: true, require_initiator: true),
     ACCOUNT_INVITED = LogEntry.new(id: 37, description: "Account was invited", require_uid: true, require_initiator: true),
     NO_SUCH_ACCOUNT_LOGIN = LogEntry.new(id: 38, description: "Attempted login to nonexistent account"),
+    TWO_STEP_EXEMPTED = LogEntry.new(id: 39, description: "Exempted from 2-step verification", require_uid: true, require_initiator: true),
 
     # We no longer expire passwords, but we keep this event for history purposes
     PASSWORD_EXPIRED = LogEntry.new(id: 6, description: "Password expired"),

--- a/app/models/event_log.rb
+++ b/app/models/event_log.rb
@@ -42,6 +42,7 @@ class EventLog < ApplicationRecord
     ACCOUNT_INVITED = LogEntry.new(id: 37, description: "Account was invited", require_uid: true, require_initiator: true),
     NO_SUCH_ACCOUNT_LOGIN = LogEntry.new(id: 38, description: "Attempted login to nonexistent account"),
     TWO_STEP_EXEMPTED = LogEntry.new(id: 39, description: "Exempted from 2-step verification", require_uid: true, require_initiator: true),
+    TWO_STEP_EXEMPTION_REASON_UPDATED = LogEntry.new(id: 40, description: "Reason for 2-step verification exemption updated", require_uid: true, require_initiator: true),
 
     # We no longer expire passwords, but we keep this event for history purposes
     PASSWORD_EXPIRED = LogEntry.new(id: 6, description: "Password expired"),

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -280,9 +280,14 @@ class User < ApplicationRecord
   end
 
   def exempt_from_2sv(reason, initiating_user)
+    initial_reason = reason_for_2sv_exemption
     update!(require_2sv: false, reason_for_2sv_exemption: reason, otp_secret_key: nil)
 
-    EventLog.record_event(self, EventLog::TWO_STEP_EXEMPTED, initiator: initiating_user, trailing_message: "for reason: #{reason}")
+    if initial_reason.blank?
+      EventLog.record_event(self, EventLog::TWO_STEP_EXEMPTED, initiator: initiating_user, trailing_message: "for reason: #{reason}")
+    else
+      EventLog.record_event(self, EventLog::TWO_STEP_EXEMPTION_REASON_UPDATED, initiator: initiating_user, trailing_message: "to: #{reason}")
+    end
   end
 
   def reset_2sv!(initiating_superadmin)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,6 +36,7 @@ class User < ApplicationRecord
 
   validates :name, presence: true
   validates :reason_for_suspension, presence: true, if: proc { |u| u.suspended? }
+  validate :user_can_be_exempted_from_2sv
   validate :organisation_admin_belongs_to_organisation
   validate :email_is_ascii_only
 
@@ -321,6 +322,10 @@ private
   def mark_two_step_mandated_changed
     @two_step_mandated_changed = require_2sv_changed?
     true
+  end
+
+  def user_can_be_exempted_from_2sv
+    errors.add(:reason_for_2sv_exemption, "#{role} users cannot be exempted from 2SV. Remove the user's exemption to change their role.") if reason_for_2sv_exemption.present? && !normal?
   end
 
   def organisation_admin_belongs_to_organisation

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -50,6 +50,7 @@ class User < ApplicationRecord
   after_initialize :generate_uid
   after_create :update_stats
   before_save :set_2sv_for_admin_roles
+  before_save :reset_2sv_exemption_reason
   before_save :mark_two_step_mandated_changed
   before_save :update_password_changed
 
@@ -247,6 +248,10 @@ class User < ApplicationRecord
     return if Rails.application.config.instance_name.present?
 
     self.require_2sv = true if role_changed? && (admin? || superadmin?)
+  end
+
+  def reset_2sv_exemption_reason
+    self.reason_for_2sv_exemption = nil if require_2sv.present?
   end
 
   def authenticate_otp(code)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -279,6 +279,10 @@ class User < ApplicationRecord
     otp_secret_key.present?
   end
 
+  def exempt_from_2sv(reason)
+    update!(require_2sv: false, reason_for_2sv_exemption: reason, otp_secret_key: nil)
+  end
+
   def reset_2sv!(initiating_superadmin)
     transaction do
       self.otp_secret_key = nil

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -66,8 +66,14 @@ class User < ApplicationRecord
   scope :with_access_to_application, ->(application) { UsersWithAccess.new(self, application).users }
   scope :with_2sv_enabled,
         lambda { |enabled|
-          enabled = ActiveRecord::Type::Boolean.new.cast(enabled)
-          where("otp_secret_key IS #{'NOT' if enabled} NULL")
+          case enabled
+          when "exempt"
+            where("reason_for_2sv_exemption IS NOT NULL")
+          when "true"
+            where("otp_secret_key IS NOT NULL")
+          else
+            where("otp_secret_key IS NULL AND reason_for_2sv_exemption IS NULL")
+          end
         }
 
   scope :with_status,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -279,8 +279,10 @@ class User < ApplicationRecord
     otp_secret_key.present?
   end
 
-  def exempt_from_2sv(reason)
+  def exempt_from_2sv(reason, initiating_user)
     update!(require_2sv: false, reason_for_2sv_exemption: reason, otp_secret_key: nil)
+
+    EventLog.record_event(self, EventLog::TWO_STEP_EXEMPTED, initiator: initiating_user, trailing_message: "for reason: #{reason}")
   end
 
   def reset_2sv!(initiating_superadmin)

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -57,7 +57,7 @@ class UserPolicy < BasePolicy
   end
 
   def exempt_from_two_step_verification?
-    current_user.belongs_to_gds? && (current_user.superadmin? || current_user.admin?)
+    current_user.belongs_to_gds? && (current_user.superadmin? || current_user.admin?) && record.normal?
   end
 
 private

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -56,6 +56,10 @@ class UserPolicy < BasePolicy
     current_user.superadmin?
   end
 
+  def exempt_from_two_step_verification?
+    current_user.belongs_to_gds? && (current_user.superadmin? || current_user.admin?)
+  end
+
 private
 
   def allow_self_only

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -57,7 +57,7 @@ class UserPolicy < BasePolicy
   end
 
   def exempt_from_two_step_verification?
-    current_user.belongs_to_gds? && (current_user.superadmin? || current_user.admin?) && record.normal?
+    current_user.belongs_to_gds? && (current_user.superadmin? || current_user.admin?) && record.normal? && ENV["PERMIT_2SV_EXEMPTION"]
   end
 
 private

--- a/app/services/user_update.rb
+++ b/app/services/user_update.rb
@@ -19,6 +19,7 @@ class UserUpdate
     record_permission_changes(old_permissions)
     record_role_change
     record_2sv_exemption_removed
+    record_2sv_mandated
     send_two_step_mandated_notification
     perform_permissions_update
     record_email_change_and_notify
@@ -92,6 +93,17 @@ private
     EventLog.record_event(
       user,
       EventLog::TWO_STEP_EXEMPTION_REMOVED,
+      initiator: current_user,
+      ip_address: user_ip,
+    )
+  end
+
+  def record_2sv_mandated
+    return unless user.require_2sv && user.previous_changes[:require_2sv]
+
+    EventLog.record_event(
+      user,
+      EventLog::TWO_STEP_MANDATED,
       initiator: current_user,
       ip_address: user_ip,
     )

--- a/app/services/user_update.rb
+++ b/app/services/user_update.rb
@@ -18,6 +18,7 @@ class UserUpdate
     record_update
     record_permission_changes(old_permissions)
     record_role_change
+    record_2sv_exemption_removed
     send_two_step_mandated_notification
     perform_permissions_update
     record_email_change_and_notify
@@ -82,6 +83,17 @@ private
       role_change.first,
       role_change.last,
       current_user,
+    )
+  end
+
+  def record_2sv_exemption_removed
+    return unless user.require_2sv && user.previous_changes[:reason_for_2sv_exemption]
+
+    EventLog.record_event(
+      user,
+      EventLog::TWO_STEP_EXEMPTION_REMOVED,
+      initiator: current_user,
+      ip_address: user_ip,
     )
   end
 

--- a/app/views/two_step_verification_exemptions/edit.html.erb
+++ b/app/views/two_step_verification_exemptions/edit.html.erb
@@ -1,0 +1,20 @@
+<% content_for :title, "Exempt user from 2-step verification - [#{@user.name}]" %>
+
+<ol class="breadcrumb">
+  <li><%= link_to @user.name, user_path(@user) %></li>
+  <li class="active">Exempt user from 2-step verification</li>
+</ol>
+
+<h1 class="page-title">Exempt &ldquo;<%= @user.name %>&rdquo; from 2-step verification</h1>
+
+<%= form_tag two_step_verification_exemption_path(@user), method: "patch", :class => 'well remove-top-padding' do %>
+  <div class="form-group add-top-margin">
+    <label for="user_reason_for_2sv_exemption">Reason for 2sv exemption</label>
+    <%= text_field_tag "user[reason_for_2sv_exemption]", @user.reason_for_2sv_exemption, class: 'form-control input-md-6' %>
+  </div>
+  <hr />
+  <p>Add a reason to exempt the user from 2-step verification. This will remove any existing requirement to log in with, or set up, 2-step verification.</p>
+  <p>This reason will be visible to the user, and to any admins who have the ability to edit this user.</p>
+  <%= submit_tag "Save", class: "btn btn-primary add-right-margin" %>
+  <%= link_to "Cancel", user_path(@user), class: "btn btn-default" %>
+<% end %>

--- a/app/views/users/_form_fields.html.erb
+++ b/app/views/users/_form_fields.html.erb
@@ -70,6 +70,10 @@
             <br/>
             Exempt a user from 2-step verification (requires a reason to be supplied).
           </p>
+        <% elsif @user.reason_for_2sv_exemption.present? %>
+          <p>
+            The user has been made exempt from 2-step verification for the following reason: <%= @user.reason_for_2sv_exemption %>
+          </p>
         <% end %>
       <% end %>
     </dd>

--- a/app/views/users/_form_fields.html.erb
+++ b/app/views/users/_form_fields.html.erb
@@ -25,7 +25,7 @@
   </p>
 <% end %>
 
-<% if policy(User).assign_role? %>
+<% if policy(User).assign_role? && @user.reason_for_2sv_exemption.blank? %>
   <p class="form-group">
     <%= f.label :role %><br />
     <%= f.select :role, options_for_select(filtered_user_roles.map(&:humanize).zip(filtered_user_roles), f.object.role), {}, class: "chosen-select form-control", 'data-module' => 'chosen' %>
@@ -36,6 +36,8 @@
       <strong>Organisation Admins</strong> can unlock and unsuspend their organisation accounts.
     </span>
   </p>
+<% elsif policy(User).assign_role? %>
+  <p>This user's role is set to <%= @user.role %>. They are currently exempted from 2sv, meaning that their role cannot be changed as admins are required to have 2sv.</p>
 <% end %>
 
 <% if policy(current_user).mandate_2sv? %>
@@ -64,7 +66,7 @@
         </p>
       <% end %>
       <% if @user.persisted? %>
-        <% if policy(current_user).exempt_from_two_step_verification? && @user.reason_for_2sv_exemption.nil? %>
+        <% if Pundit.policy(current_user, @user).exempt_from_two_step_verification? && @user.reason_for_2sv_exemption.nil? %>
           <p>
             <%= link_to 'Exempt user from 2-step verification', edit_two_step_verification_exemption_path(@user) %>
             <br/>
@@ -74,7 +76,7 @@
           <p>
             The user has been made exempt from 2-step verification for the following reason: <%= @user.reason_for_2sv_exemption %>
           </p>
-            <% if policy(current_user).exempt_from_two_step_verification? %>
+            <% if Pundit.policy(current_user, @user).exempt_from_two_step_verification? %>
               <br>
               <%= link_to 'Edit reason for 2-step verification exemption', edit_two_step_verification_exemption_path(@user) %>
             <% end %>

--- a/app/views/users/_form_fields.html.erb
+++ b/app/views/users/_form_fields.html.erb
@@ -74,6 +74,10 @@
           <p>
             The user has been made exempt from 2-step verification for the following reason: <%= @user.reason_for_2sv_exemption %>
           </p>
+            <% if policy(current_user).exempt_from_two_step_verification? %>
+              <br>
+              <%= link_to 'Edit reason for 2-step verification exemption', edit_two_step_verification_exemption_path(@user) %>
+            <% end %>
         <% end %>
       <% end %>
     </dd>

--- a/app/views/users/_form_fields.html.erb
+++ b/app/views/users/_form_fields.html.erb
@@ -63,6 +63,15 @@
           <% end %>
         </p>
       <% end %>
+      <% if @user.persisted? %>
+        <% if policy(current_user).exempt_from_two_step_verification? && @user.reason_for_2sv_exemption.nil? %>
+          <p>
+            <%= link_to 'Exempt user from 2-step verification', edit_two_step_verification_exemption_path(@user) %>
+            <br/>
+            Exempt a user from 2-step verification (requires a reason to be supplied).
+          </p>
+        <% end %>
+      <% end %>
     </dd>
   </dl>
 <% end %>

--- a/app/views/users/_form_fields.html.erb
+++ b/app/views/users/_form_fields.html.erb
@@ -44,14 +44,22 @@
   <dl>
     <dt>Account security</dt>
     <dd>
-      <% if f.object.has_2sv? %>
+      <% if @user.reason_for_2sv_exemption.present? %>
+        <p>
+          The user has been made exempt from 2-step verification for the following reason: <%= @user.reason_for_2sv_exemption %>
+        <% if Pundit.policy(current_user, @user).exempt_from_two_step_verification? %>
+          <br>
+          <%= link_to 'Edit reason for 2-step verification exemption', edit_two_step_verification_exemption_path(@user) %>
+        <% end %>
+        </p>
+      <% elsif f.object.has_2sv? %>
         <p>2-step verification enabled</p>
         <p>
           <%= link_to 'Reset 2-step verification',
             reset_two_step_verification_user_path(@user),
             data: { confirm: 'Are you sure?' },
             method: :patch
-            %><br/>
+          %><br/>
           Allows user to sign in without a verification code.<br/>
           User will be prompted to set up 2-step verification again the next time they sign in.
         </p>
@@ -59,29 +67,23 @@
         <p>2-step verification required but not set up</p>
       <% else %>
         <p>2-step verification not set up</p>
+      <% end %>
+
+      <% unless @user.require_2sv? %>
         <p class="checkbox">
           <%= f.label :require_2sv do %>
-            <%= f.check_box :require_2sv %> Ask user to set up 2-step verification
+            <%= f.check_box :require_2sv %> Mandate 2-step verification for this user <%= "(this will remove their exemption)" if @user.reason_for_2sv_exemption.present? %>
           <% end %>
-        </p>
+        <br/>
+        User will be prompted to set up 2-step verification again the next time they sign in.</p>
       <% end %>
-      <% if @user.persisted? %>
-        <% if Pundit.policy(current_user, @user).exempt_from_two_step_verification? && @user.reason_for_2sv_exemption.nil? %>
+      <% if @user.persisted? && Pundit.policy(current_user, @user).exempt_from_two_step_verification? && @user.reason_for_2sv_exemption.nil? %>
           <p>
             <%= link_to 'Exempt user from 2-step verification', edit_two_step_verification_exemption_path(@user) %>
             <br/>
             Exempt a user from 2-step verification (requires a reason to be supplied).
           </p>
-        <% elsif @user.reason_for_2sv_exemption.present? %>
-          <p>
-            The user has been made exempt from 2-step verification for the following reason: <%= @user.reason_for_2sv_exemption %>
-          </p>
-            <% if Pundit.policy(current_user, @user).exempt_from_two_step_verification? %>
-              <br>
-              <%= link_to 'Edit reason for 2-step verification exemption', edit_two_step_verification_exemption_path(@user) %>
-            <% end %>
-        <% end %>
-      <% end %>
+      <%end %>
     </dd>
   </dl>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,7 +50,7 @@ Rails.application.routes.draw do
   resources :bulk_grant_permission_sets, only: %i[new create show]
   resources :organisations, only: [:index]
   resources :suspensions, only: %i[edit update]
-  resources :two_step_verification_exemptions, only: %i[update]
+  resources :two_step_verification_exemptions, only: %i[edit update]
 
   resources :doorkeeper_applications, only: %i[index edit update] do
     member do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,6 +50,7 @@ Rails.application.routes.draw do
   resources :bulk_grant_permission_sets, only: %i[new create show]
   resources :organisations, only: [:index]
   resources :suspensions, only: %i[edit update]
+  resources :two_step_verification_exemptions, only: %i[update]
 
   resources :doorkeeper_applications, only: %i[index edit update] do
     member do

--- a/db/migrate/20230126115902_add_reason_for_2sv_exemption_to_user.rb
+++ b/db/migrate/20230126115902_add_reason_for_2sv_exemption_to_user.rb
@@ -1,0 +1,5 @@
+class AddReasonFor2svExemptionToUser < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :reason_for_2sv_exemption, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_04_19_100040) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_26_115902) do
   create_table "batch_invitation_application_permissions", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "batch_invitation_id", null: false
     t.integer "supported_permission_id", null: false
@@ -205,6 +205,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_04_19_100040) do
     t.integer "second_factor_attempts_count", default: 0
     t.string "unlock_token"
     t.boolean "require_2sv", default: false, null: false
+    t.string "reason_for_2sv_exemption"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["invitation_token"], name: "index_users_on_invitation_token"
     t.index ["invited_by_id"], name: "index_users_on_invited_by_id"

--- a/test/controllers/two_step_verification_exemptions_controller_test.rb
+++ b/test/controllers/two_step_verification_exemptions_controller_test.rb
@@ -65,6 +65,18 @@ class TwoStepVerificationExemptionsControllerTest < ActionController::TestCase
       assert user.require_2sv?
       assert_nil user.reason_for_2sv_exemption
     end
+
+    should "not be able to exempt an admin user" do
+      user = create(:organisation_admin, organisation: create(:organisation))
+      admin = create(:superadmin_user, organisation: @gds)
+      sign_in admin
+      reason_for_exemption = "accessibility reasons"
+
+      put :update, params: { id: user.id, user: { reason_for_2sv_exemption: reason_for_exemption } }
+
+      assert_equal "You do not have permission to perform this action.", flash[:alert]
+      assert_nil user.reason_for_2sv_exemption
+    end
   end
 
   context "non-gds users" do

--- a/test/controllers/two_step_verification_exemptions_controller_test.rb
+++ b/test/controllers/two_step_verification_exemptions_controller_test.rb
@@ -1,0 +1,71 @@
+require "test_helper"
+
+class TwoStepVerificationExemptionsControllerTest < ActionController::TestCase
+  setup do
+    @gds = create(:organisation, content_id: Organisation::GDS_ORG_CONTENT_ID)
+    @organisation = create(:organisation)
+  end
+
+  def assert_user_has_been_exempted_from_2sv(user, reason)
+    user.reload
+
+    assert_not user.require_2sv?
+    assert_equal reason, user.reason_for_2sv_exemption
+    assert_nil user.otp_secret_key
+  end
+
+  def assert_user_has_not_been_exempted_from_2sv(user)
+    user.reload
+
+    assert user.require_2sv?
+    assert_nil user.reason_for_2sv_exemption
+    assert user.otp_secret_key.present?
+  end
+
+  context "gds admins" do
+    admins_with_exemption_permissions = %i[superadmin_user admin_user]
+
+    admins_with_exemption_permissions.each do |admin_type_with_exemption_permission|
+      should "be able to exempt a user from any organisation when a #{admin_type_with_exemption_permission}" do
+        user = create(:user, organisation: create(:organisation))
+        admin = create(admin_type_with_exemption_permission, organisation: @gds)
+        sign_in admin
+        reason_for_exemption = "accessibility reasons"
+
+        put :update, params: { id: user.id, user: { reason_for_2sv_exemption: reason_for_exemption } }
+
+        assert_redirected_to edit_user_path(user)
+        assert_user_has_been_exempted_from_2sv(user, reason_for_exemption)
+      end
+    end
+
+    users_without_exemption_permissions = %i[super_org_admin organisation_admin user]
+
+    users_without_exemption_permissions.each do |user_type_without_exemption_permission|
+      should "not be able to exempt a user when a #{user_type_without_exemption_permission}" do
+        user = create(:two_step_enabled_user, organisation: create(:organisation))
+        super_org_admin = create(user_type_without_exemption_permission, organisation: @gds)
+        sign_in super_org_admin
+
+        put :update, params: { id: user.id, user: { reason_for_2sv_exemption: @reason_for_exemption } }
+
+        assert_user_has_not_been_exempted_from_2sv(user)
+      end
+    end
+  end
+
+  context "non-gds users" do
+    user_types = %i[superadmin_user admin_user super_org_admin organisation_admin user]
+
+    user_types.each do |user_type|
+      should "not be able to exempt a user from any organisation when logged in as a non-gds #{user_type}" do
+        user = create(:two_step_enabled_user, organisation: @organisation)
+        logged_in_as_user = create(user_type, organisation: @organisation)
+        sign_in logged_in_as_user
+        put :update, params: { id: user.id, user: { reason_for_2sv_exemption: @reason_for_exemption } }
+
+        assert_user_has_not_been_exempted_from_2sv(user)
+      end
+    end
+  end
+end

--- a/test/controllers/two_step_verification_exemptions_controller_test.rb
+++ b/test/controllers/two_step_verification_exemptions_controller_test.rb
@@ -52,6 +52,19 @@ class TwoStepVerificationExemptionsControllerTest < ActionController::TestCase
         assert_user_has_not_been_exempted_from_2sv(user)
       end
     end
+
+    should "not update exemption when a reason is not provided" do
+      user = create(:two_step_mandated_user, organisation: create(:organisation))
+      super_admin = create(:superadmin_user, organisation: @gds)
+      sign_in super_admin
+      put :update, params: { id: user.id, user: { reason_for_2sv_exemption: "" } }
+
+      user.reload
+
+      assert_redirected_to edit_two_step_verification_exemption_path(user)
+      assert user.require_2sv?
+      assert_nil user.reason_for_2sv_exemption
+    end
   end
 
   context "non-gds users" do

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -35,6 +35,7 @@ FactoryBot.define do
   end
 
   factory :two_step_enabled_user, parent: :user do
+    require_2sv { true }
     otp_secret_key { "Sssshh" }
   end
 
@@ -44,6 +45,11 @@ FactoryBot.define do
 
   factory :two_step_mandated_user, parent: :user do
     require_2sv { true }
+  end
+
+  factory :two_step_exempted_user, parent: :user do
+    require_2sv { false }
+    reason_for_2sv_exemption { "accessibility reasons" }
   end
 
   factory :user_with_pending_email_change, parent: :user do

--- a/test/helpers/users_helper_test.rb
+++ b/test/helpers/users_helper_test.rb
@@ -8,4 +8,16 @@ class UsersHelperTest < ActionView::TestCase
 
     assert_nothing_raised { sync_needed?(user.application_permissions) }
   end
+
+  test "two_step_status should reflect the user's status accurately when the user is exempted from 2sv" do
+    assert_equal "Exempted", two_step_status(create(:two_step_exempted_user))
+  end
+
+  test "two_step_status should reflect the user's status accurately when the user has 2sv set up" do
+    assert_equal "Enabled", two_step_status(create(:two_step_enabled_user))
+  end
+
+  test "two_step_status should reflect the user's status accurately when the user does not have 2sv set up" do
+    assert_equal "Not set up", two_step_status(create(:user))
+  end
 end

--- a/test/integration/admin_user_index_test.rb
+++ b/test/integration/admin_user_index_test.rb
@@ -19,7 +19,7 @@ class AdminUserIndexTest < ActionDispatch::IntegrationTest
       create(:user, name: "Bert", email: "bbbert@example.com")
       create(:user, name: "Ed", email: "ed@example.com", organisation: org1)
       create(:user, name: "Eddie", email: "eddie_bb@example.com")
-      create(:user, name: "Ernie", email: "ernie@example.com", organisation: org2)
+      create(:two_step_exempted_user, name: "Ernie", email: "ernie@example.com", organisation: org2)
       create(:suspended_user, name: "Suspended McFee", email: "suspenders@example.com")
     end
 
@@ -167,7 +167,8 @@ class AdminUserIndexTest < ActionDispatch::IntegrationTest
     should "filter users by 2SV status" do
       visit "/users"
       total_enabled = 1
-      total_disabled = 8
+      total_disabled = 7
+      total_exempted = 1
 
       within ".filter-by-two_step_status-menu .dropdown-menu" do
         click_on "Enabled"
@@ -175,6 +176,7 @@ class AdminUserIndexTest < ActionDispatch::IntegrationTest
 
       assert has_css?("td", text: "Enabled", count: total_enabled)
       assert has_no_css?("td", text: "Not set up")
+      assert has_no_css?("td", text: "Exempted")
 
       within ".filter-by-two_step_status-menu .dropdown-menu" do
         click_on "Not set up"
@@ -182,6 +184,15 @@ class AdminUserIndexTest < ActionDispatch::IntegrationTest
 
       assert has_no_css?("td", text: "Enabled")
       assert has_css?("td", text: "Not set up", count: total_disabled)
+      assert has_no_css?("td", text: "Exempted")
+
+      within ".filter-by-two_step_status-menu .dropdown-menu" do
+        click_on "Exempted"
+      end
+
+      assert has_css?("td", text: "Exempted", count: total_exempted)
+      assert has_no_css?("td", text: "Not set up")
+      assert has_no_css?("td", text: "Enabled")
     end
   end
 

--- a/test/integration/change_user_role_test.rb
+++ b/test/integration/change_user_role_test.rb
@@ -1,0 +1,45 @@
+require "test_helper"
+
+class ChangeUserRoleTest < ActionDispatch::IntegrationTest
+  setup do
+    @super_admin = create(:superadmin_user)
+  end
+
+  # TODO: there's some stuff that can be refactored here - common stuff into helpers
+  def sign_in_as_and_edit_user(sign_in_as, user_to_edit)
+    visit root_path
+    signin_with(sign_in_as)
+    visit edit_user_path(user_to_edit)
+  end
+
+  context "when logged in as a super admin" do
+    should "be able to change the role of a user who has no 2fa exemption reason" do
+      user = create(:user)
+      sign_in_as_and_edit_user(@super_admin, user)
+
+      select "Admin", from: "Role"
+      click_button "Update User"
+
+      assert user.reload.admin?
+    end
+
+    should "not be able to change the role of a user who has a 2fa exemption reason" do
+      user = create(:two_step_exempted_user)
+      sign_in_as_and_edit_user(@super_admin, user)
+
+      assert page.has_no_select?("Role")
+
+      assert page.has_text? "This user's role is set to #{user.role}. They are currently exempted from 2sv, meaning that their role cannot be changed as admins are required to have 2sv."
+    end
+  end
+
+  context "when logged in as an admin other than a superadmin" do
+    should "not be able to change a user's role or see a warning about 2sv" do
+      user = create(:two_step_exempted_user)
+      sign_in_as_and_edit_user(create(:admin_user, organisation: user.organisation), user)
+
+      assert page.has_no_select?("Role")
+      assert page.has_no_text? "This user's role is set to #{user.role}. They are currently exempted from 2sv, meaning that their role cannot be changed as admins are required to have 2sv."
+    end
+  end
+end

--- a/test/integration/exempt_from_2sv_test.rb
+++ b/test/integration/exempt_from_2sv_test.rb
@@ -38,6 +38,7 @@ class ExemptFromTwoStepVerificationTest < ActionDispatch::IntegrationTest
       assert_equal @reason_for_exemption, user_requiring_2sv.reason_for_2sv_exemption
 
       assert page.has_text? "User exempted from 2SV"
+      assert page.has_text? "The user has been made exempt from 2-step verification for the following reason: #{@reason_for_exemption}"
 
       assert_access_log_updated_with_exemption(@super_admin.name, @reason_for_exemption)
     end
@@ -57,6 +58,7 @@ class ExemptFromTwoStepVerificationTest < ActionDispatch::IntegrationTest
       assert_equal @reason_for_exemption, user_not_requiring_2sv.reason_for_2sv_exemption
 
       assert page.has_text? "User exempted from 2SV"
+      assert page.has_text? "The user has been made exempt from 2-step verification for the following reason: #{@reason_for_exemption}"
 
       assert_access_log_updated_with_exemption(@super_admin.name, @reason_for_exemption)
     end

--- a/test/integration/exempt_from_2sv_test.rb
+++ b/test/integration/exempt_from_2sv_test.rb
@@ -10,6 +10,12 @@ class ExemptFromTwoStepVerificationTest < ActionDispatch::IntegrationTest
     visit edit_user_path(user_to_edit)
   end
 
+  def assert_access_log_updated_with_exemption(initiator_name, reason)
+    click_link "Account access log"
+
+    assert page.has_text? "Exempted from 2-step verification by #{initiator_name} for reason: #{reason}"
+  end
+
   context "when logged in as a gds super admin" do
     setup do
       @gds = create(:organisation, content_id: Organisation::GDS_ORG_CONTENT_ID)
@@ -32,6 +38,8 @@ class ExemptFromTwoStepVerificationTest < ActionDispatch::IntegrationTest
       assert_equal @reason_for_exemption, user_requiring_2sv.reason_for_2sv_exemption
 
       assert page.has_text? "User exempted from 2SV"
+
+      assert_access_log_updated_with_exemption(@super_admin.name, @reason_for_exemption)
     end
 
     should "be able to see a link to exempt a user who does not yet require 2sv but is not exempt" do
@@ -49,6 +57,8 @@ class ExemptFromTwoStepVerificationTest < ActionDispatch::IntegrationTest
       assert_equal @reason_for_exemption, user_not_requiring_2sv.reason_for_2sv_exemption
 
       assert page.has_text? "User exempted from 2SV"
+
+      assert_access_log_updated_with_exemption(@super_admin.name, @reason_for_exemption)
     end
 
     should "not be able to see a link to exempt a user who already has an exemption reason" do

--- a/test/integration/exempt_from_2sv_test.rb
+++ b/test/integration/exempt_from_2sv_test.rb
@@ -67,7 +67,7 @@ class ExemptFromTwoStepVerificationTest < ActionDispatch::IntegrationTest
 
       context "when a exemption reason already exists" do
         should "be able to see a link to edit exemption reason" do
-          user_requiring_2sv = create(:two_step_mandated_user, organisation: @organisation, reason_for_2sv_exemption: "user is exempt")
+          user_requiring_2sv = create(:user, organisation: @organisation, reason_for_2sv_exemption: "user is exempt")
 
           sign_in_as_and_edit_user(@super_admin, user_requiring_2sv)
           click_link("Edit reason for 2-step verification exemption")
@@ -110,7 +110,7 @@ class ExemptFromTwoStepVerificationTest < ActionDispatch::IntegrationTest
     context "when a exemption reason already exists" do
       should "can see exemption reason but is not able to edit it" do
         reason = "user is exempt"
-        user_requiring_2sv = create(:two_step_mandated_user, organisation: @organisation, reason_for_2sv_exemption: reason)
+        user_requiring_2sv = create(:user, organisation: @organisation, reason_for_2sv_exemption: reason)
 
         sign_in_as_and_edit_user(@super_admin, user_requiring_2sv)
 

--- a/test/integration/exempt_from_2sv_test.rb
+++ b/test/integration/exempt_from_2sv_test.rb
@@ -1,0 +1,75 @@
+require "test_helper"
+
+class ExemptFromTwoStepVerificationTest < ActionDispatch::IntegrationTest
+  include EmailHelpers
+  include ActiveJob::TestHelper
+
+  def sign_in_as_and_edit_user(sign_in_as, user_to_edit)
+    visit root_path
+    signin_with(sign_in_as)
+    visit edit_user_path(user_to_edit)
+  end
+
+  context "when logged in as a gds super admin" do
+    setup do
+      @gds = create(:organisation, content_id: Organisation::GDS_ORG_CONTENT_ID)
+      @super_admin = create(:superadmin_user, organisation: @gds)
+      @reason_for_exemption = "accessibility reasons"
+    end
+
+    should "be able to see a link to exempt a user requiring 2sv from 2sv" do
+      user_requiring_2sv = create(:two_step_mandated_user, organisation: @organisation)
+
+      sign_in_as_and_edit_user(@super_admin, user_requiring_2sv)
+      click_link("Exempt user from 2-step verification")
+
+      fill_in "Reason for 2sv exemption", with: @reason_for_exemption
+      click_button "Save"
+
+      user_requiring_2sv.reload
+
+      assert_not user_requiring_2sv.require_2sv?
+      assert_equal @reason_for_exemption, user_requiring_2sv.reason_for_2sv_exemption
+
+      assert page.has_text? "User exempted from 2SV"
+    end
+
+    should "be able to see a link to exempt a user who does not yet require 2sv but is not exempt" do
+      user_not_requiring_2sv = create(:user, organisation: @organisation)
+
+      sign_in_as_and_edit_user(@super_admin, user_not_requiring_2sv)
+      click_link("Exempt user from 2-step verification")
+
+      fill_in "Reason for 2sv exemption", with: @reason_for_exemption
+      click_button "Save"
+
+      user_not_requiring_2sv.reload
+
+      assert_not user_not_requiring_2sv.require_2sv?
+      assert_equal @reason_for_exemption, user_not_requiring_2sv.reason_for_2sv_exemption
+
+      assert page.has_text? "User exempted from 2SV"
+    end
+
+    should "not be able to see a link to exempt a user who already has an exemption reason" do
+      exempted_user = create(:two_step_exempted_user, organisation: @organisation)
+
+      sign_in_as_and_edit_user(@super_admin, exempted_user)
+      assert page.has_no_link? "Exempt user from 2-step verification"
+    end
+  end
+
+  context "when logged in as a non-gds super admin" do
+    setup do
+      @super_admin = create(:superadmin_user)
+    end
+
+    should "not be able to exempt a user requiring 2sv from 2sv" do
+      user_requiring_2sv = create(:two_step_mandated_user, organisation: @organisation)
+
+      sign_in_as_and_edit_user(@super_admin, user_requiring_2sv)
+
+      assert page.has_no_link? "Exempt user from 2-step verification"
+    end
+  end
+end

--- a/test/integration/inviting_users_test.rb
+++ b/test/integration/inviting_users_test.rb
@@ -29,7 +29,7 @@ class InvitingUsersTest < ActionDispatch::IntegrationTest
 
     should "displays the 2SV mandating checkbox" do
       visit new_user_invitation_path
-      assert has_field?("Ask user to set up 2-step verification")
+      assert has_field?("Mandate 2-step verification for this user")
     end
 
     should "create and notify the user" do
@@ -126,7 +126,7 @@ class InvitingUsersTest < ActionDispatch::IntegrationTest
 
     should "display the 2SV mandating checkbox" do
       visit new_user_invitation_path
-      assert has_field?("Ask user to set up 2-step verification")
+      assert has_field?("Mandate 2-step verification for this user")
     end
 
     should "create and notify the user" do
@@ -135,7 +135,7 @@ class InvitingUsersTest < ActionDispatch::IntegrationTest
         fill_in "Name", with: "Fred Bloggs"
         select "Admin", from: "Role"
         fill_in "Email", with: "fred_admin@example.com"
-        check "Ask user to set up 2-step verification"
+        check "Mandate 2-step verification for this user"
         click_button "Create user and send email"
 
         assert_not_nil User.find_by(

--- a/test/integration/mandating_two_step_verification_test.rb
+++ b/test/integration/mandating_two_step_verification_test.rb
@@ -73,6 +73,7 @@ class MandatingTwoStepVerificationTest < ActionDispatch::IntegrationTest
       click_link "Account access log"
 
       assert page.has_text? "Exemption from 2-step verification removed by #{@super_admin.name}"
+      assert page.has_text? "2-step verification setup mandated at next login by #{@super_admin.name}"
     end
   end
 

--- a/test/integration/mandating_two_step_verification_test.rb
+++ b/test/integration/mandating_two_step_verification_test.rb
@@ -68,6 +68,11 @@ class MandatingTwoStepVerificationTest < ActionDispatch::IntegrationTest
       click_button "Update User"
 
       assert_nil user.reload.reason_for_2sv_exemption
+
+      visit edit_user_path(user)
+      click_link "Account access log"
+
+      assert page.has_text? "Exemption from 2-step verification removed by #{@super_admin.name}"
     end
   end
 

--- a/test/integration/mandating_two_step_verification_test.rb
+++ b/test/integration/mandating_two_step_verification_test.rb
@@ -58,6 +58,17 @@ class MandatingTwoStepVerificationTest < ActionDispatch::IntegrationTest
     should "be able to unset the requirement for 2fa" do
       assert_admin_can_remove_2sv_requirement_without_notifying_user(@super_admin, @user)
     end
+
+    should "remove the user's exemption reason when 2SV is mandated" do
+      user = create(:two_step_exempted_user)
+
+      sign_in_as_and_edit_user(@super_admin, user)
+
+      check "Ask user to set up 2-step verification"
+      click_button "Update User"
+
+      assert_nil user.reload.reason_for_2sv_exemption
+    end
   end
 
   context "when logged in as an admin" do

--- a/test/integration/mandating_two_step_verification_test.rb
+++ b/test/integration/mandating_two_step_verification_test.rb
@@ -16,7 +16,7 @@ class MandatingTwoStepVerificationTest < ActionDispatch::IntegrationTest
     assert page.has_text? "2-step verification not set up"
 
     perform_enqueued_jobs do
-      check "Ask user to set up 2-step verification"
+      check "Mandate 2-step verification for this user"
       click_button "Update User"
 
       assert last_email
@@ -30,7 +30,7 @@ class MandatingTwoStepVerificationTest < ActionDispatch::IntegrationTest
     sign_in_as_and_edit_user(admin, user)
 
     perform_enqueued_jobs do
-      uncheck "Ask user to set up 2-step verification"
+      uncheck "Mandate 2-step verification for this user"
       click_button "Update User"
 
       assert_not last_email
@@ -64,7 +64,7 @@ class MandatingTwoStepVerificationTest < ActionDispatch::IntegrationTest
 
       sign_in_as_and_edit_user(@super_admin, user)
 
-      check "Ask user to set up 2-step verification"
+      check "Mandate 2-step verification for this user (this will remove their exemption)"
       click_button "Update User"
 
       assert_nil user.reload.reason_for_2sv_exemption
@@ -131,7 +131,7 @@ class MandatingTwoStepVerificationTest < ActionDispatch::IntegrationTest
       non_admin_user = create(:user, organisation: @user.organisation)
       sign_in_as_and_edit_user(non_admin_user, @user)
 
-      assert page.has_no_text? "Ask user to set up 2-step verification"
+      assert page.has_no_text? "Mandate 2-step verification for this user"
     end
   end
 
@@ -145,7 +145,7 @@ class MandatingTwoStepVerificationTest < ActionDispatch::IntegrationTest
       sign_in_as_and_edit_user(@org_admin, user)
 
       assert page.has_text? "2-step verification enabled"
-      assert page.has_no_text? "Ask user to set up 2-step verification"
+      assert page.has_no_text? "Mandate 2-step verification for this user"
     end
 
     should "be able to see an appropriate message reflecting the user's 2sv status when 2sv set up" do
@@ -153,7 +153,7 @@ class MandatingTwoStepVerificationTest < ActionDispatch::IntegrationTest
       sign_in_as_and_edit_user(@org_admin, user)
 
       assert page.has_text? "2-step verification required but not set up"
-      assert page.has_no_text? "Ask user to set up 2-step verification"
+      assert page.has_no_text? "Mandate 2-step verification for this user"
     end
   end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -124,12 +124,20 @@ class UserTest < ActiveSupport::TestCase
   end
 
   context "exempt from 2sv" do
+    setup do
+      @user = create(:two_step_enabled_user)
+      @initiator = create(:superadmin_user)
+      @user.exempt_from_2sv("accessibility reasons", @initiator)
+    end
+
     should "set require 2sv to false and store the reason" do
-      user = create(:two_step_enabled_user)
-      user.exempt_from_2sv("accessibility reasons")
-      assert_not user.require_2sv?
-      assert_equal "accessibility reasons", user.reason_for_2sv_exemption
-      assert_nil user.otp_secret_key
+      assert_not @user.require_2sv?
+      assert_equal "accessibility reasons", @user.reason_for_2sv_exemption
+      assert_nil @user.otp_secret_key
+    end
+
+    should "record the event" do
+      assert_equal 1, EventLog.where(event_id: EventLog::TWO_STEP_EXEMPTED.id, uid: @user.uid, initiator: @initiator).count
     end
   end
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -139,6 +139,14 @@ class UserTest < ActiveSupport::TestCase
     should "record the event" do
       assert_equal 1, EventLog.where(event_id: EventLog::TWO_STEP_EXEMPTED.id, uid: @user.uid, initiator: @initiator).count
     end
+
+    context "for a admin user" do
+      should "prevent them being exempted from 2SV" do
+        user = build(:admin_user, reason_for_2sv_exemption: "reason")
+
+        assert_not user.valid?
+      end
+    end
   end
 
   test "email change tokens should expire" do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -242,15 +242,21 @@ class UserTest < ActiveSupport::TestCase
   end
 
   context ".with_2sv_enabled" do
-    should "return users with 2SV enabled" do
+    should "return users with 2SV enabled when true" do
       enabled_user = create(:two_step_enabled_user)
-      enabled_users = User.with_2sv_enabled(true)
+      exempt_user = create(:two_step_exempted_user)
+
+      enabled_users = User.with_2sv_enabled("true")
       assert_equal 1, enabled_users.count
       assert_equal enabled_user, enabled_users.first
 
       disabled_users = User.with_2sv_enabled("false")
       assert_equal 1, disabled_users.count
       assert_equal @user, disabled_users.first
+
+      exempt_users = User.with_2sv_enabled("exempt")
+      assert_equal 1, exempt_users.count
+      assert_equal exempt_user, exempt_users.first
     end
 
     should "encrypt otp_secret_key" do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -57,6 +57,12 @@ class UserTest < ActiveSupport::TestCase
       user.update!(name: "Foo Bar")
       assert_not user.require_2sv?
     end
+
+    should "remove reason for 2SV exemption when 2SV required" do
+      user = create(:two_step_exempted_user)
+      user.update!(require_2sv: true)
+      assert_nil user.reason_for_2sv_exemption
+    end
   end
 
   context "#send_two_step_mandated_notification?" do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -123,6 +123,16 @@ class UserTest < ActiveSupport::TestCase
     end
   end
 
+  context "exempt from 2sv" do
+    should "set require 2sv to false and store the reason" do
+      user = create(:two_step_enabled_user)
+      user.exempt_from_2sv("accessibility reasons")
+      assert_not user.require_2sv?
+      assert_equal "accessibility reasons", user.reason_for_2sv_exemption
+      assert_nil user.otp_secret_key
+    end
+  end
+
   test "email change tokens should expire" do
     @user = create(:user_with_pending_email_change, confirmation_sent_at: 15.days.ago)
     @user.confirm

--- a/test/policies/user_policy_test.rb
+++ b/test/policies/user_policy_test.rb
@@ -66,6 +66,13 @@ class UserPolicyTest < ActiveSupport::TestCase
         user = create(:superadmin_user)
         assert forbid?(create(:superadmin_user, organisation: @gds), user, permission)
       end
+
+      should "not allow for #{permission} if the PERMIT_2SV_EXEMPTION environment variable is not set" do
+        ClimateControl.modify(PERMIT_2SV_EXEMPTION: nil) do
+          user = create(:user)
+          assert forbid?(create(:superadmin_user, organisation: @gds), user, permission)
+        end
+      end
     end
   end
 

--- a/test/policies/user_policy_test.rb
+++ b/test/policies/user_policy_test.rb
@@ -16,7 +16,7 @@ class UserPolicyTest < ActiveSupport::TestCase
   user_management_actions = %i[edit create update unlock suspension cancel_email_change resend_email_change event_logs reset_2sv mandate_2sv]
   self_management_actions = %i[edit_email_or_password update_email update_password cancel_email_change resend_email_change]
   superadmin_actions = %i[assign_role]
-  gds_admin_and_superadmin_actions = %i[exempt_from_two_step_verification]
+  two_step_verification_exemption_actions = %i[exempt_from_two_step_verification]
 
   org_admin_actions = user_management_actions - %i[create]
   super_org_admin_actions = user_management_actions - %i[create]
@@ -51,13 +51,20 @@ class UserPolicyTest < ActiveSupport::TestCase
       end
     end
 
-    gds_admin_and_superadmin_actions.each do |permission|
-      should "allow for #{permission} if the superadmin belongs to gds" do
-        assert permit?(create(:superadmin_user, organisation: @gds), User, permission)
+    two_step_verification_exemption_actions.each do |permission|
+      should "allow for #{permission} if the superadmin belongs to gds and user being edited is a normal user" do
+        user = create(:user)
+        assert permit?(create(:superadmin_user, organisation: @gds), user, permission)
       end
 
-      should "not allow for #{permission} if the superadmin does not belong to gds" do
-        assert forbid?(create(:superadmin_user, organisation: @organisation), User, :exempt_from_2sv)
+      should "not allow for #{permission} if the superadmin does not belong to gds and user being edited is a normal user" do
+        user = create(:user)
+        assert forbid?(create(:superadmin_user, organisation: @organisation), user, permission)
+      end
+
+      should "not allow for #{permission} if the superadmin belongs to gds and user being edited is an admin user" do
+        user = create(:superadmin_user)
+        assert forbid?(create(:superadmin_user, organisation: @gds), user, permission)
       end
     end
   end
@@ -91,13 +98,20 @@ class UserPolicyTest < ActiveSupport::TestCase
       end
     end
 
-    gds_admin_and_superadmin_actions.each do |permission|
-      should "allow for #{permission} if the admin belongs to gds" do
-        assert permit?(create(:admin_user, organisation: @gds), User, permission)
+    two_step_verification_exemption_actions.each do |permission|
+      should "allow for #{permission} if the admin belongs to gds and user being edited is a normal user" do
+        user = create(:user)
+        assert permit?(create(:admin_user, organisation: @gds), user, permission)
       end
 
-      should "not allow for #{permission} if the admin does not belong to gds" do
-        assert forbid?(create(:admin_user, organisation: @organisation), User, :exempt_from_2sv)
+      should "not allow for #{permission} if the admin does not belong to gds and user being edited is a normal user" do
+        user = create(:user)
+        assert forbid?(create(:admin_user, organisation: @organisation), user, permission)
+      end
+
+      should "not allow for #{permission} if the admin belongs to gds and user being edited is an admin user" do
+        user = create(:admin_user)
+        assert forbid?(create(:admin_user, organisation: @gds), user, permission)
       end
     end
   end
@@ -145,9 +159,16 @@ class UserPolicyTest < ActiveSupport::TestCase
       end
     end
 
-    (superadmin_actions + gds_admin_and_superadmin_actions).each do |permission|
+    superadmin_actions.each do |permission|
       should "not allow for #{permission}" do
         assert forbid?(create(:super_org_admin), User, permission)
+      end
+    end
+
+    two_step_verification_exemption_actions.each do |permission|
+      should "not allow for #{permission}" do
+        user = create(:super_org_admin)
+        assert forbid?(create(:super_org_admin), user, permission)
       end
     end
   end
@@ -194,9 +215,16 @@ class UserPolicyTest < ActiveSupport::TestCase
       end
     end
 
-    (superadmin_actions + gds_admin_and_superadmin_actions).each do |permission|
+    superadmin_actions.each do |permission|
       should "not allow for #{permission}" do
         assert forbid?(create(:organisation_admin), User, permission)
+      end
+    end
+
+    two_step_verification_exemption_actions.each do |permission|
+      should "not allow for #{permission}" do
+        user = create(:organisation_admin)
+        assert forbid?(create(:organisation_admin), user, permission)
       end
     end
   end
@@ -230,9 +258,16 @@ class UserPolicyTest < ActiveSupport::TestCase
       end
     end
 
-    (superadmin_actions + gds_admin_and_superadmin_actions).each do |permission|
+    superadmin_actions.each do |permission|
       should "not allow for #{permission}" do
         assert forbid?(create(:user), User, permission)
+      end
+    end
+
+    two_step_verification_exemption_actions.each do |permission|
+      should "not allow for #{permission}" do
+        user = create(:user)
+        assert forbid?(create(:user), user, permission)
       end
     end
 

--- a/test/services/user_update_test.rb
+++ b/test/services/user_update_test.rb
@@ -37,4 +37,16 @@ class UserUpdateTest < ActionView::TestCase
     assert_equal app.id, add_event.application_id
     assert_equal parsed_ip_address, add_event.ip_address_string
   end
+
+  should "record when 2SV exemption has been removed" do
+    current_user = create(:superadmin_user)
+    ip_address = "1.2.3.4"
+
+    affected_user = create(:two_step_exempted_user)
+
+    params = { require_2sv: "1" }
+    UserUpdate.new(affected_user, params, current_user, ip_address).call
+
+    assert_equal 1, EventLog.where(event_id: EventLog::TWO_STEP_EXEMPTION_REMOVED.id).count
+  end
 end

--- a/test/services/user_update_test.rb
+++ b/test/services/user_update_test.rb
@@ -49,4 +49,16 @@ class UserUpdateTest < ActionView::TestCase
 
     assert_equal 1, EventLog.where(event_id: EventLog::TWO_STEP_EXEMPTION_REMOVED.id).count
   end
+
+  should "record when 2SV has been mandated" do
+    current_user = create(:superadmin_user)
+    ip_address = "1.2.3.4"
+
+    affected_user = create(:user)
+
+    params = { require_2sv: "1" }
+    UserUpdate.new(affected_user, params, current_user, ip_address).call
+
+    assert_equal 1, EventLog.where(event_id: EventLog::TWO_STEP_MANDATED.id).count
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -32,6 +32,8 @@ class ActionController::TestCase
   include Devise::Test::ControllerHelpers
   include ConfirmationTokenHelpers
 
+  ENV["PERMIT_2SV_EXEMPTION"] = "true"
+
   def sign_in(user, passed_mfa: true)
     warden.stubs(authenticate!: user)
     unless passed_mfa


### PR DESCRIPTION
This PR introduces the basics for exempting users from 2sv, adding a link on the 'edit user' page and a new page for adding and editing the exemption reason. 

The functionality is behind a feature flag, so users will not be able to exempt unless the environment has a "PERMIT_2SV_EXEMPTION". We plan to remove this feature flag once the other 2sv features are ready.

Screenshots of new functionality added:

| Scenario | Screenshot |
|----|-----|
| Link to add an exemption for a user |![Screenshot 2023-02-03 at 08 09 04](https://user-images.githubusercontent.com/6329861/216546237-036f5523-3385-475b-b20e-df3cb17915de.png)|
| Link to edit an exemption for a user|![Screenshot 2023-02-03 at 08 07 47](https://user-images.githubusercontent.com/6329861/216546002-91b1fc56-9a87-4ad5-bcce-f06bafa1a7d8.png)|
| Exemption reason displaying but no link to edit when logged in as a non-gds admin |![Screenshot 2023-02-03 at 08 10 04](https://user-images.githubusercontent.com/6329861/216546443-fa6dab34-d29c-4e45-a3f8-b732b1740673.png)|
|Create / edit an exemption reason interface|<img width="1133" alt="Screenshot 2023-02-03 at 09 47 32" src="https://user-images.githubusercontent.com/25515510/216568167-4383f723-e727-4c8d-aab3-4f6f7643c3b0.png">|

### Summary of permissions

| Logged in as user | Editing user | Can exempt? | Can mandate 2sv for an exempted user (remove an exemption)? |
|---|---|---|---|
| Gds superadmin or admin | Normal user in any organisation | Yes | Yes |
| Gds admin | Admin (any level) user in any organisation | No | n/a (can't be exempted) |
| Gds org admin | Normal gds user | No | Yes |
| Non-gds admin | Normal user in their organisation | No | Yes |

Note that any user who can edit a user with an exemption reason will be able to see the exemption reason (but not edit it).
As a reminder, the following users have the following permissions to edit users:

* Super admins - any users at any level
* Admins - any users at same or lower level below in the hierarchy (so admins, super-org admins, org admins, normal users)
* Super org admins - users in their org or a child org at same or lower level below in the hierarchy (so super-org admins, org admins, normal users)
* Org admins - users in their org or a child org at same or lower level below in the hierarchy (so org admins, normal users)
* Normal users - no edit permissions

### What's not included in this PR

Ensuring that exempted users do not get unnecessary prompts to set up 2sv - that to be covered in [this ticket](https://trello.com/c/v5jGPVxF/447-ensure-user-experience-for-2fa-exempted-users-is-consistent)

[Trello](https://trello.com/c/qijNj4uh/433-allow-admins-super-admins-gds-only-to-un-set-the-requires-2sv-flag-on-any-user-if-they-provide-a-reason-free-text-similar-to-the)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
