### PR TITLE
Run lint Rake task *before* test Rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,4 +10,5 @@ Sprockets::Rails::Task.new(Rails.application) do |t|
   t.log_level = Logger::WARN
 end
 
-task default: %i[lint test jasmine]
+Rake::Task[:default].clear_prerequisites
+task default: %i[lint jasmine test]


### PR DESCRIPTION
This changes the invocation order of the Rake tasks associated with the default Rake task to run in the following order: lint, jasmine, test. I think this is a more logical order and it matches the CI workflow more closely i.e. lint-scss, lint-javascript, lint-ruby.

Previously, they were run in the following order: test, lint, jasmine; even though they were listed in the following order: lint test jasmine. This was because prior to the redeclaration of the default Rake task in the `Rakefile`, Rails sets the test task as a prerequisite for the default task. Thus we need to clear the prerequisites if we want to run the lint & jasmine tasks before the test task.

My main motivation for making this change is that it's quite frustrating to only see Rubocop violations *after* all the Ruby tests have passed! This should fix that problem.

Note that although the test-ruby job in the CI workflow uses the test task, none of the other jobs seem to use the default task, so this should not affect the CI workflow - only local testing.