### PR TITLE
Avoid INFO-level log messages in asset:precompile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,4 +5,9 @@ require File.expand_path("config/application", __dir__)
 
 Signon::Application.load_tasks
 
+require "sprockets/rails/task"
+Sprockets::Rails::Task.new(Rails.application) do |t|
+  t.log_level = Logger::WARN
+end
+
 task default: %i[lint test jasmine]


### PR DESCRIPTION
One of these log messages is generated for every asset file when running the "default" rake task:

    I, [2023-05-24T13:43:51.865470 #2412]  INFO -- : Writing
    /govuk/signon/public/assets/signon/manifest-90aab26ade71e747f745b1227b433fd7d580a54f279ee2be6e1a67bb326bf03a.js

I don't think these log messages are particularly useful and in fact they obscure what might be a significant warning:

    W, [2023-05-24T13:43:37.862925 #2412]  WARN -- : Removed sourceMappingURL comment for missing asset 'govuk_publishing_components/vendor/lux/lux.js.map' from /root/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/govuk_publishing_components-35.4.0/app/assets/javascripts/govuk_publishing_components/vendor/lux/lux-reporter.js

I'm not planning to address the latter in this commit, but with the INFO-level messages now hidden, this should be more prominent!

I've redefined the rake tasks defined by sprockets-rails as recommended in [the documentation][1] in order to change the log_level from INFO to WARN. c.f. [this Whitehall commit][2].

[1]: https://github.com/rails/sprockets-rails/blob/v3.4.2/README.md#customize
[2]: https://github.com/alphagov/whitehall/commit/8efb2d2c8261cb5b40175a3a52c280d5e2f6eed4
