### PR TITLE
Don't push revoked bearer tokens into k8s.

### DIFF
--- a/lib/tasks/sync_kubernetes_secrets.rake
+++ b/lib/tasks/sync_kubernetes_secrets.rake
@@ -10,7 +10,7 @@ namespace :kubernetes do
     missing_users = emails - api_users.map(&:email)
 
     api_users.each do |api_user|
-      api_user.authorisations.each do |token|
+      api_user.authorisations.where(revoked_at: nil).each do |token|
         name = "signon-token-#{api_user.name}-#{token.application.name}".parameterize
         data = { bearer_token: token.token }
 


### PR DESCRIPTION
The Rake task / nightly cronjob that creates Kubernetes secrets for API users' bearer tokens was just querying for all `Authorisations` including revoked ones.

Tested: works in integration and only valid tokens are listed in the output now. Looked at adding a regression test for this but the existing tests are way overabstracted and I don't have time to fix that.