### PR TITLE
Require 2SV for users from organisations where 2SV is mandatory

### DIFF
--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -131,6 +131,6 @@ private
   end
 
   def new_user_requires_2sv(params)
-    params[:organisation_id].present? && Organisation.find(params[:organisation_id]).require_2sv?
+    (params[:organisation_id].present? && Organisation.find(params[:organisation_id]).require_2sv?) || %w[superadmin admin].include?(params[:role])
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -123,6 +123,8 @@ class UsersController < ApplicationController
     redirect_to :root, notice: "Reset 2-step verification for #{@user.email}"
   end
 
+  def require_2sv; end
+
 private
 
   def load_and_authorize_user
@@ -200,6 +202,10 @@ private
   end
 
   def user_params
+    if permitted_user_params[:skip_update_user_permissions]
+      permitted_user_params[:supported_permission_ids] = @user.supported_permission_ids
+    end
+
     UserParameterSanitiser.new(
       user_params: permitted_user_params,
       current_user_role: current_user.role.to_sym,
@@ -207,7 +213,7 @@ private
   end
 
   def permitted_user_params
-    params.require(:user).permit(:user, :name, :email, :organisation_id, :require_2sv, :role, supported_permission_ids: []).to_h
+    @permitted_user_params ||= params.require(:user).permit(:user, :name, :email, :organisation_id, :require_2sv, :role, :skip_update_user_permissions, supported_permission_ids: []).to_h
   end
 
   def password_params

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -40,6 +40,7 @@ class User < ApplicationRecord
   validate :organisation_admin_belongs_to_organisation
   validate :email_is_ascii_only
   validate :exemption_from_2sv_data_is_complete
+  validate :organisation_has_mandatory_2sv, on: :create
 
   has_many :authorisations, class_name: "Doorkeeper::AccessToken", foreign_key: :resource_owner_id
   has_many :application_permissions, class_name: "UserApplicationPermission", inverse_of: :user
@@ -366,6 +367,10 @@ private
   def exemption_from_2sv_data_is_complete
     errors.add(:expiry_date_for_2sv_exemption, "must be present if exemption reason is present") if reason_for_2sv_exemption.present? && expiry_date_for_2sv_exemption.nil?
     errors.add(:reason_for_2sv_exemption, "must be present if exemption expiry date is present") if expiry_date_for_2sv_exemption.present? && reason_for_2sv_exemption.nil?
+  end
+
+  def organisation_has_mandatory_2sv
+    errors.add(:require_2sv, "2-step verification is mandatory for all users from this organisation") if organisation && organisation.require_2sv? && !require_2sv
   end
 
   def fix_apostrophe_in_email

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -96,6 +96,12 @@ class User < ApplicationRecord
           end
         }
 
+  def require_2sv?
+    return require_2sv unless organisation
+
+    (organisation.require_2sv? && !exempt_from_2sv?) || require_2sv
+  end
+
   def prompt_for_2sv?
     return false if has_2sv?
 

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -41,6 +41,7 @@ class UserPolicy < BasePolicy
   alias_method :update_email?, :edit_email_or_password?
   alias_method :update_password?, :edit_email_or_password?
   alias_method :mandate_2sv?, :edit?
+  alias_method :require_2sv?, :edit?
   alias_method :reset_2sv?, :edit?
   alias_method :reset_two_step_verification?, :edit?
 

--- a/app/views/users/_form_fields.html.erb
+++ b/app/views/users/_form_fields.html.erb
@@ -40,7 +40,7 @@
   <p>This user's role is set to <%= @user.role %>. They are currently exempted from 2sv, meaning that their role cannot be changed as admins are required to have 2sv.</p>
 <% end %>
 
-<% if policy(current_user).mandate_2sv? %>
+<% if policy(current_user).mandate_2sv? && @user.persisted? %>
   <dl>
     <dt>Account security</dt>
     <dd>

--- a/app/views/users/require_2sv.html.erb
+++ b/app/views/users/require_2sv.html.erb
@@ -1,0 +1,16 @@
+<% content_for :title, "Create new user" %>
+
+<h1>2-step verification settings for new user</h1>
+
+<%= form_for @user, :html => {:class => 'well'} do |f| %>
+  <%= f.hidden_field :skip_update_user_permissions, value: "true" %>
+  <p class="checkbox">
+    <%= f.label :require_2sv do %>
+      <%= f.check_box :require_2sv %> Mandate 2-step verification for this user <%= "(this will remove their exemption)" if @user.exempt_from_2sv? %>
+    <% end %>
+    <br/>
+    User will be prompted to set up 2-step verification again the next time they sign in.
+  </p>
+
+  <%= f.submit "Update user", :class => 'btn btn-success' %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,6 +42,7 @@ Rails.application.routes.draw do
       delete :cancel_email_change
       get :event_logs
       patch :reset_two_step_verification
