### PR TITLE
Update 2SV mandating rake task to use slug

### DIFF
--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -152,7 +152,7 @@ namespace :users do
 
   desc "Sets 2sv on all users by organisation"
   task :set_2sv_by_org, [:org] => :environment do |_t, args|
-    organisation = Organisation.find_by(name: args.org)
+    organisation = Organisation.find_by(slug: args.org)
     raise "Couldn't find organisation: '#{args.org}'" unless organisation
 
     users_to_update = User.where(organisation_id: organisation.id, require_2sv: false)

--- a/test/lib/tasks/users_test.rb
+++ b/test/lib/tasks/users_test.rb
@@ -10,12 +10,12 @@ class UsersTaskTest < ActiveSupport::TestCase
 
   context "#set_2sv_by_org" do
     should "sets 2sv for all users within the specified org" do
-      organisation = create(:organisation, name: "Department of Health")
+      organisation = create(:organisation, slug: "department-of-health")
       users_in_organisation = @user_types.map { |user_type| create(user_type, organisation:) }
       exempted_user_in_organisation = create(:two_step_exempted_user, organisation:)
       users_in_different_organisation = @user_types.map { |user_type| create(user_type, organisation: create(:organisation)) }
 
-      Rake::Task["users:set_2sv_by_org"].invoke(organisation.name)
+      Rake::Task["users:set_2sv_by_org"].invoke(organisation.slug)
 
       assert users_in_organisation.each(&:reload).all?(&:require_2sv)
       assert_not exempted_user_in_organisation.reload.require_2sv


### PR DESCRIPTION
We are currently matching the organisation in this rake task using the name.

This has caused us an issue with a name that contains an apostrophe as we cannot execute the rake task using `kubectl`.

Therefore updating to use the slug.

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
