### PR TITLE
Move 2SV exemptions page to use GOV.UK Design System

### DIFF
--- a/app/models/two_step_verification_exemption.rb
+++ b/app/models/two_step_verification_exemption.rb
@@ -1,0 +1,49 @@
+class TwoStepVerificationExemption
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attribute :reason, :string
+  attribute :expiry_day, :string
+  attribute :expiry_month, :string
+  attribute :expiry_year, :string
+
+  attr_reader :expiry_date
+
+  validates :reason, presence: { message: "must be provided" }
+  validate :check_expiry_date
+
+  def self.from_user(user)
+    new(
+      reason: user.reason_for_2sv_exemption,
+      expiry_day: user.expiry_date_for_2sv_exemption&.day,
+      expiry_month: user.expiry_date_for_2sv_exemption&.month,
+      expiry_year: user.expiry_date_for_2sv_exemption&.year,
+    )
+  end
+
+  def self.from_params(params)
+    new(
+      reason: params[:reason],
+      expiry_day: params[:expiry_date][:day],
+      expiry_month: params[:expiry_date][:month],
+      expiry_year: params[:expiry_date][:year],
+    )
+  end
+
+private
+
+  def check_expiry_date
+    if expiry_day.blank? && expiry_month.blank? && expiry_year.blank?
+      errors.add(:expiry_date, "must be provided")
+    elsif expiry_day.blank? || expiry_month.blank? || expiry_year.blank?
+      errors.add(:expiry_date, "day must be provided") if expiry_day.blank?
+      errors.add(:expiry_date, "month must be provided") if expiry_month.blank?
+      errors.add(:expiry_date, "year must be provided") if expiry_year.blank?
+    else
+      @expiry_date = Date.parse("#{expiry_year}-#{expiry_month}-#{expiry_day}")
+      errors.add(:expiry_date, "must be in the future") unless expiry_date > Time.zone.today
+    end
+  rescue Date::Error
+    errors.add(:expiry_date, "must be a real date")
+  end
+end

--- a/app/views/two_step_verification_exemptions/edit.html.erb
+++ b/app/views/two_step_verification_exemptions/edit.html.erb
@@ -1,31 +1,80 @@
-<% content_for :title, "Exempt user from 2-step verification - [#{@user.name}]" %>
+<% content_for :title, "Exempt &ldquo;#{@user.name}&rdquo; from 2-step verification".html_safe %>
 
-<ol class="breadcrumb">
-  <li><%= link_to @user.name, user_path(@user) %></li>
-  <li class="active">Exempt user from 2-step verification</li>
-</ol>
+<% content_for :breadcrumbs,
+   render("govuk_publishing_components/components/breadcrumbs", {
+     collapse_on_mobile: true,
+     breadcrumbs: [
+       {
+         title: "Home",
+         url: root_path,
+       },
+       {
+         title: "Users",
+         url: users_path,
+       },
+       {
+         title: @user.name,
+         url: user_path(@user),
+       },
+       {
+         title: "Exempt user from 2-step verification",
+       }
+     ]
+   })
+%>
 
-<h1 class="page-title">Exempt &ldquo;<%= @user.name %>&rdquo; from 2-step verification</h1>
+<% if @exemption.errors.any? %>
+  <% content_for :error_summary do %>
+    <%= render "govuk_publishing_components/components/error_summary", {
+      title: "There is a problem",
+      items: @exemption.errors.map do |error|
+        {
+          text: error.full_message,
+          href: "#exemption_#{error.attribute}",
+        }
+      end,
+    } %>
+  <% end %>
+<% end %>
 
