### PR TITLE
Incremental improvements to the users index page

### DIFF
--- a/app/assets/stylesheets/_filters.scss
+++ b/app/assets/stylesheets/_filters.scss
@@ -48,6 +48,10 @@ a.filter-option:visited,
 
 .filter-by-name-field {
   width: 290px;
+
+  &::placeholder {
+    color: #757575;
+  }
 }
 
 // Nav compact

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -152,11 +152,7 @@ private
   end
 
   def paginate_users
-    @users = if @users.is_a?(Array)
-               Kaminari.paginate_array(@users).page(params[:page]).per(100)
-             else
-               @users.page(params[:page]).per(100)
-             end
+    @users = @users.page(params[:page]).per(100)
   end
 
   def any_filter?

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -152,7 +152,7 @@ private
   end
 
   def paginate_users
-    @users = @users.page(params[:page]).per(100)
+    @users = @users.page(params[:page]).per(25)
   end
 
   def any_filter?

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -28,7 +28,7 @@ class UsersController < ApplicationController
   def index
     authorize User
 
-    @users = policy_scope(User).includes(:organisation)
+    @users = policy_scope(User).includes(:organisation).order(:name)
     filter_users if any_filter?
     respond_to do |format|
       format.html do
@@ -152,19 +152,11 @@ private
   end
 
   def paginate_users
-    if any_filter?
-      @users = if @users.is_a?(Array)
-                 Kaminari.paginate_array(@users).page(params[:page]).per(100)
-               else
-                 @users.page(params[:page]).per(100)
-               end
-    else
-      @users, @sorting_params = @users.alpha_paginate(
-        params.fetch(:letter, "A"),
-        ALPHABETICAL_PAGINATE_CONFIG.dup,
-        &:name
-      )
-    end
+    @users = if @users.is_a?(Array)
+               Kaminari.paginate_array(@users).page(params[:page]).per(100)
+             else
+               @users.page(params[:page]).per(100)
+             end
   end
 
   def any_filter?

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -48,4 +48,9 @@ module UsersHelper
     max_last_synced_at = permissions.map(&:last_synced_at).compact.max
     max_updated_at.present? && max_last_synced_at.present? ? max_updated_at > max_last_synced_at : false
   end
+
+  def link_to_users_csv(text, params, options = {})
+    merged_params = params.permit(:filter, :role, :permission, :status, :organisation, :two_step_status).merge(format: "csv")
+    link_to text, merged_params, options
+  end
 end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -53,4 +53,8 @@ module UsersHelper
     merged_params = params.permit(:filter, :role, :permission, :status, :organisation, :two_step_status).merge(format: "csv")
     link_to text, merged_params, options
   end
+
+  def formatted_number_of_users(users)
+    pluralize(number_with_delimiter(users.total_count), "user")
+  end
 end

--- a/app/views/users/_pagination.html.erb
+++ b/app/views/users/_pagination.html.erb
@@ -1,5 +1,0 @@
-<% position ||= nil %>
-<% if position == 'top' %>
-  <h2 class="<%= @users.total_count > 100 ? 'remove' : 'add' %>-bottom-margin"><%= pluralize(number_with_delimiter(@users.total_count), 'user') %></h2>
-<% end %>
-<%= paginate(@users, theme: 'twitter-bootstrap-3') %>

--- a/app/views/users/_pagination.html.erb
+++ b/app/views/users/_pagination.html.erb
@@ -1,10 +1,5 @@
 <% position ||= nil %>
-<% if any_filter? %>
-  <% if position == 'top' %>
-    <h2 class="<%= @users.total_count > 100 ? 'remove' : 'add' %>-bottom-margin"><%= pluralize(number_with_delimiter(@users.total_count), 'user') %></h2>
-  <% end %>
-  <%= paginate(@users, theme: 'twitter-bootstrap-3') %>
-<% else %>
-  <h3 class="remove-bottom-margin">Users by initial</h3>
-  <%= alphabetical_paginate(@sorting_params) %>
+<% if position == 'top' %>
+  <h2 class="<%= @users.total_count > 100 ? 'remove' : 'add' %>-bottom-margin"><%= pluralize(number_with_delimiter(@users.total_count), 'user') %></h2>
 <% end %>
+<%= paginate(@users, theme: 'twitter-bootstrap-3') %>

