### PR TITLE
Add expiry date to 2sv exemptions

### DIFF
--- a/app/controllers/devise/two_step_verification_controller.rb
+++ b/app/controllers/devise/two_step_verification_controller.rb
@@ -68,7 +68,7 @@ private
     @otp_secret_key = params[:otp_secret_key]
     totp = ROTP::TOTP.new(@otp_secret_key)
     if totp.verify(params[:code], drift_behind: User::MAX_2SV_DRIFT_SECONDS)
-      current_user.update!(otp_secret_key: @otp_secret_key, reason_for_2sv_exemption: nil)
+      current_user.update!(otp_secret_key: @otp_secret_key, reason_for_2sv_exemption: nil, expiry_date_for_2sv_exemption: nil)
       true
     else
       false

--- a/app/controllers/two_step_verification_exemptions_controller.rb
+++ b/app/controllers/two_step_verification_exemptions_controller.rb
@@ -4,31 +4,45 @@ class TwoStepVerificationExemptionsController < ApplicationController
   def edit; end
 
   def update
-    if params[:user][:reason_for_2sv_exemption].empty?
-      flash[:alert] = "Reason for exemption must be provided"
-
+    error_string_or_parsed_params = parsed_params_or_error_string(params[:user])
+    case error_string_or_parsed_params
+    when String
+      flash[:alert] = error_string_or_parsed_params
       redirect_to edit_two_step_verification_exemption_path(@user)
-    elsif params[:user]["expiry_date_for_2sv_exemption(1i)"]
-      expiry_date = parse_date_from_user_params(params[:user])
-      if Time.zone.today >= expiry_date
-        flash[:alert] = "Expiry date must be in the future"
-
-        redirect_to edit_two_step_verification_exemption_path(@user)
-      else
-        @user.exempt_from_2sv(params[:user][:reason_for_2sv_exemption], current_user, expiry_date)
-
-        flash[:notice] = "User exempted from 2SV"
-
-        redirect_to edit_user_path(@user)
-      end
+    else
+      reason_for_2sv_exemption, valid_expiry_date = error_string_or_parsed_params
+      @user.exempt_from_2sv(reason_for_2sv_exemption, current_user, valid_expiry_date)
+      flash[:notice] = "User exempted from 2SV"
+      redirect_to edit_user_path(@user)
     end
   end
 
 private
 
+  def parsed_params_or_error_string(user_params)
+    if user_params[:reason_for_2sv_exemption].empty?
+      "Reason for exemption must be provided"
+    else
+      begin
+        expiry_date = parse_date_from_user_params(params[:user])
+        if Time.zone.today >= expiry_date
+          "Expiry date must be in the future"
+        else
+          [user_params[:reason_for_2sv_exemption], expiry_date]
+        end
+      rescue Date::Error
+        "Expiry date is not a valid date"
+      end
+    end
+  end
+
   def parse_date_from_user_params(user_params)
-    date_part_params = ["expiry_date_for_2sv_exemption(1i)", "expiry_date_for_2sv_exemption(2i)", "expiry_date_for_2sv_exemption(3i)"]
-    date_string = date_part_params.map { |param_name| user_params[param_name] }.join("/")
+    date_part_params = ["(1i)", "(2i)", "(3i)"].map { |suffix| "expiry_date_for_2sv_exemption#{suffix}" }
+    date_params = date_part_params.map { |param_name| user_params[param_name] }
+
+    raise Date::Error if date_params.any?(&:nil?)
+
+    date_string = date_params.join("/")
     Date.parse(date_string)
   end
 

--- a/app/controllers/two_step_verification_exemptions_controller.rb
+++ b/app/controllers/two_step_verification_exemptions_controller.rb
@@ -8,15 +8,19 @@ class TwoStepVerificationExemptionsController < ApplicationController
       flash[:alert] = "Reason for exemption must be provided"
 
       redirect_to edit_two_step_verification_exemption_path(@user)
