### PR TITLE
Remove Doorkeeper's /oauth/applications routes

### DIFF
--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -32,7 +32,7 @@ Doorkeeper.configure do
   admin_authenticator do |_routes|
     # Prevent all access to admin web interface, only allow application management
     # from command line
-    render text: "Access denied", status: :forbidden
+    head :forbidden
   end
 
   # If you are planning to use Doorkeeper in Rails 5 API-only application, then you might

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
 
   use_doorkeeper do
     controllers authorizations: "signin_required_authorizations"
+    skip_controllers :applications
   end
 
   devise_for :users,

--- a/test/integration/doorkeeper_integration_test.rb
+++ b/test/integration/doorkeeper_integration_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class DoorkeeperIntegrationTest < ActionDispatch::IntegrationTest
   test "prevents access to Doorkeeper's /oauth/applications page" do
     visit "/oauth/applications"
-
-    assert_equal 403, page.status_code
+  rescue ActionController::RoutingError => e
+    assert_equal 'No route matches [GET] "/oauth/applications"', e.message
   end
 end

--- a/test/integration/doorkeeper_integration_test.rb
+++ b/test/integration/doorkeeper_integration_test.rb
@@ -1,0 +1,9 @@
+require "test_helper"
+
+class DoorkeeperIntegrationTest < ActionDispatch::IntegrationTest
+  test "prevents access to Doorkeeper's /oauth/applications page" do
+    visit "/oauth/applications"
+
+    assert_equal 403, page.status_code
+  end
+end


### PR DESCRIPTION
The Doorkeeper Gem makes several /oauth/applications routes available to allow users to CRUD Applications. We don't want to allow access to these routes but a misconfiguration in our doorkeeper.rb initializer meant that we were only accidentally preventing access.

The first commit in this PR fixes the Doorkeeper configuration to properly prevent access to /oauth/applications.

The second commit in this PR then removes the route entirely.