### PR TITLE
Migrate 2SV setup page to GOVUK Design System

### DIFF
--- a/app/controllers/devise/two_step_verification_controller.rb
+++ b/app/controllers/devise/two_step_verification_controller.rb
@@ -1,7 +1,7 @@
 class Devise::TwoStepVerificationController < DeviseController
   before_action -> { authenticate_user!(force: true) }, only: :prompt
   before_action :prepare_and_validate, except: :prompt
-  layout "admin_layout", only: %w[prompt]
+  layout "admin_layout", only: %w[show update prompt]
 
   attr_reader :otp_secret_key
 

--- a/app/views/devise/two_step_verification/show.html.erb
+++ b/app/views/devise/two_step_verification/show.html.erb
@@ -1,97 +1,67 @@
-<% title = current_user.has_2sv? ? "Use a new phone" : "Set up 2-step verification" %>
-<% content_for :title, title %>
-<% invalid_code_entered = flash[:invalid_code] %>
+<% content_for :title, current_user.has_2sv? ? "Use a new phone" : "Set up 2-step verification" %>
 
-<h1><%= title %></h1>
-<div class="row">
-  <div class="col-md-8">
-    <% if current_user.has_2sv? %>
-      <div class="alert alert-warning">
-        <p>Setting up a new phone will replace your existing one. You will only be able to sign in with your new phone.</p>
-      </div>
-    <% end %>
-    <p class="lead">Make your Signon account more secure by setting up 2-step verification. You’ll need to install an app on your phone which will generate a verification code to enter when you sign in.</p>
+<% if flash[:invalid_code].present? %>
+  <% content_for :error_summary do %>
+    <%= render "govuk_publishing_components/components/error_summary", {
+      title: "There is a problem",
+      items: [{ text: flash[:invalid_code], href: "#enter-code" }],
+    } %>
+  <% end %>
+<% end %>
 
