### PR TITLE
Make exempted 2sv user experience consistent with their status

### DIFF
--- a/app/controllers/devise/two_step_verification_controller.rb
+++ b/app/controllers/devise/two_step_verification_controller.rb
@@ -68,7 +68,7 @@ private
     @otp_secret_key = params[:otp_secret_key]
     totp = ROTP::TOTP.new(@otp_secret_key)
     if totp.verify(params[:code], drift_behind: User::MAX_2SV_DRIFT_SECONDS)
-      current_user.update!(otp_secret_key: @otp_secret_key)
+      current_user.update!(otp_secret_key: @otp_secret_key, reason_for_2sv_exemption: nil)
       true
     else
       false

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -2,7 +2,7 @@ module UsersHelper
   def two_step_status(user)
     if user.has_2sv?
       "Enabled"
-    elsif user.reason_for_2sv_exemption.present?
+    elsif user.exempt_from_2sv?
       "Exempted"
     else
       "Not set up"

--- a/app/models/api_user.rb
+++ b/app/models/api_user.rb
@@ -13,6 +13,6 @@ private
   end
 
   def reason_for_2sv_exemption_blank
-    errors.add(:reason_for_2sv_exemption, "can't be present for api user") if reason_for_2sv_exemption.present?
+    errors.add(:reason_for_2sv_exemption, "can't be present for api user") if exempt_from_2sv?
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -101,6 +101,10 @@ class User < ApplicationRecord
     require_2sv?
   end
 
+  def exempt_from_2sv?
+    reason_for_2sv_exemption.present?
+  end
+
   def event_logs
     EventLog.where(uid:).order(created_at: :desc).includes(:user_agent)
   end
@@ -336,7 +340,7 @@ private
   end
 
   def user_can_be_exempted_from_2sv
-    errors.add(:reason_for_2sv_exemption, "#{role} users cannot be exempted from 2SV. Remove the user's exemption to change their role.") if reason_for_2sv_exemption.present? && !normal?
+    errors.add(:reason_for_2sv_exemption, "#{role} users cannot be exempted from 2SV. Remove the user's exemption to change their role.") if exempt_from_2sv? && !normal?
   end
 
   def organisation_admin_belongs_to_organisation

