### PR TITLE
Remove 2SV-related feature flags

### DIFF
--- a/app/policies/organisation_policy.rb
+++ b/app/policies/organisation_policy.rb
@@ -10,7 +10,7 @@ class OrganisationPolicy < BasePolicy
   end
 
   def edit?
-    current_user.superadmin? && ENV["MANDATE_2SV_FOR_ORGANISATION"]
+    current_user.superadmin?
   end
 
   class Scope < ::BasePolicy::Scope

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -61,8 +61,7 @@ class UserPolicy < BasePolicy
     current_user.belongs_to_gds? &&
       (current_user.superadmin? || current_user.admin?) &&
       record.normal? &&
-      !record.api_user &&
-      ENV["PERMIT_2SV_EXEMPTION"]
+      !record.api_user
   end
 
 private

--- a/test/integration/mandate_2sv_for_organisation_test.rb
+++ b/test/integration/mandate_2sv_for_organisation_test.rb
@@ -27,13 +27,6 @@ class Mandate2svForOrganisationTest < ActionDispatch::IntegrationTest
           click_button "Update Organisation"
           assert page.has_text? "true"
         end
-
-        should "not be able to see the edit link when the MANDATE_2SV_FOR_ORGANISATION env variable is nil" do
-          ClimateControl.modify(MANDATE_2SV_FOR_ORGANISATION: nil) do
-            visit organisations_path
-            assert page.has_no_link? "Edit"
-          end
-        end
       end
 
       context "organisation mandates 2sv" do

--- a/test/policies/organisation_policy_test.rb
+++ b/test/policies/organisation_policy_test.rb
@@ -24,12 +24,6 @@ class OrganisationPolicyTest < ActiveSupport::TestCase
       assert forbid?(create(:organisation_admin), User, :edit)
       assert forbid?(create(:user), User, :edit)
     end
-
-    should "not allow for a superadmin when the MANDATE_2SV_FOR_ORGANISATION is not present" do
-      ClimateControl.modify(MANDATE_2SV_FOR_ORGANISATION: nil) do
-        assert forbid?(create(:superadmin_user), User, :edit)
-      end
-    end
   end
 
   context "can_assign" do

--- a/test/policies/user_policy_test.rb
+++ b/test/policies/user_policy_test.rb
@@ -67,13 +67,6 @@ class UserPolicyTest < ActiveSupport::TestCase
         assert forbid?(create(:superadmin_user, organisation: @gds), user, permission)
       end
 
-      should "not allow for #{permission} if the PERMIT_2SV_EXEMPTION environment variable is not set" do
-        ClimateControl.modify(PERMIT_2SV_EXEMPTION: nil) do
-          user = create(:user)
-          assert forbid?(create(:superadmin_user, organisation: @gds), user, permission)
-        end
-      end
-
       should "not allow for #{permission} if the user is an api user" do
         user = create(:api_user)
         assert forbid?(create(:superadmin_user, organisation: @gds), user, permission)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -32,8 +32,6 @@ class ActionController::TestCase
   include Devise::Test::ControllerHelpers
   include ConfirmationTokenHelpers
 
-  ENV["MANDATE_2SV_FOR_ORGANISATION"] = "true"
-
   def sign_in(user, passed_mfa: true)
     warden.stubs(authenticate!: user)
     unless passed_mfa

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -32,7 +32,6 @@ class ActionController::TestCase
   include Devise::Test::ControllerHelpers
   include ConfirmationTokenHelpers
 
-  ENV["PERMIT_2SV_EXEMPTION"] = "true"
   ENV["MANDATE_2SV_FOR_ORGANISATION"] = "true"
 
   def sign_in(user, passed_mfa: true)


### PR DESCRIPTION
Trello: https://trello.com/c/A4DSAq6g

These 2SV-related feature flags have served their purpose:

* `PERMIT_2SV_EXEMPTION` (originally introduced in #2083)
* `MANDATE_2SV_FOR_ORGANISATION` (originally introduced in #2100)

The functionality behind them can now be enabled permanently.

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
