### PR TITLE
Use design system for batch invitations show

### DIFF
--- a/app/controllers/batch_invitations_controller.rb
+++ b/app/controllers/batch_invitations_controller.rb
@@ -7,6 +7,8 @@ class BatchInvitationsController < ApplicationController
   helper_method :applications_and_permissions
   helper_method :recent_batch_invitations
 
+  layout "admin_layout", only: %w[show]
+
   def new
     @batch_invitation = BatchInvitation.new(organisation_id: current_user.organisation_id)
     authorize @batch_invitation

--- a/app/views/batch_invitations/show.html.erb
+++ b/app/views/batch_invitations/show.html.erb
@@ -1,50 +1,56 @@
 <% content_for :title, "Creating a batch of users" %>
 
 <% if @batch_invitation.in_progress? %>
-  <% content_for(:content_for_head) do %>
+  <% content_for(:head) do %>
     <meta http-equiv="refresh" content="3">
   <% end %>
 <% end %>
 
-<div class="page-title">
-  <h1>Creating a batch of users</h1>
-</div>
-
 <% if @batch_invitation.in_progress? %>
-  <div class="alert alert-info">
-    <%= batch_invite_status_message(@batch_invitation) %>
-  </div>
+  <%= render "govuk_publishing_components/components/notice", {
+    title: batch_invite_status_message(@batch_invitation)
+  } %>
 <% elsif @batch_invitation.all_successful? %>
-  <div class="alert alert-success">
-    <%= batch_invite_status_message(@batch_invitation) %>
-  </div>
+  <%= render "govuk_publishing_components/components/success_alert", {
+    message: batch_invite_status_message(@batch_invitation)
+  } %>
 <% else %>
-  <div class="alert alert-danger">
-    <%= batch_invite_status_message(@batch_invitation) %>
-  </div>
+  <%= render "govuk_publishing_components/components/error_alert", {
+    message: batch_invite_status_message(@batch_invitation)
+  } %>
 <% end %>
 
-<table class="batch-invitation-users table table-bordered">
-  <thead>
-    <tr class="table-header">
-      <th>Name</th>
-      <th>Email</th>
-      <th>Organisation</th>
-      <th>Outcome</th>
-    </tr>
-  </thead>
-  <tbody>
-    <% @batch_invitation.batch_invitation_users.each do |user| %>
-      <tr class="<%= user.outcome == "failed" ? "error" : "" %>">
-        <td><%= user.name %></td>
-        <td><%= user.email %></td>
-        <td><%= batch_invite_organisation_for_user(user) %></td>
-        <td><%= user.humanized_outcome %></td>
-      </tr>
-    <% end %>
-  </tbody>
-</table>
-
-<div class="well">
-  <%= link_to "All users", users_path, class: "btn btn-primary" %>
-</div>
+<%= render "govuk_publishing_components/components/table", {
+  caption: "Users processed in this batch",
+  caption_classes: "govuk-visually-hidden",
+  head: [
+    {
+      text: "Name"
+    },
+    {
+      text: "Email",
+    },
+    {
+      text: "Organisation",
+    },
+    {
+      text: "Outcome",
+    },
+  ],
+  rows: @batch_invitation.batch_invitation_users.map do |user|
+  [
+    {
+      text: user.name
+    },
+    {
+      text: user.email,
+    },
+    {
+      text: batch_invite_organisation_for_user(user),
+    },
+    {
+      text: user.humanized_outcome,
+    },
+  ]
+  end,
+  } %>

--- a/app/views/batch_invitations/show.html.erb
+++ b/app/views/batch_invitations/show.html.erb
@@ -1,4 +1,26 @@
 <% content_for :title, "Creating a batch of users" %>