-    else
-      if params[:user]["expiry_date_for_2sv_exemption(1i)"]
-        expiry_date = parse_date_from_user_params(params[:user])
+    elsif params[:user]["expiry_date_for_2sv_exemption(1i)"]
+      expiry_date = parse_date_from_user_params(params[:user])
+      if Time.zone.today >= expiry_date
+        flash[:alert] = "Expiry date must be in the future"
+
+        redirect_to edit_two_step_verification_exemption_path(@user)
+      else
+        @user.exempt_from_2sv(params[:user][:reason_for_2sv_exemption], current_user, expiry_date)
+
+        flash[:notice] = "User exempted from 2SV"
+
+        redirect_to edit_user_path(@user)
       end
-      @user.exempt_from_2sv(params[:user][:reason_for_2sv_exemption], current_user, expiry_date)
-
-      flash[:notice] = "User exempted from 2SV"
-
-      redirect_to edit_user_path(@user)
     end
   end
 

--- a/app/controllers/two_step_verification_exemptions_controller.rb
+++ b/app/controllers/two_step_verification_exemptions_controller.rb
@@ -9,7 +9,10 @@ class TwoStepVerificationExemptionsController < ApplicationController
 
       redirect_to edit_two_step_verification_exemption_path(@user)
     else
-      @user.exempt_from_2sv(params[:user][:reason_for_2sv_exemption], current_user)
+      if params[:user]["expiry_date_for_2sv_exemption(1i)"]
+        expiry_date = parse_date_from_user_params(params[:user])
+      end
+      @user.exempt_from_2sv(params[:user][:reason_for_2sv_exemption], current_user, expiry_date)
 
       flash[:notice] = "User exempted from 2SV"
 
@@ -18,6 +21,12 @@ class TwoStepVerificationExemptionsController < ApplicationController
   end
 
 private
+
+  def parse_date_from_user_params(user_params)
+    date_part_params = ["expiry_date_for_2sv_exemption(1i)", "expiry_date_for_2sv_exemption(2i)", "expiry_date_for_2sv_exemption(3i)"]
+    date_string = date_part_params.map { |param_name| user_params[param_name] }.join("/")
+    Date.parse(date_string)
+  end
 
   def load_and_authorize_user
     @user = User.find(params[:id])

--- a/app/models/event_log.rb
+++ b/app/models/event_log.rb
@@ -42,7 +42,7 @@ class EventLog < ApplicationRecord
     ACCOUNT_INVITED = LogEntry.new(id: 37, description: "Account was invited", require_uid: true, require_initiator: true),
     NO_SUCH_ACCOUNT_LOGIN = LogEntry.new(id: 38, description: "Attempted login to nonexistent account"),
     TWO_STEP_EXEMPTED = LogEntry.new(id: 39, description: "Exempted from 2-step verification", require_uid: true, require_initiator: true),
-    TWO_STEP_EXEMPTION_REASON_UPDATED = LogEntry.new(id: 40, description: "Reason for 2-step verification exemption updated", require_uid: true, require_initiator: true),
+    TWO_STEP_EXEMPTION_UPDATED = LogEntry.new(id: 40, description: "2-step verification exemption updated", require_uid: true, require_initiator: true),
     TWO_STEP_EXEMPTION_REMOVED = LogEntry.new(id: 41, description: "Exemption from 2-step verification removed", require_uid: true, require_initiator: true),
     TWO_STEP_MANDATED = LogEntry.new(id: 42, description: "2-step verification setup mandated at next login", require_uid: true, require_initiator: true),
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -39,6 +39,7 @@ class User < ApplicationRecord
   validate :user_can_be_exempted_from_2sv
   validate :organisation_admin_belongs_to_organisation
   validate :email_is_ascii_only
+  validate :exemption_from_2sv_data_is_complete
 
   has_many :authorisations, class_name: "Doorkeeper::AccessToken", foreign_key: :resource_owner_id
   has_many :application_permissions, class_name: "UserApplicationPermission", inverse_of: :user
@@ -354,6 +355,11 @@ private
 
   def email_is_ascii_only
     errors.add(:email, "can't contain non-ASCII characters") unless email.blank? || email.ascii_only?