+      get :require_2sv
     end
   end
   resource :user, only: [:show]

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -16,11 +16,20 @@ User.create!(
   organisation: gds,
 )
 
-test_organisation = Organisation.create!(
-  name: "Test Organisation",
+test_organisation_without_2sv = Organisation.create!(
+  name: "Test Organisation without mandatory 2SV",
   content_id: SecureRandom.uuid,
   organisation_type: :ministerial_department,
   slug: "test-organisation",
+  require_2sv: false,
+)
+
+test_organisation_with_2sv = Organisation.create!(
+  name: "Test Organisation with mandatory 2SV",
+  content_id: SecureRandom.uuid,
+  organisation_type: :ministerial_department,
+  slug: "test-organisation-with-2sv",
+  require_2sv: true,
 )
 
 User.create!(
@@ -29,7 +38,7 @@ User.create!(
   password: "6fe552ca-d406-4c54-b7a6-041ed1ade6cd",
   role: :normal,
   confirmed_at: Time.zone.now,
-  organisation: test_organisation,
+  organisation: test_organisation_without_2sv,
 )
 
 # The following user has 2SV enabled by default. Scan the QR code with your authenticator app to generate a code to login.
@@ -65,7 +74,18 @@ User.create!(
   password: "6fe552ca-d406-4c54-b7a6-041ed1ade6cd",
   role: :normal,
   confirmed_at: Time.zone.now,
-  organisation: test_organisation,
+  organisation: test_organisation_without_2sv,
+  require_2sv: true,
+  otp_secret_key: "I5X6Y3VN3CAATYQRBPAZ7KMFLK2RWYJ5",
+)
+
+User.create!(
+  name: "Test User from organisation with mandatory 2SV",
+  email: "test.user.2sv.organisation@gov.uk",
+  password: "6fe552ca-d406-4c54-b7a6-041ed1ade6cd",
+  role: :normal,
+  confirmed_at: Time.zone.now,
+  organisation: test_organisation_with_2sv,
   require_2sv: true,
   otp_secret_key: "I5X6Y3VN3CAATYQRBPAZ7KMFLK2RWYJ5",
 )
@@ -78,4 +98,14 @@ User.create!(
   role: :normal,
   confirmed_at: Time.zone.now,
   require_2sv: false,
+)
+
+application = Doorkeeper::Application.create!(
+  name: "Test Application 1",
+  redirect_uri: "https://www.gov.uk",
+)
+
+SupportedPermission.create!(
+  name: "Editor",
+  application:,
 )

--- a/test/controllers/invitations_controller_test.rb
+++ b/test/controllers/invitations_controller_test.rb
@@ -60,6 +60,24 @@ class InvitationsControllerTest < ActionController::TestCase
       post :create, params: { user: { name: "Testing Org Admins", email: "testing_org_admins@example.com" } }
       assert_redirected_to root_path
     end
+
+    should "save user and render 2SV form when user assigned to organisation that does not require 2SV" do
+      organisation = create(:organisation, require_2sv: false)
+
+      post :create, params: { user: { name: "User Name", email: "person@gov.uk", organisation_id: organisation.id } }
+
+      assert_redirected_to require_2sv_user_path(User.last)
+      assert_equal "User Name", User.last.name
+    end
+
+    should "save user and not render 2SV form when user assigned to organisation that requires 2SV" do
+      organisation = create(:organisation, require_2sv: true)
+
+      post :create, params: { user: { name: "User Name", email: "person@gov.uk", organisation_id: organisation.id } }
+
+      assert_redirected_to users_path
+      assert_equal "User Name", User.last.name
+    end
   end
 
   context "POST resend" do

--- a/test/controllers/invitations_controller_test.rb
+++ b/test/controllers/invitations_controller_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class InvitationsControllerTest < ActionController::TestCase
   setup do
     request.env["devise.mapping"] = Devise.mappings[:user]
-    @user = create(:admin_user)
+    @user = create(:superadmin_user)
     sign_in @user
   end
 
@@ -74,6 +74,24 @@ class InvitationsControllerTest < ActionController::TestCase
       organisation = create(:organisation, require_2sv: true)
 
       post :create, params: { user: { name: "User Name", email: "person@gov.uk", organisation_id: organisation.id } }
+
+      assert_redirected_to users_path
+      assert_equal "User Name", User.last.name
+    end
+
+    should "not render 2SV form and saves user when user is a superadmin" do
+      organisation = create(:organisation, require_2sv: false)
+
+      post :create, params: { user: { name: "User Name", email: "person@gov.uk", organisation_id: organisation.id, role: "superadmin" } }
+
+      assert_redirected_to users_path
+      assert_equal "User Name", User.last.name
+    end
+
+    should "not render 2SV form and saves user when user is an admin" do
+      organisation = create(:organisation, require_2sv: false)
+
+      post :create, params: { user: { name: "User Name", email: "person@gov.uk", organisation_id: organisation.id, role: "admin" } }
 
       assert_redirected_to users_path
       assert_equal "User Name", User.last.name

--- a/test/integration/inviting_users_test.rb
+++ b/test/integration/inviting_users_test.rb
@@ -27,21 +27,70 @@ class InvitingUsersTest < ActionDispatch::IntegrationTest
       assert has_no_select?("Role")
     end
 
-    should "displays the 2SV mandating checkbox" do
-      visit new_user_invitation_path
-      assert has_field?("Mandate 2-step verification for this user")
-    end
+    context "for an organisation without mandatory 2SV" do
+      setup do
+        create(:organisation, name: "Test Organisation without 2SV", require_2sv: false)
+      end
 
-    should "create and notify the user" do
-      perform_enqueued_jobs do
-        visit new_user_invitation_path
-        fill_in "Name", with: "Fred Bloggs"
-        fill_in "Email", with: "fred@example.com"
-        click_button "Create user and send email"
+      should "create and notify the user with 2SV selected" do
+        perform_enqueued_jobs do
+          visit new_user_invitation_path
+          fill_in "Name", with: "Fred Bloggs"
+          fill_in "Email", with: "fred@example.com"
+          select "Test Organisation without 2SV", from: "Organisation"
+          click_button "Create user and send email"
 
-        assert_not_nil User.where(email: "fred@example.com", role: "normal").first
-        assert_equal "fred@example.com", last_email.to[0]
-        assert_match "Please confirm your account", last_email.subject
+          assert_equal "fred@example.com", last_email.to[0]
+          assert_match "Please confirm your account", last_email.subject
+
+          assert has_field?("Mandate 2-step verification for this user")
+          check "Mandate 2-step verification for this user"
+          click_button "Update user"
+
+          assert_not_nil User.where(email: "fred@example.com", role: "normal").last
+          assert_equal "fred@example.com", last_email.to[0]
+          assert_match "Make your Signon account more secure", last_email.subject
+          assert User.where(email: "fred@example.com", role: "normal").last.require_2sv?
+        end
+      end
+
+      should "create and notify the user without 2SV selected" do
+        perform_enqueued_jobs do
+          visit new_user_invitation_path
+          fill_in "Name", with: "Fred Bloggs"
+          fill_in "Email", with: "fred@example.com"
+          select "Test Organisation without 2SV", from: "Organisation"
+          click_button "Create user and send email"
+
+          assert has_field?("Mandate 2-step verification for this user")
+          click_button "Update user"
+
+          assert_not_nil User.where(email: "fred@example.com", role: "normal").last
+          assert_equal "fred@example.com", last_email.to[0]
+          assert_match "Please confirm your account", last_email.subject
+          assert_equal false, User.where(email: "fred@example.com", role: "normal").last.require_2sv?
+        end
+      end
+
+      context "for an organisation with mandatory 2SV" do
+        setup do
+          create(:organisation, name: "Test Organisation with 2SV", require_2sv: true)
+        end
+
+        should "create and notify the user" do
+          perform_enqueued_jobs do
+            visit new_user_invitation_path
+            fill_in "Name", with: "Fred Bloggs"
+            fill_in "Email", with: "fred@example.com"
+            select "Test Organisation with 2SV", from: "Organisation"
+            click_button "Create user and send email"
+
+            assert_not_nil User.where(email: "fred@example.com", role: "normal").last
+            assert_equal "fred@example.com", last_email.to[0]
+            assert_match "Please confirm your account", last_email.subject
+            assert User.where(email: "fred@example.com", role: "normal").last.require_2sv?
+          end
+        end
       end
     end
 
@@ -51,6 +100,8 @@ class InvitingUsersTest < ActionDispatch::IntegrationTest
         fill_in "Name", with: "Fred Bloggs"
         fill_in "Email", with: "fred@example.com"
         click_button "Create user and send email"
+
+        click_button "Update user"
 
         user = User.find_by(email: "fred@example.com")
         visit edit_user_path(user)
@@ -80,6 +131,8 @@ class InvitingUsersTest < ActionDispatch::IntegrationTest
 
       click_button "Create user and send email"
 
+      click_button "Update user"
+
       u = User.find_by(email: "alicia@example.com")
       assert_not u.has_access_to? application_one
       assert_includes u.permissions_for(application_one), "editor"
@@ -97,6 +150,8 @@ class InvitingUsersTest < ActionDispatch::IntegrationTest
       fill_in "Name", with: "Alicia Smith"
       fill_in "Email", with: "alicia@example.com"
       click_button "Create user and send email"
+
+      click_button "Update user"
 
       u = User.find_by(email: "alicia@example.com")
       assert u.has_access_to? application_two
@@ -124,19 +179,17 @@ class InvitingUsersTest < ActionDispatch::IntegrationTest
       assert has_select?("Role")
     end
 
-    should "display the 2SV mandating checkbox" do
-      visit new_user_invitation_path
-      assert has_field?("Mandate 2-step verification for this user")
-    end
-
     should "create and notify the user" do
       perform_enqueued_jobs do
         visit new_user_invitation_path
         fill_in "Name", with: "Fred Bloggs"
         select "Admin", from: "Role"
         fill_in "Email", with: "fred_admin@example.com"
-        check "Mandate 2-step verification for this user"
         click_button "Create user and send email"
+
+        assert has_field?("Mandate 2-step verification for this user")
+        check "Mandate 2-step verification for this user"
+        click_button "Update user"
 
         assert_not_nil User.find_by(
           email: "fred_admin@example.com",
@@ -165,6 +218,8 @@ class InvitingUsersTest < ActionDispatch::IntegrationTest
 
       click_button "Create user and send email"
 
+      click_button "Update user"
+
       u = User.find_by(email: "alicia@example.com")
       assert_not u.has_access_to? application_one
       assert_includes u.permissions_for(application_one), "editor"
@@ -182,6 +237,9 @@ class InvitingUsersTest < ActionDispatch::IntegrationTest
       fill_in "Name", with: "Alicia Smith"
       fill_in "Email", with: "alicia@example.com"
       click_button "Create user and send email"
+
+      check "Mandate 2-step verification for this user"
+      click_button "Update user"
 
       u = User.find_by(email: "alicia@example.com")
       assert u.has_access_to? application_two

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -82,6 +82,12 @@ class UserTest < ActiveSupport::TestCase
       organisation.update!(require_2sv: true)
       assert_not user.require_2sv?
     end
+
+    should "be invalid if a new user from an organisation with mandatory 2SV but 2SV is not selected" do
+      organisation = create(:organisation, require_2sv: true)
+      user = build(:user, organisation:)
+      assert_not user.valid?
+    end
   end
 
   context "#send_two_step_mandated_notification?" do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -64,6 +64,24 @@ class UserTest < ActiveSupport::TestCase
       assert_nil user.reason_for_2sv_exemption
       assert_nil user.expiry_date_for_2sv_exemption
     end
+
+    should "require 2SV for the user when it is switched on for their organisation and they are not exempt" do
+      organisation = create(:organisation, require_2sv: false)
+      user = create(:user, organisation:)
+      assert_not user.require_2sv?
+
+      organisation.update!(require_2sv: true)
+      assert user.require_2sv?
+    end
+
+    should "not require 2SV for the user when it is switched on for their organisation and they are exempt" do
+      organisation = create(:organisation, require_2sv: false)
+      user = create(:two_step_exempted_user, organisation:)
+      assert_not user.require_2sv?
+
+      organisation.update!(require_2sv: true)
+      assert_not user.require_2sv?
+    end
   end
 
   context "#send_two_step_mandated_notification?" do


### PR DESCRIPTION
This implements the following:

- requires 2SV for all existing users (who are not exempt) from an organisation when their organisation is set to require 2SV
- requires 2SV for all new users from an organisation when their organisation is set to require 2SV (e.g. for users created by rake tasks, or in bulk)
- moves the 2SV checkbox during registration to a separate page, so it is only presented to users who are not required to have 2SV (either by membership of an organisation or because they are an admin/superadmin role)

Validations are still carried out when the first form is submitted, hence why we now need to explicitly check the submission is valid without persisted the user in the database.

The following user flows are now present during registration:

1. New user who is being assigned to an organisation that has mandatory 2SV or has admin/superadmin status:

![Screenshot showing registration form for a new user belonging to a 2SV mandated organisation](https://user-images.githubusercontent.com/6329861/217834027-e6756931-79e0-4945-8064-882e36079a7a.png)

![Screen showing flash message of An invitation email has been sent to test11@gov.uk.](https://user-images.githubusercontent.com/6329861/217834188-58e585e8-c021-4b8f-9f88-3085e4487e4a.png)

2. New user who is being assigned to an organisation that does not have mandatory 2SV and is not admin/superadmin:

![Screenshot showing registration form for a user being assigned to an organisation without mandatory 2SV](https://user-images.githubusercontent.com/6329861/217834339-772a7980-3f57-44d8-b660-b9f6509cabcc.png)

![Screenshot showing new intermediate page with 2SV question and flash message of An invitation email has been sent to test2@gov.uk.](https://user-images.githubusercontent.com/6329861/218780497-c67ff2e2-e46a-42e5-ac06-1dea48a8df94.png)

[Trello card](https://trello.com/c/a3Zu69Td)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