+<% content_for :breadcrumbs,
+   render("govuk_publishing_components/components/breadcrumbs", {
+     collapse_on_mobile: true,
+     breadcrumbs: [
+       {
+         title: "Home",
+         url: root_path,
+       },
+       {
+         title: "Users",
+         url: users_path,
+       },
+       {
+         title: "Upload a batch of users",
+         url: new_batch_invitation_path,
+       },
+       {
+         title: "Creating a batch of users",
+       }
+     ]
+   })
+%>
 
 <% if @batch_invitation.in_progress? %>
   <% content_for(:head) do %>

--- a/app/views/layouts/admin_layout.html.erb
+++ b/app/views/layouts/admin_layout.html.erb
@@ -14,6 +14,8 @@
   <div class="govuk-width-container">
     <% if yield(:back_link).present? %>
       <%= render "govuk_publishing_components/components/back_link", href: yield(:back_link) %>
+    <% elsif yield(:breadcrumbs).present? %>
+      <%= yield(:breadcrumbs) %>
     <% end %>
 
     <main class="govuk-main-wrapper" id="main-content" role="main">

--- a/test/controllers/batch_invitations_controller_test.rb
+++ b/test/controllers/batch_invitations_controller_test.rb
@@ -178,9 +178,9 @@ class BatchInvitationsControllerTest < ActionController::TestCase
 
     should "list the users being created" do
       get :show, params: { id: @bi.id }
-      assert_select "table.batch-invitation-users tbody tr", 2
-      assert_select "table.batch-invitation-users td", "a@m.com"
-      assert_select "table.batch-invitation-users td", "b@m.com"
+      assert_select "table tbody tr", 2
+      assert_select "table td", "a@m.com"
+      assert_select "table td", "b@m.com"
     end
 
     should "include a meta refresh" do
@@ -191,8 +191,8 @@ class BatchInvitationsControllerTest < ActionController::TestCase
     should "show the state of the processing" do
       @user1.update_column(:outcome, "failed")
       get :show, params: { id: @bi.id }
-      assert_select "div.alert", /In progress/i
-      assert_select "div.alert", /1 of 2 users processed/i
+      assert_select "section.gem-c-notice", /In progress/i
+      assert_select "section.gem-c-notice", /1 of 2 users processed/i
     end
 
     should "show the outcome for each user" do
@@ -208,7 +208,7 @@ class BatchInvitationsControllerTest < ActionController::TestCase
       end
 
       should "show the state of the processing" do
-        assert_select "div.alert", "2 users processed."
+        assert_select "div.gem-c-success-alert", /2 users processed/
       end
 
       should "no longer include the meta refresh" do


### PR DESCRIPTION
Trello: https://trello.com/c/jPK7WHy8/135-migrate-batchinvitations-to-use-design-system

This PR migrates the batch invitations show page (e.g. http://signon.dev.gov.uk/batch_invitations/1) to use the design system. 

I've made the following significant choices: 

1. Use the `notice` component to indicate when a batch is still being processed (the previous `alert-info` div)
2. Use a `success_alert` component to indicate that all records were successfully processed (the previous `alert-success` div)
3. Use an `error_alert` component to indicate if one or more records in the batch couldn't be processed (the previous `alert-danger` div). The previous alert didn't provide a mechanism for the user to fix the error so for now I've retained that behaviour by using an `error_alert` rather than a `form_error_summary` for example.
4. I've removed the button to link to "All users". The design system docs suggest that buttons should only be used to "move through a transaction" and that isn't really what it was doing here. I've instead added a breadcrumb trail which includes "all users" to reinstate the behaviour provided by this button.

# Before
![before](https://github.com/alphagov/signon/assets/16707/c7bd2920-a434-4b6c-96e9-e72a726d59e7)

# After
![success](https://github.com/alphagov/signon/assets/16707/27e8f87a-12ee-4b15-95d6-d6d0b41c996b)
![in_progress](https://github.com/alphagov/signon/assets/16707/419551e7-5545-48a4-a4a8-dc16caabb057)
![error](https://github.com/alphagov/signon/assets/16707/2ddcf052-b77a-4b44-ac36-852dffde2ae3)