-    <div class="panel-group" id="setup-steps" role="tablist" aria-multiselectable="true">
-      <div class="panel panel-part">
-        <div class="panel-heading" role="tab" id="step-one-heading">
-          <h4 class="panel-title">
-            <a role="button" data-toggle="collapse" data-parent="#setup-steps" href="#step-one" aria-expanded="true" aria-controls="step-one">
-              1. Install a verification app on your phone
-            </a>
-          </h4>
-        </div>
-        <div id="step-one" class="panel-collapse collapse <% unless invalid_code_entered %>in<% end %>" role="tabpanel" aria-labelledby="step-one-heading">
-          <div class="panel-body">
-            <p class="lead">Install a verification app from the app store on your phone - for example, Google Authenticator or Microsoft Authenticator.</p>
-            <a class="collapsed btn btn-lg btn-success" role="button" data-toggle="collapse" data-parent="#setup-steps" href="#step-two" aria-expanded="false" aria-controls="step-two">
-              Next
-            </a>
-          </div>
-        </div>
-      </div>
-      <div class="panel panel-part">
-        <div class="panel-heading" role="tab" id="step-two-heading">
-          <h4 class="panel-title">
-            <a class="collapsed" role="button" data-toggle="collapse" data-parent="#setup-steps" href="#step-two" aria-expanded="false" aria-controls="step-two">
-              2. Scan the barcode using your app
-            </a>
-          </h4>
-        </div>
-        <div id="step-two" class="panel-collapse collapse" role="tabpanel" aria-labelledby="step-two-heading">
-          <div class="panel-body">
-            <p class="lead">In your app add a new account and scan the barcode:</p>
-            <ul class="list-group">
-              <li class="list-group-item">
-                <%= image_tag(qr_code_data_uri(user: current_user, otp_secret_key: @otp_secret_key), width: 180) %>
-              </li>
-            </ul>
-            <p class="add-bottom-margin">If you cannot use a barcode, you can enter a code instead. This is sometimes called a set-up key, a secret key, or an activation key. Enter this code when asked: <%= @otp_secret_key%></p>
-            <a class="collapsed btn btn-lg btn-success" role="button" data-toggle="collapse" data-parent="#setup-steps" href="#step-three" aria-expanded="false" aria-controls="step-three">
-              Next
-            </a>
-          </div>
-        </div>
-      </div>
-      <div class="panel panel-part">
-        <div class="panel-heading" role="tab" id="step-three-heading">
-          <h4 class="panel-title">
-            <a class="collapsed" role="button" data-toggle="collapse" data-parent="#setup-steps" href="#step-three" aria-expanded="false" aria-controls="step-three">
-              3. Enter the verification code shown in the app
-            </a>
-          </h4>
-        </div>
-        <div id="step-three" class="panel-collapse collapse <% if invalid_code_entered %>in<% end %>" role="tabpanel" aria-labelledby="step-three-heading">
-          <div class="panel-body" data-module="track-click">
-              <% if invalid_code_entered %>
-                <%= content_tag :div,
-                  invalid_code_entered,
-                  class: 'alert alert-danger',
-                  data: track_analytics_data(:danger, invalid_code_entered) %>
-              <% end %>
-              <%= form_tag two_step_verification_path, method: :put do %>
-                <%= hidden_field_tag :otp_secret_key, @otp_secret_key%>
-                <div class="form-group <% if invalid_code_entered %>has-error text-danger<% end %>">
-                  <%= label_tag :code, 'Code from app' %>
-                  <%= text_field_tag :code, nil,
-                    class: 'form-control input-md-4 input-lg',
-                    placeholder: 'Enter 6-digit code',
-                    autocomplete: 'off' %>
-                </div>
-                <button name="submit" id="submit_code" class="btn btn-lg btn-success js-track">
-                  <% if current_user.has_2sv? %>
-                    Finish replacing your phone
-                  <% else %>
-                    Finish set up
-                  <% end %>
-                </button>
-                <% unless current_user.has_2sv? %>
-                  <a href="/" class="btn btn-lg btn-default add-left-margin js-track">Cancel</a>
-                <% end %>
-              <% end %>
-          </div>
-        </div>
-      </div>
-    </div>
+<% if current_user.has_2sv? %>
+  <%= render "govuk_publishing_components/components/warning_text", {
+    text: "Setting up a new phone will replace your existing one. You will only be able to sign in with your new phone."
+  } %>
+<% end %>
+
+<%= render "govuk_publishing_components/components/lead_paragraph", {
+  text: "Make your Signon account more secure by setting up 2-step verification. You’ll need to install an app on your phone which will generate a verification code to enter when you sign in."
+} %>
+
+<h2 class="govuk-heading-m">1. Install a verification app on your phone</h2>
+
+<p class="govuk-body">
+    Install a verification app from the app store on your phone - for
+    example, Google Authenticator or Microsoft Authenticator.
+</p>
+
+<h2 class="govuk-heading-m">2. Scan the barcode using your app</h2>
+
+<p class="govuk-body">In your app add a new account and scan the barcode:</p>
+
+<%= image_tag(qr_code_data_uri(user: current_user, otp_secret_key: @otp_secret_key), width: 180) %>
+
+<details class="govuk-details" data-module="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      If you cannot use a barcode
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    You can enter a code instead. This is sometimes called a set-up key, a secret key, or an activation key. Enter this code when asked: <%= @otp_secret_key%>
   </div>
-</div>
+</details>
+
+<h2 id="enter-code" class="govuk-heading-m">3. Enter the verification code shown in the app</h2>
+
+<%= form_tag two_step_verification_path, method: :put do %>
+  <%= hidden_field_tag :otp_secret_key, @otp_secret_key%>
+
+  <%= render "govuk_publishing_components/components/input", {
+    label: { text: "Code from app" },
+    name: "code",
+    type: "text",
+    error_message: flash[:invalid_code]
+  } %>
+
+  <div class="govuk-button-group">
+    <%= render "govuk_publishing_components/components/button", {
+      text: current_user.has_2sv? ? "Finish replacing your phone" : "Finish set up",
+    } %>
+
+    <% unless current_user.has_2sv? %>
+      <%= link_to "Cancel", root_path, class: "govuk-link govuk-link--no-visited-state" %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/devise/two_step_verification/show.html.erb
+++ b/app/views/devise/two_step_verification/show.html.erb
@@ -52,6 +52,7 @@
     label: { text: "Code from app" },
     name: "code",
     type: "text",
