### PR TITLE
Improve logging of failed batch invitations

### DIFF
--- a/app/models/batch_invitation_user.rb
+++ b/app/models/batch_invitation_user.rb
@@ -19,8 +19,9 @@ class BatchInvitationUser < ApplicationRecord
     )
 
     invite_user_with_attributes(sanitised_attributes, inviting_user)
-  rescue InvalidOrganisationSlug
+  rescue InvalidOrganisationSlug => e
     update_column(:outcome, "failed")
+    GovukError.notify(e)
   end
 
   def humanized_outcome
@@ -67,9 +68,11 @@ private
           update_column(:outcome, "success")
         else
           update_column(:outcome, "failed")
+          GovukError.notify("User not persisted", extras: sanitised_attributes.to_h)
         end
-      rescue StandardError
+      rescue StandardError => e
         update_column(:outcome, "failed")
+        GovukError.notify(e, extras: sanitised_attributes.to_h)
       end
     end
   end

--- a/test/models/batch_invitation_user_test.rb
+++ b/test/models/batch_invitation_user_test.rb
@@ -53,6 +53,13 @@ class BatchInvitationUserTest < ActiveSupport::TestCase
 
         assert_equal "failed", user.reload.outcome
       end
+
+      should "log the error" do
+        GovukError.expects(:notify).once
+
+        user = create(:batch_invitation_user, batch_invitation: @batch_invitation)
+        user.invite(@inviting_user, [])
+      end
     end
 
     context "the user could not be saved (eg email is blank)" do
@@ -62,6 +69,13 @@ class BatchInvitationUserTest < ActiveSupport::TestCase
 
         assert_equal "failed", user.reload.outcome
       end
+
+      should "log the error" do
+        GovukError.expects(:notify).once
+
+        user = create(:batch_invitation_user, batch_invitation: @batch_invitation, email: nil)
+        user.invite(@inviting_user, [])
+      end
     end
 
     context "organisation slug is invalid" do
@@ -70,6 +84,13 @@ class BatchInvitationUserTest < ActiveSupport::TestCase
         user.invite(@inviting_user, [])
 
         assert_equal "failed", user.reload.outcome
+      end
+
+      should "log the error" do
+        GovukError.expects(:notify).once
+
+        user = create(:batch_invitation_user, batch_invitation: @batch_invitation, email: "foo@example.com", organisation_slug: "not-a-real-slug")
+        user.invite(@inviting_user, [])
       end
     end
   end

--- a/test/models/batch_invitation_user_test.rb
+++ b/test/models/batch_invitation_user_test.rb
@@ -42,6 +42,19 @@ class BatchInvitationUserTest < ActiveSupport::TestCase
       end
     end
 
+    context "inviting the user raises an exception" do
+      setup do
+        User.expects(:invite!).raises(StandardError)
+      end
+
+      should "record a failure outcome" do
+        user = create(:batch_invitation_user, batch_invitation: @batch_invitation)
+        user.invite(@inviting_user, [])
+
+        assert_equal "failed", user.reload.outcome
+      end
+    end
+
     context "the user could not be saved (eg email is blank)" do
       should "record it as a failure" do
         user = create(:batch_invitation_user, batch_invitation: @batch_invitation, email: nil)


### PR DESCRIPTION
Trello: https://trello.com/c/8oHupLq2/138-investigate-errors-with-uploading-batch-of-users-to-production

We've recently received notice that a user attempted to upload a batch of users and some or all of those users failed. We don't currently provide much guidance to the user on why their batches have failed, and in fact, we don't receive any information as the product team because those exceptions are currently being rescued silently.

This commit logs (via `GovukError`) some information about why the process failed, and I'm hoping we'll be able to use that information to improve the experience for the users, or at least be able to deal with their issues manually via the second-line process.