--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -3,7 +3,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <% unless current_user.has_2sv? %>
+    <% unless current_user.has_2sv? || current_user.reason_for_2sv_exemption.present? %>
       <%= render "govuk_publishing_components/components/notice", {
         title: "Make your account more secure",
         description_text: (render "devise/two_step_verification/make_your_account_more_secure")

--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -3,7 +3,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <% unless current_user.has_2sv? || current_user.reason_for_2sv_exemption.present? %>
+    <% unless current_user.has_2sv? || current_user.exempt_from_2sv? %>
       <%= render "govuk_publishing_components/components/notice", {
         title: "Make your account more secure",
         description_text: (render "devise/two_step_verification/make_your_account_more_secure")

--- a/app/views/users/_form_fields.html.erb
+++ b/app/views/users/_form_fields.html.erb
@@ -44,7 +44,7 @@
   <dl>
     <dt>Account security</dt>
     <dd>
-      <% if @user.reason_for_2sv_exemption.present? %>
+      <% if @user.exempt_from_2sv? %>
         <p>
           The user has been made exempt from 2-step verification for the following reason: <%= @user.reason_for_2sv_exemption %>
         <% if Pundit.policy(current_user, @user).exempt_from_two_step_verification? %>
@@ -72,7 +72,7 @@
       <% unless @user.require_2sv? %>
         <p class="checkbox">
           <%= f.label :require_2sv do %>
-            <%= f.check_box :require_2sv %> Mandate 2-step verification for this user <%= "(this will remove their exemption)" if @user.reason_for_2sv_exemption.present? %>
+            <%= f.check_box :require_2sv %> Mandate 2-step verification for this user <%= "(this will remove their exemption)" if @user.exempt_from_2sv? %>
           <% end %>
         <br/>
         User will be prompted to set up 2-step verification again the next time they sign in.</p>

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -156,6 +156,7 @@ namespace :users do
     raise "Couldn't find organisation: '#{args.org}'" unless organisation
 
     users_to_update = User.where(organisation_id: organisation.id, require_2sv: false)
+                          .where(reason_for_2sv_exemption: nil)
 
     puts "found #{users_to_update.size} users without 2sv in organsation #{args.org} to set require 2sv flag on"
 
@@ -164,7 +165,9 @@ namespace :users do
 
   desc "Sets 2sv on all users by email domain"
   task :set_2sv_by_email_domain, [:domain] => :environment do |_t, args|
-    users_to_update = User.where("email LIKE ?", "%#{args.domain}").where(require_2sv: false)
+    users_to_update = User.where("email LIKE ?", "%#{args.domain}")
+                          .where(require_2sv: false)
+                          .where(reason_for_2sv_exemption: nil)
 
     puts "found #{users_to_update.size} users without 2sv with email domain #{args.domain} to set require 2sv flag on"
 

--- a/test/integration/dashboard_test.rb
+++ b/test/integration/dashboard_test.rb
@@ -42,13 +42,26 @@ class DashboardTest < ActionDispatch::IntegrationTest
     end
   end
 
-  context "when the user is not enrolled in 2SV" do
+  context "when the user is not enrolled in 2SV and is not exempted" do
     should "display the 'set up' link" do
       user = create(:user)
       visit root_path
       signin_with(user)
 
       assert_response_contains("Make your account more secure")
+      assert has_link?("Start set up")
+      assert has_link?("Set up 2-step verification")
+    end
+  end
+
+  context "when the user is not enrolled in 2sv but has an exemption reason" do
+    should "not display the main 'make your account secure' 2sv banner, but should still contain a link to set up" do
+      user = create(:two_step_exempted_user)
+      visit root_path
+      signin_with(user)
+
+      refute_response_contains("Make your account more secure")
+      assert has_no_link?("Start set up")
       assert has_link?("Set up 2-step verification")
     end
   end

--- a/test/lib/tasks/users_test.rb
+++ b/test/lib/tasks/users_test.rb
@@ -12,11 +12,13 @@ class UsersTaskTest < ActiveSupport::TestCase
     should "sets 2sv for all users within the specified org" do
       organisation = create(:organisation, name: "Department of Health")
       users_in_organisation = @user_types.map { |user_type| create(user_type, organisation:) }
+      exempted_user_in_organisation = create(:two_step_exempted_user, organisation:)
       users_in_different_organisation = @user_types.map { |user_type| create(user_type, organisation: create(:organisation)) }
 
       Rake::Task["users:set_2sv_by_org"].invoke(organisation.name)
 
       assert users_in_organisation.each(&:reload).all?(&:require_2sv)
+      assert_not exempted_user_in_organisation.reload.require_2sv
       assert(users_in_different_organisation.each(&:reload).all? { |user| !user.require_2sv })
     end
   end
@@ -26,11 +28,13 @@ class UsersTaskTest < ActiveSupport::TestCase
       targeted_domain = "@some.domain.gov.uk"
       other_domain = "@domain.gov.uk"
       users_in_domain = @user_types.map { |user_type| create(user_type, email: user_type.to_s + targeted_domain) }
+      exempted_user_in_domain = create(:two_step_exempted_user, email: "exempted_user#{targeted_domain}")
       users_in_other_domain = @user_types.map { |user_type| create(user_type, email: user_type.to_s + other_domain) }
 
       Rake::Task["users:set_2sv_by_email_domain"].invoke(targeted_domain)
 
       assert users_in_domain.each(&:reload).all?(&:require_2sv)
+      assert_not exempted_user_in_domain.reload.require_2sv
       assert(users_in_other_domain.each(&:reload).all? { |user| !user.require_2sv })
     end
   end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -65,6 +65,23 @@ class UserTest < ActiveSupport::TestCase
     end
   end
 
+  context "#exempt_from_2sv??" do
+    should "be true if exemption reason is present" do
+      user = create(:two_step_exempted_user)
+      assert user.exempt_from_2sv?
+    end
+
+    should "be false if exemption reason is nil" do
+      user = create(:user)
+      assert_not user.exempt_from_2sv?
+    end
+
+    should "be false if exemption reason is an empty string" do
+      user = create(:user, reason_for_2sv_exemption: "")
+      assert_not user.exempt_from_2sv?
+    end
+  end
+
   context "#send_two_step_mandated_notification?" do
     context "when not mandated" do
       should "return false" do


### PR DESCRIPTION
In a [previous PR](https://github.com/alphagov/signon/pull/2095), we introduced the ability to exempt a user from 2sv, based on providing an exemption reason.

This PR ensures that users who are exempted (i.e. those with exemption reasons) have an experience that is consistent with this status. This means:

* They are excluded from any rake tasks to bulk set the `require_2sv' flag on groups of users
* They do not see large call to actions to set up 2sv, although they are still able to set this up in the UI if their circumstances change
* When they set up 2sv, their exemption reason is removed, meaning that they no longer appear in the list of exempted users.

Screenshot to illustrate the difference when logging in as an exempted user:


| Before this change | After this change |
| ---- | ---- |
|<img width="1006" alt="Screenshot 2023-02-06 at 11 19 02" src="https://user-images.githubusercontent.com/25515510/216958571-6d60cfe7-1ec3-48c0-bc52-98a4205b4de4.png">|<img width="1021" alt="Screenshot 2023-02-06 at 11 17 48" src="https://user-images.githubusercontent.com/25515510/216958386-27e6523b-4ab6-4ef0-8f2c-ab3685f035ea.png">|

[Trello](https://trello.com/c/v5jGPVxF/447-ensure-user-experience-for-2fa-exempted-users-is-consistent)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
