### PR TITLE
Remove Doorkeeper's /oauth/token/info route

### DIFF
--- a/app/controllers/signin_required_authorizations_controller.rb
+++ b/app/controllers/signin_required_authorizations_controller.rb
@@ -25,6 +25,10 @@ class SigninRequiredAuthorizationsController < Doorkeeper::AuthorizationsControl
     render plain: "Not found", status: :not_found
   end
 
+  def destroy
+    render plain: "Not found", status: :not_found
+  end
+
 private
 
   def pre_authorizable?

--- a/app/controllers/signin_required_authorizations_controller.rb
+++ b/app/controllers/signin_required_authorizations_controller.rb
@@ -9,16 +9,12 @@ class SigninRequiredAuthorizationsController < Doorkeeper::AuthorizationsControl
 
   def new
     if pre_authorizable?
-      if skip_authorization? || matching_token?
-        if user_has_signin_permission_to_application?
-          auth = authorize_response
-          redirect_to auth.redirect_uri, allow_other_host: true
-        else
-          session[:signin_missing_for_application] = application.try(:id)
-          redirect_to signin_required_path
-        end
+      if user_has_signin_permission_to_application?
+        auth = authorize_response
+        redirect_to auth.redirect_uri, allow_other_host: true
       else
-        render :new
+        session[:signin_missing_for_application] = application.try(:id)
+        redirect_to signin_required_path
       end
     else
       render :error

--- a/app/controllers/signin_required_authorizations_controller.rb
+++ b/app/controllers/signin_required_authorizations_controller.rb
@@ -22,12 +22,7 @@ class SigninRequiredAuthorizationsController < Doorkeeper::AuthorizationsControl
   end
 
   def create
-    if user_has_signin_permission_to_application?
-      super
-    else
-      session[:signin_missing_for_application] = application.try(:id)
-      redirect_to signin_required_path
-    end
+    render plain: "Not found", status: :not_found
   end
 
 private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
 
   use_doorkeeper do
     controllers authorizations: "signin_required_authorizations"
-    skip_controllers :applications, :authorized_applications
+    skip_controllers :applications, :authorized_applications, :token_info
   end
 
   devise_for :users,

--- a/test/controllers/signin_required_authorizations_controller_test.rb
+++ b/test/controllers/signin_required_authorizations_controller_test.rb
@@ -26,27 +26,6 @@ class SigninRequiredAuthorizationsControllerTest < ActionController::TestCase
     end
   end
 
-  context "GET #new token request with native url" do
-    setup do
-      auth_type_is_allowed "implicit"
-      @application.update! redirect_uri: "urn:ietf:wg:oauth:2.0:oob"
-      get :new, params: { client_id: @application.uid, response_type: "token", redirect_uri: @application.redirect_uri }
-    end
-
-    should "redirect immediately" do
-      assert_response :redirect
-      assert_redirected_to(/oauth\/token\/info\?access_token=/)
-    end
-
-    should "not issue a grant" do
-      assert_equal 0, Doorkeeper::AccessGrant.count
-    end
-
-    should "issue a token" do
-      assert_equal 1, Doorkeeper::AccessToken.count
-    end
-  end
-
   context "GET #new code request with native url" do
     setup do
       auth_type_is_allowed "authorization_code"

--- a/test/controllers/signin_required_authorizations_controller_test.rb
+++ b/test/controllers/signin_required_authorizations_controller_test.rb
@@ -117,8 +117,11 @@ class SigninRequiredAuthorizationsControllerTest < ActionController::TestCase
       assert_response :ok
     end
 
-    should "not issue any token" do
+    should "not issue a grant" do
       assert_equal 0, Doorkeeper::AccessGrant.count
+    end
+
+    should "not issue a token" do
       assert_equal 0, Doorkeeper::AccessToken.count
     end
   end
@@ -139,8 +142,12 @@ class SigninRequiredAuthorizationsControllerTest < ActionController::TestCase
       assert_redirected_to signin_required_path
     end
 
-    should "not issue any access token" do
-      assert Doorkeeper::AccessToken.all.empty?
+    should "not issue a grant" do
+      assert_equal 0, Doorkeeper::AccessGrant.count
+    end
+
+    should "not issue a token" do
+      assert_equal 0, Doorkeeper::AccessToken.count
     end
   end
 end

--- a/test/controllers/signin_required_authorizations_controller_test.rb
+++ b/test/controllers/signin_required_authorizations_controller_test.rb
@@ -132,10 +132,8 @@ class SigninRequiredAuthorizationsControllerTest < ActionController::TestCase
     end
   end
 
-  context "GET #new token request with native url and skip_authorization true" do
+  context "GET #new token request with native url" do
     setup do
-      # technically redundant as this is our configuration anyway
-      Doorkeeper.configuration.stubs(skip_authorization: ->(*_args) { true })
       @application.update! redirect_uri: "urn:ietf:wg:oauth:2.0:oob"
       get :new, params: { client_id: @application.uid, response_type: "token", redirect_uri: @application.redirect_uri }
     end
@@ -154,11 +152,9 @@ class SigninRequiredAuthorizationsControllerTest < ActionController::TestCase
     end
   end
 
