### PR TITLE
Populate missing created_at timestamps in Doorkeeper::Application models

### DIFF
--- a/db/migrate/20230622122857_add_missing_application_created_at_timestamps.rb
+++ b/db/migrate/20230622122857_add_missing_application_created_at_timestamps.rb
@@ -1,0 +1,5 @@
+class AddMissingApplicationCreatedAtTimestamps < ActiveRecord::Migration[7.0]
+  def up
+    Doorkeeper::Application.where(created_at: nil).update_all(created_at: Date.parse("2012-01-01"))
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_13_153019) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_22_122857) do
   create_table "batch_invitation_application_permissions", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "batch_invitation_id", null: false
     t.integer "supported_permission_id", null: false


### PR DESCRIPTION
We've got 3 records in oauth_applications where the created_at timestamp is null.

```
Doorkeeper::Application.table_name
=> "oauth_applications"

Doorkeeper::Application.where(created_at: nil).count
=> 3

Doorkeeper::Application.where(created_at: nil).map(&:name)
=> ["Panopticon", "Publisher", "Whitehall"]
```

These missing timestamps are causing the following [exception when viewing /oauth/authorized_applications][1].

```
ActionView::Template::Error /oauth/authorized_applications

undefined method `strftime' for nil:NilClass
```

The exception is being raised in [the Doorkeeper template][2].

The [oauth_applications table doesn't allow null values in the created_at field][3] so I'm unclear on how we've got these entries.

The earliest created_at in the table is 27 Apr 2012 so I've chosen to set the created_at for these 3 apps to be 1 Jan 2012:

```
Doorkeeper::Application.all.map(&:created_at).compact.sort.first
=> Fri, 27 Apr 2012 15:47:26.000000000 BST +01:00
```

[1]: https://govuk.sentry.io/issues/4267814895/activity/?project=202251
[2]: https://github.com/doorkeeper-gem/doorkeeper/blob/b3d6787341561e5bc51336e3e04622ca131d6445/app/views/doorkeeper/authorized_applications/index.html.erb#L18
[3]: https://github.com/alphagov/signon/blob/36309ededd35a9e18b7712a25b2af7f9f0b397aa/db/schema.rb#L107