-<%= form_tag two_step_verification_exemption_path(@user), method: "patch", :class => 'well remove-top-padding' do %>
-  <div class="add-top-margin">
-    <p>You are about to exempt this user from having 2-step verification on their account. This will remove any existing
-      requirement to log in with, or set up 2-step verification.</p>
-  </div>
-  <div class="form-group">
-    <label for="user_reason_for_2sv_exemption">Reason for 2-step verification exemption</label>
-    <%= text_field_tag "user[reason_for_2sv_exemption]", @user.reason_for_2sv_exemption, class: 'form-control input-md-6' %>
-  </div>
-  <p>Please provide a reason for granting this exemption above.</p>
-  <p>Please note - the reason you enter above will be visible to the user, and any admins who have the ability to edit
-    the user.</p>
-  <div class="form-group add-top-margin">
-    <label for="user_expiry_date_for_2sv_exemption">Expiry date for exemption</label>
-    <div class="form-inline">
-      <%= date_select :user, :expiry_date_for_2sv_exemption, {start_year: Time.zone.today.year, default: Time.zone.today + 1, selected: @user.expiry_date_for_2sv_exemption} %>
-    </div>
-  </div>
-  <p>All exemptions must have an expiry date. As this date approaches, this exemption will need to be reviewed.</p>
-  <%= submit_tag "Save", class: "btn btn-primary add-right-margin" %>
-  <%= link_to "Cancel", user_path(@user), class: "btn btn-default" %>
+<%= render "govuk_publishing_components/components/lead_paragraph", {
+  text: %{
+    You are about to exempt this user from having 2-step verification on their account.
+    This will remove any existing requirement to log in with, or set up 2-step verification.
+  }
+} %>
+
+<%= form_tag two_step_verification_exemption_path(@user), method: "patch" do %>
+  <%= render "govuk_publishing_components/components/input", {
+    id: "exemption_reason",
+    label: { text: "Reason for 2-step verification exemption" },
+    type: "text",
+    name: "exemption[reason]",
+    value: @exemption.reason,
+    hint: %{
+      Please provide a reason for granting this exemption above.
+      Please note - the reason you enter will be visible to the user, and any admins who have the ability to edit the user.
+    },
+    error_items: @exemption.errors.full_messages_for(:reason).map { |message| { text: message } }
+  } %>
+
+  <%= render "govuk_publishing_components/components/date_input", {
+    id: "exemption_expiry_date",
+    legend_text: "Expiry date for exemption",
+    name: "exemption[expiry_date]",
+    items: [
+      { name: "day", width: 2, value: @exemption.expiry_day },
+      { name: "month", width: 2, value: @exemption.expiry_month },
+      { name: "year", width: 4, value: @exemption.expiry_year }
+    ],
+    hint: %{
+      All exemptions must have an expiry date.
+      As this date approaches, this exemption will need to be reviewed.
+    },
+    error_items: @exemption.errors.full_messages_for(:expiry_date).map { |message| { text: message } }
+  } %>
+
+  <%= render "govuk_publishing_components/components/button", {
+    text: "Save"
+  } %>
 <% end %>

--- a/test/factories/two_step_verification_exemption.rb
+++ b/test/factories/two_step_verification_exemption.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :two_step_verification_exemption do
+    reason { "a very good reason" }
+    expiry_day { Time.zone.today.day + 1 }
+    expiry_month { Time.zone.today.month }
+    expiry_year { Time.zone.today.year }
+  end
+end

--- a/test/integration/managing_two_step_verification_test.rb
+++ b/test/integration/managing_two_step_verification_test.rb
@@ -205,7 +205,6 @@ class ManagingTwoStepVerificationTest < ActionDispatch::IntegrationTest
 
           assert_user_has_not_been_exempted_from_2sv(user_requiring_2sv)
           assert page.has_text?("Expiry date must be in the future")
-          assert_equal edit_two_step_verification_exemption_path(user_requiring_2sv), current_path
         end
 
         context "when a exemption reason already exists" do
@@ -216,9 +215,9 @@ class ManagingTwoStepVerificationTest < ActionDispatch::IntegrationTest
             click_link("Edit reason or expiry date for 2-step verification exemption")
 
             assert page.has_field?("Reason for 2-step verification exemption", with: "user is exempt")
-            assert page.has_field?("user_expiry_date_for_2sv_exemption_1i", with: @expiry_date.year)
-            assert page.has_field?("user_expiry_date_for_2sv_exemption_2i", with: @expiry_date.month)
-            assert page.has_field?("user_expiry_date_for_2sv_exemption_3i", with: @expiry_date.day)
+            assert page.has_field?("Year", with: @expiry_date.year)
+            assert page.has_field?("Month", with: @expiry_date.month)
+            assert page.has_field?("Day", with: @expiry_date.day)
 
             new_expiry_date = 1.month.from_now.to_date
             fill_in_exemption_form(@reason_for_exemption, new_expiry_date)

