### PR TITLE
Migrate api_users new page to design system

### DIFF
--- a/app/controllers/api_users_controller.rb
+++ b/app/controllers/api_users_controller.rb
@@ -1,7 +1,7 @@
 class ApiUsersController < ApplicationController
   include UserPermissionsControllerMethods
 
-  layout "admin_layout", only: %w[index]
+  layout "admin_layout", only: %w[index new create]
 
   before_action :authenticate_user!
   before_action :load_and_authorize_api_user, only: %i[edit update]

--- a/app/views/api_users/new.html.erb
+++ b/app/views/api_users/new.html.erb
@@ -1,9 +1,45 @@
 <% content_for :title, "Create new API user" %>
 
-<h1>Create new API user</h1>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @api_user do |f| %>
+      <% if @api_user.errors.present? %>
+        <%= render "govuk_publishing_components/components/error_summary", {
+          id: "error-summary",
+          title: "There was a problem with your new API user",
+          items: @api_user.errors.map do |error|
+          {
+            text: error.full_message,
+            href: "#api_user_#{error.attribute}",
+          }
+          end
+          } %>
+      <% end %>
 
-<%= form_for @api_user, html: { class: 'well add-top-margin' } do |f| %>
-  <%= render partial: "form_fields", locals: { f: f } %>
+      <%= render "govuk_publishing_components/components/input", {
+        label: {
+          text: "Name"
+        },
+        name: "api_user[name]",
+        id: "api_user_name",
+        error_items: @api_user.errors.full_messages_for(:name).map {|message| { text: message } },
+        value: @api_user.name,
+        } %>
 
-  <%= f.submit "Create API user", :class => 'btn btn-success add-top-margin' %>
-<% end %>
+      <%= render "govuk_publishing_components/components/input", {
+        label: {
+          text: "Email"
+        },
+        name: "api_user[email]",
+        id: "api_user_email",
+        type: "email",
+        error_items: @api_user.errors.full_messages_for(:email).map {|message| { text: message } },
+        value: @api_user.email,
+        } %>
+
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Create API user"
+        } %>
+    <% end %>
+  </div>
+</div>

--- a/test/controllers/api_users_controller_test.rb
+++ b/test/controllers/api_users_controller_test.rb
@@ -59,7 +59,7 @@ class ApiUsersControllerTest < ActionController::TestCase
         post :create, params: { api_user: { name: "Content Store Application", email: "content.store at gov uk" } }
 
         assert_template :new
-        assert_select "div.alert ul li", "Email is invalid"
+        assert_select "div.govuk-error-summary", /Email is invalid/
       end
     end
 


### PR DESCRIPTION
Trello: https://trello.com/c/XwCQCdMu/140-migrate-apiusers-new-to-use-design-system

This commit moves the api_users new page to use the design system. The changes here should be fairly uncontroversial, but have involved rewriting most of the template.

I've specified that the `create` action should use the `admin_layout` in the ApiUsersController so that the correct layout is used when the page re-renders on validation error.

The `_form_fields` partial referenced in the old template is still used by the `edit` view, which will be migrated as a separate piece of work.

I've had to slightly change the integration test to target the error summary div provided by the design system, and to use a regex to match the text rather than an exact string (since the design system `error_summary` partial suggests adding a title).

# Before
![old](https://github.com/alphagov/signon/assets/16707/cdb826a4-9c53-428c-8018-da46cbc8be8f)

# After
![new](https://github.com/alphagov/signon/assets/16707/c5e01aa1-dae4-4e29-84a2-6986c02de7a8)
![errors](https://github.com/alphagov/signon/assets/16707/be337e32-9d31-4eaa-b67f-84b83660f414)