+  end
+
+  def exemption_from_2sv_data_is_complete
+    errors.add(:expiry_date_for_2sv_exemption, "must be present if exemption reason is present") if reason_for_2sv_exemption.present? && expiry_date_for_2sv_exemption.nil?
+    errors.add(:reason_for_2sv_exemption, "must be present if exemption expiry date is present") if expiry_date_for_2sv_exemption.present? && reason_for_2sv_exemption.nil?
   end
 
   def fix_apostrophe_in_email

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -300,9 +300,9 @@ class User < ApplicationRecord
     update!(require_2sv: false, reason_for_2sv_exemption: reason, otp_secret_key: nil, expiry_date_for_2sv_exemption: expiry_date)
 
     if initial_reason.blank?
-      EventLog.record_event(self, EventLog::TWO_STEP_EXEMPTED, initiator: initiating_user, trailing_message: "for reason: #{reason}")
+      EventLog.record_event(self, EventLog::TWO_STEP_EXEMPTED, initiator: initiating_user, trailing_message: "for reason: #{reason} expiring on date: #{expiry_date}")
     else
-      EventLog.record_event(self, EventLog::TWO_STEP_EXEMPTION_REASON_UPDATED, initiator: initiating_user, trailing_message: "to: #{reason}")
+      EventLog.record_event(self, EventLog::TWO_STEP_EXEMPTION_UPDATED, initiator: initiating_user, trailing_message: "to: #{reason} expiring on date: #{expiry_date}")
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -255,7 +255,10 @@ class User < ApplicationRecord
   end
 
   def reset_2sv_exemption_reason
-    self.reason_for_2sv_exemption = nil if require_2sv.present?
+    if require_2sv.present?
+      self.reason_for_2sv_exemption =  nil
+      self.expiry_date_for_2sv_exemption = nil
+    end
   end
 
   def authenticate_otp(code)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -295,7 +295,7 @@ class User < ApplicationRecord
     otp_secret_key.present?
   end
 
-  def exempt_from_2sv(reason, initiating_user, expiry_date = nil)
+  def exempt_from_2sv(reason, initiating_user, expiry_date)
     initial_reason = reason_for_2sv_exemption
     update!(require_2sv: false, reason_for_2sv_exemption: reason, otp_secret_key: nil, expiry_date_for_2sv_exemption: expiry_date)
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -295,9 +295,9 @@ class User < ApplicationRecord
     otp_secret_key.present?
   end
 
-  def exempt_from_2sv(reason, initiating_user)
+  def exempt_from_2sv(reason, initiating_user, expiry_date = nil)
     initial_reason = reason_for_2sv_exemption
-    update!(require_2sv: false, reason_for_2sv_exemption: reason, otp_secret_key: nil)
+    update!(require_2sv: false, reason_for_2sv_exemption: reason, otp_secret_key: nil, expiry_date_for_2sv_exemption: expiry_date)
 
     if initial_reason.blank?
       EventLog.record_event(self, EventLog::TWO_STEP_EXEMPTED, initiator: initiating_user, trailing_message: "for reason: #{reason}")

--- a/app/presenters/user_export_presenter.rb
+++ b/app/presenters/user_export_presenter.rb
@@ -27,6 +27,7 @@ class UserExportPresenter
       "Created",
       "Status",
       "2SV Status",
+      "2SV Exemption Expiry Date",
     ].concat applications.map(&:name)
   end
 
@@ -41,6 +42,7 @@ class UserExportPresenter
       user.created_at.try(:to_formatted_s, :db),
       user.status.humanize,
       two_step_status(user),
+      user.expiry_date_for_2sv_exemption.try(:strftime, "%d/%m/%Y"),
     ].concat(app_permissions_for(user))
   end
 

--- a/app/views/two_step_verification_exemptions/edit.html.erb
+++ b/app/views/two_step_verification_exemptions/edit.html.erb
@@ -8,12 +8,17 @@
 <h1 class="page-title">Exempt &ldquo;<%= @user.name %>&rdquo; from 2-step verification</h1>
 
 <%= form_tag two_step_verification_exemption_path(@user), method: "patch", :class => 'well remove-top-padding' do %>
