### PR TITLE
Migrate bulk grant permission sets show to design system

### DIFF
--- a/app/controllers/bulk_grant_permission_sets_controller.rb
+++ b/app/controllers/bulk_grant_permission_sets_controller.rb
@@ -1,5 +1,5 @@
 class BulkGrantPermissionSetsController < ApplicationController
-  layout "admin_layout", only: %w[new create]
+  layout "admin_layout"
 
   before_action :authenticate_user!
 

--- a/app/helpers/bulk_grant_permission_sets_helper.rb
+++ b/app/helpers/bulk_grant_permission_sets_helper.rb
@@ -13,16 +13,16 @@ module BulkGrantPermissionSetsHelper
   end
 
   def formatted_row(application, permissions)
-    content_tag(:tr) do
-      content_tag(:td, formatted_application_name(application)) +
-        content_tag(:td, formatted_application_access(application, permissions)) +
-        content_tag(:td, formatted_other_permissions(application, permissions))
-    end
+    [
+      { text: formatted_application_name(application) },
+      { text: formatted_application_access(application, permissions) },
+      { text: formatted_other_permissions(application, permissions) },
+    ]
   end
 
   def formatted_application_name(application)
     if application.retired?
-      content_tag(:del, application.name)
+      "#{application.name} (retired)"
     else
       application.name
     end

--- a/app/helpers/bulk_grant_permission_sets_helper.rb
+++ b/app/helpers/bulk_grant_permission_sets_helper.rb
@@ -12,6 +12,14 @@ module BulkGrantPermissionSetsHelper
       .group_by(&:application)
   end
 
+  def formatted_row(application, permissions)
+    content_tag(:tr) do
+      content_tag(:td, formatted_application_name(application)) +
+        content_tag(:td, formatted_application_access(application, permissions)) +
+        content_tag(:td, formatted_other_permissions(application, permissions))
+    end
+  end
+
   def formatted_application_name(application)
     if application.retired?
       content_tag(:del, application.name)

--- a/app/helpers/bulk_grant_permission_sets_helper.rb
+++ b/app/helpers/bulk_grant_permission_sets_helper.rb
@@ -11,4 +11,12 @@ module BulkGrantPermissionSetsHelper
       .order("oauth_applications.name, supported_permissions.name")
       .group_by(&:application)
   end
+
+  def formatted_application_name(application)
+    if application.retired?
+      content_tag(:del, application.name)
+    else
+      application.name
+    end
+  end
 end

--- a/app/helpers/bulk_grant_permission_sets_helper.rb
+++ b/app/helpers/bulk_grant_permission_sets_helper.rb
@@ -4,26 +4,6 @@ module BulkGrantPermissionSetsHelper
       .reject(&:retired?)
   end
 
-  def bulk_grant_permission_set_status_message(bulk_grant_permission_set)
-    if bulk_grant_permission_set.in_progress?
-      "In progress. #{bulk_grant_permission_set.processed_users} of #{bulk_grant_permission_set.total_users} users processed."
-    elsif bulk_grant_permission_set.successful?
-      "All #{bulk_grant_permission_set.processed_users} users processed."
-    else
-      "Only #{bulk_grant_permission_set.processed_users} of #{bulk_grant_permission_set.total_users} users processed."
-    end
-  end
-
-  def bulk_grant_permission_set_status_class(bulk_grant_permission_set)
-    if bulk_grant_permission_set.in_progress?
-      "alert-info"
-    elsif bulk_grant_permission_set.successful?
-      "alert-success"
-    else
-      "alert-danger"
-    end
-  end
-
   def bulk_grant_permissions_by_application(bulk_grant_permission_set)
     bulk_grant_permission_set
       .supported_permissions

--- a/app/helpers/bulk_grant_permission_sets_helper.rb
+++ b/app/helpers/bulk_grant_permission_sets_helper.rb
@@ -27,4 +27,8 @@ module BulkGrantPermissionSetsHelper
       "No"
     end
   end
+
+  def formatted_other_permissions(application, permissions)
+    (permissions - [application.signin_permission]).map(&:name).to_sentence
+  end
 end

--- a/app/helpers/bulk_grant_permission_sets_helper.rb
+++ b/app/helpers/bulk_grant_permission_sets_helper.rb
@@ -19,4 +19,12 @@ module BulkGrantPermissionSetsHelper
       application.name
     end
   end
+
+  def formatted_application_access(application, permissions)
+    if permissions.include?(application.signin_permission)
+      "Yes"
+    else
+      "No"
+    end
+  end
 end

--- a/app/views/bulk_grant_permission_sets/new.html.erb
+++ b/app/views/bulk_grant_permission_sets/new.html.erb
@@ -1,4 +1,22 @@
 <% content_for :title, "Grant access to all users" %>