--- a/app/views/users/_user_filter.html.erb
+++ b/app/views/users/_user_filter.html.erb
@@ -34,8 +34,7 @@
           <% end %>
         </li>
         <li class="<% if any_filter? %>add-right-margin <% end %>pull-right">
-          <% merged_params = params.permit(:filter, :role, :permission, :status, :organisation, :two_step_status).merge(format: "csv") %>
-          <%= link_to "Export as CSV", merged_params, class: "btn btn-default" %>
+          <%= link_to_users_csv "Export as CSV", params, class: "btn btn-default" %>
         </li>
       </ul>
     </header>

--- a/app/views/users/_user_filter.html.erb
+++ b/app/views/users/_user_filter.html.erb
@@ -9,6 +9,18 @@
         <% end %>
       <% end %>
       <ul class="nav nav-compact nav-pills">
+        <li class="filter-by-name">
+          <%= form_tag nil, method: "get", class: 'add-right-margin form-inline' do %>
+          <%= hidden_field_tag :role, params[:role] if params[:role] %>
+          <%= hidden_field_tag :permission, params[:permission] if params[:permission] %>
+          <%= hidden_field_tag :status, params[:status] if params[:status] %>
+          <%= hidden_field_tag :organisation, params[:organisation] if params[:organisation] %>
+          <%= hidden_field_tag :two_step_status, params[:two_step_status] if params[:two_step_status] %>
+          <%= label_tag 'filter', 'Name or email', class: 'add-right-margin sr-only' %>
+          <%= text_field_tag "filter", params[:filter], placeholder: "Name or email", class: 'form-control filter-by-name-field' %>
+          <%= submit_tag "Filter", class: "btn btn-default" %>
+          <% end %>
+        </li>
         <li class="nav-pill-text">
           <strong>Filter by</strong>
         </li>
@@ -21,18 +33,6 @@
           <%= render partial: 'user_filter_group', locals: {filter_type: :organisation} %>
         <% end %>
         <%= render partial: 'user_filter_group', locals: {filter_type: :two_step_status} %>
-        <li class="filter-by-name">
-          <%= form_tag nil, method: "get", class: 'add-left-margin form-inline' do %>
-          <%= hidden_field_tag :role, params[:role] if params[:role] %>
-          <%= hidden_field_tag :permission, params[:permission] if params[:permission] %>
-          <%= hidden_field_tag :status, params[:status] if params[:status] %>
-          <%= hidden_field_tag :organisation, params[:organisation] if params[:organisation] %>
-          <%= hidden_field_tag :two_step_status, params[:two_step_status] if params[:two_step_status] %>
-          <%= label_tag 'filter', 'Name or email', class: 'add-right-margin' %>
-          <%= text_field_tag "filter", params[:filter], class: 'form-control filter-by-name-field' %>
-          <%= submit_tag "Search", class: "btn btn-default" %>
-          <% end %>
-        </li>
       </ul>
     </header>
   </div>

--- a/app/views/users/_user_filter.html.erb
+++ b/app/views/users/_user_filter.html.erb
@@ -33,9 +33,6 @@
           <%= submit_tag "Search", class: "btn btn-default" %>
           <% end %>
         </li>
-        <li class="<% if any_filter? %>add-right-margin <% end %>pull-right">
-          <%= link_to_users_csv "Export as CSV", params, class: "btn btn-default" %>
-        </li>
       </ul>
     </header>
   </div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -13,9 +13,9 @@
   </div>
 </div>
 
-<%= render partial: "user_filter" %>
+<h2><%= pluralize(number_with_delimiter(@users.total_count), 'user') %></h2>
 
-<h2 class="add-bottom-margin"><%= pluralize(number_with_delimiter(@users.total_count), 'user') %></h2>
+<%= render partial: "user_filter" %>
 
 <table class="table table-striped table-bordered">
   <thead>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -22,7 +22,6 @@
       <th scope="col">Name and email</th>
       <th scope="col">Role</th>
       <th scope="col">Organisation</th>
-      <th scope="col">Sign-in count</th>
       <th scope="col">Last sign-in</th>
       <th scope="col">Created</th>
       <th scope="col">Status</th>
@@ -44,7 +43,6 @@
         </td>
         <td class="role"><%= user.role.humanize %></td>
         <td class="organisation"><%= user.organisation.try(:name) %></td>