--- a/test/models/two_step_verification_exemption_test.rb
+++ b/test/models/two_step_verification_exemption_test.rb
@@ -1,0 +1,105 @@
+require "test_helper"
+
+class TwoStepVerificationExemptionTest < ActiveSupport::TestCase
+  setup do
+    @today = Time.zone.today
+  end
+
+  context "validation" do
+    should "be valid if a reason and a valid expiry date are provided" do
+      exemption = build(:two_step_verification_exemption)
+      assert exemption.valid?
+    end
+
+    should "be invalid if no reason is provided]" do
+      exemption = build(:two_step_verification_exemption, reason: nil)
+      assert_not exemption.valid?
+      assert_includes exemption.errors[:reason], "must be provided"
+    end
+
+    should "be invalid if blank reason is provided]" do
+      exemption = build(:two_step_verification_exemption, reason: "")
+      assert_not exemption.valid?
+      assert_includes exemption.errors[:reason], "must be provided"
+    end
+
+    should "be invalid if none of the expiry date fields are provided" do
+      exemption = build(:two_step_verification_exemption, expiry_day: nil, expiry_month: nil, expiry_year: nil)
+      assert_not exemption.valid?
+      assert_includes exemption.errors[:expiry_date], "must be provided"
+    end
+
+    should "be invalid if all of the expiry date fields are blank" do
+      exemption = build(:two_step_verification_exemption, expiry_day: "", expiry_month: "", expiry_year: "")
+      assert_not exemption.valid?
+      assert_includes exemption.errors[:expiry_date], "must be provided"
+    end
+
+    should "be invalid if any of the expiry date fields are not provided" do
+      exemption = build(:two_step_verification_exemption, expiry_day: nil, expiry_year: nil)
+      assert_not exemption.valid?
+      assert_includes exemption.errors[:expiry_date], "day must be provided"
+      assert_includes exemption.errors[:expiry_date], "year must be provided"
+    end
+
+    should "be invalid if some of the expiry date fields are blank" do
+      exemption = build(:two_step_verification_exemption, expiry_day: "", expiry_month: "")
+      assert_not exemption.valid?
+      assert_includes exemption.errors[:expiry_date], "day must be provided"
+      assert_includes exemption.errors[:expiry_date], "month must be provided"
+    end
+
+    should "be invalid if the expiry date is not in the future" do
+      exemption = build(:two_step_verification_exemption, expiry_day: @today.day, expiry_month: @today.month, expiry_year: @today.year)
+      assert_not exemption.valid?
+      assert_includes exemption.errors[:expiry_date], "must be in the future"
+    end
+
+    should "be invalid if the expiry date is not a valid date" do
+      exemption = build(:two_step_verification_exemption, expiry_day: 31, expiry_month: 2, expiry_year: @today.year + 1)
+      assert_not exemption.valid?
+      assert_includes exemption.errors[:expiry_date], "must be a real date"
+    end
+  end
+
+  context ".from_user" do
+    should "build exemption from attributes on a user" do
+      user = build(:user, reason_for_2sv_exemption: "reason", expiry_date_for_2sv_exemption: @today)
+      exemption = TwoStepVerificationExemption.from_user(user)
+
+      assert_equal "reason", exemption.reason
+      assert_equal @today.day.to_s, exemption.expiry_day
+      assert_equal @today.month.to_s, exemption.expiry_month
+      assert_equal @today.year.to_s, exemption.expiry_year
+    end
+
+    should "build exemption from attributes on a user even when they are nil" do
+      user = build(:user, reason_for_2sv_exemption: nil, expiry_date_for_2sv_exemption: nil)
+      exemption = TwoStepVerificationExemption.from_user(user)
+
+      assert_nil exemption.reason
+      assert_nil exemption.expiry_day
+      assert_nil exemption.expiry_month
+      assert_nil exemption.expiry_year
+    end
+  end
+
+  context ".from_params" do
+    should "build exemption from permitted controller params" do
+      params = ActionController::Parameters.new(
+        "exemption" => {
+          "reason" => "reason",
+          "expiry_date" => { "day" => "23", "month" => "11", "year" => "2025" },
+        },
+      )
+      .require(:exemption).permit(:reason, expiry_date: %i[day month year])
+
+      exemption = TwoStepVerificationExemption.from_params(params)
+
+      assert_equal "reason", exemption.reason
+      assert_equal "23", exemption.expiry_day
+      assert_equal "11", exemption.expiry_month
+      assert_equal "2025", exemption.expiry_year
+    end
+  end
+end

