### PR TITLE
Do not send sensitive tokens to Google Analytics

### DIFF
--- a/app/views/layouts/admin_layout.html.erb
+++ b/app/views/layouts/admin_layout.html.erb
@@ -73,6 +73,10 @@
       ga('set', 'dimension8', "<%= current_user.organisation ? current_user.organisation.slug : '(not set)' %>");
     <% end %>
 
-    ga('send', 'pageview');
+    <% if sensitive_query_parameters? %>
+      ga('send', 'pageview', { page: '<%= sanitised_fullpath %>' });
+    <% else %>
+      ga('send', 'pageview');
+    <% end %>
   </script>
 <% end %>

--- a/test/integration/inviting_users_test.rb
+++ b/test/integration/inviting_users_test.rb
@@ -15,6 +15,17 @@ class InvitingUsersTest < ActionDispatch::IntegrationTest
     assert_response_contains("You are now signed in")
   end
 
+  should "not send invitation token to Google Analytics" do
+    user = User.invite!(name: "Jim", email: "jim@web.com")
+    visit accept_user_invitation_path(invitation_token: user.raw_invitation_token, foo: "bar")
+
+    query = URI(google_analytics_page_view_path).query
+    params = Rack::Utils.parse_nested_query(query)
+
+    assert_not params.keys.include?("invitation_token")
+    assert params.keys.include?("foo")
+  end
+
   context "as an admin" do
     setup do
       admin = create(:user, role: "admin")

--- a/test/integration/password_reset_test.rb
+++ b/test/integration/password_reset_test.rb
@@ -130,4 +130,16 @@ class PasswordResetTest < ActionDispatch::IntegrationTest
 
     Rack::Attack.enabled = false
   end
+
+  should "not send password reset token to Google Analytics" do
+    user = create(:user)
+    token = user.send_reset_password_instructions
+    visit edit_user_password_path(reset_password_token: token, foo: "bar")
+
+    query = URI(google_analytics_page_view_path).query
+    params = Rack::Utils.parse_nested_query(query)
+
+    assert_not params.keys.include?("reset_password_token")
+    assert params.keys.include?("foo")
+  end
 end

--- a/test/support/analytics_helpers.rb
+++ b/test/support/analytics_helpers.rb
@@ -17,4 +17,15 @@ module AnalyticsHelpers
     dimension_set_js_code += "', \"#{with_value}\")" if with_value.present?
     assert_match(/#{Regexp.escape(dimension_set_js_code)}/, page.body)
   end
+
+  def google_analytics_page_view_path
+    case page.body
+    when Regexp.new("ga\\('send', 'pageview', { page: '(?<explicit_path>[^']*)' }\\)")
+      Regexp.last_match[:explicit_path]
+    when Regexp.new("ga\\('send', 'pageview'\\)")
+      page.current_path
+    else
+      flunk "Google Analytics page view not sent"
+    end
+  end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/4fDGiKTz

Since both the passwords controller and invitation controller pages were switched over to use the new design system layout in [this commit][1], the sensitive `password_reset_token` and `invitation_token` query string parameters have inadvertently been sent to Google Analytics when previously they was redacted.

I've confirmed that I can see recently generated `password_reset_token` & `invitation_token` values in Google Analytics. This is a security risk, because someone who has access to Google Analytics might be able to gain access to someone else's Signon account.

Before the change mentioned above, all pages were using the application layout as opposed to the `admin_layout` layout. The application layout provides content to the `govuk_admin_template` layout via various calls to `content_for`. In particular, the application layout calls `ApplicationHelper#sensitive_query_parameters?` and if that's `true`, it calls `ApplicationHelper#sanitised_fullpath` which redacts the sensitive query parameters and passes the result to the `govuk_admin_template` layout via the `custom_pageview_fullpath` content key (see [this code][2]). If any such content is provided, the `govuk_admin_template` calls `GOVUKAdmin.trackPageview` passing the `custom_pageview_fullpath` as an explicit path rather than just sending a page view with an implicit path which would include the sensitive query parameters (see [this code][3]).

This commit effectively re-implements the relevant functionality (that was being provided by `govuk_admin_template`) in the `admin_layout` layout. It also adds some integration tests to to try to prevent any similar regression in the future.

[1]: 68f10e98a8a7bd142d4fd68e0709d4ebc384a673
[2]: https://github.com/alphagov/signon/blob/934b80cbf5a8c6f771458363dbada2ecc5eb7b23/app/views/layouts/application.html.erb#L10-L12
[3]: https://github.com/alphagov/govuk_admin_template/blob/0f4a4b169e3d117d75b762970a8399de1a11855e/app/views/layouts/govuk_admin_template.html.erb#L122-L123
