### PR TITLE
Add foreign key to oauth_access_tokens.application_id

### DIFF
--- a/db/migrate/20230613153019_add_foreign_key_constraint_to_application_id_on_oauth_access_tokens.rb
+++ b/db/migrate/20230613153019_add_foreign_key_constraint_to_application_id_on_oauth_access_tokens.rb
@@ -1,0 +1,14 @@
+class AddForeignKeyConstraintToApplicationIdOnOauthAccessTokens < ActiveRecord::Migration[7.0]
+  def change
+    Doorkeeper::AccessToken.all.select { |at| at.application.nil? }.each do |access_token|
+      Doorkeeper::Application.create!(
+        id: access_token.application_id,
+        name: "Unknown #{access_token.application_id}",
+        redirect_uri: "https://example.com/",
+        description: "Added in migration (previously deleted?)",
+      )
+    end
+
+    add_foreign_key :oauth_access_tokens, :oauth_applications, column: :application_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_09_131935) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_13_153019) do
   create_table "batch_invitation_application_permissions", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "batch_invitation_id", null: false
     t.integer "supported_permission_id", null: false
@@ -218,4 +218,5 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_09_131935) do
   end
 
   add_foreign_key "event_logs", "user_agents", name: "event_logs_user_agent_id_fk"
+  add_foreign_key "oauth_access_tokens", "oauth_applications", column: "application_id"
 end


### PR DESCRIPTION
Trello: https://trello.com/c/chkpC1am

We've been seeing [`ActionView::Template::Error` exceptions][1] in integration when editing the SSO Push user in integration. It appears to be happening because that user has a couple of access tokens associated with it that have `application_id` which point to non-existent applications.

I think we could argue whether or not we actually need (or indeed should) to be able to edit this "singleton" `ApiUser`, but either way it doesn't seem good from a database integrity point of view that an access token can end up with an `application_id` that points to a non-existent application.

In the migration we create dummy applications for those access tokens to point to. And then we add the foreign key constraint. This was the least controversial way I could come up with to prevent the exception from happening again.

[1]: https://govuk.sentry.io/issues/3975889554/?project=202251
