### PR TITLE
Migrate user suspension edit page to design system

### DIFF
--- a/app/controllers/suspensions_controller.rb
+++ b/app/controllers/suspensions_controller.rb
@@ -2,6 +2,8 @@ class SuspensionsController < ApplicationController
   before_action :authenticate_user!, :load_and_authorize_user
   respond_to :html
 
+  layout "admin_layout"
+
   rescue_from ActiveRecord::RecordInvalid, with: :render_edit
 
   def update

--- a/app/models/suspension.rb
+++ b/app/models/suspension.rb
@@ -1,0 +1,43 @@
+class Suspension
+  include ActiveModel::Validations
+  validates :reason_for_suspension, presence: true, if: :suspend
+
+  attr_reader :suspend, :reason_for_suspension, :user, :initiator, :ip_address
+
+  def initialize(suspend: nil, reason_for_suspension: nil, user: nil, initiator: nil, ip_address: nil)
+    @suspend = suspend
+    @reason_for_suspension = reason_for_suspension
+    @user = user
+    @initiator = initiator
+    @ip_address = ip_address
+  end
+
+  def save
+    return false unless valid?
+
+    if suspend
+      user.suspend(reason_for_suspension)
+    else
+      user.unsuspend
+    end
+
+    EventLog.record_event(user, action, initiator:, ip_address:)
+    PermissionUpdater.perform_on(user)
+    ReauthEnforcer.perform_on(user)
+  end
+  alias_method :save!, :save
+
+  def suspended?
+    suspend
+  end
+
+private
+
+  def action
+    if suspend
+      EventLog::ACCOUNT_SUSPENDED
+    else
+      EventLog::ACCOUNT_UNSUSPENDED
+    end
+  end
+end

--- a/app/views/suspensions/edit.html.erb
+++ b/app/views/suspensions/edit.html.erb
@@ -22,6 +22,20 @@
    })
 %>
 
+<% if @suspension.errors.present? %>
+  <%= render "govuk_publishing_components/components/error_summary", {
+    id: "error-summary",
+    title: "There was a problem with your suspension",
+    items: @suspension.errors.map do |error|
+    {
+      text: error.full_message,
+      href: "#user_#{error.attribute}",
+    }
+    end
+} %>
+
+<% end %>
+
 <%= form_tag suspension_path(@user), method: "put" do %>
   <%= render "govuk_publishing_components/components/hint", {
     text: "After the user has been unsuspended, they will need to reset their password."
@@ -33,7 +47,7 @@
       {
         label: "Suspended?",
         value: 1,
-        checked: @user.suspended?,
+        checked: @suspension.suspended?,
       }
     ]
   } %>
@@ -43,7 +57,8 @@
       text: "Reason for suspension"
     },
     name: "user[reason_for_suspension]",
