### PR TITLE
Accept 2sv codes with spaces

### DIFF
--- a/app/controllers/devise/two_step_verification_controller.rb
+++ b/app/controllers/devise/two_step_verification_controller.rb
@@ -50,8 +50,9 @@ private
 
   def verify_code_and_update
     @otp_secret_key = params[:otp_secret_key]
-    totp = ROTP::TOTP.new(@otp_secret_key)
-    if totp.verify(params[:code], drift_behind: User::MAX_2SV_DRIFT_SECONDS)
+    result = CodeVerifier.new(params[:code], @otp_secret_key).verify
+
+    if result
       current_user.update!(otp_secret_key: @otp_secret_key, reason_for_2sv_exemption: nil, expiry_date_for_2sv_exemption: nil)
       true
     else

--- a/app/helpers/two_step_verification_helper.rb
+++ b/app/helpers/two_step_verification_helper.rb
@@ -44,4 +44,18 @@ private
       viewbox: true,
     ).html_safe
   end
+
+  def two_factor_code_input(**args)
+    options = {
+      label: { text: "Code from app" },
+      hint: "Enter 6-digit code",
+      name: "code",
+      type: "text",
+      autocomplete: "one-time-code",
+      inputmode: "numeric",
+      width: 10,
+    }.merge(args)
+
+    GovukPublishingComponents.render("govuk_publishing_components/components/input", options)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,7 +7,6 @@ class User < ApplicationRecord
   UNSUSPENSION_GRACE_PERIOD = 7.days
 
   MAX_2SV_LOGIN_ATTEMPTS = 10
-  MAX_2SV_DRIFT_SECONDS = 30
   REMEMBER_2SV_SESSION_FOR = 30.days
 
   USER_STATUS_SUSPENDED = "suspended".freeze
@@ -270,8 +269,7 @@ class User < ApplicationRecord
   end
 
   def authenticate_otp(code)
-    totp = ROTP::TOTP.new(otp_secret_key)
-    result = totp.verify(code, drift_behind: MAX_2SV_DRIFT_SECONDS)
+    result = CodeVerifier.new(code, otp_secret_key).verify
 
     if result
       update!(second_factor_attempts_count: 0)

--- a/app/views/devise/two_step_verification/show.html.erb
+++ b/app/views/devise/two_step_verification/show.html.erb
@@ -51,16 +51,7 @@
 <%= form_tag two_step_verification_path, method: :put do %>
   <%= hidden_field_tag :otp_secret_key, @otp_secret_key%>
 