-  context "GET #new code request with native url and skip_authorization true" do
+  context "GET #new code request with native url" do
     setup do
       auth_type_is_allowed "authorization_code"
-      # technically redundant as this is our configuration anyway
-      Doorkeeper.configuration.stubs(skip_authorization: ->(*_args) { true })
       @application.update! redirect_uri: "urn:ietf:wg:oauth:2.0:oob"
       get :new, params: { client_id: @application.uid, response_type: "code", redirect_uri: @application.redirect_uri }
     end
@@ -177,10 +173,8 @@ class SigninRequiredAuthorizationsControllerTest < ActionController::TestCase
     end
   end
 
-  context "GET #new with skip_authorization true" do
+  context "GET #new" do
     setup do
-      # technically redundant as this is our configuration anyway
-      Doorkeeper.configuration.stubs(skip_authorization: ->(*_args) { true })
       get :new, params: { client_id: @application.uid, response_type: "token", redirect_uri: @application.redirect_uri }
     end
 
@@ -227,12 +221,10 @@ class SigninRequiredAuthorizationsControllerTest < ActionController::TestCase
     end
   end
 
-  context "GET #new with skip_authorization true when the user does not have signin permission for the app" do
+  context "GET #new when the user does not have signin permission for the app" do
     setup do
       @user.application_permissions.where(supported_permission_id: @application.signin_permission).destroy_all
       @user.application_permissions.reload
-      # technically redundant as this is our configuration anyway
-      Doorkeeper.configuration.stubs(skip_authorization: ->(*_args) { true })
       get :new, params: { client_id: @application.uid, response_type: "token", redirect_uri: @application.redirect_uri }
     end
 

--- a/test/controllers/signin_required_authorizations_controller_test.rb
+++ b/test/controllers/signin_required_authorizations_controller_test.rb
@@ -21,7 +21,6 @@ class SigninRequiredAuthorizationsControllerTest < ActionController::TestCase
   setup do
     @application = create(:application)
     @user = create(:user, with_signin_permissions_for: [@application])
-    auth_type_is_allowed("implicit")
     @controller.stubs(current_resource_owner: @user)
   end
 
@@ -34,6 +33,7 @@ class SigninRequiredAuthorizationsControllerTest < ActionController::TestCase
 
   context "GET #new token request with native url" do
     setup do
+      auth_type_is_allowed "implicit"
       @application.update! redirect_uri: "urn:ietf:wg:oauth:2.0:oob"
       get :new, params: { client_id: @application.uid, response_type: "token", redirect_uri: @application.redirect_uri }
     end
@@ -75,6 +75,7 @@ class SigninRequiredAuthorizationsControllerTest < ActionController::TestCase
 
   context "GET #new" do
     setup do
+      auth_type_is_allowed "implicit"
       get :new, params: { client_id: @application.uid, response_type: "token", redirect_uri: @application.redirect_uri }
     end
 
@@ -107,6 +108,7 @@ class SigninRequiredAuthorizationsControllerTest < ActionController::TestCase
 
   context "GET #new with errors" do
     setup do
+      auth_type_is_allowed "implicit"
       default_scopes_exist :public
       get :new, params: { an_invalid: "request" }
     end
@@ -123,6 +125,7 @@ class SigninRequiredAuthorizationsControllerTest < ActionController::TestCase
 
   context "GET #new when the user does not have signin permission for the app" do
     setup do
+      auth_type_is_allowed "implicit"
       @user.application_permissions.where(supported_permission_id: @application.signin_permission).destroy_all
       @user.application_permissions.reload
       get :new, params: { client_id: @application.uid, response_type: "token", redirect_uri: @application.redirect_uri }

--- a/test/controllers/signin_required_authorizations_controller_test.rb
+++ b/test/controllers/signin_required_authorizations_controller_test.rb
@@ -18,6 +18,13 @@ class SigninRequiredAuthorizationsControllerTest < ActionController::TestCase
     end
   end
 
+  context "DELETE #destroy" do
+    should "return 404" do
+      delete :destroy
+      assert_response :not_found
+    end
+  end
+
   context "GET #new code request with native url" do
     setup do
       @application.update! redirect_uri: "urn:ietf:wg:oauth:2.0:oob"

--- a/test/controllers/signin_required_authorizations_controller_test.rb
+++ b/test/controllers/signin_required_authorizations_controller_test.rb
@@ -6,10 +6,6 @@ class SigninRequiredAuthorizationsControllerTest < ActionController::TestCase
     Rack::Utils.parse_query(fragment)[param]
   end
 
-  def translated_error_message(key)
-    I18n.translate key, scope: %i[doorkeeper errors messages]
-  end
-
   def default_scopes_exist(*scopes)
     Doorkeeper.configuration.stubs(default_scopes: Doorkeeper::OAuth::Scopes.from_array(scopes))
   end
@@ -30,105 +26,9 @@ class SigninRequiredAuthorizationsControllerTest < ActionController::TestCase
   end
 
   context "POST #create" do
