### PR TITLE
Remove references to sign-on-o-tron

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -69,7 +69,7 @@ Devise.setup do |config|
   # config.http_authenticatable_on_xhr = true
 
   # The realm used in Http Basic Authentication. "Application" by default.
-  config.http_authentication_realm = "Sign-On-O-Tron"
+  config.http_authentication_realm = "Signon"
 
   # It will change confirmation, password recovery and other workflows
   # to behave the same regardless if the e-mail provided was right or wrong.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -84,7 +84,7 @@ Rails.application.routes.draw do
   match "/users/:id" => redirect("/users/%{id}/edit"), via: :get
   match "/suspensions/:id" => redirect("/users/%{id}/edit"), via: :get
 
-  # compatibility with Sign-on-o-tron 1
+  # compatibility with Signon 1
   post "oauth/access_token" => "doorkeeper/tokens#create"
 
   get "/signin-required" => "root#signin_required"

--- a/db/migrate/20230629083629_update_sso_push_user_name.rb
+++ b/db/migrate/20230629083629_update_sso_push_user_name.rb
@@ -1,0 +1,13 @@
+class UpdateSSOPushUserName < ActiveRecord::Migration[7.0]
+  OLD_USER_NAME = "Signonotron API Client (permission and suspension updater)".freeze
+  NEW_USER_NAME = "Signon API Client (permission and suspension updater)".freeze
+  USER_EMAIL = "signon+permissions@alphagov.co.uk".freeze
+
+  def up
+    update "UPDATE users SET name = '#{NEW_USER_NAME}' WHERE email = '#{USER_EMAIL}'"
+  end
+
+  def down
+    update "UPDATE users SET name = '#{OLD_USER_NAME}' WHERE email = '#{USER_EMAIL}'"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_22_122857) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_29_083629) do
   create_table "batch_invitation_application_permissions", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "batch_invitation_id", null: false
     t.integer "supported_permission_id", null: false

--- a/docs/oauth.md
+++ b/docs/oauth.md
@@ -1,7 +1,7 @@
-# Sign-On-O-Tron and OAuth2
+# Signon and OAuth2
 
 The GOV.UK admin and editorial systems share a single sign-on system. User
-accounts are created and managed in the sign-on-o-tron application. Users
+accounts are created and managed in the Signon application. Users
 are then authorized to access any given app by use of the OAuth2 protocol.
 
 The OAuth2 provider functionality is provided by the
@@ -36,7 +36,7 @@ account, which are the resource to be shared with the client.
 
 ### Resource server
 
-The resource server is the sign-on-o-tron application, where the resource
+The resource server is the Signon application, where the resource
 is a set of us user permissions.
 
 ### Client
@@ -45,7 +45,7 @@ The clients are the various admin and editorial applications.
 
 ### Authorization server
 
-The sign-on-o-tron application.
+The Signon application.
 
 ## Client Registration
 
@@ -110,7 +110,7 @@ mitigate the risk of cross-site request forgery.
 
 While OAuth itself is an authorization protocol we are using it to authorize
 an application’s permission to retrieve details of a given user. The
-sign-on-o-tron application will return details of a user and the client
+Signon application will return details of a user and the client
 applications are responsible for interpreting those to provide authorization
 *within* that application.
 
@@ -124,7 +124,7 @@ will return something a JSON response such as:
         "name": "Fake User",
         "email": "fake.user@digital.cabinet-office.gov.uk",
         "permissions": {
-          "Need-o-Tron": ["signin","admin"],
+          "Maslow": ["signin","admin"],
           "Publisher": ["signin"],
           "Whitehall": ["signin"],
           "Panopticon": ["signin"],
@@ -155,7 +155,7 @@ application an HTTP PUT to /users/{user.uid} with the full user object in
 JSON (as above). The application MUST then update its record of that user's
 permissions and change its behaviour accordingly.
 
-Where a user has been suspended sign-on-o-tron will send each application
+Where a user has been suspended Signon will send each application
 an HTTP POST to /users/{user.uid}/reauth. The application MUST then invalidate
 the user’s current session and redirect them to the authorization server.
 

--- a/lib/sso_push_credential.rb
+++ b/lib/sso_push_credential.rb
@@ -1,6 +1,6 @@
 class SSOPushCredential
   PERMISSIONS = %w[signin user_update_permission].freeze
-  USER_NAME = "Signonotron API Client (permission and suspension updater)".freeze
+  USER_NAME = "Signon API Client (permission and suspension updater)".freeze
   USER_EMAIL = "signon+permissions@alphagov.co.uk".freeze
 
   class << self


### PR DESCRIPTION
This app was renamed from Sign-on-o-tron to Signon some years ago, but a bunch of the code and docs still reference the old name which is confusing.

A couple of the changes are not without risk of breaking things:

1. Changing the name of the Basic HTTP Authentication realm
2. Changing the name of the SSO Push user

However, I think the risk is worth it for reducing developer confusion! What do you think?

See the individual commit notes for more details.