### PR TITLE
Don't ask for 2SV code unless they have 2SV setup

### DIFF
--- a/app/controllers/devise/two_step_verification_session_controller.rb
+++ b/app/controllers/devise/two_step_verification_session_controller.rb
@@ -2,6 +2,8 @@ class Devise::TwoStepVerificationSessionController < DeviseController
   layout "admin_layout"
 
   before_action { |c| c.authenticate_user! force: true }
+  before_action :ensure_user_has_2sv_setup
+
   skip_before_action :handle_two_step_verification
 
   def new; end
@@ -35,5 +37,11 @@ class Devise::TwoStepVerificationSessionController < DeviseController
         render :new
       end
     end
+  end
+
+private
+
+  def ensure_user_has_2sv_setup
+    redirect_to root_path unless current_user.has_2sv?
   end
 end

--- a/test/integration/two_step_verification_test.rb
+++ b/test/integration/two_step_verification_test.rb
@@ -107,6 +107,16 @@ class TwoStepVerificationTest < ActionDispatch::IntegrationTest
           assert_response_contains "2-step verification set up"
         end
       end
+
+      context "when visiting the 2SV sign-in page" do
+        setup do
+          visit new_two_step_verification_session_path
+        end
+
+        should "redirect to home page" do
+          assert_response_contains "Make your account more secure"
+        end
+      end
     end
 
     context "for a user with a 2sv exemption reason" do

--- a/test/integration/two_step_verification_test.rb
+++ b/test/integration/two_step_verification_test.rb
@@ -10,7 +10,7 @@ class TwoStepVerificationTest < ActionDispatch::IntegrationTest
       ROTP::Base32.stubs(random_base32: @new_secret)
     end
 
-    context "with an existing 2SV setup" do
+    context "signed in with an existing 2SV setup" do
       setup do
         @user = create(:user, email: "jane.user@example.com", otp_secret_key: @original_secret)
         visit new_user_session_path
@@ -61,46 +61,51 @@ class TwoStepVerificationTest < ActionDispatch::IntegrationTest
         @user = create(:user, email: "jane.user@example.com")
         visit root_path
         signin_with(@user)
-        visit two_step_verification_path
       end
 
-      should "show the TOTP secret" do
-        assert_response_contains "Enter this code when asked: #{@new_secret}"
-      end
-
-      should "reject an invalid code, reuse the secret and log the rejection" do
-        fill_in "code", with: "abcdef"
-        click_button "Finish set up"
-
-        assert_response_contains "Sorry that code didn’t work. Please try again."
-        assert_response_contains "Enter this code when asked: #{@new_secret}"
-        assert_equal 1, EventLog.where(event_id: EventLog::TWO_STEP_ENABLE_FAILED.id, uid: @user.uid).count
-      end
-
-      should "accept a valid code, persist the secret, log an event and notify by email" do
-        success = "2-step verification set up".freeze
-        perform_enqueued_jobs do
-          enter_2sv_code(@new_secret)
-          click_button "Finish set up"
-
-          assert_response_contains success
-          assert_equal @new_secret, @user.reload.otp_secret_key
-          assert_equal 1, EventLog.where(event_id: EventLog::TWO_STEP_ENABLED.id, uid: @user.uid).count
-
-          assert last_email
-          assert success, last_email.subject
-        end
-      end
-
-      should "accept a valid code from a device which has a small time lag" do
-        old_code = Timecop.freeze(29.seconds.ago) { ROTP::TOTP.new(@new_secret).now }
-
-        Timecop.freeze do
-          fill_in "code", with: old_code
-          click_button "Finish set up"
+      context "when visiting the 2SV setup page" do
+        setup do
+          visit two_step_verification_path
         end
 
-        assert_response_contains "2-step verification set up"
+        should "show the TOTP secret" do
+          assert_response_contains "Enter this code when asked: #{@new_secret}"
+        end
+
+        should "reject an invalid code, reuse the secret and log the rejection" do
+          fill_in "code", with: "abcdef"
+          click_button "Finish set up"
+
+          assert_response_contains "Sorry that code didn’t work. Please try again."
+          assert_response_contains "Enter this code when asked: #{@new_secret}"
+          assert_equal 1, EventLog.where(event_id: EventLog::TWO_STEP_ENABLE_FAILED.id, uid: @user.uid).count
+        end
+
+        should "accept a valid code, persist the secret, log an event and notify by email" do
+          success = "2-step verification set up".freeze
+          perform_enqueued_jobs do
+            enter_2sv_code(@new_secret)
+            click_button "Finish set up"
+
+            assert_response_contains success
+            assert_equal @new_secret, @user.reload.otp_secret_key
+            assert_equal 1, EventLog.where(event_id: EventLog::TWO_STEP_ENABLED.id, uid: @user.uid).count
+
+            assert last_email
+            assert success, last_email.subject
+          end
+        end
+
+        should "accept a valid code from a device which has a small time lag" do
+          old_code = Timecop.freeze(29.seconds.ago) { ROTP::TOTP.new(@new_secret).now }
+
+          Timecop.freeze do
+            fill_in "code", with: old_code
+            click_button "Finish set up"
+          end
+
+          assert_response_contains "2-step verification set up"
+        end
       end
     end
 


### PR DESCRIPTION
Trello: https://trello.com/c/YxXfT38U

We've been seeing `NoMethodError` exceptions on `POST` requests to `/users/two_step_verification/session`. The exception was happening deep in the bowels of the ROTP gem, but the reason why it was happening was that `User#otp_secret_key` was `nil`.

I've managed to reproduce the problem with a user that's signed in but doesn't have 2SV setup, by visiting the `/users/two_step_verification/session/new path` (entered directly into the browser location) and submitting a code. Since the user doesn't have 2SV setup, `User#otp_secret_key` is `nil` and the exception is raised in `Devise::TwoStepVerificationSessionController#create`.

I haven't managed to track down a place where the application might send a user in this state to this page, so that remains a bit of a mystery. However, in any case it makes sense to add a belt-and-braces before filter to redirect the user to the home page where there will be the option to setup 2SV if they want to.
