### PR TITLE
Fix 2SV flash alert displayed on success after failure

### DIFF
--- a/app/controllers/devise/two_step_verification_session_controller.rb
+++ b/app/controllers/devise/two_step_verification_session_controller.rb
@@ -27,7 +27,7 @@ class Devise::TwoStepVerificationSessionController < DeviseController
       redirect_to_prior_flow
       current_user.update!(second_factor_attempts_count: 0)
     else
-      flash[:alert] = find_message(:attempt_failed)
+      flash.now[:alert] = find_message(:attempt_failed)
       if current_user.max_2sv_login_attempts?
         sign_out(current_user)
         render :max_2sv_login_attempts_reached


### PR DESCRIPTION
Trello: https://trello.com/c/9C8iNaKn

In `Devise::TwoStepVerificationSessionController#create`, if the 2SV code was invalid, the flash alert was set and the "new" template was *rendered*.  Although the flash alert was rendered at this point, it was not removed from the flash. So if the user then submitted the correct code, they were redirected to the "prior flow" (the root path by default) and the flash alert was (incorrectly) displayed again.

This commit uses `ActionDispatch::Flash::FlashHash#now` to set the flash alert - it is now removed as soon as it is rendered for the first time in the "new" template and not the second time in the subsequent "success" page.

Fixes #1417.