+    width: 10,
     error_message: flash[:invalid_code]
   } %>
 

--- a/app/views/devise/two_step_verification/show.html.erb
+++ b/app/views/devise/two_step_verification/show.html.erb
@@ -51,6 +51,7 @@
 
   <%= render "govuk_publishing_components/components/input", {
     label: { text: "Code from app" },
+    hint: "Enter 6-digit code",
     name: "code",
     type: "text",
     width: 10,

--- a/app/views/devise/two_step_verification/show.html.erb
+++ b/app/views/devise/two_step_verification/show.html.erb
@@ -1,4 +1,5 @@
 <% content_for :title, current_user.has_2sv? ? "Use a new phone" : "Set up 2-step verification" %>
+<% content_for :back_link, root_path %>
 
 <% if flash[:invalid_code].present? %>
   <% content_for :error_summary do %>

--- a/app/views/layouts/admin_layout.html.erb
+++ b/app/views/layouts/admin_layout.html.erb
@@ -29,6 +29,8 @@
         } %>
       <% end %>
 
+      <%= yield(:error_summary) %>
+
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
           <span class="govuk-caption-l"><%= yield(:context) %></span>

--- a/test/integration/two_step_verification_prompt_test.rb
+++ b/test/integration/two_step_verification_prompt_test.rb
@@ -30,6 +30,7 @@ class TwoStepVerificationPromptTest < ActionDispatch::IntegrationTest
         assert page.has_text?("Set up 2-step verification")
 
         enter_2sv_code(secret)
+        click_button "Finish set up"
 
         assert_equal users_path, current_path
       end

--- a/test/integration/two_step_verification_test.rb
+++ b/test/integration/two_step_verification_test.rb
@@ -25,7 +25,7 @@ class TwoStepVerificationTest < ActionDispatch::IntegrationTest
 
       should "reject an invalid code, reuse the secret and log the rejection" do
         fill_in "code", with: "abcdef"
-        click_button "submit_code"
+        click_button "Finish replacing your phone"
 
         assert_response_contains "Sorry that code didn’t work. Please try again."
         assert_response_contains "Enter this code when asked: #{@new_secret}"
@@ -35,6 +35,7 @@ class TwoStepVerificationTest < ActionDispatch::IntegrationTest
       should "accept a valid code, persist the secret and log the event" do
         perform_enqueued_jobs do
           enter_2sv_code(@new_secret)
+          click_button "Finish replacing your phone"
 
           assert_response_contains "2-step verification phone changed successfully"
           assert_equal @new_secret, @user.reload.otp_secret_key
@@ -47,6 +48,7 @@ class TwoStepVerificationTest < ActionDispatch::IntegrationTest
 
       should "require the code again on next login" do
         enter_2sv_code(@new_secret)
+        click_button "Finish replacing your phone"
 
         click_link "Sign out"
 
@@ -68,7 +70,7 @@ class TwoStepVerificationTest < ActionDispatch::IntegrationTest
 
       should "reject an invalid code, reuse the secret and log the rejection" do
         fill_in "code", with: "abcdef"
-        click_button "submit_code"
+        click_button "Finish set up"
 
         assert_response_contains "Sorry that code didn’t work. Please try again."
         assert_response_contains "Enter this code when asked: #{@new_secret}"
@@ -79,6 +81,7 @@ class TwoStepVerificationTest < ActionDispatch::IntegrationTest
         success = "2-step verification set up".freeze
         perform_enqueued_jobs do
           enter_2sv_code(@new_secret)
+          click_button "Finish set up"
 
           assert_response_contains success
           assert_equal @new_secret, @user.reload.otp_secret_key
@@ -94,7 +97,7 @@ class TwoStepVerificationTest < ActionDispatch::IntegrationTest
 
         Timecop.freeze do
           fill_in "code", with: old_code
-          click_button "submit_code"
+          click_button "Finish set up"
         end
 
         assert_response_contains "2-step verification set up"
