### PR TITLE
Allow (super) org admins to re-try editing users

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -52,6 +52,7 @@ class UsersController < ApplicationController
     if updater.call
       redirect_to users_path, notice: "Updated user #{@user.email} successfully"
     else
+      @application_permissions = all_applications_and_permissions_for(@user)
       render :edit
     end
   end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -713,6 +713,26 @@ class UsersControllerTest < ActionController::TestCase
           assert_redirected_to root_path
           assert_match(/You do not have permission to perform this action./, flash[:alert])
         end
+
+        should "redisplay the form if save fails" do
+          admin = create(:organisation_admin)
+          sign_in admin
+
+          put :update, params: { id: admin.id, user: { name: "" } }
+
+          assert_select "form#edit_user_#{admin.id}"
+        end
+      end
+
+      context "super organisation admin" do
+        should "redisplay the form if save fails" do
+          admin = create(:super_org_admin)
+          sign_in admin
+
+          put :update, params: { id: admin.id, user: { name: "" } }
+
+          assert_select "form#edit_user_#{admin.id}"
+        end
       end
 
       should "redisplay the form if save fails" do


### PR DESCRIPTION
Trello: https://trello.com/c/1c6vLRnN

We found a bug[1] which prevented organisation and super organisation admins to retry validation errors when editing a user. This commit fixes that bug and adds a couple of tests to catch any regressions.

[1] https://govuk.sentry.io/issues/4307435188/?project=202251