-        <td><%= user.sign_in_count %></td>
         <td class="last-sign-in">
           <% if user.current_sign_in_at %>
             <%= time_ago_in_words(user.current_sign_in_at) %> ago

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -3,8 +3,8 @@
 <div class="page-title clearfix remove-top-margin">
   <h1 class="pull-left"><%= user_role_text %></h1>
   <div class="pull-right add-top-margin">
-    <%= link_to "Create user", new_user_invitation_path, class: "btn btn-success add-right-margin" %>
     <% if policy(User).new? %>
+      <%= link_to "Create user", new_user_invitation_path, class: "btn btn-success add-right-margin" %>
       <%= link_to "Upload a batch of users", new_batch_invitation_path, class: "btn btn-default add-right-margin" %>
     <% end %>
     <% if policy(BulkGrantPermissionSet).new? %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -23,7 +23,8 @@
 <table class="table table-striped table-bordered">
   <thead>
     <tr class="table-header">
-      <th scope="col">Name and email</th>
+      <th scope="col">Name</th>
+      <th scope="col">Email</th>
       <th scope="col">Role</th>
       <th scope="col">Organisation</th>
       <th scope="col">Last sign-in</th>
@@ -35,14 +36,14 @@
   <tbody>
     <% @users.each do |user| %>
       <tr>
-        <td class="email">
+        <td class="name">
           <%= user.unusable_account? ? "<del>".html_safe : "" %>
             <strong>
               <%= link_to "#{user.name}", edit_user_path(user) %>
             </strong>
           <%= user.unusable_account? ? "</del>".html_safe : "" %>
-          <br><span class="text-muted"><%= user.email %></span>
         </td>
+        <td class="email"><%= user.email %></td>
         <td class="role"><%= user.role.humanize %></td>
         <td class="organisation"><%= user.organisation.try(:name) %></td>
         <td class="last-sign-in">

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -23,7 +23,6 @@
       <th scope="col">Role</th>
       <th scope="col">Organisation</th>
       <th scope="col">Last sign-in</th>
-      <th scope="col">Created</th>
       <th scope="col">Status</th>
       <th scope="col"><%= two_step_abbr_tag %> Status</th>
       <th scope="col"><%= two_step_abbr_tag %> Exemption Expiry</th>
@@ -50,7 +49,6 @@
             never signed in
           <% end %>
         </td>
-        <td><%= time_ago_in_words(user.created_at) %> ago</td>
         <td><%= user.status.humanize %></td>
         <td><%= two_step_status(user) %></td>
         <td>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -14,7 +14,7 @@
 </div>
 
 <div class="clearfix">
-  <h2 class="pull-left remove-top-margin"><%= pluralize(number_with_delimiter(@users.total_count), 'user') %></h2>
+  <h2 class="pull-left remove-top-margin"><%= formatted_number_of_users(@users) %></h2>
   <%= link_to_users_csv "Export as CSV", params, class: "btn btn-default pull-right" %>
 </div>
 

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -25,7 +25,6 @@
       <th scope="col">Last sign-in</th>
       <th scope="col">Status</th>
       <th scope="col"><%= two_step_abbr_tag %> Status</th>
-      <th scope="col"><%= two_step_abbr_tag %> Exemption Expiry</th>
       <th scope="col">Actions</th>
     </tr>
   </thead>
@@ -51,13 +50,6 @@
         </td>
         <td><%= user.status.humanize %></td>
         <td><%= two_step_status(user) %></td>
-        <td>
-          <% if user.expiry_date_for_2sv_exemption.nil? %>
-            n/a
-          <% else %>
-            <%= user.expiry_date_for_2sv_exemption.strftime("%d/%m/%Y") %>
-          <% end %>
-        </td>
         <td>
           <% if user.invited_but_not_accepted %>
             <%= form_tag resend_user_invitation_path(user) do %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -13,7 +13,10 @@
   </div>
 </div>
 
-<h2><%= pluralize(number_with_delimiter(@users.total_count), 'user') %></h2>
+<div class="clearfix">
+  <h2 class="pull-left remove-top-margin"><%= pluralize(number_with_delimiter(@users.total_count), 'user') %></h2>
+  <%= link_to_users_csv "Export as CSV", params, class: "btn btn-default pull-right" %>
+</div>
 
 <%= render partial: "user_filter" %>
 

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -14,7 +14,8 @@
 </div>
 
 <%= render partial: "user_filter" %>