@@ -117,6 +120,7 @@ class TwoStepVerificationTest < ActionDispatch::IntegrationTest
         success = "2-step verification set up".freeze
         perform_enqueued_jobs do
           enter_2sv_code(@new_secret)
+          click_button "Finish set up"
 
           assert_response_contains success
           assert_nil @user.reload.reason_for_2sv_exemption
@@ -131,6 +135,7 @@ class TwoStepVerificationTest < ActionDispatch::IntegrationTest
 
       should "require the code again on next login" do
         enter_2sv_code(@new_secret)
+        click_button "Finish set up"
 
         click_link "Sign out"
 

--- a/test/support/user_helpers.rb
+++ b/test/support/user_helpers.rb
@@ -34,7 +34,6 @@ module UserHelpers
   def enter_2sv_code(secret)
     Timecop.freeze do
       fill_in "code", with: ROTP::TOTP.new(secret).now
-      click_button "submit_code"
     end
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/Ht3aHQTT

This PR adopts the GDS design system for the show and update actions on the TwoStepVerificationController. A user sees this page when they add or change the two-step verification code for their account.

The main change to the page is the switch from collapsable sections to having everything visible by default. We considered using the step-by-step, accordion or tabs components/patterns but it's not obvious that these are suitable for forms. Also since there's not a lot of content in each "step", it's not obvious that there's a lot of benefit to the user of hiding some of the "steps". So we've just made the "steps" into numbered headings with non-collapsing content. We don't think this looks too bad. If there's too much content on the page, we could consider splitting the page into multiple pages.

We've made use of the details component to hide the explanation for those users that can't use the barcode. The Design System recommends this component for content that's not relevant to all users which seems appropriate here.

As the design system [recommends][1], we now show an error summary at the top of the page with a link that takes the user to the heading for step 3 as well as highlighting the form field where the error has occurred.

We've retained the QR code as it was previously rendered (using a data uri in an img tag). We noticed that the [qrcode](https://github.com/whomwah/rqrcode) gem supports SVG rendering so we could adopt that as an enhancement (it would make the QR code more responsive to screen width). This would also fix a content security policy warning we're seeing in production [2].

The new version of the page doesn't include any of the custom analytics tracking that was in the original version. We've recently discovered that no events have been recorded in GA for this app since June 2017, so we assume something has inadvertently broken the code. This means it doesn't seem worthwhile trying to reimplement the custom analytics tracking in the new version of the page. Note that we will still see page views for this page as we do for all pages.

The following screenshots capture the main interactions, we can demo the additional states (such as a cancel link being available when the user first sets up 2sv) if it helps to review this. 

[1]: https://design-system.service.gov.uk/components/error-summary/
[2] We see `[Report Only] Refused to load the image...` in production, but the QR code image *does* seem to render (in Chrome at least, we haven't tested it elsewhere). The image doesn't render in development, so changing it would improve the development story.  

# Before

## Step 1 expanded (default)
<img width="675" alt="before_step_1" src="https://github.com/alphagov/signon/assets/16707/e5616d21-f6ef-48d3-8a7e-2b4ad0651c71">

## Step 2 expanded
<img width="675" alt="before_step_2" src="https://github.com/alphagov/signon/assets/16707/84b0c72c-e6a0-400d-a8b9-0a3973a73464">

## Step 3 expanded
<img width="675" alt="before_step_3" src="https://github.com/alphagov/signon/assets/16707/52d8ff8d-5b1c-4a95-8997-a9754bcf3daa">

## When incorrect code entered
<img width="675" alt="before_error" src="https://github.com/alphagov/signon/assets/16707/6892238b-2c13-4ef6-9bad-2b67d11d1baa">

# After

## On page load
![on_page_load](https://github.com/alphagov/signon/assets/16707/3e03c97f-733c-413a-9f0d-b746d00a6490)

## User opens additional details
![details_expanded](https://github.com/alphagov/signon/assets/16707/5c982f5b-2247-4fa4-a4ae-caadf6234e5b)

## When incorrect code entered
![error](https://github.com/alphagov/signon/assets/16707/a98c5096-5760-4312-8f91-d5e484f78111)

