### PR TITLE
Remove broken analytics event tracking code

### DIFF
--- a/app/helpers/analytics_helper.rb
+++ b/app/helpers/analytics_helper.rb
@@ -1,9 +1,0 @@
-module AnalyticsHelper
-  def track_analytics_data(type, message)
-    {
-      "module" => "auto-track-event",
-      "track-action" => "alert-#{type}",
-      "track-label" => strip_tags(message),
-    }
-  end
-end

--- a/app/views/bulk_grant_permission_sets/new.html.erb
+++ b/app/views/bulk_grant_permission_sets/new.html.erb
@@ -12,7 +12,7 @@
       <div class="alert alert-danger">
         <ul>
           <% @bulk_grant_permission_set.errors.full_messages.each do |message| %>
-            <%= content_tag :li, message, data: track_analytics_data(:danger, message) %>
+            <%= content_tag :li, message %>
           <% end %>
         </ul>
       </div>

--- a/app/views/devise/passwords/_change_password_errors.html.erb
+++ b/app/views/devise/passwords/_change_password_errors.html.erb
@@ -6,7 +6,7 @@
     <div class="govuk-error-summary__body">
       <ul class="govuk-list govuk-error-summary__list">
         <% resource.errors.full_messages.each do |message| %>
-          <%= content_tag :li, message, data: track_analytics_data(:danger, message) %>
+          <%= content_tag :li, message %>
         <% end %>
       </ul>
     </div>

--- a/app/views/devise/two_step_verification_session/max_2sv_login_attempts_reached.html.erb
+++ b/app/views/devise/two_step_verification_session/max_2sv_login_attempts_reached.html.erb
@@ -5,7 +5,7 @@
   <h1>Your account is locked</h1>
 </div>
 
-<div class="callout callout-danger" data-module="auto-track-event" data-track-action="alert-danger" data-track-label="Too many attempts">
+<div class="callout callout-danger">
   <p class="lead">
     Your account has been locked because an incorrect 2-step verification code was entered too many times.
   </p>

--- a/app/views/shared/_bootstrap_flash_messages.html.erb
+++ b/app/views/shared/_bootstrap_flash_messages.html.erb
@@ -1,6 +1,5 @@
 <% bootstrap_flash_message_keys.each do |k| %>
   <%= content_tag :div,
     flash[k],
-    class: "alert alert-#{bootstrap_flash_class(k)}",
-    data: track_analytics_data(bootstrap_flash_class(k), flash[k]) %>
+    class: "alert alert-#{bootstrap_flash_class(k)}" %>
 <% end %>

--- a/app/views/users/_form_errors.html.erb
+++ b/app/views/users/_form_errors.html.erb
@@ -3,7 +3,7 @@
   <div class="govuk-error-summary__body">
     <ul class="govuk-list govuk-error-summary__list">
       <% @user.errors.full_messages.each do |message| %>
-        <%= content_tag :li, message, data: track_analytics_data(:danger, message) %>
+        <%= content_tag :li, message %>
       <% end %>
     </ul>
   </div>


### PR DESCRIPTION
While working on #2174 we discovered that no events have been sent to Google Analytics from the signon app since June 2017. This strongly suggests that nobody has been looking at them and so it seems sensible to simplify the app by removing the relevant code.

I haven't spent any time investigating why the code hasn't been working, but my guess is that something changed in govuk_admin_template and the signon app wasn't updated accordingly, or perhaps a bit like in #2190 it got broken inadvertently when some of the pages were moved to follow the Design System.
