### PR TITLE
Move bulk_grant_permission_sets/new page to design system

### DIFF
--- a/app/controllers/bulk_grant_permission_sets_controller.rb
+++ b/app/controllers/bulk_grant_permission_sets_controller.rb
@@ -1,11 +1,7 @@
 class BulkGrantPermissionSetsController < ApplicationController
-  include UserPermissionsControllerMethods
-
   layout "admin_layout", only: %w[new create]
 
   before_action :authenticate_user!
-
-  helper_method :applications_and_permissions
 
   def new
     @bulk_grant_permission_set = BulkGrantPermissionSet.new

--- a/app/controllers/bulk_grant_permission_sets_controller.rb
+++ b/app/controllers/bulk_grant_permission_sets_controller.rb
@@ -1,5 +1,8 @@
 class BulkGrantPermissionSetsController < ApplicationController
   include UserPermissionsControllerMethods
+
+  layout "admin_layout", only: %w[new create]
+
   before_action :authenticate_user!
 
   helper_method :applications_and_permissions
@@ -11,7 +14,8 @@ class BulkGrantPermissionSetsController < ApplicationController
 
   def create
     @bulk_grant_permission_set = BulkGrantPermissionSet.new(user: current_user)
-    @bulk_grant_permission_set.supported_permission_ids = params[:user][:supported_permission_ids] if params[:user]
+    application = Doorkeeper::Application.find_by(id: params[:application_id])
+    @bulk_grant_permission_set.supported_permission_ids = [application.signin_permission.id]
     authorize @bulk_grant_permission_set
 
     if @bulk_grant_permission_set.save

--- a/app/helpers/bulk_grant_permission_sets_helper.rb
+++ b/app/helpers/bulk_grant_permission_sets_helper.rb
@@ -1,6 +1,7 @@
 module BulkGrantPermissionSetsHelper
   def bulk_grant_permission_set_applications
     Pundit.policy_scope(current_user, :user_permission_manageable_application)
+      .reject(&:retired?)
   end
 
   def bulk_grant_permission_set_status_message(bulk_grant_permission_set)

--- a/app/helpers/bulk_grant_permission_sets_helper.rb
+++ b/app/helpers/bulk_grant_permission_sets_helper.rb
@@ -1,4 +1,8 @@
 module BulkGrantPermissionSetsHelper
+  def bulk_grant_permission_set_applications
+    Pundit.policy_scope(current_user, :user_permission_manageable_application)
+  end
+
   def bulk_grant_permission_set_status_message(bulk_grant_permission_set)
     if bulk_grant_permission_set.in_progress?
       "In progress. #{bulk_grant_permission_set.processed_users} of #{bulk_grant_permission_set.total_users} users processed."

--- a/app/views/bulk_grant_permission_sets/new.html.erb
+++ b/app/views/bulk_grant_permission_sets/new.html.erb
@@ -1,25 +1,14 @@
-<% content_for :title, "Grant permissions to all users" %>
+<% content_for :title, "Grant access to all users" %>
 
-<div class="page-title">
-  <h1>Grant permissions to all users</h1>
-</div>
+<%= form_for @bulk_grant_permission_set do |f| %>
+  <%= render "govuk_publishing_components/components/select", {
+    id: "application_id",
+    label: "Application",
+    name: "application_id",
+    options: Doorkeeper::Application.all.map { |application| { text: application.name, value: application.id } }
+    } %>
 
-<div class="well">
-  <%= form_for @bulk_grant_permission_set do |f| %>
-    <h2>Permissions to grant</h2>
-
-    <% if @bulk_grant_permission_set.errors.count > 0 %>
-      <div class="alert alert-danger">
-        <ul>
-          <% @bulk_grant_permission_set.errors.full_messages.each do |message| %>
-            <%= content_tag :li, message %>
-          <% end %>
-        </ul>
-      </div>
-    <% end %>
-
-    <%= render partial: "shared/user_permissions", locals: { user_object: User.new } %>
-
-    <%= f.submit "Grant permissions to all users", :class => 'btn btn-success' %>
-  <% end %>
-</div>
+  <%= render "govuk_publishing_components/components/button", {
+    text: "Grant access to all users"
+    } %>
+<% end %>

--- a/app/views/bulk_grant_permission_sets/new.html.erb
+++ b/app/views/bulk_grant_permission_sets/new.html.erb
@@ -5,7 +5,7 @@
     id: "application_id",
     label: "Application",
     name: "application_id",
