### PR TITLE
Change PR template to reflect change in app ownership

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.
+This application is owned by the Access & Permissions team.
 
 ⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
 


### PR DESCRIPTION
This app is now owned by the Access & Permissions team.

Note that I've removed the request to contact us in Slack; instead I've enabled Slack notifications for PRs on this repo in the #govuk-publishing-access-and-permissions-team channel.