### PR TITLE
Add rake task to enable 2SV on an organisation

### DIFF
--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -150,7 +150,7 @@ namespace :users do
     UserPermissionMigrator.migrate(source: source_application, target: target_application)
   end
 
-  desc "Sets 2sv on all users by organisation"
+  desc "Sets 2sv on all existing users by organisation"
   task :set_2sv_by_org, [:org] => :environment do |_t, args|
     organisation = Organisation.find_by(slug: args.org)
     raise "Couldn't find organisation: '#{args.org}'" unless organisation
@@ -161,6 +161,16 @@ namespace :users do
     puts "found #{users_to_update.size} users without 2sv in organsation #{args.org} to set require 2sv flag on"
 
     users_to_update.each { |user| user.update(require_2sv: true) }
+  end
+
+  desc "Sets 2sv on an organisation"
+  task :set_2sv_for_org, [:org] => :environment do |_t, args|
+    organisation = Organisation.find_by(slug: args.org)
+    raise "Couldn't find organisation: '#{args.org}'" unless organisation
+
+    organisation.update!(require_2sv: true)
+
+    puts "mandated 2sv for organsation #{args.org}"
   end
 
   desc "Sets 2sv on all users by email domain"

--- a/test/lib/tasks/users_test.rb
+++ b/test/lib/tasks/users_test.rb
@@ -23,6 +23,16 @@ class UsersTaskTest < ActiveSupport::TestCase
     end
   end
 
+  context "#set_2sv_for_org" do
+    should "sets 2sv for the specified org" do
+      organisation = create(:organisation, slug: "department-of-health")
+
+      Rake::Task["users:set_2sv_for_org"].invoke(organisation.slug)
+
+      assert organisation.reload.require_2sv?
+    end
+  end
+
   context "#set_2sv_by_email_domain" do
     should "sets 2sv for all users within the specified email domain" do
       targeted_domain = "@some.domain.gov.uk"


### PR DESCRIPTION
We currently have a rake task to enable 2SV for all existing users from an organisation, however we have to use the UI to enable it on an organisation.

This adds a rake task so it can be done without lots of clicking (e.g. when updating organisations in bulk).

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

[Trello card](https://trello.com/c/4Je11yym)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
