### PR TITLE
Add rake task to mandate 2SV for organisation admin and super admin users

### DIFF
--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -173,4 +173,14 @@ namespace :users do
 
     users_to_update.each { |user| user.update(require_2sv: true) }
   end
+
+  desc "Sets 2sv on all organisation admin and organisation superadmin users"
+  task set_2sv_for_org_admins: :environment do
+    org_admin_users = User.where(role: "organisation_admin")
+    super_org_admin_users = User.where(role: "super_organisation_admin")
+
+    users_to_update = org_admin_users + super_org_admin_users
+
+    users_to_update.each { |user| user.update(require_2sv: true) }
+  end
 end

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -39,6 +39,11 @@ FactoryBot.define do
     otp_secret_key { "Sssshh" }
   end
 
+  factory :two_step_enabled_organisation_admin, parent: :organisation_admin do
+    require_2sv { true }
+    otp_secret_key { "Sssshh" }
+  end
+
   factory :two_step_mandated_superadmin_user, parent: :superadmin_user do
     require_2sv { true }
   end


### PR DESCRIPTION
This will allow us to mandate 2SV for all existing organisation admin and super admin users.

This task can be removed once it has been run in production.

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

[Trello card](https://trello.com/c/UGfyyMQ1/562-general-template)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