+<% content_for :breadcrumbs,
+   render("govuk_publishing_components/components/breadcrumbs", {
+     collapse_on_mobile: true,
+     breadcrumbs: [
+       {
+         title: "Home",
+         url: root_path,
+       },
+       {
+         title: "Users",
+         url: users_path,
+       },
+       {
+         title: "Grant access to all users",
+       },
+     ]
+   })
+%>
 
 <%= form_for @bulk_grant_permission_set do |f| %>
   <%= render "govuk_publishing_components/components/select", {

--- a/app/views/bulk_grant_permission_sets/show.html.erb
+++ b/app/views/bulk_grant_permission_sets/show.html.erb
@@ -10,9 +10,19 @@
   <h1>Granting permissions to all users</h1>
 </div>
 
-<div class="alert <%= bulk_grant_permission_set_status_class(@bulk_grant_permission_set) %>">
-  <%= bulk_grant_permission_set_status_message(@bulk_grant_permission_set) %>
-</div>
+<% if @bulk_grant_permission_set.in_progress? %>
+  <div class="alert alert-info">
+    In progress. <%= @bulk_grant_permission_set.processed_users %>} of <%= @bulk_grant_permission_set.total_users %> users processed.
+  </div>
+<% elsif @bulk_grant_permission_set.successful? %>
+  <div class="alert alert-success">
+    All <%= @bulk_grant_permission_set.processed_users %> users processed.
+  </div>
+<% else %>
+  <div class="alert alert-danger">
+    Only <%= @bulk_grant_permission_set.processed_users %> of <%= @bulk_grant_permission_set.total_users %> users processed.
+  </div>
+<% end %>
 
 <table class="table table-bordered table-striped table-on-white">
   <thead>

--- a/app/views/bulk_grant_permission_sets/show.html.erb
+++ b/app/views/bulk_grant_permission_sets/show.html.erb
@@ -34,11 +34,7 @@
   </thead>
   <tbody>
     <% bulk_grant_permissions_by_application(@bulk_grant_permission_set).each do |(application, permissions)| %>
-      <tr>
-        <td><%= formatted_application_name(application) %></td>
-        <td><%= formatted_application_access(application, permissions) %></td>
-        <td><%= formatted_other_permissions(application, permissions) %></td>
-      </tr>
+      <%= formatted_row(application, permissions) %>
     <% end %>
   </tbody>
 </table>

--- a/app/views/bulk_grant_permission_sets/show.html.erb
+++ b/app/views/bulk_grant_permission_sets/show.html.erb
@@ -1,4 +1,26 @@
-<% content_for :title, "Granting permissions to all users" %>
+<% content_for :title, "Result" %>
+<% content_for :breadcrumbs,
+   render("govuk_publishing_components/components/breadcrumbs", {
+     collapse_on_mobile: true,
+     breadcrumbs: [
+       {
+         title: "Home",
+         url: root_path,
+       },
+       {
+         title: "Users",
+         url: users_path,
+       },
+       {
+         title: "Grant access to all users",
+         url: new_bulk_grant_permission_set_path,
+       },
+       {
+         title: "Result",
+       }
+     ]
+   })
+%>
 
 <% if @bulk_grant_permission_set.in_progress? %>
   <% content_for(:head) do %>

--- a/app/views/bulk_grant_permission_sets/show.html.erb
+++ b/app/views/bulk_grant_permission_sets/show.html.erb
@@ -35,13 +35,7 @@
   <tbody>
     <% bulk_grant_permissions_by_application(@bulk_grant_permission_set).each do |(application, permissions)| %>
       <tr>
-        <td>
-          <% if application.retired? %>
-            <del><%= application.name %></del>
-          <% else %>
-            <%= application.name %>
-          <% end %>
-        </td>
+        <td><%= formatted_application_name(application) %></td>
         <td>
           <% if permissions.include? application.signin_permission %>
             Yes

--- a/app/views/bulk_grant_permission_sets/show.html.erb
+++ b/app/views/bulk_grant_permission_sets/show.html.erb
@@ -1,45 +1,32 @@
 <% content_for :title, "Granting permissions to all users" %>
 
 <% if @bulk_grant_permission_set.in_progress? %>
-  <% content_for(:content_for_head) do %>
+  <% content_for(:head) do %>
     <meta http-equiv="refresh" content="3">
   <% end %>
 <% end %>
 
-<div class="page-title">
-  <h1>Granting permissions to all users</h1>
-</div>
-
 <% if @bulk_grant_permission_set.in_progress? %>