-    setup do
-      post :create, params: { client_id: @application.uid, response_type: "token", redirect_uri: @application.redirect_uri }
-    end
-
-    should "redirect after authorization" do
-      assert_response :redirect
-    end
-
-    should "redirect to client redirect uri" do
-      assert_redirected_to(/^#{@application.redirect_uri}/)
-    end
-
-    should "include access token in fragment" do
-      assert_equal Doorkeeper::AccessToken.first.token, fragments("access_token")
-    end
-
-    should "include token type in fragment" do
-      assert_equal "Bearer", fragments("token_type")
-    end
-
-    should "include token expiration in fragment" do
-      assert_not_nil fragments("expires_in")
-      assert fragments("expires_in").to_i >= 1.hour.to_i
-    end
-
-    should "issue the token for the current client" do
-      assert_equal @application.id, Doorkeeper::AccessToken.first.application_id
-    end
-
-    should "issue the token for the current resource owner" do
-      assert_equal @user.id, Doorkeeper::AccessToken.first.resource_owner_id
-    end
-  end
-
-  context "POST #create with errors" do
-    setup do
-      default_scopes_exist :public
-      post :create, params: { client_id: @application.uid, response_type: "token", scope: "invalid", redirect_uri: @application.redirect_uri }
-    end
-
-    should "redirect after authorization" do
-      assert_response :redirect
-    end
-
-    should "redirect to client redirect uri" do
-      assert_redirected_to(/^#{@application.redirect_uri}/)
-    end
-
-    should "not include access token in fragment" do
-      assert_nil fragments("access_token")
-    end
-
-    should "include error in fragment" do
-      assert_equal "invalid_scope", fragments("error")
-    end
-
-    should "include error description in fragment" do
-      assert_equal translated_error_message(:invalid_scope), fragments("error_description")
-    end
-
-    should "not issue any access token" do
-      assert Doorkeeper::AccessToken.all.empty?
-    end
-  end
-
-  context "POST #create when the user does not have signin permission for the app" do
-    setup do
-      @user.application_permissions.where(supported_permission_id: @application.signin_permission).destroy_all
-      @user.application_permissions.reload
-      post :create, params: { client_id: @application.uid, response_type: "token", redirect_uri: @application.redirect_uri }
-    end
-
-    should "redirect after authorization" do
-      assert_response :redirect
-    end
-
-    should "redirect to signin required error path" do
-      assert_redirected_to signin_required_path
-    end
-
-    should "not issue any access token" do
-      assert Doorkeeper::AccessToken.all.empty?
-    end
-  end
-
-  context "POST #create with application already authorized" do
-    setup do
-      Doorkeeper.configuration.stubs(reuse_access_token: true)
-      @access_token = create(:access_token, resource_owner_id: @user.id, application_id: @application.id)
-      @access_token.save!
-      post :create, params: { client_id: @application.uid, response_type: "token", redirect_uri: @application.redirect_uri }
-    end
-
-    should "returns the existing access token in a fragment" do
-      assert_equal fragments("access_token"), @access_token.token
-    end
-
-    should "not creates a new access token" do
-      assert_equal Doorkeeper::AccessToken.count, 1
+    should "return 404" do
+      post :create
+      assert_response :not_found
     end
   end
 

--- a/test/controllers/signin_required_authorizations_controller_test.rb
+++ b/test/controllers/signin_required_authorizations_controller_test.rb
@@ -24,9 +24,9 @@ class SigninRequiredAuthorizationsControllerTest < ActionController::TestCase
       get :new, params: { client_id: @application.uid, response_type: "code", redirect_uri: @application.redirect_uri }
     end
 
-    should "redirect immediately" do
+    should "redirect to the native url endpoint and include the access grant code" do
       assert_response :redirect
-      assert_redirected_to(/oauth\/authorize\//)
+      assert_redirected_to(/oauth\/authorize\/native\?code=#{Doorkeeper::AccessGrant.first.token}/)
     end
 
     should "issue a grant" do
@@ -43,9 +43,9 @@ class SigninRequiredAuthorizationsControllerTest < ActionController::TestCase
       get :new, params: { client_id: @application.uid, response_type: "code", redirect_uri: @application.redirect_uri }
     end
 
-    should "redirect immediately" do
+    should "redirect to the application redirect uri and include the access grant code" do
       assert_response :redirect
-      assert_redirected_to(/^#{@application.redirect_uri}/)
+      assert_redirected_to(/^#{@application.redirect_uri}\?code=#{Doorkeeper::AccessGrant.first.token}/)
     end
 
     should "issue a grant" do


### PR DESCRIPTION
Trello: https://trello.com/c/JvVlLMB4/182-remove-oauth-token-info-doorkeeper-route

Doorkeeper's [/oauth/token/info route is used as the redirect URI for native apps in the Implicit grant flow](https://github.com/doorkeeper-gem/doorkeeper/blob/v5.6.6/lib/doorkeeper/oauth/authorization/token.rb#L77-L83). Our Doorkeeper configuration prevents the Implict grant flow so we can remove this route.

The first 9 commits improve our `SigninRequiredAuthorizationsController` and associated tests and the final commit removes the /oauth/token/info route.