### PR TITLE
Avoid ActionView::TemplateError on signin-required page

### DIFF
--- a/app/helpers/root_helper.rb
+++ b/app/helpers/root_helper.rb
@@ -1,6 +1,6 @@
 module RootHelper
   def gds_only_application_and_non_gds_user?(application)
-    application.gds_only? && !current_user.belongs_to_gds?
+    application.present? && application.gds_only? && !current_user.belongs_to_gds?
   end
 
   def signin_required_title(application)

--- a/test/helpers/root_helper_test.rb
+++ b/test/helpers/root_helper_test.rb
@@ -1,0 +1,36 @@
+require "test_helper"
+
+class RootHelperTest < ActionView::TestCase
+  attr_reader :application, :current_user
+
+  setup do
+    @application = build(:application)
+    @current_user = build(:user)
+  end
+
+  context "#gds_only_application_and_non_gds_user?" do
+    should "returns false if application is not GDS-only and user belongs to GDS" do
+      application.stubs(:gds_only?).returns(false)
+      current_user.stubs(:belongs_to_gds?).returns(true)
+      assert_not gds_only_application_and_non_gds_user?(application)
+    end
+
+    should "returns false if application is not GDS-only and user does not belong to GDS" do
+      application.stubs(:gds_only?).returns(false)
+      current_user.stubs(:belongs_to_gds?).returns(false)
+      assert_not gds_only_application_and_non_gds_user?(application)
+    end
+
+    should "returns false if application is GDS-only and user belongs to GDS" do
+      application.stubs(:gds_only?).returns(true)
+      current_user.stubs(:belongs_to_gds?).returns(true)
+      assert_not gds_only_application_and_non_gds_user?(application)
+    end
+
+    should "returns true if application is GDS-only and user does not belong to GDS" do
+      application.stubs(:gds_only?).returns(true)
+      current_user.stubs(:belongs_to_gds?).returns(false)
+      assert gds_only_application_and_non_gds_user?(application)
+    end
+  end
+end

--- a/test/helpers/root_helper_test.rb
+++ b/test/helpers/root_helper_test.rb
@@ -9,6 +9,10 @@ class RootHelperTest < ActionView::TestCase
   end
 
   context "#gds_only_application_and_non_gds_user?" do
+    should "returns false if application is nil" do
+      assert_not gds_only_application_and_non_gds_user?(nil)
+    end
+
     should "returns false if application is not GDS-only and user belongs to GDS" do
       application.stubs(:gds_only?).returns(false)
       current_user.stubs(:belongs_to_gds?).returns(true)


### PR DESCRIPTION
Trello: https://trello.com/c/RPnXXRR2

We've been seeing `ActionView::TemplateError` exceptions on this page. It seems as if it's possible for the `application` to be `nil` which seems to be reinforced by the use of `Object#try` when setting `session[:signin_missing_for_application]` in `SigninRequiredAuthorizationsController` actions.

I did try to work out under what circumstances the `application` might not be set, but it's really hard to follow all the code involving the Devise, Doorkeeper and/or Pundit gems. So for the moment, I've just added a guard condition to `RootHelper#gds_only_application_and_non_gds_user?` to make sure the user doesn't end up seeing an error page.