-  <div class="alert alert-info">
-    In progress. <%= @bulk_grant_permission_set.processed_users %>} of <%= @bulk_grant_permission_set.total_users %> users processed.
-  </div>
+  <%= render "govuk_publishing_components/components/notice", {
+    title: "In progress. #{@bulk_grant_permission_set.processed_users} of #{@bulk_grant_permission_set.total_users} users processed."
+    } %>
 <% elsif @bulk_grant_permission_set.successful? %>
-  <div class="alert alert-success">
-    All <%= @bulk_grant_permission_set.processed_users %> users processed.
-  </div>
+  <%= render "govuk_publishing_components/components/success_alert", {
+    message: "All #{@bulk_grant_permission_set.processed_users} users processed."
+    } %>
 <% else %>
-  <div class="alert alert-danger">
-    Only <%= @bulk_grant_permission_set.processed_users %> of <%= @bulk_grant_permission_set.total_users %> users processed.
-  </div>
+  <%= render "govuk_publishing_components/components/error_alert", {
+    message: "Only #{@bulk_grant_permission_set.processed_users} of #{@bulk_grant_permission_set.total_users} users processed."
+    } %>
 <% end %>
 
-<table class="table table-bordered table-striped table-on-white">
-  <thead>
-    <tr class="table-header">
-      <th>Application</th>
-      <th>Has access to?</th>
-      <th>Other Permissions</th>
-    </tr>
-  </thead>
-  <tbody>
-    <% bulk_grant_permissions_by_application(@bulk_grant_permission_set).each do |(application, permissions)| %>
-      <%= formatted_row(application, permissions) %>
-    <% end %>
-  </tbody>
-</table>
-
-
-<div class="well">
-  <%= link_to "All users", users_path, class: "btn btn-primary" %>
-</div>
+<%= render "govuk_publishing_components/components/table", {
+  head: [
+    { text: "Application" },
+    { text: "Has access to?" },
+    { text: "Other Permissions" },
+  ],
+  rows: bulk_grant_permissions_by_application(@bulk_grant_permission_set).map { |(application, permissions)|
+    formatted_row(application, permissions)
+  },
+} %>

--- a/app/views/bulk_grant_permission_sets/show.html.erb
+++ b/app/views/bulk_grant_permission_sets/show.html.erb
@@ -37,9 +37,7 @@
       <tr>
         <td><%= formatted_application_name(application) %></td>
         <td><%= formatted_application_access(application, permissions) %></td>
-        <td>
-          <%= (permissions - [application.signin_permission]).map { |p| p.name }.to_sentence %>
-        </td>
+        <td><%= formatted_other_permissions(application, permissions) %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/bulk_grant_permission_sets/show.html.erb
+++ b/app/views/bulk_grant_permission_sets/show.html.erb
@@ -36,13 +36,7 @@
     <% bulk_grant_permissions_by_application(@bulk_grant_permission_set).each do |(application, permissions)| %>
       <tr>
         <td><%= formatted_application_name(application) %></td>
-        <td>
-          <% if permissions.include? application.signin_permission %>
-            Yes
-          <% else %>
-            No
-          <% end %>
-        </td>
+        <td><%= formatted_application_access(application, permissions) %></td>
         <td>
           <%= (permissions - [application.signin_permission]).map { |p| p.name }.to_sentence %>
         </td>

--- a/test/integration/bulk_granting_permisions_test.rb
+++ b/test/integration/bulk_granting_permisions_test.rb
@@ -66,7 +66,7 @@ class BulkGrantingPermissionsTest < ActionDispatch::IntegrationTest
       click_button "Grant access to all users"
 
       assert_response_contains("Scheduled grant of 1 permissions to all users")
-      assert_response_contains("Granting permissions to all users")
+      assert_response_contains("Result")
       assert_response_contains("All #{User.all.count} users processed")
 
       app_permissions_line = "#{application.name} Yes"


### PR DESCRIPTION
Trello: https://trello.com/c/gGY6x4mJ/173-migrate-bulkgrantpermissionsets-to-use-design-system

This PR migrates the BulkGrantPermissionSets#show action ([example, integration](https://signon.integration.publishing.service.gov.uk/bulk_grant_permission_sets/1)) to use the design system.

Note, since #2221 we now only support the bulk granting of the `signin` permission to applications. However there are older "permission sets" that granted other permissions, so I've decided that the show page should still display the additional permissions that were granted by those sets. We may want to revisit that decision later, and perhaps simplify this view further but for now, and in the interest of moving the page to the design system in a straightforward way, I've kept the current behaviour. 

# Before

![before](https://github.com/alphagov/signon/assets/16707/06dab2a7-6822-451e-8c30-bdf7292b1103)

# After

![after](https://github.com/alphagov/signon/assets/16707/ed477fcb-43c4-4644-843b-b2db35a066ae)