### PR TITLE
Allow setting secrets via environment variables in development

### DIFF
--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -1,8 +1,8 @@
 development:
   active_record_encryption:
-    primary_key: 5iYPUMb6NWxlsyiRGyBrVgfY6ZPhm5ZA
-    key_derivation_salt: q8sHPMCYthvtuM5N7mv2438my5v4DPaP
-  secret_key_base: 101615e3369d108c13f7182caf9bb988fc8f2d8d309ebd16d39b34bece4b4bd0944df576bfa2ff35984e7c447658cc25810540b50759c15c2b94f8ef26867a8a
+    primary_key: <%= ENV.fetch("ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY", "5iYPUMb6NWxlsyiRGyBrVgfY6ZPhm5ZA") %>
+    key_derivation_salt: <%= ENV.fetch("ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT", "q8sHPMCYthvtuM5N7mv2438my5v4DPaP") %>
+  secret_key_base: <%= ENV.fetch("SECRET_KEY_BASE", "101615e3369d108c13f7182caf9bb988fc8f2d8d309ebd16d39b34bece4b4bd0944df576bfa2ff35984e7c447658cc25810540b50759c15c2b94f8ef26867a8a") %>
 test:
   active_record_encryption:
     primary_key: 5iYPUMb6NWxlsyiRGyBrVgfY6ZPhm5ZA


### PR DESCRIPTION
Previously the secrets were hard-coded in development. I've found myself needing to change them, but if I just change the hard-coded values, there's a danger I might push sensitive secrets into the public repo. So it seems safer to allow the secrets to be overridden using the same env vars that are used in production, but fallback to the hard-coded values if those env vars are not set.