-<%= render partial: "pagination", locals: {position: 'top'} %>
+
+<h2 class="add-bottom-margin"><%= pluralize(number_with_delimiter(@users.total_count), 'user') %></h2>
 
 <table class="table table-striped table-bordered">
   <thead>
@@ -67,4 +68,4 @@
   </tbody>
 </table>
 
-<%= render partial: "pagination" %>
+<%= paginate(@users, theme: 'twitter-bootstrap-3') %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -15,7 +15,7 @@
 
 <div class="clearfix">
   <h2 class="pull-left remove-top-margin"><%= formatted_number_of_users(@users) %></h2>
-  <%= link_to_users_csv "Export as CSV", params, class: "btn btn-default pull-right" %>
+  <%= link_to_users_csv "Export #{formatted_number_of_users(@users)} as CSV", params, class: "btn btn-default pull-right" %>
 </div>
 
 <%= render partial: "user_filter" %>

--- a/config/initializers/alphabetical_paginate_config.rb
+++ b/config/initializers/alphabetical_paginate_config.rb
@@ -1,9 +1,0 @@
-ALPHABETICAL_PAGINATE_CONFIG = {
-  db_field: "users.name",
-  numbers: false,
-  others: false,
-  include_all: false,
-  js: false,
-  bootstrap3: true,
-  db_mode: true,
-}.freeze

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -262,6 +262,12 @@ class UsersControllerTest < ActionController::TestCase
         assert_select "a", text: "Grant access to all users"
       end
 
+      should "display 'Export N users as CSV' button" do
+        get :index
+
+        assert_select "a", text: "Export 1 user as CSV", href: users_path(format: "csv")
+      end
+
       should "list users" do
         create(:user, email: "another_user@email.com")
         get :index

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -323,16 +323,6 @@ class UsersControllerTest < ActionController::TestCase
         end
       end
 
-      should "let you paginate by the first letter of the name" do
-        create(:user, name: "alf", email: "a@email.com")
-        create(:user, name: "zed", email: "z@email.com")
-
-        get :index, params: { letter: "Z" }
-
-        assert_select "td.email", /z@email.com/
-        assert_select "tbody tr", count: 1
-      end
-
       context "filter" do
         setup do
           create(:user, email: "not_admin@gov.uk")

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -244,6 +244,24 @@ class UsersControllerTest < ActionController::TestCase
     end
 
     context "GET index" do
+      should "display 'Create user' button" do
+        get :index
+
+        assert_select "a", text: "Create user"
+      end
+
+      should "display 'Upload a batch of users' button" do
+        get :index
+
+        assert_select "a", text: "Upload a batch of users"
+      end
+
+      should "display 'Grant access to all users' button" do
+        get :index
+
+        assert_select "a", text: "Grant access to all users"
+      end
+
       should "list users" do
         create(:user, email: "another_user@email.com")
         get :index
@@ -889,6 +907,33 @@ class UsersControllerTest < ActionController::TestCase
       @user.update_column(:role, "normal")
       get :index
       assert_redirected_to root_path
+    end
+  end
+
+  context "as Organisation Admin" do
+    setup do
+      @user = create(:organisation_admin)
+      sign_in @user
+    end
+
+    context "GET index" do
+      should "not display 'Create user' button" do
+        get :index
+
+        assert_select "a", text: "Create user", count: 0
+      end
+
+      should "not display 'Upload a batch of users' button" do
+        get :index
+
+        assert_select "a", text: "Upload a batch of users", count: 0
+      end
+
+      should "not display 'Grant access to all users' button" do
+        get :index
+
+        assert_select "a", text: "Grant access to all users", count: 0
+      end
     end
   end
 end

--- a/test/integration/admin_user_index_test.rb
+++ b/test/integration/admin_user_index_test.rb
@@ -32,7 +32,7 @@ class AdminUserIndexTest < ActionDispatch::IntegrationTest
 
       within "table" do
         assert has_css?("td", text: "Enabled", count: 1)
-        assert has_css?("td", text: "Not set up", count: 3)
+        assert has_css?("td", text: "Not set up", count: 7)
       end
     end
 
