### PR TITLE
Move two TwoStepVerificationController methods into TwoStepVerificationHelper

### DIFF
--- a/app/controllers/devise/two_step_verification_controller.rb
+++ b/app/controllers/devise/two_step_verification_controller.rb
@@ -24,16 +24,6 @@ class Devise::TwoStepVerificationController < DeviseController
     end
   end
 
-  def otp_secret_key_uri
-    issuer = I18n.t("devise.issuer")
-    if Rails.application.config.instance_name
-      issuer = "#{Rails.application.config.instance_name.titleize} #{issuer}"
-    end
-
-    issuer = ERB::Util.url_encode(issuer)
-    "otpauth://totp/#{issuer}:#{current_user.email}?secret=#{@otp_secret_key.upcase}&issuer=#{issuer}"
-  end
-
 private
 
   def send_notification(_user, mode)
@@ -45,7 +35,8 @@ private
   end
 
   def qr_code_data_uri
-    qr_code = RQRCode::QRCode.new(otp_secret_key_uri, level: :m)
+    uri = otp_secret_key_uri(user: current_user, otp_secret_key: @otp_secret_key)
+    qr_code = RQRCode::QRCode.new(uri, level: :m)
     qr_code.as_png(size: 180, fill: ChunkyPNG::Color::TRANSPARENT).to_data_url
   end
   helper_method :qr_code_data_uri

--- a/app/controllers/devise/two_step_verification_controller.rb
+++ b/app/controllers/devise/two_step_verification_controller.rb
@@ -34,13 +34,6 @@ private
     end
   end
 
-  def qr_code_data_uri
-    uri = otp_secret_key_uri(user: current_user, otp_secret_key: @otp_secret_key)
-    qr_code = RQRCode::QRCode.new(uri, level: :m)
-    qr_code.as_png(size: 180, fill: ChunkyPNG::Color::TRANSPARENT).to_data_url
-  end
-  helper_method :qr_code_data_uri
-
   def prepare_and_validate
     redirect_to(:root) && return if current_user.nil?
 

--- a/app/helpers/two_step_verification_helper.rb
+++ b/app/helpers/two_step_verification_helper.rb
@@ -35,4 +35,10 @@ private
     issuer = ERB::Util.url_encode(issuer)
     "otpauth://totp/#{issuer}:#{user.email}?secret=#{otp_secret_key.upcase}&issuer=#{issuer}"
   end
+
+  def qr_code_data_uri(user:, otp_secret_key:)
+    uri = otp_secret_key_uri(user:, otp_secret_key:)
+    qr_code = RQRCode::QRCode.new(uri, level: :m)
+    qr_code.as_png(size: 180, fill: ChunkyPNG::Color::TRANSPARENT).to_data_url
+  end
 end

--- a/app/helpers/two_step_verification_helper.rb
+++ b/app/helpers/two_step_verification_helper.rb
@@ -25,4 +25,14 @@ private
   def on_2sv_setup_journey
     controller_path == Devise::TwoStepVerificationController.controller_path
   end
+
+  def otp_secret_key_uri(user:, otp_secret_key:)
+    issuer = I18n.t("devise.issuer")
+    if Rails.application.config.instance_name
+      issuer = "#{Rails.application.config.instance_name.titleize} #{issuer}"
+    end
+
+    issuer = ERB::Util.url_encode(issuer)
+    "otpauth://totp/#{issuer}:#{user.email}?secret=#{otp_secret_key.upcase}&issuer=#{issuer}"
+  end
 end

--- a/app/views/devise/two_step_verification/show.html.erb
+++ b/app/views/devise/two_step_verification/show.html.erb
@@ -43,7 +43,7 @@
             <p class="lead">In your app add a new account and scan the barcode:</p>
             <ul class="list-group">
               <li class="list-group-item">
-                <%= image_tag(qr_code_data_uri, width: 180) %>
+                <%= image_tag(qr_code_data_uri(user: current_user, otp_secret_key: @otp_secret_key), width: 180) %>
               </li>
             </ul>
             <p class="add-bottom-margin">If you cannot use a barcode, you can enter a code instead. This is sometimes called a set-up key, a secret key, or an activation key. Enter this code when asked: <%= @otp_secret_key%></p>

