### PR TITLE
Remove Doorkeeper authorized_application routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
 
   use_doorkeeper do
     controllers authorizations: "signin_required_authorizations"
-    skip_controllers :applications
+    skip_controllers :applications, :authorized_applications
   end
 
   devise_for :users,


### PR DESCRIPTION
This removes the following routes:

```
oauth_authorized_applications GET    /oauth/authorized_applications(.:format)     doorkeeper/authorized_applications#index
 oauth_authorized_application DELETE /oauth/authorized_applications/:id(.:format) doorkeeper/authorized_applications#destroy
```

The /oauth/authorized_applications page lists the applications you've granted access to, with the option for revoking that access. It's not linked from anywhere in Signon and I've used Logit to confirm that there haven't been any requests to these routes (by searching for "/oauth/authorized_applications") in staging or production since 1 Jan 2023. The same search query returns results for me viewing that page in integration so I think it's safe to rely on this meaning that these pages aren't used in staging/production.

## Screenshot of the page being removed

![image](https://github.com/alphagov/signon/assets/6556/b5932bbc-323c-4f44-bc16-584de83a7739)
