### PR TITLE
Migrate API users index page to GOV.UK Design System

### DIFF
--- a/app/controllers/api_users_controller.rb
+++ b/app/controllers/api_users_controller.rb
@@ -1,6 +1,8 @@
 class ApiUsersController < ApplicationController
   include UserPermissionsControllerMethods
 
+  layout "admin_layout", only: %w[index]
+
   before_action :authenticate_user!
   before_action :load_and_authorize_api_user, only: %i[edit update]
   helper_method :applications_and_permissions, :visible_applications

--- a/app/helpers/api_users_helper.rb
+++ b/app/helpers/api_users_helper.rb
@@ -2,4 +2,23 @@ module ApiUsersHelper
   def truncate_access_token(token)
     raw "#{token[0..7]}#{'&bull;' * 24}#{token[-8..]}"
   end
+
+  def api_user_name(user)
+    anchor_tag = link_to(user.name, edit_api_user_path(user), class: "govuk-link")
+    user.suspended? ? content_tag(:del, anchor_tag) : anchor_tag
+  end
+
+  def permissions_by_application(user)
+    content_tag(:ul, class: "govuk-list") do
+      safe_join(
+        visible_applications(user).map do |application|
+          next unless user.permissions_for(application).any?
+
+          content_tag(:li) do
+            content_tag(:abbr, application.name, title: "Permissions: #{user.permissions_for(application).to_sentence}")
+          end
+        end,
+      )
+    end
+  end
 end

--- a/app/views/api_users/index.html.erb
+++ b/app/views/api_users/index.html.erb
@@ -1,55 +1,65 @@
-<% content_for :title, "API Users" %>
+<% content_for :title, "API users" %>
 
-<div class="row">
-  <div class="col-md-5 page-title remove-top-margin">
-    <h1>API Users</h1>
-  </div>
-
-  <div class="col-md-7 text-right">
-    <%= link_to "Create API user", new_api_user_path, class: "btn btn-success add-top-margin" %>
-  </div>
+<div class="govuk-form-group">
+  <%= render "govuk_publishing_components/components/button", {
+    text: "Create API user",
+    href: new_api_user_path
+  } %>
 </div>
 
-  <table class="table table-striped table-bordered" data-module="filterable-table">
-    <thead>
-      <tr class="table-header">
-        <th scope="col" style="width: 300px">Name and email</th>
-        <th scope="col">Apps</th>
-        <th scope="col">Role</th>
-        <th scope="col" style="width: 75px">Sign-ins</th>
-        <th scope="col">Created</th>
-        <th scope="col">Suspended?</th>
-      </tr>
-      <tr class="if-no-js-hide table-header-secondary">
-        <td colspan="6">
-          <form>
-            <label for="api-filter" class="rm">Filter API users</label>
-            <input id="api-filter" type="text" class="form-control normal js-filter-table-input" placeholder="Filter API users">
-          </form>
-        </td>
-      </tr>
-    </thead>
-    <tbody>
-      <% @api_users.each do |user| %>
-        <tr>
-          <td class="email">
-            <%= user.suspended? ? "<del>".html_safe : "" %>
-              <%= link_to "#{user.name}", edit_api_user_path(user), class: 'bold js-open-on-submit' %>
-            <%= user.suspended? ? "</del>".html_safe : "" %>
-            <span class="text-muted"><br /><%= user.email %></span>
-          </td>
-          <td>
-            <% visible_applications(user).each do |application| %>
-              <% if user.permissions_for(application).any? %>
-                <abbr title="Permissions: <%= user.permissions_for(application).to_sentence %>" data-toggle="tooltip" data-placement="right"><%= application.name %></abbr><br />
-              <% end %>
-            <% end %>
-          </td>
-          <td class="role"><%= user.role.humanize %></td>
-          <td><%= user.sign_in_count %></td>
-          <td><%= time_ago_in_words(user.created_at) %> ago</td>
-          <td><%= user.suspended? ? "Yes" : "No" %></td>
-        </tr>
-      <% end %>
-    </tbody>
-  </table>
+<%= render "govuk_publishing_components/components/table", {
+  caption: "API users",
+  caption_classes: "govuk-visually-hidden",
+  filterable: true,
+  label: "Filter API users",
+  head: [
+    {
+      text: "Name"
+    },
+    {
+      text: "Email",
+    },
+    {
+      text: "Apps",
+    },
+    {
+      text: "Role",
+    },
+    {
+      text: "Sign-ins",
+      format: "numeric"
+    },
+    {
+      text: "Created",
+    },
+    {
+      text: "Suspended?",
+    },
+  ],
+  rows: @api_users.map do |user|
+    [
+      {
+        text: api_user_name(user)
+      },
+      {
+        text: user.email,
+      },
+      {
+        text: permissions_by_application(user),
+      },
+      {
+        text: user.role.humanize,
+      },
+      {
+        text: user.sign_in_count,
+        format: "numeric"
+      },
+      {
+        text: "#{time_ago_in_words(user.created_at)} ago",
+      },
+      {
+        text: user.suspended? ? "Yes" : "No",
+      },
+    ]
+  end,
+} %>