-    options: Doorkeeper::Application.all.map { |application| { text: application.name, value: application.id } }
+    options: bulk_grant_permission_set_applications.map { |application| { text: application.name, value: application.id } }
     } %>
 
   <%= render "govuk_publishing_components/components/button", {

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -8,7 +8,7 @@
       <%= link_to "Upload a batch of users", new_batch_invitation_path, class: "btn btn-default add-right-margin" %>
     <% end %>
     <% if policy(BulkGrantPermissionSet).new? %>
-      <%= link_to "Grant permissions to all users", new_bulk_grant_permission_set_path, class: "btn btn-default" %>
+      <%= link_to "Grant access to all users", new_bulk_grant_permission_set_path, class: "btn btn-default" %>
     <% end %>
   </div>
 </div>

--- a/test/helpers/bulk_grant_permission_sets_helper_test.rb
+++ b/test/helpers/bulk_grant_permission_sets_helper_test.rb
@@ -7,6 +7,7 @@ class BulkGrantPermissionSetsHelperTest < ActionView::TestCase
     setup do
       @first_application = create(:application, name: "Application A")
       @second_application = create(:application, name: "Application B")
+      @retired_application = create(:application, retired: true)
     end
 
     context "for a superadmin" do
@@ -14,7 +15,7 @@ class BulkGrantPermissionSetsHelperTest < ActionView::TestCase
         @current_user = create(:user, role: "superadmin")
       end
 
-      should "return all applications in alphabetical order" do
+      should "return all non-retired applications in alphabetical order" do
         assert_equal [@first_application, @second_application], bulk_grant_permission_set_applications
       end
     end
@@ -24,7 +25,7 @@ class BulkGrantPermissionSetsHelperTest < ActionView::TestCase
         @current_user = create(:user, role: "admin")
       end
 
-      should "return all applications in alphabetical order" do
+      should "return all non-retired applications in alphabetical order" do
         assert_equal [@first_application, @second_application], bulk_grant_permission_set_applications
       end
     end

--- a/test/helpers/bulk_grant_permission_sets_helper_test.rb
+++ b/test/helpers/bulk_grant_permission_sets_helper_test.rb
@@ -1,0 +1,32 @@
+require "test_helper"
+
+class BulkGrantPermissionSetsHelperTest < ActionView::TestCase
+  attr_reader :current_user
+
+  context "#bulk_grant_permission_set_applications" do
+    setup do
+      @first_application = create(:application, name: "Application A")
+      @second_application = create(:application, name: "Application B")
+    end
+
+    context "for a superadmin" do
+      setup do
+        @current_user = create(:user, role: "superadmin")
+      end
+
+      should "return all applications in alphabetical order" do
+        assert_equal [@first_application, @second_application], bulk_grant_permission_set_applications
+      end
+    end
+
+    context "for an admin" do
+      setup do
+        @current_user = create(:user, role: "admin")
+      end
+
+      should "return all applications in alphabetical order" do
+        assert_equal [@first_application, @second_application], bulk_grant_permission_set_applications
+      end
+    end
+  end
+end

--- a/test/integration/bulk_granting_permisions_test.rb
+++ b/test/integration/bulk_granting_permisions_test.rb
@@ -15,21 +15,13 @@ class BulkGrantingPermissionsTest < ActionDispatch::IntegrationTest
   should "superadmin user can grant multiple permissions to all users in one go" do
     user = create(:superadmin_user)
 
-    permissions = {
-      @application => %w[signin],
-    }
-
-    perform_bulk_grant_as_user(user, permissions)
+    perform_bulk_grant_as_user(user, @application)
   end
 
   should "admin user can grant multiple permissions to all users in one go" do
     user = create(:admin_user)
 
-    permissions = {
-      @application => %w[signin],
-    }
-
-    perform_bulk_grant_as_user(user, permissions)
+    perform_bulk_grant_as_user(user, @application)
   end
 
   should "super organisation admin user can not grant multiple permissions to all users in one go" do
@@ -62,42 +54,28 @@ class BulkGrantingPermissionsTest < ActionDispatch::IntegrationTest
     assert_equal root_path, current_path
   end
 
-  def perform_bulk_grant_as_user(acting_user, permissions)
+  def perform_bulk_grant_as_user(acting_user, application)
     perform_enqueued_jobs do
       visit root_path
       signin_with(acting_user)
 
       visit new_bulk_grant_permission_set_path
 
-      select permissions.keys.first.name, from: "Application"
+      select application.name, from: "Application"
 
       click_button "Grant access to all users"
 
-      assert_response_contains("Scheduled grant of #{permissions.map { |_app, perms| perms.count }.inject(:+)} permissions to all users")
+      assert_response_contains("Scheduled grant of 1 permissions to all users")
       assert_response_contains("Granting permissions to all users")
       assert_response_contains("All #{User.all.count} users processed")
 
-      permissions.each do |application, app_permissions|
-        app_permissions_line = "#{application.name} "
-        app_permissions_line <<
-          if app_permissions.include? "signin"
-            "Yes"
-          else
-            "No"
-          end
-        assert_response_contains app_permissions_line
-      end
+      app_permissions_line = "#{application.name} Yes"
+      assert_response_contains app_permissions_line
 
       [acting_user, @users, @org_admins, @admins, @superadmins].flatten.each do |user|
         user.reload
-        assert_has_permissions user, permissions
+        assert_equal %w[signin], user.permissions_for(application)
       end
-    end
-  end
-
-  def assert_has_permissions(user, permissions)
-    permissions.each do |application, app_permissions|
-      assert_equal app_permissions.sort, user.permissions_for(application).sort
     end
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/Kf19VBou/148-migrate-bulkgrantpermissionsets-new-to-use-design-system

We've decided to replace this page with a simple form that allows an admin to grant the signin permission to all users for a specific application, since that is all the current system seems to be used for (there are three BulkGrantPermissionSet records in the production database, and they all grant "signin" permission to one or two applications).

This means we don't have to worry about finding a design-system alternative for the permissions multi-select box.

We think this can be extended to include specific permissions at a later date (perhaps as a second "step" in the flow) if we want/need to.

We still have a page that shows the results of previous runs of this bulk update (e.g. `http://signon.dev.gov.uk/bulk_grant_permission_sets/1`) so I haven't been able to simplify the code in BulkGrantPermissionSet any further at this stage. Perhaps when we come to port that page to the design system we can decide if we want to continue to support viewing details of batches that were processed with multiple applications and/or permissions and simplify the code further at that point.

# Before

![Screenshot_2023-06-26_14-35-41](https://github.com/alphagov/signon/assets/16707/f3ef8401-b045-4170-8848-0285c2225dd1)

# After

![Screenshot_2023-06-26_14-35-10](https://github.com/alphagov/signon/assets/16707/3f7baf34-42c2-4527-b2ac-7c80b6bc9891)