-  <div class="form-group add-top-margin">
+  <div class="add-top-margin">
+    <p>You are about to exempt this user from having 2 step verification on their account. This will remove any existing
+      requirement to log in with, or set up 2 step verification.</p>
+  </div>
+  <div class="form-group">
     <label for="user_reason_for_2sv_exemption">Reason for 2sv exemption</label>
     <%= text_field_tag "user[reason_for_2sv_exemption]", @user.reason_for_2sv_exemption, class: 'form-control input-md-6' %>
   </div>
-  <p>Add a reason to exempt the user from 2-step verification. This will remove any existing requirement to log in with, or set up, 2-step verification.</p>
-  <p>This reason will be visible to the user, and to any admins who have the ability to edit this user.</p>
+  <p>Please provide a reason for granting this exemption above.</p>
+  <p>Please note - the reason you enter above will be visible to the user, and any admin who have the ability to edit
+    the user.</p>
   <div class="form-group add-top-margin">
     <label for="user_expiry_date_for_2sv_exemption">Expiry date for exemption</label>
     <div class="form-inline">

--- a/app/views/two_step_verification_exemptions/edit.html.erb
+++ b/app/views/two_step_verification_exemptions/edit.html.erb
@@ -12,9 +12,15 @@
     <label for="user_reason_for_2sv_exemption">Reason for 2sv exemption</label>
     <%= text_field_tag "user[reason_for_2sv_exemption]", @user.reason_for_2sv_exemption, class: 'form-control input-md-6' %>
   </div>
-  <hr />
   <p>Add a reason to exempt the user from 2-step verification. This will remove any existing requirement to log in with, or set up, 2-step verification.</p>
   <p>This reason will be visible to the user, and to any admins who have the ability to edit this user.</p>
+  <div class="form-group add-top-margin">
+    <label for="user_expiry_date_for_2sv_exemption">Expiry date for exemption</label>
+    <div class="form-inline">
+      <%= date_select :user, :expiry_date_for_2sv_exemption, {start_year: Time.zone.today.year, selected: Time.zone.today + 1} %>
+    </div>
+  </div>
+  <p>All exemptions must have an expiry date. As this date approaches, this exemption will need to be reviewed.</p>
   <%= submit_tag "Save", class: "btn btn-primary add-right-margin" %>
   <%= link_to "Cancel", user_path(@user), class: "btn btn-default" %>
 <% end %>

--- a/app/views/users/_form_fields.html.erb
+++ b/app/views/users/_form_fields.html.erb
@@ -49,7 +49,7 @@
           The user has been made exempt from 2-step verification for the following reason: <%= @user.reason_for_2sv_exemption %>
         <% if Pundit.policy(current_user, @user).exempt_from_two_step_verification? %>
           <br>
-          <%= link_to 'Edit reason for 2-step verification exemption', edit_two_step_verification_exemption_path(@user) %>
+          <%= link_to 'Edit reason or expiry date for 2-step verification exemption', edit_two_step_verification_exemption_path(@user) %>
         <% end %>
         </p>
       <% elsif f.object.has_2sv? %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -27,6 +27,7 @@
       <th scope="col">Created</th>
       <th scope="col">Status</th>
       <th scope="col"><%= two_step_abbr_tag %> Status</th>
+      <th scope="col"><%= two_step_abbr_tag %> Exemption Expiry</th>
       <th scope="col">Actions</th>
     </tr>
   </thead>
@@ -54,6 +55,13 @@
         <td><%= time_ago_in_words(user.created_at) %> ago</td>
         <td><%= user.status.humanize %></td>
         <td><%= two_step_status(user) %></td>
+        <td>
+          <% if user.expiry_date_for_2sv_exemption.nil? %>
+            n/a
+          <% else %>
+            <%= user.expiry_date_for_2sv_exemption.strftime("%d/%m/%Y") %>
+          <% end %>
+        </td>
         <td>
           <% if user.invited_but_not_accepted %>
             <%= form_tag resend_user_invitation_path(user) do %>