--- a/app/views/api_users/index.html.erb
+++ b/app/views/api_users/index.html.erb
@@ -26,7 +26,7 @@
       text: "Role",
     },
     {
-      text: "Sign-ins",
+      text: "Sign‑ins",
       format: "numeric"
     },
     {

--- a/app/views/api_users/index.html.erb
+++ b/app/views/api_users/index.html.erb
@@ -40,8 +40,8 @@
           </td>
           <td>
             <% visible_applications(user).each do |application| %>
-              <% if permissions_for_application = user.permissions_for(application) %>
-                <abbr title="Permissions: <%= permissions_for_application.to_sentence %>" data-toggle="tooltip" data-placement="right"><%= application.name %></abbr><br />
+              <% if user.permissions_for(application).any? %>
+                <abbr title="Permissions: <%= user.permissions_for(application).to_sentence %>" data-toggle="tooltip" data-placement="right"><%= application.name %></abbr><br />
               <% end %>
             <% end %>
           </td>

--- a/app/views/organisations/index.html.erb
+++ b/app/views/organisations/index.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, "Organisations" %>
 
-<%= GovukPublishingComponents::AppHelpers::TableHelper.helper(self, "Applications", { caption_classes: "govuk-visually-hidden" }) do |t| %>
+<%= GovukPublishingComponents::AppHelpers::TableHelper.helper(self, "Organisations", { caption_classes: "govuk-visually-hidden" }) do |t| %>
   <%= t.head do %>
     <%= t.header "Name" %>
     <%= t.header "Organisation Type" %>

--- a/test/controllers/api_users_controller_test.rb
+++ b/test/controllers/api_users_controller_test.rb
@@ -32,13 +32,13 @@ class ApiUsersControllerTest < ActionController::TestCase
       should "list api users" do
         create(:api_user, email: "api_user@email.com")
         get :index
-        assert_select "td.email", /api_user@email.com/
+        assert_select "td", "api_user@email.com"
       end
 
       should "not list web users" do
         create(:user, email: "web_user@email.com")
         get :index
-        assert_select "td.email", count: 0, text: /web_user@email.com/
+        assert_select "td", count: 0, text: "web_user@email.com"
       end
     end
 

--- a/test/integration/manage_api_users_test.rb
+++ b/test/integration/manage_api_users_test.rb
@@ -16,9 +16,9 @@ class ManageApiUsersTest < ActionDispatch::IntegrationTest
     end
 
     should "be able to view a list of API users alongwith their authorised applications" do
-      assert page.has_selector?("td.email", text: @api_user.name)
-      assert page.has_selector?("td.email", text: @api_user.email)
-      assert page.has_selector?("td.role", text: "Normal")
+      assert page.has_selector?("td", text: @api_user.name)
+      assert page.has_selector?("td", text: @api_user.email)
+      assert page.has_selector?("td", text: "Normal")
 
       assert page.has_selector?("abbr", text: @application.name)
       assert page.has_selector?("td:last-child", text: "No") # suspended?


### PR DESCRIPTION
Trello: https://trello.com/c/U0fhO3gx

This is part of the ongoing effort to migrate all of the application's user interface to using the GOV.UK Design System.

* We've moved name & email address into separate columns rather than distinguishing them using typography.
* The "Create API user" button is now on the left rather than over on the right. It's not obvious that having it on the right is something that the design system recommends.
* We've retained the use of the `del` element to visually distinguish suspended users since this seems semantically correct and their suspended state is also visible in a separate column anyway.
* We've retained the use of the `abbr` element for application permissions, even though we think it's being abused in order to provide a tooltip. Note that originally this element was also being given a tooltip by JavaScript from Bootstrap; this is no longer the case. Perhaps a `details` element would be more appropriate here?
* We've had to make a few assertions less specific, because the GOV.UK design system table doesn't make it easy to add CSS classes to individual columns.

Note that we've redacted email addresses in the following screenshots:

| Description | Before | After |
|-------------|--------|-------|
| Filter by "Collections" | <img width="1389" alt="filter-by-collections before" src="https://github.com/alphagov/signon/assets/3169/bb0fdd6d-ed0e-4077-8460-8f609bee8d41"> | <img width="1389" alt="filter-by-collections after" src="https://github.com/alphagov/signon/assets/3169/6006a944-a263-44be-98ac-6bb7943c618c"> |
| Filter by "Calc" | <img width="1389" alt="filter-by-calc before" src="https://github.com/alphagov/signon/assets/3169/e74214c4-41aa-4757-81c7-02bea664bd96"> | <img width="1389" alt="filter-by-calc after" src="https://github.com/alphagov/signon/assets/3169/ef6702c9-96a6-4046-a53b-ac080b723cc1"> |

We have screenshots of the full page before and after the changes, but we didn't want to include them here because they included some PII. Let us know in the comments if it would be useful to see them.