@@ -43,33 +43,6 @@ class AdminUserIndexTest < ActionDispatch::IntegrationTest
 
       actual_last_sign_in_strings = page.all("table tr td.last-sign-in").map(&:text).map(&:strip)[0..1]
       assert_equal ["5 minutes ago", "never signed in"], actual_last_sign_in_strings
-    end
-
-    should "see list of users paginated alphabetically" do
-      visit "/users"
-
-      assert page.has_content?("Users")
-
-      expected = [
-        "Aardvark aardvark@example.com",
-        "Abbey abbey@example.com",
-        "Abbot mr_ab@example.com",
-        "Admin User admin@example.com",
-      ]
-      actual = page.all("table tr td.email").map(&:text).map(&:strip)
-      assert_equal expected, actual
-
-      within first(".pagination") do
-        click_on "E"
-      end
-
-      expected = [
-        "Ed ed@example.com",
-        "Eddie eddie_bb@example.com",
-        "Ernie ernie@example.com",
-      ]
-      actual = page.all("table tr td.email").map(&:text).map(&:strip)
-      assert_equal expected, actual
     end
 
     should "be able to filter users" do
@@ -88,7 +61,6 @@ class AdminUserIndexTest < ActionDispatch::IntegrationTest
 
       click_on "Users"
 
-      assert page.has_content?("Users by initial")
       assert page.has_content?("Aardvark aardvark@example.com")
     end
 

--- a/test/integration/admin_user_index_test.rb
+++ b/test/integration/admin_user_index_test.rb
@@ -49,7 +49,7 @@ class AdminUserIndexTest < ActionDispatch::IntegrationTest
       visit "/users"
 
       fill_in "Name or email", with: "bb"
-      click_on "Search"
+      click_on "Filter"
 
       assert page.has_content?("Abbey abbey@example.com")
       assert page.has_content?("Abbot mr_ab@example.com")


### PR DESCRIPTION
Trello: https://trello.com/c/QuwuPtZW

We're planning to move this page (like every other page in the Signon app) to use the GOV.UK Design System. However, we haven't yet worked out how to implement the filtering using the Design System. So in the meantime, we've decided to make some incremental improvements which will also help when we come to move the page to the Design System.

Please see the commit note for details and motivations for each change, but in summary we've:

* removed some of the less useful columns
* split the name & email into separate columns
* replaced the "Users by initial" pagination with standard pagination
* removed the pagination controls from the top of the table and reduced the number of users on each page to make the pagination controls at the bottom of the table more discoverable
* made the filter controls more prominent and more closely associated them with the table
* moved the name & email filter to the left of the other filter controls and changed the button text from "Search" to "Filter"
* moved the "Export as CSV" button away from the filter controls and particularly away from the clear filters button
* only display "Create user" button if you have actually have permission to create a user

Note: Names & emails were blurred to anonymise the users just for the screenshots - they're not really blurred in the implementation!

### Before

#### No filters applied
<img width="1326" alt="Screenshot 2023-07-27 at 15 42 23" src="https://github.com/alphagov/signon/assets/3169/e9570dc8-676a-40bf-a30f-4cde229d8629">

#### 2 dropdown filters applied
<img width="1326" alt="Screenshot 2023-07-27 at 15 44 10" src="https://github.com/alphagov/signon/assets/3169/994a2dd0-d398-49d4-ad9f-e7824e742407">

#### Name & email filter applied
<img width="1326" alt="Screenshot 2023-07-27 at 15 46 17" src="https://github.com/alphagov/signon/assets/3169/99aa3155-2c77-496b-94db-f0be6c0d5bfc">

### After

#### No filters applied
<img width="1326" alt="Screenshot 2023-07-27 at 15 51 06" src="https://github.com/alphagov/signon/assets/3169/8e365db2-9e7e-434e-8fa8-76f75cc36bf0">

#### 2 dropdown filters applied
<img width="1326" alt="Screenshot 2023-07-27 at 15 50 52" src="https://github.com/alphagov/signon/assets/3169/dc7b530d-264b-4f81-9c6b-5068c0f4998c">

#### Name & email filter applied
<img width="1326" alt="Screenshot 2023-07-27 at 15 52 20" src="https://github.com/alphagov/signon/assets/3169/99ab5fa4-8061-4a44-ae38-db9b33536793">