-  <%= render "govuk_publishing_components/components/input", {
-    label: { text: "Code from app" },
-    hint: "Enter 6-digit code",
-    name: "code",
-    type: "text",
-    autocomplete: "one-time-code",
-    inputmode: "numeric",
-    width: 10,
-    error_message: flash[:invalid_code]
-    } %>
+  <%= two_factor_code_input(error_message: flash[:invalid_code]) %>
 
   <div class="govuk-button-group">
     <%= render "govuk_publishing_components/components/button", {

--- a/app/views/devise/two_step_verification/show.html.erb
+++ b/app/views/devise/two_step_verification/show.html.erb
@@ -56,9 +56,11 @@
     hint: "Enter 6-digit code",
     name: "code",
     type: "text",
+    autocomplete: "one-time-code",
+    inputmode: "numeric",
     width: 10,
     error_message: flash[:invalid_code]
-  } %>
+    } %>
 
   <div class="govuk-button-group">
     <%= render "govuk_publishing_components/components/button", {

--- a/app/views/devise/two_step_verification_session/new.html.erb
+++ b/app/views/devise/two_step_verification_session/new.html.erb
@@ -5,15 +5,16 @@
   <div class="govuk-grid-column-one-half">
     <%= form_tag(two_step_verification_session_path, method: :post) do %>
       <%= render "govuk_publishing_components/components/input", {
-        label: {
-          text: "Your verification code"
-        },
+        label: { text: "Code from app" },
+        hint: "Enter 6-digit code",
         name: "code",
+        type: "text",
+        autocomplete: "one-time-code",
+        inputmode: "numeric",
+        width: 10,
         autofocus: true,
         tabindex: 0,
-        autocomplete: "off",
-        hint: "Use the app on your phone to get your 6-digit verification code. You will not need to do this again for 30 days."
-      } %>
+        } %>
 
       <%= render "govuk_publishing_components/components/button", {
         text: "Sign in"

--- a/app/views/devise/two_step_verification_session/new.html.erb
+++ b/app/views/devise/two_step_verification_session/new.html.erb
@@ -4,17 +4,7 @@
 <div class="govuk-grid-row govuk-!-margin-bottom-5">
   <div class="govuk-grid-column-one-half">
     <%= form_tag(two_step_verification_session_path, method: :post) do %>
-      <%= render "govuk_publishing_components/components/input", {
-        label: { text: "Code from app" },
-        hint: "Enter 6-digit code",
-        name: "code",
-        type: "text",
-        autocomplete: "one-time-code",
-        inputmode: "numeric",
-        width: 10,
-        autofocus: true,
-        tabindex: 0,
-        } %>
+      <%= two_factor_code_input(autofocus: true, tabindex: 0) %>
 
       <%= render "govuk_publishing_components/components/button", {
         text: "Sign in"

--- a/lib/code_verifier.rb
+++ b/lib/code_verifier.rb
@@ -1,0 +1,16 @@
+class CodeVerifier
+  MAX_2SV_DRIFT_SECONDS = 30
+
+  attr_reader :code, :otp_secret_key
+
+  def initialize(code, otp_secret_key)
+    @code = code
+    @otp_secret_key = otp_secret_key
+  end
+
+  def verify
+    totp = ROTP::TOTP.new(otp_secret_key)
+
+    totp.verify(code, drift_behind: MAX_2SV_DRIFT_SECONDS)
+  end
+end

--- a/lib/code_verifier.rb
+++ b/lib/code_verifier.rb
@@ -11,6 +11,12 @@ class CodeVerifier
   def verify
     totp = ROTP::TOTP.new(otp_secret_key)
 
-    totp.verify(code, drift_behind: MAX_2SV_DRIFT_SECONDS)
+    totp.verify(clean_code, drift_behind: MAX_2SV_DRIFT_SECONDS)
+  end
+
+private
+
+  def clean_code
+    code.gsub(/[ -]/, "")
   end
 end

--- a/test/helpers/two_step_verification_helper_test.rb
+++ b/test/helpers/two_step_verification_helper_test.rb
@@ -49,4 +49,28 @@ class TwoStepVerificationHelperTest < ActionView::TestCase
       assert_match %r{<svg.*>.*</svg>}, qr_code_svg(user: @user, otp_secret_key: @secret)
     end
   end
+
+  context "two_factor_code_input" do
+    attr_reader :component_name
+
+    setup do
+      @component_name = "govuk_publishing_components/components/input"
+    end
+
+    should "render the input component" do
+      GovukPublishingComponents
+        .expects(:render)
+        .with(component_name, anything)
+
+      two_factor_code_input
+    end
+
+    should "pass additional arguments to the component renderer" do
+      GovukPublishingComponents
+        .expects(:render)
+        .with(component_name, has_entry(additional: "argument"))
+
+      two_factor_code_input(additional: "argument")
+    end
+  end
 end

--- a/test/integration/authorise_application_test.rb
+++ b/test/integration/authorise_application_test.rb
@@ -41,7 +41,7 @@ class AuthoriseApplicationTest < ActionDispatch::IntegrationTest
     ignoring_spurious_error do
       visit "/oauth/authorize?response_type=code&client_id=#{@app.uid}&redirect_uri=#{@app.redirect_uri}"
     end
-    assert_response_contains("get your 6-digit verification code")
+    assert_response_contains("Enter 6-digit code")
     assert_not Doorkeeper::AccessGrant.find_by(resource_owner_id: @user.id)
   end
 

--- a/test/integration/sign_in_test.rb
+++ b/test/integration/sign_in_test.rb
@@ -116,7 +116,7 @@ class SignInTest < ActionDispatch::IntegrationTest
     should "prompt for a verification code" do
       visit root_path
       signin_with(email: "email@example.com", password: "some password with various $ymb0l$", second_step: false)
-      assert_response_contains "get your 6-digit verification code"
+      assert_response_contains "Enter 6-digit code"
       assert_selector "input[name=code]"
     end
 
@@ -145,7 +145,7 @@ class SignInTest < ActionDispatch::IntegrationTest
       visit root_path
       signin_with(email: "email@example.com", password: "some password with various $ymb0l$", second_step: false)
       visit root_path
-      assert_response_contains "get your 6-digit verification code"
+      assert_response_contains "Enter 6-digit code"
       assert_selector "input[name=code]"
     end
 
@@ -160,7 +160,7 @@ class SignInTest < ActionDispatch::IntegrationTest
       visit root_path
       signin_with(email: "email@example.com", password: "some password with various $ymb0l$", second_step: "")
 
-      assert_response_contains "get your 6-digit verification code"
+      assert_response_contains "Enter 6-digit code"
       assert_equal 1, EventLog.where(event_id: EventLog::TWO_STEP_VERIFICATION_FAILED.id, uid: @user.uid).count
     end
 
@@ -170,7 +170,7 @@ class SignInTest < ActionDispatch::IntegrationTest
       visit root_path
       signin_with(email: "email@example.com", password: "some password with various $ymb0l$", second_step: old_code)
 
-      assert_response_contains "get your 6-digit verification code"
+      assert_response_contains "Enter 6-digit code"
       assert_equal 1, EventLog.where(event_id: EventLog::TWO_STEP_VERIFICATION_FAILED.id, uid: @user.uid).count
     end
 
@@ -178,7 +178,7 @@ class SignInTest < ActionDispatch::IntegrationTest
       visit root_path
       signin_with(email: "email@example.com", password: "some password with various $ymb0l$", second_step: "abcdef")
 
-      assert_response_contains "get your 6-digit verification code"
+      assert_response_contains "Enter 6-digit code"
       assert_equal 1, EventLog.where(event_id: EventLog::TWO_STEP_VERIFICATION_FAILED.id, uid: @user.uid).count
     end
 
@@ -226,7 +226,7 @@ class SignInTest < ActionDispatch::IntegrationTest
 
         visit root_path
         signin_with(email: "email@example.com", password: "some password with various $ymb0l$", second_step: false)
-        assert_response_contains "get your 6-digit verification code"
+        assert_response_contains "Enter 6-digit code"
         assert_selector "input[name=code]"
       end
     end
@@ -244,7 +244,7 @@ class SignInTest < ActionDispatch::IntegrationTest
       signin_with(email: "email@example.com", password: "some password with various $ymb0l$", second_step: false)
       Capybara.current_session.driver.request.cookies["remember_2sv_session"] = remember_2sv_session
       visit root_path
-      assert_response_contains "get your 6-digit verification code"
+      assert_response_contains "Enter 6-digit code"
       assert_selector "input[name=code]"
     end
 
@@ -259,7 +259,7 @@ class SignInTest < ActionDispatch::IntegrationTest
       @user.update!(otp_secret_key: ROTP::Base32.random_base32)
       signin_with(email: "email@example.com", password: "some password with various $ymb0l$", second_step: false)
 
-      assert_response_contains "get your 6-digit verification code"
+      assert_response_contains "Enter 6-digit code"
       assert_selector "input[name=code]"
     end
 

--- a/test/lib/code_verifier_test.rb
+++ b/test/lib/code_verifier_test.rb
@@ -1,0 +1,18 @@
+require "test_helper"
+
+class CodeVerifierTest < ActiveSupport::TestCase
+  attr_reader :secret
+
+  setup do
+    @secret = "topsecret"
+  end
+
+  test "#verify" do
+    totp = ROTP::TOTP.new(secret)
+    valid_code = totp.now
+
+    verifier = CodeVerifier.new(valid_code, secret)
+
+    assert verifier.verify
+  end
+end

--- a/test/lib/code_verifier_test.rb
+++ b/test/lib/code_verifier_test.rb
@@ -8,11 +8,31 @@ class CodeVerifierTest < ActiveSupport::TestCase
   end
 
   test "#verify" do
-    totp = ROTP::TOTP.new(secret)
-    valid_code = totp.now
-
     verifier = CodeVerifier.new(valid_code, secret)
 
     assert verifier.verify
+  end
+
+  test "#verify when the code contains additional spaces" do
+    valid_code_with_spaces = " #{valid_code[0..2]} #{valid_code[3..5]} "
+
+    verifier = CodeVerifier.new(valid_code_with_spaces, secret)
+
+    assert verifier.verify
+  end
+
+  test "#verify when the code contains dashes" do
+    valid_code_with_dashes = "#{valid_code[0..2]}-#{valid_code[3..5]}"
+
+    verifier = CodeVerifier.new(valid_code_with_dashes, secret)
+
+    assert verifier.verify
+  end
+
+private
+
+  def valid_code
+    totp = ROTP::TOTP.new(secret)
+    totp.now
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/eZussIrd

We've had reports from our users that when they type in the code from their 2sv application, if they include a space (which the apps often include in their display between each group of 3 digits) we don't
accept the code and the "Sorry that code didn’t work. Please try again." error doesn't help them resolve the issue.

This PR allows the user to separate the digits of their code with either space or `-` characters, and also include leading or trailing spaces. So for a valid code `123456` we now accept, for example, ` 123456 `, `123 456`, `123-456`, `12 34 56`.

The first two commits in this PR aren't strictly required to achieve this change, but I found it a little confusing that we had two slightly different ways of asking the user for the 6 digit code so I took the opportunity to extract the generation of that input field into a helper method and make them consistent.