### PR TITLE
Add client side validation to catch common 2sv code errors

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,4 +1,5 @@
 //= require govuk_publishing_components/dependencies
 //= require govuk_publishing_components/all_components
 //= require password-strength-indicator
+//= require two-factor-validation-error
 //= require rails-ujs

--- a/app/assets/javascripts/two-factor-validation-error.js
+++ b/app/assets/javascripts/two-factor-validation-error.js
@@ -1,0 +1,22 @@
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function (Modules) {
+  'use strict'
+
+  function TwoFactorValidationError (module) {
+    this.module = module
+  }
+
+  TwoFactorValidationError.prototype.init = function () {
+    this.module.oninvalid = function (event) {
+      event.target.setCustomValidity('This code should contain 6 digits with no spaces')
+    }
+
+    this.module.oninput = function (event) {
+      event.target.setCustomValidity('')
+    }
+  }
+
+  Modules.TwoFactorValidationError = TwoFactorValidationError
+})(window.GOVUK.Modules)

--- a/app/views/devise/two_step_verification/show.html.erb
+++ b/app/views/devise/two_step_verification/show.html.erb
@@ -48,17 +48,19 @@
 
 <h2 id="enter-code" class="govuk-heading-m">3. Enter the verification code shown in the app</h2>
 
-<%= form_tag two_step_verification_path, method: :put do %>
+<%= form_tag two_step_verification_path, method: :put, id: "code_input" do %>
   <%= hidden_field_tag :otp_secret_key, @otp_secret_key%>
 
   <%= render "govuk_publishing_components/components/input", {
     label: { text: "Code from app" },
     hint: "Enter 6-digit code",
     name: "code",
-    type: "text",
+    type: "number",
+    pattern: "^[0-9]{6}$",
     width: 10,
+    data: { module: "two-factor-validation-error"},
     error_message: flash[:invalid_code]
-  } %>
+    } %>
 
   <div class="govuk-button-group">
     <%= render "govuk_publishing_components/components/button", {


### PR DESCRIPTION
Trello: https://trello.com/c/eZussIrd/158-accept-2sv-codes-with-spaces

We've had reports from our users that when they type in the code from their 2sv application, if they include a space (which the apps often include in their display between each group of 3 digits) we don't accept the code and the "Sorry that code didn’t work. Please try again." error doesn't help them resolve the issue.

This commit improves things slightly by changing the type of the input field to "number" and including a regex pattern to match 6 consecutive numbers. I've added some JavaScript to further customise the error message (by default it is "Please match the format requested") to be more helpful.

Note that we need to clear the validation message with an `oninput` handler to clear any errors previously set by the `oninvalid` handler if the user has already made an invalid attempt.

We think a longer-term solution to this problem is to improve the input field (for example by having 6 separate boxes, one for each number). I think it would also be a good idea to change the controller code to use a model with validations so that we can do more comprehensive validation of the code on the server side. But those are bigger changes and this feels like a useful improvement to the current behaviour.

<img width="631" alt="Screenshot 2023-06-26 at 16 56 22" src="https://github.com/alphagov/signon/assets/16707/6ab9d38e-4904-492c-9ba5-6dcbf674db07">