--- a/test/support/managing_two_sv_helpers.rb
+++ b/test/support/managing_two_sv_helpers.rb
@@ -96,10 +96,9 @@ module ManagingTwoSvHelpers
   end
 
   def fill_in_expiry_date(date)
-    element = "user_expiry_date_for_2sv_exemption"
-    select date.year.to_s, from: "#{element}_1i"
-    select date.strftime("%B"), from: "#{element}_2i"
-    select date.day.to_s, from: "#{element}_3i"
+    fill_in "Day", with: date.day
+    fill_in "Month", with: date.month
+    fill_in "Year", with: date.year
   end
 
   def assert_user_has_been_exempted_from_2sv(user, reason, expiry_date)


### PR DESCRIPTION
Trello: https://trello.com/c/oqt4y7dH

I've introduced a new `TwoStepVerificationExemption` `ActiveModel` model to implement the field validation for this form; previously the validation was all done in the controller.

My main motivation for doing this was to be able to store validation errors against a particular field so that I could implement the Design System error summary correctly with links to the invalid fields and so I could implement something close to [the date field][1] validation recommended by the Design System.

However, I think it also bring some other benefits: the code is now a bit more idiomatic Rails, it's easier to test the validation, and when validation fails the values the user entered are retained (i.e. we re-render the form rather than redirecting as we did previously). The latter is more relevant now that we're effectively using 3 text inputs for the date field rather than 3 select elements.

I've intentionally implemented the `expiry_date` validation in a "heirarchical" manner, i.e. the user doesn't immediately see a bunch of validation errors as they would if I'd used standard Rails validation. Instead they see the most "important" validation error(s) first and then if they fix those, they might see less "important" validation errors. I haven't actually seen any guidance on this, but it felt overwhelming for the user to see many different validation errors for a single date field when e.g. the problem is that none of the values have been entered at all. Also this was how the validation was working previously.

The Design System documentation re [validation errors on a date input][2] recommends highlighting individual inputs within the date input (e.g. just the `day` field) if it's possible to determine that's where the problem lies. Although the new `TwoStepVerificationExemption` model makes it feasible to do this, the `date_input` component [3] in the `govuk_publishing_components` gem doesn't currently support setting an error on the individual `day`, `month` & `year` fields. I plan to suggest changing the `date_input` component to support this in the future.

I've haven't included a "Cancel" button, because we now have a decent breadcrumb trail. This is what we've done elsewhere when converting pages to use the GOV.UK Design System.

### Before

![signon dev gov uk_two_step_verification_exemptions_15805_edit](https://github.com/alphagov/signon/assets/3169/2fd730f3-cda4-4d41-8693-675f48890a68)

![signon dev gov uk_two_step_verification_exemptions_15805_edit (1)](https://github.com/alphagov/signon/assets/3169/cceb8a58-afd1-472b-baa8-fdc95e2d07b0)

### After

![signon dev gov uk_two_step_verification_exemptions_15805_edit (2)](https://github.com/alphagov/signon/assets/3169/397511a2-f276-47c3-98c3-a7b56b96970d)

![signon dev gov uk_two_step_verification_exemptions_15805](https://github.com/alphagov/signon/assets/3169/0c28fb8d-9c61-4b21-8984-cc8cb267ac6f)


[1]: https://design-system.service.gov.uk/components/date-input/
[2]: https://design-system.service.gov.uk/components/date-input/#error-messages
[3]: https://github.com/alphagov/govuk_publishing_components/blob/45ea966343920fb73990a4c3b3ed517b76219d56/app/views/govuk_publishing_components/components/_date_input.html.erb
