### PR TITLE
Remove unwanted spaces from users names

### DIFF
--- a/app/models/batch_invitation_user.rb
+++ b/app/models/batch_invitation_user.rb
@@ -3,6 +3,8 @@ class BatchInvitationUser < ApplicationRecord
 
   validates :outcome, inclusion: { in: [nil, "success", "failed", "skipped"] }
 
+  before_save :strip_whitespace_from_name
+
   scope :processed, -> { where.not(outcome: nil) }
   scope :unprocessed, -> { where(outcome: nil) }
   scope :failed, -> { where(outcome: "failed") }
@@ -89,5 +91,9 @@ private
       user_params: raw_attributes,
       current_user_role: inviting_user.role.to_sym,
     ).sanitise
+  end
+
+  def strip_whitespace_from_name
+    name.strip!
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -54,6 +54,7 @@ class User < ApplicationRecord
   before_save :reset_2sv_exemption_reason
   before_save :mark_two_step_mandated_changed
   before_save :update_password_changed
+  before_save :strip_whitespace_from_name
 
   scope :web_users, -> { where(api_user: false) }
   scope :not_suspended, -> { where(suspended_at: nil) }
@@ -373,6 +374,10 @@ private
 
   def fix_apostrophe_in_email
     email.tr!("’", "'") if email.present? && email_changed?
+  end
+
+  def strip_whitespace_from_name
+    name.strip!
   end
 
   def update_password_changed

--- a/db/migrate/20230802095323_strip_whitespace_from_users_names.rb
+++ b/db/migrate/20230802095323_strip_whitespace_from_users_names.rb
@@ -1,0 +1,11 @@
+class StripWhitespaceFromUsersNames < ActiveRecord::Migration[7.0]
+  NAME_HAS_LEADING_OR_TRAILING_SPACE = "name REGEXP('^\s+') OR name REGEXP('\s+$')".freeze
+
+  def up
+    User.where(NAME_HAS_LEADING_OR_TRAILING_SPACE).each(&:save!)
+
+    BatchInvitationUser.where(NAME_HAS_LEADING_OR_TRAILING_SPACE).each(&:save!)
+  end
+
+  def down; end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_29_103443) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_02_095323) do
   create_table "batch_invitation_application_permissions", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "batch_invitation_id", null: false
     t.integer "supported_permission_id", null: false

--- a/test/models/batch_invitation_user_test.rb
+++ b/test/models/batch_invitation_user_test.rb
@@ -1,6 +1,14 @@
 require "test_helper"
 
 class BatchInvitationUserTest < ActiveSupport::TestCase
+  context ".create!" do
+    should "strip unwanted whitespace from name before persisting" do
+      user = create(:batch_invitation_user, name: "  Ailean Millard ")
+
+      assert_equal "Ailean Millard", user.name
+    end
+  end
+
   context "invite" do
     setup do
       @inviting_user = create(:admin_user)

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -523,6 +523,12 @@ class UserTest < ActiveSupport::TestCase
     assert_not user.persisted?
   end
 
+  test "strips unwanted whitespace from name before creating User" do
+    user = create(:user, name: "  Tina Jerković ")
+
+    assert_equal "Tina Jerković", user.name
+  end
+
   test "doesn't allow previously used password" do
     password = @user.password
 


### PR DESCRIPTION
https://trello.com/c/WVFDaA9C/203-remove-spaces-at-the-beginning-of-some-users-names-which-confuses-ordering

We have some cases of `User` and `BatchInvitationUser` records in our production data that have leading and/or trailing whitespace in their name columns and we'd like to remove that whitespace because, in the case of `User`, it breaks alphabetical sorting by name.

Here we introduce some code to stop that happening again and a migration to fix the existing data.