### PR TITLE
Move SSO Push check from job creation to job execution time

### DIFF
--- a/app/jobs/permission_updater.rb
+++ b/app/jobs/permission_updater.rb
@@ -6,6 +6,7 @@ class PermissionUpdater < PushUserUpdatesJob
     application = ::Doorkeeper::Application.find_by(id: application_id)
     # It's possible they've been deleted between when the job was scheduled and run.
     return if user.nil? || application.nil?
+    return unless application.supports_push_updates?
 
     api = SSOPushClient.new(application)
     presenter = UserOAuthPresenter.new(user, application)

--- a/app/jobs/push_user_updates_job.rb
+++ b/app/jobs/push_user_updates_job.rb
@@ -7,7 +7,7 @@ class PushUserUpdatesJob < ApplicationJob
 
   class << self
     def perform_on(user)
-      user.applications_used.select(&:supports_push_updates?)
+      user.applications_used
         .each { |application| perform_later(user.uid, application.id) }
     end
   end

--- a/app/jobs/reauth_enforcer.rb
+++ b/app/jobs/reauth_enforcer.rb
@@ -5,6 +5,7 @@ class ReauthEnforcer < PushUserUpdatesJob
     application = ::Doorkeeper::Application.find_by(id: application_id)
     # It's possible the application has been deleted between when the job was scheduled and run.
     return if application.nil?
+    return unless application.supports_push_updates?
 
     api = SSOPushClient.new(application)
     api.reauth_user(uid)

--- a/test/jobs/permission_updater_test.rb
+++ b/test/jobs/permission_updater_test.rb
@@ -11,7 +11,7 @@ class PermissionUpdaterTest < ActiveSupport::TestCase
     SSOPushCredential.user_email = @sso_push_user.email
 
     @user = create(:user)
-    @application = create(:application, redirect_uri: "https://app.com/callback", with_supported_permissions: %w[user_update_permission])
+    @application = create(:application, redirect_uri: "https://app.com/callback", supports_push_updates: true)
     @signin_permission = @user.grant_application_permission(@application, "signin")
     @other_permission = @user.grant_application_permission(@application, "user_update_permission")
   end
@@ -67,6 +67,14 @@ class PermissionUpdaterTest < ActiveSupport::TestCase
         SSOPushClient.expects(:new).never
 
         PermissionUpdater.new.perform(@user.uid, @application.id + 42)
+      end
+
+      should "do nothing if the application doesn't support push updates" do
+        @application = create(:application, supports_push_updates: false)
+
+        SSOPushClient.expects(:new).never
+
+        PermissionUpdater.new.perform(@user.uid, @application.id)
       end
 
       should "not raise if the user has no permissions for the application" do

--- a/test/jobs/push_user_updates_job_test.rb
+++ b/test/jobs/push_user_updates_job_test.rb
@@ -9,26 +9,12 @@ class PushUserUpdatesJobTest < ActiveSupport::TestCase
   context "perform_on" do
     should "perform_async updates on user's used applications" do
       user = create(:user)
-      foo_app, _bar_app = *create_list(:application, 2, supports_push_updates: true)
+      foo_app, _bar_app = *create_list(:application, 2)
 
       # authenticate access
       ::Doorkeeper::AccessToken.create!(resource_owner_id: user.id, application_id: foo_app.id, token: "1234")
 
       assert_enqueued_with(job: TestJob, args: [user.uid, foo_app.id]) do
-        TestJob.perform_on(user)
-      end
-    end
-
-    should "perform_async updates for applications that support push updates" do
-      user = create(:user)
-      yopusha = create(:application, supports_push_updates: true)
-      nopusha = create(:application, supports_push_updates: false)
-
-      # authenticate access
-      ::Doorkeeper::AccessToken.create!(resource_owner_id: user.id, application_id: yopusha.id, token: "1234")
-      ::Doorkeeper::AccessToken.create!(resource_owner_id: user.id, application_id: nopusha.id, token: "5678")
-
-      assert_enqueued_with(job: TestJob, args: [user.uid, yopusha.id]) do
         TestJob.perform_on(user)
       end
     end

--- a/test/jobs/reauth_enforcer_test.rb
+++ b/test/jobs/reauth_enforcer_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class ReauthEnforcerTest < ActiveSupport::TestCase
   context "perform" do
     should "request an app for reauthorising a user" do
-      app = create(:application)
+      app = create(:application, supports_push_updates: true)
       uid = "01aac80d-0bbf-4667-9892-3b304654f3de"
 
       mock_client = mock("sso_push_client")
@@ -17,6 +17,16 @@ class ReauthEnforcerTest < ActiveSupport::TestCase
       SSOPushClient.any_instance.expects(:reauth_user).never
 
       ReauthEnforcer.new.perform("a-uid", 123)
+    end
+
+    should "do nothing if the application doesn't support push updates" do
+      app = create(:application, supports_push_updates: false)
+
+      mock_client = mock("sso_push_client")
+      SSOPushClient.stubs(:new).returns(mock_client)
+      mock_client.expects(:reauth_user).never
+
+      ReauthEnforcer.new.perform("a-uid", app.id)
     end
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/chkpC1am

We've been seeing `SSOPushError` exceptions for an application even having disabled its support for push updates. We believe this is happening, because some jobs were created before support for push updates was disabled, the job then failed, and now it's retrying. And since the check against `Doorkeeper::Application#supports_push_updates?` was only happening at job creation time, the job will keep failing and triggering these exceptions.

By moving the check to job execution time, the failed jobs will succeed when they next retry without triggering an exception. This change will also protect us against something similar happening again in the future.

Note that I had to remove `with_supported_permissions: %w[user_update_permission]` from the creation of the application in `PermissionUpdaterTest#setup`, because that permission now gets automatically added in `Doorkeeper::Application#create_user_update_supported_permission` which is triggered by an `after_save` callback not that `Doorkeeper::Application#supports_push_updates` is `true`. Leaving it in place wasn't an option, because it triggered an exception due to a database uniqueness constraint. In any case, the new setup seems more realistic.