--- a/db/migrate/20230209131935_add2_sv_exemption_expiry_date_to_users.rb
+++ b/db/migrate/20230209131935_add2_sv_exemption_expiry_date_to_users.rb
@@ -1,0 +1,5 @@
+class Add2SvExemptionExpiryDateToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :expiry_date_for_2sv_exemption, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_06_131707) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_09_131935) do
   create_table "batch_invitation_application_permissions", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "batch_invitation_id", null: false
     t.integer "supported_permission_id", null: false
@@ -207,6 +207,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_06_131707) do
     t.string "unlock_token"
     t.boolean "require_2sv", default: false, null: false
     t.string "reason_for_2sv_exemption"
+    t.date "expiry_date_for_2sv_exemption"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["invitation_token"], name: "index_users_on_invitation_token"
     t.index ["invited_by_id"], name: "index_users_on_invited_by_id"

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -50,6 +50,7 @@ FactoryBot.define do
   factory :two_step_exempted_user, parent: :user do
     require_2sv { false }
     reason_for_2sv_exemption { "accessibility reasons" }
+    expiry_date_for_2sv_exemption { (Time.zone.today + 1).to_date }
   end
 
   factory :user_with_pending_email_change, parent: :user do

--- a/test/integration/managing_two_step_verification_test.rb
+++ b/test/integration/managing_two_step_verification_test.rb
@@ -275,12 +275,11 @@ class ManagingTwoStepVerificationTest < ActionDispatch::IntegrationTest
 
       context "when a exemption reason already exists" do
         should "can see exemption reason but is not able to edit it" do
-          reason = "user is exempt"
-          user_requiring_2sv = create(:user, organisation: @organisation, reason_for_2sv_exemption: reason)
+          user_requiring_2sv = create(:two_step_exempted_user, organisation: @organisation)
 
           sign_in_as_and_edit_user(@super_admin, user_requiring_2sv)
 
-          assert page.has_text? "The user has been made exempt from 2-step verification for the following reason: #{@reason}"
+          assert page.has_text? "The user has been made exempt from 2-step verification for the following reason: #{user_requiring_2sv.reason_for_2sv_exemption}"
           assert page.has_no_link? "Edit reason or expiry date for 2-step verification exemption"
         end
       end

--- a/test/integration/managing_two_step_verification_test.rb
+++ b/test/integration/managing_two_step_verification_test.rb
@@ -171,23 +171,19 @@ class ManagingTwoStepVerificationTest < ActionDispatch::IntegrationTest
         @expiry_date = 5.days.from_now.to_date
       end
 
-      def exemption_message(initiator_name, reason)
-        "Exempted from 2-step verification by #{initiator_name} for reason: #{reason}"
-      end
-
       context "when the user being edited is not an admin or superadmin" do
         should "be able to exempt a user requiring 2sv from 2sv" do
           user_requiring_2sv = create(:two_step_mandated_user, organisation: @organisation)
 
           user_can_be_exempted_from_2sv(@super_admin, user_requiring_2sv, @reason_for_exemption, @expiry_date)
-          assert_user_access_log_contains_messages(user_requiring_2sv, ["Exempted from 2-step verification by #{@super_admin.name} for reason: #{@reason_for_exemption}"])
+          assert_user_access_log_contains_messages(user_requiring_2sv, [exemption_message(@super_admin, @reason_for_exemption, @expiry_date)])
         end
 
         should "be able to exempt a user who does not yet require 2sv but is not exempt" do
           user_not_requiring_2sv = create(:user, organisation: @organisation)
 
           user_can_be_exempted_from_2sv(@super_admin, user_not_requiring_2sv, @reason_for_exemption, @expiry_date)
-          assert_user_access_log_contains_messages(user_not_requiring_2sv, ["Exempted from 2-step verification by #{@super_admin.name} for reason: #{@reason_for_exemption}"])
+          assert_user_access_log_contains_messages(user_not_requiring_2sv, [exemption_message(@super_admin, @reason_for_exemption, @expiry_date)])
         end
 
         should "not be able to see a link to exempt a user who already has an exemption reason" do
