### PR TITLE
Migrate OrganisationsController#edit page to design system

### DIFF
--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -1,5 +1,5 @@
 class OrganisationsController < ApplicationController
-  layout "admin_layout", only: %w[index]
+  layout "admin_layout"
 
   before_action :authenticate_user!
 

--- a/app/views/organisations/edit.html.erb
+++ b/app/views/organisations/edit.html.erb
@@ -1,21 +1,43 @@
 <% content_for :title, "Require 2-step verification for #{@organisation.name}" %>
+<% content_for :breadcrumbs,
+   render("govuk_publishing_components/components/breadcrumbs", {
+     collapse_on_mobile: true,
+     breadcrumbs: [
+       {
+         title: "Home",
+         url: root_path,
+       },
+       {
+         title: "Organisations",
+         url: organisations_path,
+       },
+       {
+         title: "Require 2-step verification",
+       },
+     ]
+   })
+%>
 
-<ol class="breadcrumb">
-  <li><%= link_to "Organisations", organisations_path %></li>
-  <li class="active">Require 2-step verification</li>
-</ol>
+<%= form_tag organisation_path(@organisation), method: "put" do %>
+  <%= render "govuk_publishing_components/components/hint", {
+    text: "This will ensure that all users in an organisation who are not
+           exempted from 2-step verification must set up 2-step verification on
+           their next login. They will not be able to perform any actions
+           in Signon before this is set up."
+  } %>
 
-<h1 class="page-title">Require 2-step verification for &ldquo;<%= @organisation.name %>&rdquo;</h1>
+  <%= render "govuk_publishing_components/components/checkboxes", {
+    name: "organisation[require_2sv]",
+    items: [
+      {
+        label: "Mandate 2-step verification for #{@organisation.name}",
+        value: 1,
+        checked: @organisation.require_2sv?,
+      }
+    ]
+  } %>
 
-<%= form_tag organisation_path(@organisation), method: "put", :class => 'well remove-top-padding' do %>
-  <div class="checkbox add-top-margin">
-    <label>
-      <%= check_box_tag "organisation[require_2sv]", "1", @organisation.require_2sv? %>
-      Mandate 2-step verification for <%= @organisation.name  %>
-    </label>
-  </div>
-  <p>This will ensure that all users in an organisation who are not exempted from 2-step verification must set up 2-step verification on their next login.</p>
-  <p>They will not be able to perform any actions in signon before this is set up.</p>
-  <%= submit_tag "Update Organisation", class: "btn btn-primary add-right-margin" %>
-  <%= link_to "Cancel", organisations_path, class: "btn btn-default" %>
+  <%= render "govuk_publishing_components/components/button", {
+    text: "Update organisation"
+  } %>
 <% end %>

--- a/test/integration/mandate_2sv_for_organisation_test.rb
+++ b/test/integration/mandate_2sv_for_organisation_test.rb
@@ -24,7 +24,7 @@ class Mandate2svForOrganisationTest < ActionDispatch::IntegrationTest
         should "be able to edit organisation 2sv status" do
           click_edit_2sv_button_for(@organisation)
           check "Mandate 2-step verification for #{@organisation.name}"
-          click_button "Update Organisation"
+          click_button "Update organisation"
           assert page.has_text? "true"
         end
       end
@@ -42,7 +42,7 @@ class Mandate2svForOrganisationTest < ActionDispatch::IntegrationTest
         should "be able to edit organisation 2sv status" do
           click_edit_2sv_button_for(@organisation)
           uncheck "Mandate 2-step verification for #{@organisation.name}"
-          click_button "Update Organisation"
+          click_button "Update organisation"
           assert page.has_text? "false"
         end
       end


### PR DESCRIPTION
Trello: https://trello.com/c/uPouwNMf

I decided to remove the "cancel" button as we have the breadcrumb trail to return to the previous page, and the component guide suggests we should aim to have a single button per page[1].

I've downcased the button text to be consistent with other uses of buttons.

[1] https://components.publishing.service.gov.uk/component-guide/button

# Before
![before](https://github.com/alphagov/signon/assets/16707/6f6e4dc6-b3dd-4cf0-9478-8169d3fcc274)

# After
![after](https://github.com/alphagov/signon/assets/16707/d244ed0c-5d89-493f-9890-555af9705c8e)
