### PR TITLE
Fix flakey sign-in and sign-out integration tests

### DIFF
--- a/test/support/analytics_helpers.rb
+++ b/test/support/analytics_helpers.rb
@@ -10,12 +10,12 @@ module AnalyticsHelpers
 
   def refute_dimension_is_set(dimension)
     js_code = dimension_set_js_code(dimension)
-    assert_no_match(/#{Regexp.escape(js_code)}/, page.body)
+    assert_not page.has_text?(:all, js_code)
   end
 
   def assert_dimension_is_set(dimension, with_value: nil)
     js_code = dimension_set_js_code(dimension, with_value:)
-    assert_match(/#{Regexp.escape(js_code)}/, page.body)
+    assert page.has_text?(:all, js_code)
   end
 
 private

--- a/test/support/analytics_helpers.rb
+++ b/test/support/analytics_helpers.rb
@@ -9,12 +9,19 @@ module AnalyticsHelpers
   end
 
   def refute_dimension_is_set(dimension)
-    assert_no_match(/#{Regexp.escape("GOVUKAdmin.setDimension(#{dimension}")}/, page.body)
+    js_code = dimension_set_js_code(dimension)
+    assert_no_match(/#{Regexp.escape(js_code)}/, page.body)
   end
 
   def assert_dimension_is_set(dimension, with_value: nil)
-    dimension_set_js_code = "ga('set', 'dimension#{dimension}"
-    dimension_set_js_code += "', \"#{with_value}\")" if with_value.present?
-    assert_match(/#{Regexp.escape(dimension_set_js_code)}/, page.body)
+    js_code = dimension_set_js_code(dimension, with_value:)
+    assert_match(/#{Regexp.escape(js_code)}/, page.body)
+  end
+
+private
+
+  def dimension_set_js_code(dimension, with_value: nil)
+    code = "ga('set', 'dimension#{dimension}"
+    with_value.present? ? code + "', \"#{with_value}\")" : code
   end
 end


### PR DESCRIPTION
* Fix `AnalyticsHelper#refute_dimension_is_set` assertion which hasn't been doing anything useful since [this commit](https://github.com/alphagov/signon/commit/7fe1e64b593e01e3cc1d38049c78778262a47a3d).
* Use Capybara matcher in `AnalyticsHelper` assertions so they will use the built-in waiting mechanism in the hope this fixes the intermittent integration test failures we've seen in `test/integration/sign_in_test.rb` &
`test/integration/sign_out_test.rb`.

See commit notes for more details.