@@ -220,7 +216,7 @@ class ManagingTwoStepVerificationTest < ActionDispatch::IntegrationTest
 
             assert_user_has_been_exempted_from_2sv(user_requiring_2sv, @reason_for_exemption, new_expiry_date)
 
-            assert_user_access_log_contains_messages(user_requiring_2sv, ["Reason for 2-step verification exemption updated by #{@super_admin.name} to: #{@reason_for_exemption}"])
+            assert_user_access_log_contains_messages(user_requiring_2sv, ["2-step verification exemption updated by #{@super_admin.name} to: #{@reason_for_exemption} expiring on date: #{new_expiry_date}"])
           end
         end
       end

--- a/test/integration/managing_two_step_verification_test.rb
+++ b/test/integration/managing_two_step_verification_test.rb
@@ -37,7 +37,10 @@ class ManagingTwoStepVerificationTest < ActionDispatch::IntegrationTest
         sign_in_as_and_edit_user(@super_admin, user)
         mandate_2sv_for_exempted_user
 
-        assert_nil user.reload.reason_for_2sv_exemption
+        user.reload
+
+        assert_nil user.reason_for_2sv_exemption
+        assert_nil user.expiry_date_for_2sv_exemption
 
         expected_account_logs = [
           "Exemption from 2-step verification removed by #{@super_admin.name}",

--- a/test/integration/managing_two_step_verification_test.rb
+++ b/test/integration/managing_two_step_verification_test.rb
@@ -197,6 +197,18 @@ class ManagingTwoStepVerificationTest < ActionDispatch::IntegrationTest
           assert page.has_no_link? "Exempt user from 2-step verification"
         end
 
+        should "not be able to exempt a user with an expiry date that is not in the future" do
+          user_requiring_2sv = create(:two_step_mandated_user, organisation: @organisation)
+
+          sign_in_as_and_edit_user(@super_admin, user_requiring_2sv)
+          click_link("Exempt user from 2-step verification")
+          fill_in_exemption_form(@reason_for_exemption, Time.zone.today.to_date)
+
+          assert_user_has_not_been_exempted_from_2sv(user_requiring_2sv)
+          assert page.has_text?("Expiry date must be in the future")
+          assert_equal edit_two_step_verification_exemption_path(user_requiring_2sv), current_path
+        end
+
         context "when a exemption reason already exists" do
           should "be able to edit exemption reason and date" do
             user_requiring_2sv = create(:user, organisation: @organisation, reason_for_2sv_exemption: "user is exempt", expiry_date_for_2sv_exemption: @expiry_date)

--- a/test/integration/two_step_verification_test.rb
+++ b/test/integration/two_step_verification_test.rb
@@ -113,13 +113,14 @@ class TwoStepVerificationTest < ActionDispatch::IntegrationTest
         assert_response_contains "Enter this code when asked: #{@new_secret}"
       end
 
-      should "accept a valid code, persist the secret, log an event and notify by email, and remove the exemption reason" do
+      should "accept a valid code, persist the secret, log an event and notify by email, and remove the exemption reason and expiry date" do
         success = "2-step verification set up".freeze
         perform_enqueued_jobs do
           enter_2sv_code(@new_secret)
 
           assert_response_contains success
           assert_nil @user.reload.reason_for_2sv_exemption
+          assert_nil @user.reload.expiry_date_for_2sv_exemption
           assert_equal @new_secret, @user.reload.otp_secret_key
           assert_equal 1, EventLog.where(event_id: EventLog::TWO_STEP_ENABLED.id, uid: @user.uid).count
 

--- a/test/models/user_export_presenter_test.rb
+++ b/test/models/user_export_presenter_test.rb
@@ -23,6 +23,7 @@ class UserExportPresenterTest < ActiveSupport::TestCase
       "Created",
       "Status",
       "2SV Status",
+      "2SV Exemption Expiry Date",
       "App 0",
       "App 1",
       "App 2",
@@ -45,7 +46,17 @@ class UserExportPresenterTest < ActiveSupport::TestCase
   should "output user details" do
     row = UserExportPresenter.new([]).row(@user)
     expected = [
-      "Test User", "test@dept.gov.uk", "Normal", nil, 0, nil, "2015-01-15 09:00:00", "Active", "Enabled"
+      "Test User", "test@dept.gov.uk", "Normal", nil, 0, nil, "2015-01-15 09:00:00", "Active", "Enabled", nil
+    ]
+    assert_equal(expected, row)
+  end
+
+  should "include exemption date for an exempted user" do
+    exemption_date = (Time.zone.today + 1).to_date
+    user = create(:two_step_exempted_user, name: "Exempted User", email: "exempted@dept.gov.uk", expiry_date_for_2sv_exemption: exemption_date)
+    row = UserExportPresenter.new([]).row(user)
+    expected = [
+      "Exempted User", "exempted@dept.gov.uk", "Normal", nil, 0, nil, "2015-01-15 09:00:00", "Active", "Exempted", exemption_date.strftime("%d/%m/%Y")
     ]
     assert_equal(expected, row)
   end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -58,10 +58,11 @@ class UserTest < ActiveSupport::TestCase
       assert_not user.require_2sv?
     end
 
-    should "remove reason for 2SV exemption when 2SV required" do
+    should "remove reason and expiry date for 2SV exemption when 2SV required" do
       user = create(:two_step_exempted_user)
       user.update!(require_2sv: true)
       assert_nil user.reason_for_2sv_exemption
+      assert_nil user.expiry_date_for_2sv_exemption
     end
   end
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -150,12 +150,14 @@ class UserTest < ActiveSupport::TestCase
     setup do
       @user = create(:two_step_enabled_user)
       @initiator = create(:superadmin_user)
-      @user.exempt_from_2sv("accessibility reasons", @initiator)
+      @expiry_date = Time.zone.today + 10
+      @user.exempt_from_2sv("accessibility reasons", @initiator, @expiry_date)
     end
 
-    should "set require 2sv to false and store the reason" do
+    should "set require 2sv to false and store the reason and expiry date" do
       assert_not @user.require_2sv?
       assert_equal "accessibility reasons", @user.reason_for_2sv_exemption
+      assert_equal @expiry_date, @user.expiry_date_for_2sv_exemption
       assert_nil @user.otp_secret_key
     end
 

--- a/test/support/managing_two_sv_helpers.rb
+++ b/test/support/managing_two_sv_helpers.rb
@@ -108,4 +108,13 @@ module ManagingTwoSvHelpers
     assert page.has_text? "User exempted from 2SV"
     assert page.has_text? "The user has been made exempt from 2-step verification for the following reason: #{reason}"
   end
+
+  def assert_user_has_not_been_exempted_from_2sv(user)
+    currently_requires_2sv = user.require_2sv
+
+    user.reload
+    assert_equal currently_requires_2sv, user.require_2sv
+    assert_nil user.reason_for_2sv_exemption
+    assert_nil user.expiry_date_for_2sv_exemption
+  end
 end

--- a/test/support/managing_two_sv_helpers.rb
+++ b/test/support/managing_two_sv_helpers.rb
@@ -77,21 +77,33 @@ module ManagingTwoSvHelpers
     assert page.has_no_link? "Reset 2-step verification"
   end
 
-  def user_can_be_exempted_from_2sv(signed_in_as, user_being_exempted, reason)
+  def user_can_be_exempted_from_2sv(signed_in_as, user_being_exempted, reason, expiry_date)
     sign_in_as_and_edit_user(signed_in_as, user_being_exempted)
     click_link("Exempt user from 2-step verification")
+    fill_in_exemption_form(reason, expiry_date)
 
-    fill_in "Reason for 2sv exemption", with: reason
-    click_button "Save"
-
-    assert_user_has_been_exempted_from_2sv(user_being_exempted, reason)
+    assert_user_has_been_exempted_from_2sv(user_being_exempted, reason, expiry_date)
   end
 
-  def assert_user_has_been_exempted_from_2sv(user, reason)
+  def fill_in_exemption_form(reason, expiry_date)
+    fill_in "Reason for 2sv exemption", with: reason
+    fill_in_expiry_date(expiry_date)
+    click_button "Save"
+  end
+
+  def fill_in_expiry_date(date)
+    element = "user_expiry_date_for_2sv_exemption"
+    select date.year.to_s, from: "#{element}_1i"
+    select date.strftime("%B"), from: "#{element}_2i"
+    select date.day.to_s, from: "#{element}_3i"
+  end
+
+  def assert_user_has_been_exempted_from_2sv(user, reason, expiry_date)
     user.reload
 
     assert_not user.require_2sv?
     assert_equal reason, user.reason_for_2sv_exemption
+    assert_equal expiry_date, user.expiry_date_for_2sv_exemption
 
     assert page.has_text? "User exempted from 2SV"
     assert page.has_text? "The user has been made exempt from 2-step verification for the following reason: #{reason}"

--- a/test/support/managing_two_sv_helpers.rb
+++ b/test/support/managing_two_sv_helpers.rb
@@ -7,6 +7,10 @@ module ManagingTwoSvHelpers
     visit edit_user_path(user_to_edit)
   end
 
+  def exemption_message(initiator, reason, expiry_date)
+    "Exempted from 2-step verification by #{initiator.name} for reason: #{reason} expiring on date: #{expiry_date}"
+  end
+
   def assert_user_access_log_contains_messages(user, messages)
     visit edit_user_path(user)
     click_link "Account access log"


### PR DESCRIPTION
This PR implements adding an expiry date to the 2sv exemptions form. Exemptions must now be created with expiry dates, reflecting the thought that some exemption reasons will be temporary and should be reviewed at some point.

This PR:
* Adds the exemption expiry date to the user interface and handles in the backend code
* Adds the expiry date to access logs when an exemption is created or updated
* Adds the expiry date to the information displayed about users on the users index page, and in the csv export from that page
* Updates some copy on the existing form as requested by Indy.

Screenshots:

| | Currently | Edit exemption form in this PR |
|----|----|----|
| Edit exemption form |<img width="1164" alt="Screenshot 2023-02-10 at 14 40 43" src="https://user-images.githubusercontent.com/25515510/218119216-3152b37a-4243-4083-81dc-67b0c3e6f636.png">|<img width="1174" alt="Screenshot 2023-02-10 at 14 29 54" src="https://user-images.githubusercontent.com/25515510/218117264-a00282c6-dc0f-49b8-876c-3a63185e398e.png">|
| Account access log when exemption is created |<img width="1159" alt="Screenshot 2023-02-10 at 14 41 37" src="https://user-images.githubusercontent.com/25515510/218119416-f21e67b0-e6ff-4355-89ca-71259cfcf218.png">|<img width="1169" alt="Screenshot 2023-02-10 at 14 30 59" src="https://user-images.githubusercontent.com/25515510/218117309-fc5243a7-7ffc-4ed4-8e7b-bb71a96cfef3.png">|
| Users index page |<img width="1189" alt="Screenshot 2023-02-10 at 14 38 05" src="https://user-images.githubusercontent.com/25515510/218118668-4fa9e311-d9f7-4642-9dd4-e9c28e8554ad.png">| <img width="1173" alt="Screenshot 2023-02-10 at 14 31 12" src="https://user-images.githubusercontent.com/25515510/218117371-e292cb8c-0b74-4a7c-87fb-2ae7a1e8b5bf.png">|


### What's not in this PR 

At least for the MVP, we're not planning on implementing any behaviour around expiry dates. For example, once someone's 2sv exemption expiry date has passed, they will still be able to log in without setting up 2sv, and nobody will be automatically alerted. Currently, the plan is to manage exemption expiries in an offline process, given the small number we expect.

[Trello](https://trello.com/c/Eelrmilj/456-implement-exemption-expiry-dates-for-2sv)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
