### PR TITLE
Migrate authorisations new to design system

### DIFF
--- a/app/controllers/authorisations_controller.rb
+++ b/app/controllers/authorisations_controller.rb
@@ -1,6 +1,8 @@
 class AuthorisationsController < ApplicationController
   include UserPermissionsControllerMethods
 
+  layout "admin_layout", only: %w[new]
+
   before_action :authenticate_user!
   before_action :load_and_authorize_api_user
 

--- a/app/views/authorisations/new.html.erb
+++ b/app/views/authorisations/new.html.erb
@@ -1,4 +1,26 @@
 <% content_for :title, "Create new access token for \"#{@api_user.name}\"" %>
+<% content_for :breadcrumbs,
+   render("govuk_publishing_components/components/breadcrumbs", {
+     collapse_on_mobile: true,
+     breadcrumbs: [
+       {
+         title: "Home",
+         url: root_path,
+       },
+       {
+         title: "API users",
+         url: api_users_path,
+       },
+       {
+         title: "Edit API user",
+         url: edit_api_user_path(@api_user),
+       },
+       {
+         title: "Create new access token",
+       }
+     ]
+   })
+%>
 
 <%= form_for @authorisation, url: [:api_user, :authorisations] do |_| %>
   <%= render "govuk_publishing_components/components/select", {

--- a/app/views/authorisations/new.html.erb
+++ b/app/views/authorisations/new.html.erb
@@ -1,13 +1,14 @@
-<% content_for :title, "Create new access token" %>
+<% content_for :title, "Create new access token for \"#{@api_user.name}\"" %>
 
-<h1>Create new access token for "<%= @api_user.name %>"</h1>
+<%= form_for @authorisation, url: [:api_user, :authorisations] do |_| %>
+  <%= render "govuk_publishing_components/components/select", {
+    id: "doorkeeper_access_token_application_id",
+    label: "Application",
+    name: "doorkeeper_access_token[application_id]",
+    options: Doorkeeper::Application.all.map { |application| { text: application.name, value: application.id } }
+    } %>
 
-<%= form_for @authorisation, url: [:api_user, :authorisations], html: { class: 'well add-top-margin' } do |f| %>
-
-  <p class="form-group">
-    <%= f.label :application_id %><br />
-    <%= f.select :application_id, options_from_collection_for_select(Doorkeeper::Application.all, 'id', 'name'), {}, class: "chosen-select form-control" %>
-  </p>
-
-  <%= f.submit "Create access token", :class => 'btn btn-success add-top-margin' %>
+  <%= render "govuk_publishing_components/components/button", {
+    text: "Create access token"
+    } %>
 <% end %>


### PR DESCRIPTION
Use the design system to render the authorisations new page (e.g. `/api_users/1/authorisations/new`).

# Before 

![before](https://github.com/alphagov/signon/assets/16707/3a2aa9e6-4ca5-4582-999f-0dba7efc2d84)

# After

![after](https://github.com/alphagov/signon/assets/16707/271e2f4e-3e87-404a-b6e9-27143b8b1751)