-    value: @user.reason_for_suspension,
+    value: @suspension.reason_for_suspension,
+    error_items: @suspension.errors.full_messages_for(:reason_for_suspension).map {|message| { text: message } },
   } %>
 
   <%= render "govuk_publishing_components/components/button", {

--- a/app/views/suspensions/edit.html.erb
+++ b/app/views/suspensions/edit.html.erb
@@ -1,25 +1,52 @@
 <% content_for :title, "Suspend [#{@user.name}]" %>
+<% content_for :breadcrumbs,
+   render("govuk_publishing_components/components/breadcrumbs", {
+     collapse_on_mobile: true,
+     breadcrumbs: [
+       {
+         title: "Home",
+         url: root_path,
+       },
+       {
+         title: "Users",
+         url: users_path,
+       },
+       {
+         title: @user.name,
+         url: user_path(@user),
+       },
+       {
+         title: "Suspend",
+       },
+     ]
+   })
+%>
 
-<ol class="breadcrumb">
-  <li><%= link_to @user.name, user_path(@user) %></li>
-  <li class="active">Suspend</li>
-</ol>
+<%= form_tag suspension_path(@user), method: "put" do %>
+  <%= render "govuk_publishing_components/components/hint", {
+    text: "After the user has been unsuspended, they will need to reset their password."
+  } %>
 
-<h1 class="page-title">Suspend &ldquo;<%= @user.name %>&rdquo;</h1>
+  <%= render "govuk_publishing_components/components/checkboxes", {
+    name: "user[suspended]",
+    items: [
+      {
+        label: "Suspended?",
+        value: 1,
+        checked: @user.suspended?,
+      }
+    ]
+  } %>
 
-<%= form_tag suspension_path(@user), method: "put", :class => 'well remove-top-padding' do %>
-  <div class="checkbox add-top-margin">
-    <label>
-      <%= check_box_tag "user[suspended]", "1", @user.suspended? %>
-      Suspended?
-    </label>
-  </div>
-  <div class="form-group">
-    <label for="user_reason_for_suspension">Reason for suspension</label>
-    <%= text_field_tag "user[reason_for_suspension]", @user.reason_for_suspension, class: 'form-control input-md-6' %>
-  </div>
-  <hr />
-  <p>After the user has been unsuspended, they will need to reset their password.</p>
-  <%= submit_tag "Save", class: "btn btn-primary add-right-margin" %>
-  <%= link_to "Cancel", user_path(@user), class: "btn btn-default" %>
+  <%= render "govuk_publishing_components/components/input", {
+    label: {
+      text: "Reason for suspension"
+    },
+    name: "user[reason_for_suspension]",
+    value: @user.reason_for_suspension,
+  } %>
+
+  <%= render "govuk_publishing_components/components/button", {
+    text: "Save"
+  } %>
 <% end %>

--- a/test/controllers/suspensions_controller_test.rb
+++ b/test/controllers/suspensions_controller_test.rb
@@ -74,20 +74,6 @@ class SuspensionsControllerTest < ActionController::TestCase
       assert_equal "Negligence", another_user.reason_for_suspension
     end
 
-    should "trigger permissions to be updated on downstream apps" do
-      another_user = create(:user)
-      PermissionUpdater.expects(:perform_on).with(another_user)
-
-      put :update, params: { id: another_user.id, user: { suspended: "1", reason_for_suspension: "Negligence" } }
-    end
-
-    should "enforce reauth on downstream apps" do
-      another_user = create(:user)
-      ReauthEnforcer.expects(:perform_on).with(another_user)
-
-      put :update, params: { id: another_user.id, user: { suspended: "1", reason_for_suspension: "Negligence" } }
-    end
-
     should "redisplay the form if the reason is blank" do
       another_user = create(:user)
       put :update, params: { id: another_user.id, user: { suspended: "1", reason_for_suspension: "" } }

--- a/test/models/suspension_test.rb
+++ b/test/models/suspension_test.rb
@@ -1,0 +1,97 @@
+require "test_helper"
+
+class SuspensionTest < ActiveSupport::TestCase
+  setup do
+    EventLog.stubs(:record_event)
+    PermissionUpdater.stubs(:perform_on)
+    ReauthEnforcer.stubs(:perform_on)
+  end
+
+  should "be valid when a reason is given for a suspension" do
+    suspension = Suspension.new(suspend: true, reason_for_suspension: "A reason")
+
+    assert suspension.valid?
+  end
+
+  should "be valid when no reason is given for an unsuspension" do
+    suspension = Suspension.new(suspend: false)
+
+    assert suspension.valid?
+  end
+
+  should "be invalid when no reason is given for a suspension" do
+    suspension = Suspension.new(suspend: true)
+
+    assert_not suspension.valid?
+  end
+
+  should "not save an invalid suspension" do
+    suspension = Suspension.new(suspend: true)
+
+    assert_not suspension.valid?
+    assert_not suspension.save
+  end
+
+  should "suspend a user when suspend is true and a reason is given" do
+    user = mock
+    user.expects(:suspend).with("A reason")
+
+    suspension = Suspension.new(suspend: true, reason_for_suspension: "A reason", user:)
+
+    suspension.save!
+  end
+
+  should "unsuspend a user when suspend is false" do
+    user = mock
+    user.expects(:unsuspend)
+
+    suspension = Suspension.new(suspend: false, user:)
+
+    suspension.save!
+  end
+
+  should "log unsuspend events" do
+    user = stub(unsuspend: true)
+    initiator = mock
+    ip_address = "127.0.0.1"
+
+    EventLog.expects(:record_event).with(user, EventLog::ACCOUNT_UNSUSPENDED, initiator:, ip_address:)
+    suspension = Suspension.new(suspend: false, user:, initiator:, ip_address:)
+
+    suspension.save!
+  end
+
+  should "log suspend events" do
+    user = stub(suspend: true)
+    initiator = mock
+    ip_address = "127.0.0.1"
+
+    EventLog.expects(:record_event).with(user, EventLog::ACCOUNT_SUSPENDED, initiator:, ip_address:)
+    suspension = Suspension.new(suspend: true, reason_for_suspension: "A reason", user:, initiator:, ip_address:)
+
+    suspension.save!
+  end
+
+  should "call the PermissionUpdater when saving" do
+    user = stub(unsuspend: true)
+
+    PermissionUpdater.expects(:perform_on).with(user)
+    suspension = Suspension.new(suspend: false, user:)
+
+    suspension.save!
+  end
+
+  should "call the ReauthEnforcer when saving" do
+    user = stub(unsuspend: true)
+
+    ReauthEnforcer.expects(:perform_on).with(user)
+    suspension = Suspension.new(suspend: false, user:)
+
+    suspension.save!
+  end
+
+  should "be suspended when suspend is true" do
+    assert Suspension.new(suspend: true).suspended?
+    assert_not Suspension.new(suspend: false).suspended?
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/il1tKvaJ/181-migrate-suspensions-edit-to-use-design-system

I've removed the "cancel" button in favour of the breadcrumb trail, as the component guide suggests[1] that we should try to have a single button on each page.

I've also improved the error handling and made it follow the design system pattern by adding a Suspension model which uses ActiveRecord validations. Details in the second commit.

[1] https://components.publishing.service.gov.uk/component-guide/button

# Before

![before](https://github.com/alphagov/signon/assets/16707/7e330f75-461d-495a-b808-a5d4a83ae2d1)

## With errors

![before_errors](https://github.com/alphagov/signon/assets/16707/56837aa3-1a52-4392-a33d-2fc68e255642)

# After

![after](https://github.com/alphagov/signon/assets/16707/ec147032-aa80-4583-a518-acdc504f2ca5)

## With errors

![after_errors](https://github.com/alphagov/signon/assets/16707/46b5994b-bdee-4184-8859-9406475197f1)



