### PR TITLE
Remove test for doorkeeper version

### DIFF
--- a/app/controllers/signin_required_authorizations_controller.rb
+++ b/app/controllers/signin_required_authorizations_controller.rb
@@ -1,6 +1,11 @@
 class SigninRequiredAuthorizationsController < Doorkeeper::AuthorizationsController
   include Pundit::Authorization
-  EXPECTED_DOORKEEPER_VERSION = "5.6.4".freeze
+  # This controller was based on (and inherits from)
+  # https://github.com/doorkeeper-gem/doorkeeper/blob/main/app/controllers/doorkeeper/authorizations_controller.rb
+  #
+  # Future doorkeeper changes may result in test failures in this controller.
+  # If you see a failure after upgrading the Doorkeeper gem, then check the
+  # doorkeeper version of this controller for any changes that may need to be ported here.
 
   def new
     if pre_authorizable?

--- a/test/controllers/signin_required_authorizations_controller_test.rb
+++ b/test/controllers/signin_required_authorizations_controller_test.rb
@@ -29,15 +29,6 @@ class SigninRequiredAuthorizationsControllerTest < ActionController::TestCase
     @controller.stubs(current_resource_owner: @user)
   end
 
-  test "warn if doorkeeper has been updated" do
-    # We extracted SigninRequiredAuthorizationsController and its tests from
-    # those for Doorkeeper::AuthorizationsController in version 4.2.6 it's very
-    # possible that future versions of doorkeeper change the implementation or
-    # tests and we should keep our versions up to date.  They may also have
-    # introduced a better way for us to customise the behaviour.
-    assert_equal SigninRequiredAuthorizationsController::EXPECTED_DOORKEEPER_VERSION, Doorkeeper::VERSION::STRING, "SigninRequiredAuthorizationsController was extracted from Doorkeeper::AuthorizationsController and has been checked against version #{SigninRequiredAuthorizationsController::EXPECTED_DOORKEEPER_VERSION} of the Gem.  It's now #{Doorkeeper::VERSION::STRING} so review the new version to check for updates."
-  end
-
   context "POST #create" do
     setup do
       post :create, params: { client_id: @application.uid, response_type: "token", redirect_uri: @application.redirect_uri }


### PR DESCRIPTION
We currently have a test to ensure doorkeeper matches a hardcoded version. This value has to be updated each time the doorkeeper gem is upgraded.

We understand the reason being that a controller was based on (and inherits from) another controller in doorkeeper.

The expectation was developers would compare the controller in this app to the equivalent in doorkeeper before making any updates.

We know from anecdotal (and commit history) that this has not happened. It therefore feels this test is not achieving its original purpose.

We know the test coverage of this controller is good, so are removing the version check test and instead relying on the controller's tests to see if there have been any breaking changes in doorkeeper.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
