### PR TITLE
Fix batch invitation for organisations that require 2sv

### DIFF
--- a/app/models/batch_invitation_user.rb
+++ b/app/models/batch_invitation_user.rb
@@ -14,6 +14,7 @@ class BatchInvitationUser < ApplicationRecord
         email:,
         organisation_id:,
         supported_permission_ids:,
+        require_2sv:,
       },
       inviting_user,
     )
@@ -52,6 +53,12 @@ class BatchInvitationUser < ApplicationRecord
     else
       @organisation_from_slug = nil
     end
+  end
+
+  def require_2sv
+    Organisation.find(organisation_id).require_2sv?
+  rescue ActiveRecord::RecordNotFound
+    true
   end
 
   class InvalidOrganisationSlug < StandardError; end

--- a/test/integration/batch_inviting_users_test.rb
+++ b/test/integration/batch_inviting_users_test.rb
@@ -99,6 +99,23 @@ class BatchInvitingUsersTest < ActionDispatch::IntegrationTest
     end
   end
 
+  context "when the organisation mandates 2sv" do
+    setup do
+      @user = create(:superadmin_user)
+      @department_of_security = create(
+        :organisation,
+        slug: "department-of-security",
+        name: "Department of Security",
+        require_2sv: true,
+      )
+    end
+
+    should "allow creating users whose details are specified in a CSV file, assigning them all to one org" do
+      perform_batch_invite_with_user(@user, @application, organisation: @department_of_security)
+      assert_user_created_and_invited("fred@example.com", @application, organisation: @department_of_security)
+    end
+  end
+
   def perform_batch_invite_with_user(user, application, organisation:, fixture_file: "users.csv", user_count: 1)
     perform_enqueued_jobs do
       visit root_path

--- a/test/models/batch_invitation_user_test.rb
+++ b/test/models/batch_invitation_user_test.rb
@@ -17,6 +17,7 @@ class BatchInvitationUserTest < ActiveSupport::TestCase
         email: user.email,
         organisation_id: user.organisation_id,
         supported_permission_ids: [1, 2, 3],
+        require_2sv: false,
       )
       User.expects(:invite!).with(invitation_attributes, @inviting_user)
 
@@ -126,6 +127,47 @@ class BatchInvitationUserTest < ActiveSupport::TestCase
       user = create(:batch_invitation_user, batch_invitation: @batch_invitation, organisation_slug: local_organisation.slug)
 
       assert_equal local_organisation.id, user.organisation_id
+    end
+  end
+
+  context "#require_2sv" do
+    should "be true when the organisation provided to the batch requires 2sv" do
+      organisation = create(:organisation, require_2sv: true)
+      batch_invitation = create(:batch_invitation, organisation:)
+      user = create(:batch_invitation_user, batch_invitation:)
+
+      assert user.require_2sv
+    end
+
+    should "be false when the organisation provided to the batch does not require 2sv" do
+      organisation = create(:organisation, require_2sv: false)
+      batch_invitation = create(:batch_invitation, organisation:)
+      user = create(:batch_invitation_user, batch_invitation:)
+
+      assert_not user.require_2sv
+    end
+
+    should "be true when the organisation provided to the user requires 2sv" do
+      user_organisation = create(:organisation, require_2sv: true)
+      batch_invitation = create(:batch_invitation)
+      user = create(:batch_invitation_user, batch_invitation:, organisation_slug: user_organisation.slug)
+
+      assert user.require_2sv
+    end
+
+    should "be false when the organisation provided to the user does not require 2sv" do
+      user_organisation = create(:organisation, require_2sv: false)
+      batch_invitation = create(:batch_invitation)
+      user = create(:batch_invitation_user, batch_invitation:, organisation_slug: user_organisation.slug)
+
+      assert_not user.require_2sv
+    end
+
+    should "be true if no organisation available" do
+      batch_invitation = create(:batch_invitation)
+      user = create(:batch_invitation_user, batch_invitation:)
+
+      assert user.require_2sv
     end
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/8oHupLq2

We've been seeing a "User not persisted" exception in Sentry[1] when a user batch invites users whose organisation requires 2sv. This was because we were not providing the `require_2sv` parameter in the call to `User.invite!`. We've been validating that created users must have `require_2sv` set to `true` when their organisation requires it since c5a4fedc57 but hadn't updated the batch invitation tool to reflect that.

This commit sets the appropriate `require_2sv` value on the invited user. I've made sure that the value is true even when no organisation is provided to the batch or the individual user - I'm not entirely sure if it's possible for the batch upload code to reach that state but given that we're now enforcing 2sv for all users unless they seek an exemption it seems like a sensible fallback value.

[1] e.g. https://govuk.sentry.io/issues/4270811143/?project=202251
