### PR TITLE
Prevent api users from having 2sv required or exemption reasons set

### DIFF
--- a/app/models/api_user.rb
+++ b/app/models/api_user.rb
@@ -1,6 +1,18 @@
 class ApiUser < User
   default_scope { where(api_user: true).order(:name) }
+  validate :reason_for_2sv_exemption_blank
+  validate :require_2sv_is_false
 
   DEFAULT_TOKEN_LIFE = 2.years.to_i
   AUTOROTATABLE_TOKEN_LIFE = 60.days.to_i
+
+private
+
+  def require_2sv_is_false
+    errors.add(:require_2sv, "can't be true for api user") if require_2sv
+  end
+
+  def reason_for_2sv_exemption_blank
+    errors.add(:reason_for_2sv_exemption, "can't be present for api user") if reason_for_2sv_exemption.present?
+  end
 end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -57,7 +57,11 @@ class UserPolicy < BasePolicy
   end
 
   def exempt_from_two_step_verification?
-    current_user.belongs_to_gds? && (current_user.superadmin? || current_user.admin?) && record.normal? && ENV["PERMIT_2SV_EXEMPTION"]
+    current_user.belongs_to_gds? &&
+      (current_user.superadmin? || current_user.admin?) &&
+      record.normal? &&
+      !record.api_user &&
+      ENV["PERMIT_2SV_EXEMPTION"]
   end
 
 private

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -69,3 +69,13 @@ User.create!(
   require_2sv: true,
   otp_secret_key: "I5X6Y3VN3CAATYQRBPAZ7KMFLK2RWYJ5",
 )
+
+User.create!(
+  name: "Test Api User",
+  api_user: true,
+  email: "test.apiuser@gov.uk",
+  password: "6fe552ca-d406-4c54-b7a6-041ed1ade6cd",
+  role: :normal,
+  confirmed_at: Time.zone.now,
+  require_2sv: false,
+)

--- a/test/integration/exempt_from_2sv_test.rb
+++ b/test/integration/exempt_from_2sv_test.rb
@@ -92,6 +92,32 @@ class ExemptFromTwoStepVerificationTest < ActionDispatch::IntegrationTest
         assert page.has_no_link? "Exempt user from 2-step verification"
       end
     end
+
+    context "when the user being edited is an api user" do
+      setup do
+        @api_user = create(:api_user)
+      end
+
+      should "not be able to see a link to exempt the user when accessing via the edit user path" do
+        sign_in_as_and_edit_user(@super_admin, @api_user)
+        assert page.has_no_link? "Exempt user from 2-step verification"
+      end
+
+      should "not be able to see a link to exempt the user when accessing via the edit api user path" do
+        sign_in_as_and_edit_user(@super_admin, @api_user)
+        visit edit_api_user_path(@api_user)
+
+        assert page.has_no_link? "Exempt user from 2-step verification"
+      end
+
+      should "not be able to exempt an api user when accessing the edit exemption reason path directly" do
+        sign_in_as_and_edit_user(@super_admin, @api_user)
+        visit edit_two_step_verification_exemption_path(@api_user)
+
+        assert page.has_text?("You do not have permission to perform this action.")
+        assert_equal "/", current_path
+      end
+    end
   end
 
   context "when logged in as a non-gds super admin" do

--- a/test/models/api_user_test.rb
+++ b/test/models/api_user_test.rb
@@ -1,0 +1,22 @@
+require "test_helper"
+class ApiUserTest < ActiveSupport::TestCase
+  should "not be valid if require 2sv is set to true" do
+    user = build(:api_user, require_2sv: true)
+    assert_not user.valid?
+  end
+
+  should "be valid if require 2sv is set to false" do
+    user = build(:api_user, require_2sv: false)
+    assert user.valid?
+  end
+
+  should "not be valid if a reason for 2sv exemption exists" do
+    user = build(:api_user, reason_for_2sv_exemption: "some reason")
+    assert_not user.valid?
+  end
+
+  should "be valid if reason for 2sv exemption is nil" do
+    user = build(:api_user, reason_for_2sv_exemption: nil)
+    assert user.valid?
+  end
+end

--- a/test/policies/user_policy_test.rb
+++ b/test/policies/user_policy_test.rb
@@ -73,6 +73,11 @@ class UserPolicyTest < ActiveSupport::TestCase
           assert forbid?(create(:superadmin_user, organisation: @gds), user, permission)
         end
       end
+
+      should "not allow for #{permission} if the user is an api user" do
+        user = create(:api_user)
+        assert forbid?(create(:superadmin_user, organisation: @gds), user, permission)
+      end
     end
   end
 


### PR DESCRIPTION
Depends on https://github.com/alphagov/signon/pull/2083 [merged]

Signon has two types of users - human users, and 'api users'. An api user is created in the case where we want communication between two applications to be authenticated, so an api user is created for one of the applications, granting it access to another via a bearer token. Api users can be for applications internal to GDS and external.

Because we don't want to enforce 2sv on these users, this contains:

* some preventative work ensuring that api users cannot have the 'require_2sv' flag set to true. This should give us a layer of safety when setting this flag across big groups of users, when we turn 2sv on for all human users.
* Some work to prevent users from being able to give api users exemption reasons in the UI - since these users cannot have 2sv set on them, setting / editing an exemption doesn't make sense.

[Trello](https://trello.com/c/ezvggxS1/450-ensure-api-users-cannot-be-exempted-and-cannot-have-2sv-required)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
