### PR TITLE
Migrate UsersController#require_2sv page to design system

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,7 +3,7 @@ require "csv"
 class UsersController < ApplicationController
   include UserPermissionsControllerMethods
 
-  layout "admin_layout", only: %w[edit_email_or_password event_logs]
+  layout "admin_layout", only: %w[edit_email_or_password event_logs require_2sv]
 
   before_action :authenticate_user!, except: :show
   before_action :load_and_authorize_user, except: %i[index show]

--- a/app/views/users/require_2sv.html.erb
+++ b/app/views/users/require_2sv.html.erb
@@ -1,16 +1,23 @@
-<% content_for :title, "Create new user" %>
+<% content_for :title, "2-step verification settings for new user" %>
 
-<h1>2-step verification settings for new user</h1>
-
-<%= form_for @user, :html => {:class => 'well'} do |f| %>
+<%= form_for @user do |f| %>
   <%= f.hidden_field :skip_update_user_permissions, value: "true" %>
-  <p class="checkbox">
-    <%= f.label :require_2sv do %>
-      <%= f.check_box :require_2sv %> Mandate 2-step verification for this user <%= "(this will remove their exemption)" if @user.exempt_from_2sv? %>
-    <% end %>
-    <br/>
-    User will be prompted to set up 2-step verification again the next time they sign in.
-  </p>
+  <%= render "govuk_publishing_components/components/hint", {
+    text: "User will be prompted to set up 2-step verification again the next time they sign in."
+  } %>
 
-  <%= f.submit "Update user", :class => 'btn btn-success' %>
+  <%= render "govuk_publishing_components/components/checkboxes", {
+    name: "user[require_2sv]",
+    items: [
+      {
+        label: "Mandate 2-step verification for this user #{'(this will remove their exemption)' if @user.exempt_from_2sv?}",
+        value: 1,
+        checked: @user.require_2sv?,
+      }
+    ]
+  } %>
+
+  <%= render "govuk_publishing_components/components/button", {
+    text: "Update user"
+  } %>
 <% end %>


### PR DESCRIPTION
Trello: https://trello.com/c/pEwkk3Dt

I've used the standard hint, checkbox and button components.

This page is shown as part of the user creation journey for users where their organisation doesn't mandate 2sv but we want to mandate it for the specific user. I've decided not to include a breadcrumb trail as there's not really any consideration made for navigating forward and backwards in this journey (the record is saved and the user emailed before we reach this page, for example).

# Before
![before](https://github.com/alphagov/signon/assets/16707/be29bdec-84c5-436e-8b6d-8f8c027b5c06)

# After
![after](https://github.com/alphagov/signon/assets/16707/86fce429-cfcd-4390-929b-ab83dc5bd892)