--- a/test/controllers/two_step_verification_controller_test.rb
+++ b/test/controllers/two_step_verification_controller_test.rb
@@ -31,48 +31,4 @@ class TwoStepVerificationControllerTest < ActionController::TestCase
       assert_redirected_to new_two_step_verification_session_path
     end
   end
-
-  context "otp_secret_key_uri" do
-    setup do
-      @secret = ROTP::Base32.random_base32
-      ROTP::Base32.stubs(random_base32: @secret)
-
-      get :show
-    end
-
-    should "include the secret key uppercased" do
-      assert_match %r{#{@secret.upcase}}, @controller.otp_secret_key_uri
-    end
-
-    should "include the environment titleised" do
-      assert_match %r{issuer=Development%20.*%20Signon}, @controller.otp_secret_key_uri
-    end
-
-    context "in production" do
-      setup do
-        @old_instance_name = Rails.application.config.instance_name
-        Rails.application.config.instance_name = nil
-      end
-
-      teardown do
-        Rails.application.config.instance_name = @old_instance_name
-      end
-
-      should "not include the environment name" do
-        assert_match %r{issuer=.*%20Signon}, @controller.otp_secret_key_uri
-        assert_no_match %r{issuer=Development%20.*%20Signon}, @controller.otp_secret_key_uri
-      end
-    end
-
-    context "when different issuer name is provided within the localisation data" do
-      should "use the value provided by i18n" do
-        I18n.stubs(t: "issuer test")
-        assert_match %r{issuer=Development%20issuer%20test}, @controller.otp_secret_key_uri
-      end
-    end
-
-    should "include the user's email" do
-      assert_match %r{#{@user.email}}, @controller.otp_secret_key_uri
-    end
-  end
 end

--- a/test/helpers/two_step_verification_helper_test.rb
+++ b/test/helpers/two_step_verification_helper_test.rb
@@ -1,0 +1,46 @@
+require "test_helper"
+
+class TwoStepVerificationHelperTest < ActionView::TestCase
+  context "otp_secret_key_uri(user: @user, otp_secret_key: @secret)" do
+    setup do
+      @user = build(:user)
+      @secret = ROTP::Base32.random_base32
+      ROTP::Base32.stubs(random_base32: @secret)
+    end
+
+    should "include the secret key uppercased" do
+      assert_match %r{#{@secret.upcase}}, otp_secret_key_uri(user: @user, otp_secret_key: @secret)
+    end
+
+    should "include the environment titleised" do
+      assert_match %r{issuer=Development%20.*%20Signon}, otp_secret_key_uri(user: @user, otp_secret_key: @secret)
+    end
+
+    context "in production" do
+      setup do
+        @old_instance_name = Rails.application.config.instance_name
+        Rails.application.config.instance_name = nil
+      end
+
+      teardown do
+        Rails.application.config.instance_name = @old_instance_name
+      end
+
+      should "not include the environment name" do
+        assert_match %r{issuer=.*%20Signon}, otp_secret_key_uri(user: @user, otp_secret_key: @secret)
+        assert_no_match %r{issuer=Development%20.*%20Signon}, otp_secret_key_uri(user: @user, otp_secret_key: @secret)
+      end
+    end
+
+    context "when different issuer name is provided within the localisation data" do
+      should "use the value provided by i18n" do
+        I18n.stubs(t: "issuer test")
+        assert_match %r{issuer=Development%20issuer%20test}, otp_secret_key_uri(user: @user, otp_secret_key: @secret)
+      end
+    end
+
+    should "include the user's email" do
+      assert_match %r{#{@user.email}}, otp_secret_key_uri(user: @user, otp_secret_key: @secret)
+    end
+  end
+end


### PR DESCRIPTION
### Move `otp_secret_key_uri` method from controller to helper

It's not idiomatic Rails to have a public method on a controller which is not an action. I considered just making the method private, but since it was being called from a bunch of tests I decided to move it to a helper.

While the current_user method is probably accessible from `TwoStepVerificationHelper` methods, I decided it was helpful to make the user an explicit method argument to highlight that the URI is different for different users.

### Move `qr_code_data_uri` method from controller to helper

This helper method is only used in a template (not in the controller), so it makes more sense to move it to the relevant helper.
