### PR TITLE
Change trailing_message column from varchar(255) to text

### DIFF
--- a/db/migrate/20230801131609_change_event_logs_trailing_message_column.rb
+++ b/db/migrate/20230801131609_change_event_logs_trailing_message_column.rb
@@ -1,0 +1,9 @@
+class ChangeEventLogsTrailingMessageColumn < ActiveRecord::Migration[7.0]
+  def up
+    change_column :event_logs, :trailing_message, :text
+  end
+
+  def down
+    change_column :event_logs, :trailing_message, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -62,7 +62,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_02_095323) do
     t.datetime "created_at", precision: nil, null: false
     t.integer "initiator_id"
     t.integer "application_id"
-    t.string "trailing_message"
+    t.text "trailing_message"
     t.integer "event_id"
     t.decimal "ip_address", precision: 38
     t.integer "user_agent_id"


### PR DESCRIPTION
https://trello.com/c/mZuBjUXu

When a user has permissions added/removed we [record an event that includes the name of each permission][1]. If the length of the string containing all of these permission names exceeded 255 characters then the following exception was raised:

ActiveRecord::ValueTooLong
Mysql2::Error: Data too long for column 'trailing_message' at row 1

I considered truncating the message if it exceeded 255 characters but can't be confident that this data isn't being used elsewhere.

[1]: https://github.com/alphagov/signon/blob/0a2293f76e0ceb5d3eaf4c5e5167037cc82b80d1/app/services/user_update.rb#L52
