### PR TITLE
Fix migration adding foreign key constraint to oauth_access_tokens

### DIFF
--- a/db/migrate/20230613153019_add_foreign_key_constraint_to_application_id_on_oauth_access_tokens.rb
+++ b/db/migrate/20230613153019_add_foreign_key_constraint_to_application_id_on_oauth_access_tokens.rb
@@ -1,14 +1,5 @@
 class AddForeignKeyConstraintToApplicationIdOnOauthAccessTokens < ActiveRecord::Migration[7.0]
   def change
-    Doorkeeper::AccessToken.all.select { |at| at.application.nil? }.each do |access_token|
-      Doorkeeper::Application.create!(
-        id: access_token.application_id,
-        name: "Unknown #{access_token.application_id}",
-        redirect_uri: "https://example.com/",
-        description: "Added in migration (previously deleted?)",
-      )
-    end
-
     add_foreign_key :oauth_access_tokens, :oauth_applications, column: :application_id
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/chkpC1am

This fixes the migration that was added in #2201.

It turns out that there are some orphaned `supported_permissions` records in integration which reference the same `application_id` as the orphaned `oauth_access_tokens` records. Unfortunately, because we were using `Doorkeeper::Application.create!` to create the missing applications, the `create_signin_supported_permission` `after_create` callback was being triggered and since an orphan "signin" supported permission already existed, a `Mysql2::Error` was triggered:

    Mysql2::Error: Duplicate entry '3905-signin' for key
    'supported_permissions.index_supported_permissions_on_application_id_and_name'

Originally I attempted to address this by using
`Doorkeeper::Application.insert!` vs `create!` in order to skip the
callbacks and thus avoid the above exception. However, it turns out we
need _some_ of the callbacks (hidden away in the Doorkeeper gem) to set
some non-nullable database fields on `oauth_applications` (`uid` & `secret`).
So, since the orphan records only exist in integration, I decided to fix
them manually in a Rails console using the following code:

```ruby
class ::Doorkeeper::Application < ActiveRecord::Base
  def create_signin_supported_permission; end
end

application_id = 3905
Doorkeeper::Application.create!(
  id: application_id,
  name: "Unknown #{application_id}",
  redirect_uri: "https://example.com/unknown-#{application_id}",
  description: "Added in migration (previously deleted?)",
)

application_id = 3906
Doorkeeper::Application.create!(
  id: application_id,
  name: "Unknown #{application_id}",
  redirect_uri: "https://example.com/unknown-#{application_id}",
  description: "Added in migration (previously deleted?)",
)
```
