### PR TITLE
Add user research recruitment banner

### DIFF
--- a/app/assets/stylesheets/_user_research_recruitment_banner.scss
+++ b/app/assets/stylesheets/_user_research_recruitment_banner.scss
@@ -16,3 +16,10 @@
 .user-research-recruitment-banner__intro {
   color: govuk-colour("white");
 }
+
+.user-research-recruitment-banner__hide-this {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: govuk-colour("white");
+}

--- a/app/assets/stylesheets/_user_research_recruitment_banner.scss
+++ b/app/assets/stylesheets/_user_research_recruitment_banner.scss
@@ -16,6 +16,10 @@
   color: govuk-colour("white");
 }
 
+.user-research-recruitment-banner__buttons {
+  @include govuk-responsive-padding(6, "bottom");
+}
+
 .user-research-recruitment-banner__hide-this {
   background: none;
   border: none;

--- a/app/assets/stylesheets/_user_research_recruitment_banner.scss
+++ b/app/assets/stylesheets/_user_research_recruitment_banner.scss
@@ -1,16 +1,15 @@
 .user-research-recruitment-banner {
   background-color: $govuk-brand-colour;
-  padding-top: 3em;
+  @include govuk-responsive-padding(8, "top");
 }
 
 .user-research-recruitment-banner__divider {
-  margin-top: 0;
   border-bottom: 1px solid govuk-colour("white");
 }
 
 .user-research-recruitment-banner__title {
   color: govuk-colour("white");
-  margin-bottom: 25px;
+  @include govuk-responsive-margin(5, "bottom");
 }
 
 .user-research-recruitment-banner__intro {

--- a/app/assets/stylesheets/_user_research_recruitment_banner.scss
+++ b/app/assets/stylesheets/_user_research_recruitment_banner.scss
@@ -1,0 +1,18 @@
+.user-research-recruitment-banner {
+  background-color: $govuk-brand-colour;
+  padding-top: 3em;
+}
+
+.user-research-recruitment-banner__divider {
+  margin-top: 0;
+  border-bottom: 1px solid govuk-colour("white");
+}
+
+.user-research-recruitment-banner__title {
+  color: govuk-colour("white");
+  margin-bottom: 25px;
+}
+
+.user-research-recruitment-banner__intro {
+  color: govuk-colour("white");
+}

--- a/app/assets/stylesheets/_user_research_recruitment_banner.scss
+++ b/app/assets/stylesheets/_user_research_recruitment_banner.scss
@@ -18,6 +18,7 @@
 
 .user-research-recruitment-banner__buttons {
   @include govuk-responsive-padding(6, "bottom");
+  align-items: center;
 }
 
 .user-research-recruitment-banner__hide-this {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,4 +1,5 @@
 @import "govuk_publishing_components/all_components";
+@import "user_research_recruitment_banner";
 
 // TODO: move into component
 .gem-c-success-alert,

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -14,4 +14,16 @@ class RootController < ApplicationController
   def signin_required
     @application = ::Doorkeeper::Application.find_by(id: session.delete(:signin_missing_for_application))
   end
+
+  def dismiss_user_research_recruitment_banner
+    cookies[:dismiss_user_research_recruitment_banner] = true
+    redirect_to root_path
+  end
+
+private
+
+  def show_user_research_recruitment_banner?
+    !cookies[:dismiss_user_research_recruitment_banner]
+  end
+  helper_method :show_user_research_recruitment_banner?
 end

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -1,4 +1,6 @@
 class RootController < ApplicationController
+  USER_RESEARCH_RECRUITMENT_FORM_URL = "https://docs.google.com/forms/d/1Bdu_GqOrSR4j6mbuzXkFTQg6FRktRMQc8Y-q879Mny8/viewform".freeze
+
   layout "admin_layout"
 
   include UserPermissionsControllerMethods
@@ -20,10 +22,15 @@ class RootController < ApplicationController
     redirect_to root_path
   end
 
+  def user_research_recruitment_form
+    current_user.update!(user_research_recruitment_banner_hidden: true)
+    redirect_to USER_RESEARCH_RECRUITMENT_FORM_URL, allow_other_host: true
+  end
+
 private
 
   def show_user_research_recruitment_banner?
-    !cookies[:dismiss_user_research_recruitment_banner]
+    !cookies[:dismiss_user_research_recruitment_banner] && !current_user.user_research_recruitment_banner_hidden?
   end
   helper_method :show_user_research_recruitment_banner?
 end

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -1,6 +1,4 @@
 class RootController < ApplicationController
-  USER_RESEARCH_RECRUITMENT_FORM_URL = "https://docs.google.com/forms/d/1Bdu_GqOrSR4j6mbuzXkFTQg6FRktRMQc8Y-q879Mny8/viewform".freeze
-
   layout "admin_layout"
 
   include UserPermissionsControllerMethods
@@ -15,16 +13,6 @@ class RootController < ApplicationController
 
   def signin_required
     @application = ::Doorkeeper::Application.find_by(id: session.delete(:signin_missing_for_application))
-  end
-
-  def dismiss_user_research_recruitment_banner
-    cookies[:dismiss_user_research_recruitment_banner] = true
-    redirect_to root_path
-  end
-
-  def user_research_recruitment_form
-    current_user.update!(user_research_recruitment_banner_hidden: true)
-    redirect_to USER_RESEARCH_RECRUITMENT_FORM_URL, allow_other_host: true
   end
 
 private

--- a/app/controllers/user_research_recruitment_controller.rb
+++ b/app/controllers/user_research_recruitment_controller.rb
@@ -1,0 +1,16 @@
+class UserResearchRecruitmentController < ApplicationController
+  USER_RESEARCH_RECRUITMENT_FORM_URL = "https://docs.google.com/forms/d/1Bdu_GqOrSR4j6mbuzXkFTQg6FRktRMQc8Y-q879Mny8/viewform".freeze
+
+  before_action :authenticate_user!
+  skip_after_action :verify_authorized
+
+  def dismiss_user_research_recruitment_banner
+    cookies[:dismiss_user_research_recruitment_banner] = true
+    redirect_to root_path
+  end
+
+  def user_research_recruitment_form
+    current_user.update!(user_research_recruitment_banner_hidden: true)
+    redirect_to USER_RESEARCH_RECRUITMENT_FORM_URL, allow_other_host: true
+  end
+end

--- a/app/controllers/user_research_recruitment_controller.rb
+++ b/app/controllers/user_research_recruitment_controller.rb
@@ -4,12 +4,12 @@ class UserResearchRecruitmentController < ApplicationController
   before_action :authenticate_user!
   skip_after_action :verify_authorized
 
-  def dismiss_user_research_recruitment_banner
+  def dismiss_banner
     cookies[:dismiss_user_research_recruitment_banner] = true
     redirect_to root_path
   end
 
-  def user_research_recruitment_form
+  def participate
     current_user.update!(user_research_recruitment_banner_hidden: true)
     redirect_to USER_RESEARCH_RECRUITMENT_FORM_URL, allow_other_host: true
   end

--- a/app/views/layouts/admin_layout.html.erb
+++ b/app/views/layouts/admin_layout.html.erb
@@ -11,6 +11,8 @@
     navigation_items: navigation_items,
   }%>
 
+  <%= yield(:user_research_recruitment_banner) %>
+
   <div class="govuk-width-container">
     <% if yield(:back_link).present? %>
       <%= render "govuk_publishing_components/components/back_link", href: yield(:back_link) %>

--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -4,7 +4,7 @@
   <% content_for :user_research_recruitment_banner do %>
     <section class="user-research-recruitment-banner">
       <div class="govuk-width-container">
-        <hr class="user-research-recruitment-banner__divider govuk-section-break govuk-section-break--l">
+        <hr class="user-research-recruitment-banner__divider govuk-section-break govuk-section-break--l govuk-!-margin-top-0">
         <h1 class="user-research-recruitment-banner__title govuk-heading-xl">Help us improve GOV.UK Publishing</h1>
         <p class="user-research-recruitment-banner__intro govuk-body">We're holding research sessions to make Publishing work better.</p>
         <div class="govuk-button-group">

--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -10,7 +10,8 @@
         <div class="govuk-button-group">
           <%= button_to 'Sign up to take part in research',
                         user_research_recruitment_participate_path,
-                        class: 'govuk-!-font-size-24 govuk-!-font-weight-bold govuk-button govuk-button--inverse'
+                        class: 'govuk-!-font-size-24 govuk-!-font-weight-bold govuk-button govuk-button--inverse',
+                        form: { target: '_blank' }
           %>
           <%= button_to 'Hide this',
                         user_research_recruitment_dismiss_banner_path,

--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -9,11 +9,11 @@
         <p class="user-research-recruitment-banner__intro govuk-body">We're holding research sessions to make Publishing work better.</p>
         <div class="govuk-button-group">
           <%= button_to 'Sign up to take part in research',
-                        user_research_recruitment_form_path,
+                        user_research_recruitment_participate_path,
                         class: 'govuk-!-font-size-24 govuk-!-font-weight-bold govuk-button govuk-button--inverse'
           %>
           <%= button_to 'Hide this',
-                        dismiss_user_research_recruitment_banner_path,
+                        user_research_recruitment_dismiss_banner_path,
                         class: 'user-research-recruitment-banner__hide-this govuk-link govuk-link--inverse'
           %>
         </div>

--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -8,9 +8,9 @@
         <h1 class="user-research-recruitment-banner__title govuk-heading-xl">Help us improve GOV.UK Publishing</h1>
         <p class="user-research-recruitment-banner__intro govuk-body">We're holding research sessions to make Publishing work better.</p>
         <div class="govuk-button-group">
-          <%= link_to 'Sign up to take part in research',
-                      'https://docs.google.com/forms/d/1Bdu_GqOrSR4j6mbuzXkFTQg6FRktRMQc8Y-q879Mny8/viewform',
-                      class: 'govuk-!-font-size-24 govuk-!-font-weight-bold govuk-button govuk-button--inverse'
+          <%= button_to 'Sign up to take part in research',
+                        user_research_recruitment_form_path,
+                        class: 'govuk-!-font-size-24 govuk-!-font-weight-bold govuk-button govuk-button--inverse'
           %>
           <%= button_to 'Hide this',
                         dismiss_user_research_recruitment_banner_path,

--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -8,7 +8,7 @@
         <h1 class="user-research-recruitment-banner__title govuk-heading-xl">Help us improve GOV.UK Publishing</h1>
         <p class="user-research-recruitment-banner__intro govuk-body">We're holding research sessions to make Publishing work better.</p>
         <div class="user-research-recruitment-banner__buttons govuk-button-group">
-          <%= button_to 'Sign up to take part in research',
+          <%= button_to 'Find out more',
                         user_research_recruitment_participate_path,
                         class: 'govuk-!-font-size-24 govuk-!-font-weight-bold govuk-button govuk-button--inverse',
                         form: { target: '_blank' }

--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -1,5 +1,21 @@
 <% content_for :title, "Your applications" %>
 
+<% content_for :user_research_recruitment_banner do %>
+  <section class="user-research-recruitment-banner">
+    <div class="govuk-width-container">
+      <hr class="user-research-recruitment-banner__divider govuk-section-break govuk-section-break--l">
+      <h1 class="user-research-recruitment-banner__title govuk-heading-xl">Help us improve GOV.UK Publishing</h1>
+      <p class="user-research-recruitment-banner__intro govuk-body">We're holding research sessions to make Publishing work better.</p>
+      <div>
+        <%= link_to 'Sign up to take part in research',
+                    'https://docs.google.com/forms/d/1Bdu_GqOrSR4j6mbuzXkFTQg6FRktRMQc8Y-q879Mny8/viewform',
+                    class: 'govuk-!-font-size-24 govuk-!-font-weight-bold govuk-button govuk-button--inverse'
+        %>
+      </div>
+    </div>
+  </section>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 

--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -1,19 +1,25 @@
 <% content_for :title, "Your applications" %>
 
-<% content_for :user_research_recruitment_banner do %>
-  <section class="user-research-recruitment-banner">
-    <div class="govuk-width-container">
-      <hr class="user-research-recruitment-banner__divider govuk-section-break govuk-section-break--l">
-      <h1 class="user-research-recruitment-banner__title govuk-heading-xl">Help us improve GOV.UK Publishing</h1>
-      <p class="user-research-recruitment-banner__intro govuk-body">We're holding research sessions to make Publishing work better.</p>
-      <div>
-        <%= link_to 'Sign up to take part in research',
-                    'https://docs.google.com/forms/d/1Bdu_GqOrSR4j6mbuzXkFTQg6FRktRMQc8Y-q879Mny8/viewform',
-                    class: 'govuk-!-font-size-24 govuk-!-font-weight-bold govuk-button govuk-button--inverse'
-        %>
+<% if show_user_research_recruitment_banner? %>
+  <% content_for :user_research_recruitment_banner do %>
+    <section class="user-research-recruitment-banner">
+      <div class="govuk-width-container">
+        <hr class="user-research-recruitment-banner__divider govuk-section-break govuk-section-break--l">
+        <h1 class="user-research-recruitment-banner__title govuk-heading-xl">Help us improve GOV.UK Publishing</h1>
+        <p class="user-research-recruitment-banner__intro govuk-body">We're holding research sessions to make Publishing work better.</p>
+        <div class="govuk-button-group">
+          <%= link_to 'Sign up to take part in research',
+                      'https://docs.google.com/forms/d/1Bdu_GqOrSR4j6mbuzXkFTQg6FRktRMQc8Y-q879Mny8/viewform',
+                      class: 'govuk-!-font-size-24 govuk-!-font-weight-bold govuk-button govuk-button--inverse'
+          %>
+          <%= button_to 'Hide this',
+                        dismiss_user_research_recruitment_banner_path,
+                        class: 'user-research-recruitment-banner__hide-this govuk-link govuk-link--inverse'
+          %>
+        </div>
       </div>
-    </div>
-  </section>
+    </section>
+  <% end %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -7,7 +7,7 @@
         <hr class="user-research-recruitment-banner__divider govuk-section-break govuk-section-break--l govuk-!-margin-top-0">
         <h1 class="user-research-recruitment-banner__title govuk-heading-xl">Help us improve GOV.UK Publishing</h1>
         <p class="user-research-recruitment-banner__intro govuk-body">We're holding research sessions to make Publishing work better.</p>
-        <div class="govuk-button-group">
+        <div class="user-research-recruitment-banner__buttons govuk-button-group">
           <%= button_to 'Sign up to take part in research',
                         user_research_recruitment_participate_path,
                         class: 'govuk-!-font-size-24 govuk-!-font-weight-bold govuk-button govuk-button--inverse',

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -77,4 +77,6 @@ Rails.application.routes.draw do
   get "/signin-required" => "root#signin_required"
 
   root to: "root#index"
+
+  post "/dismiss-user-research-recruitment-banner" => "root#dismiss_user_research_recruitment_banner"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -79,4 +79,5 @@ Rails.application.routes.draw do
   root to: "root#index"
 
   post "/dismiss-user-research-recruitment-banner" => "root#dismiss_user_research_recruitment_banner"
+  post "/user-research-recruitment-form" => "root#user_research_recruitment_form"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -78,6 +78,6 @@ Rails.application.routes.draw do
 
   root to: "root#index"
 
-  post "/dismiss-user-research-recruitment-banner" => "user_research_recruitment#dismiss_user_research_recruitment_banner"
-  post "/user-research-recruitment-form" => "user_research_recruitment#user_research_recruitment_form"
+  post "/dismiss-user-research-recruitment-banner" => "user_research_recruitment#dismiss_banner"
+  post "/user-research-recruitment-form" => "user_research_recruitment#participate"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -78,6 +78,6 @@ Rails.application.routes.draw do
 
   root to: "root#index"
 
-  post "/dismiss-user-research-recruitment-banner" => "user_research_recruitment#dismiss_banner"
-  post "/user-research-recruitment-form" => "user_research_recruitment#participate"
+  post "/user-research-recruitment/dismiss-banner" => "user_research_recruitment#dismiss_banner"
+  post "/user-research-recruitment/participate" => "user_research_recruitment#participate"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -78,6 +78,6 @@ Rails.application.routes.draw do
 
   root to: "root#index"
 
-  post "/dismiss-user-research-recruitment-banner" => "root#dismiss_user_research_recruitment_banner"
-  post "/user-research-recruitment-form" => "root#user_research_recruitment_form"
+  post "/dismiss-user-research-recruitment-banner" => "user_research_recruitment#dismiss_user_research_recruitment_banner"
+  post "/user-research-recruitment-form" => "user_research_recruitment#user_research_recruitment_form"
 end

--- a/db/migrate/20230804094159_add_user_research_recruitment_banner_hidden_to_users.rb
+++ b/db/migrate/20230804094159_add_user_research_recruitment_banner_hidden_to_users.rb
@@ -1,0 +1,5 @@
+class AddUserResearchRecruitmentBannerHiddenToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :user_research_recruitment_banner_hidden, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_02_095323) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_04_094159) do
   create_table "batch_invitation_application_permissions", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "batch_invitation_id", null: false
     t.integer "supported_permission_id", null: false
@@ -209,6 +209,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_02_095323) do
     t.boolean "require_2sv", default: false, null: false
     t.string "reason_for_2sv_exemption"
     t.date "expiry_date_for_2sv_exemption"
+    t.boolean "user_research_recruitment_banner_hidden", default: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["invitation_token"], name: "index_users_on_invitation_token"
     t.index ["invited_by_id"], name: "index_users_on_invited_by_id"

--- a/test/controllers/root_controller_test.rb
+++ b/test/controllers/root_controller_test.rb
@@ -64,4 +64,20 @@ class RootControllerTest < ActionController::TestCase
     assert_select "h1", "You don’t have permission to use this app."
     assert_select "p", count: 0
   end
+
+  test "#dismiss_user_research_recruitment_banner sets session cookie" do
+    sign_in create(:user)
+
+    post :dismiss_user_research_recruitment_banner
+
+    assert cookies[:dismiss_user_research_recruitment_banner]
+  end
+
+  test "#dismiss_user_research_recruitment_banner redirects to root path" do
+    sign_in create(:user)
+
+    post :dismiss_user_research_recruitment_banner
+
+    assert_redirected_to root_path
+  end
 end

--- a/test/controllers/root_controller_test.rb
+++ b/test/controllers/root_controller_test.rb
@@ -64,37 +64,4 @@ class RootControllerTest < ActionController::TestCase
     assert_select "h1", "You don’t have permission to use this app."
     assert_select "p", count: 0
   end
-
-  test "#dismiss_user_research_recruitment_banner sets session cookie" do
-    sign_in create(:user)
-
-    post :dismiss_user_research_recruitment_banner
-
-    assert cookies[:dismiss_user_research_recruitment_banner]
-  end
-
-  test "#dismiss_user_research_recruitment_banner redirects to root path" do
-    sign_in create(:user)
-
-    post :dismiss_user_research_recruitment_banner
-
-    assert_redirected_to root_path
-  end
-
-  test "#user_research_recruitment_form sets user_research_recruitment_banner_hidden to true for the current_user" do
-    user = create(:user)
-    sign_in user
-
-    post :user_research_recruitment_form
-
-    assert user.user_research_recruitment_banner_hidden?
-  end
-
-  test "#user_research_recruitment_form redirects to the google form" do
-    sign_in create(:user)
-
-    post :user_research_recruitment_form
-
-    assert_redirected_to RootController::USER_RESEARCH_RECRUITMENT_FORM_URL
-  end
 end

--- a/test/controllers/root_controller_test.rb
+++ b/test/controllers/root_controller_test.rb
@@ -80,4 +80,21 @@ class RootControllerTest < ActionController::TestCase
 
     assert_redirected_to root_path
   end
+
+  test "#user_research_recruitment_form sets user_research_recruitment_banner_hidden to true for the current_user" do
+    user = create(:user)
+    sign_in user
+
+    post :user_research_recruitment_form
+
+    assert user.user_research_recruitment_banner_hidden?
+  end
+
+  test "#user_research_recruitment_form redirects to the google form" do
+    sign_in create(:user)
+
+    post :user_research_recruitment_form
+
+    assert_redirected_to RootController::USER_RESEARCH_RECRUITMENT_FORM_URL
+  end
 end

--- a/test/controllers/user_research_recruitment_controller_test.rb
+++ b/test/controllers/user_research_recruitment_controller_test.rb
@@ -1,47 +1,47 @@
 require "test_helper"
 
 class UserResearchRecruitmentControllerTest < ActionController::TestCase
-  test "#dismiss_user_research_recruitment_banner requires signed in users" do
-    post :dismiss_user_research_recruitment_banner
+  test "#dismiss_banner requires signed in users" do
+    post :dismiss_banner
 
     assert_redirected_to new_user_session_path
   end
 
-  test "#dismiss_user_research_recruitment_banner sets session cookie" do
+  test "#dismiss_banner sets session cookie" do
     sign_in create(:user)
 
-    post :dismiss_user_research_recruitment_banner
+    post :dismiss_banner
 
     assert cookies[:dismiss_user_research_recruitment_banner]
   end
 
-  test "#dismiss_user_research_recruitment_banner redirects to root path" do
+  test "#dismiss_banner redirects to root path" do
     sign_in create(:user)
 
-    post :dismiss_user_research_recruitment_banner
+    post :dismiss_banner
 
     assert_redirected_to root_path
   end
 
-  test "#user_research_recruitment_form requires users to be signed in" do
-    post :user_research_recruitment_form
+  test "#participate requires users to be signed in" do
+    post :participate
 
     assert_redirected_to new_user_session_path
   end
 
-  test "#user_research_recruitment_form sets user_research_recruitment_banner_hidden to true for the current_user" do
+  test "#participate sets user_research_recruitment_banner_hidden to true for the current_user" do
     user = create(:user)
     sign_in user
 
-    post :user_research_recruitment_form
+    post :participate
 
     assert user.user_research_recruitment_banner_hidden?
   end
 
-  test "#user_research_recruitment_form redirects to the google form" do
+  test "#participate redirects to the google form" do
     sign_in create(:user)
 
-    post :user_research_recruitment_form
+    post :participate
 
     assert_redirected_to UserResearchRecruitmentController::USER_RESEARCH_RECRUITMENT_FORM_URL
   end

--- a/test/controllers/user_research_recruitment_controller_test.rb
+++ b/test/controllers/user_research_recruitment_controller_test.rb
@@ -1,0 +1,48 @@
+require "test_helper"
+
+class UserResearchRecruitmentControllerTest < ActionController::TestCase
+  test "#dismiss_user_research_recruitment_banner requires signed in users" do
+    post :dismiss_user_research_recruitment_banner
+
+    assert_redirected_to new_user_session_path
+  end
+
+  test "#dismiss_user_research_recruitment_banner sets session cookie" do
+    sign_in create(:user)
+
+    post :dismiss_user_research_recruitment_banner
+
+    assert cookies[:dismiss_user_research_recruitment_banner]
+  end
+
+  test "#dismiss_user_research_recruitment_banner redirects to root path" do
+    sign_in create(:user)
+
+    post :dismiss_user_research_recruitment_banner
+
+    assert_redirected_to root_path
+  end
+
+  test "#user_research_recruitment_form requires users to be signed in" do
+    post :user_research_recruitment_form
+
+    assert_redirected_to new_user_session_path
+  end
+
+  test "#user_research_recruitment_form sets user_research_recruitment_banner_hidden to true for the current_user" do
+    user = create(:user)
+    sign_in user
+
+    post :user_research_recruitment_form
+
+    assert user.user_research_recruitment_banner_hidden?
+  end
+
+  test "#user_research_recruitment_form redirects to the google form" do
+    sign_in create(:user)
+
+    post :user_research_recruitment_form
+
+    assert_redirected_to UserResearchRecruitmentController::USER_RESEARCH_RECRUITMENT_FORM_URL
+  end
+end

--- a/test/integration/user_research_recruitment_banner_test.rb
+++ b/test/integration/user_research_recruitment_banner_test.rb
@@ -13,7 +13,7 @@ class UserResearchRecruitmentBannerTest < ActionDispatch::IntegrationTest
     signin_with(user)
 
     assert has_content?(user_research_recruitment_banner_title)
-    assert has_css?("form[action='#{user_research_recruitment_participate_path}']", text: "Sign up to take part in research")
+    assert has_css?("form[action='#{user_research_recruitment_participate_path}']", text: "Find out more")
   end
 
   should "not display the banner on any page other than the dashboard" do
@@ -63,7 +63,7 @@ class UserResearchRecruitmentBannerTest < ActionDispatch::IntegrationTest
 
       within ".user-research-recruitment-banner" do
         allowing_request_to_user_research_recruitment_google_form do
-          click_on "Sign up to take part in research"
+          click_on "Find out more"
         end
       end
 

--- a/test/integration/user_research_recruitment_banner_test.rb
+++ b/test/integration/user_research_recruitment_banner_test.rb
@@ -13,7 +13,7 @@ class UserResearchRecruitmentBannerTest < ActionDispatch::IntegrationTest
     signin_with(user)
 
     assert has_content?(user_research_recruitment_banner_title)
-    assert has_css?("form[action='#{user_research_recruitment_form_path}']", text: "Sign up to take part in research")
+    assert has_css?("form[action='#{user_research_recruitment_participate_path}']", text: "Sign up to take part in research")
   end
 
   should "not display the banner on any page other than the dashboard" do

--- a/test/integration/user_research_recruitment_banner_test.rb
+++ b/test/integration/user_research_recruitment_banner_test.rb
@@ -26,7 +26,31 @@ class UserResearchRecruitmentBannerTest < ActionDispatch::IntegrationTest
     assert_not has_content?(user_research_recruitment_banner_title)
   end
 
-  should "hide the banner until the next session"
+  should "hide the banner until the next session" do
+    user = create(:user, name: "user-name", email: "user@example.com")
+
+    using_session("Session 1") do
+      visit new_user_session_path
+      signin_with(user)
+
+      assert has_content?(user_research_recruitment_banner_title)
+
+      within ".user-research-recruitment-banner" do
+        click_on "Hide this"
+      end
+
+      visit root_path
+
+      assert_not has_content?(user_research_recruitment_banner_title)
+    end
+
+    using_session("Session 2") do
+      visit new_user_session_path
+      signin_with(user)
+
+      assert has_content?(user_research_recruitment_banner_title)
+    end
+  end
 
   should "hide the banner permanently if the user clicks the button to participate in user research"
 

--- a/test/integration/user_research_recruitment_banner_test.rb
+++ b/test/integration/user_research_recruitment_banner_test.rb
@@ -89,6 +89,6 @@ private
   def allowing_request_to_user_research_recruitment_google_form
     yield
   rescue ActionController::RoutingError
-    raise unless current_url == RootController::USER_RESEARCH_RECRUITMENT_FORM_URL
+    raise unless current_url == UserResearchRecruitmentController::USER_RESEARCH_RECRUITMENT_FORM_URL
   end
 end

--- a/test/integration/user_research_recruitment_banner_test.rb
+++ b/test/integration/user_research_recruitment_banner_test.rb
@@ -1,0 +1,38 @@
+require "test_helper"
+
+class UserResearchRecruitmentBannerTest < ActionDispatch::IntegrationTest
+  should "not display the banner on the login page" do
+    visit new_user_session_path
+
+    assert_not has_content?(user_research_recruitment_banner_title)
+  end
+
+  should "display the banner on the dashboard" do
+    user = create(:user, name: "user-name", email: "user@example.com")
+    visit new_user_session_path
+    signin_with(user)
+
+    assert has_content?(user_research_recruitment_banner_title)
+    assert has_link?("Sign up to take part in research", href: "https://docs.google.com/forms/d/1Bdu_GqOrSR4j6mbuzXkFTQg6FRktRMQc8Y-q879Mny8/viewform")
+  end
+
+  should "not display the banner on any page other than the dashboard" do
+    user = create(:user, name: "user-name", email: "user@example.com")
+    visit new_user_session_path
+    signin_with(user)
+
+    click_on "Change your email or password"
+
+    assert_not has_content?(user_research_recruitment_banner_title)
+  end
+
+  should "hide the banner until the next session"
+
+  should "hide the banner permanently if the user clicks the button to participate in user research"
+
+private
+
+  def user_research_recruitment_banner_title
+    "Help us improve GOV.UK Publishing"
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/yGMU3sR2

This adds a "sticky" banner on the Signon home page to recruit user research participants for GOV.UK Publishing. The "Sign up to take part in research" button opens a Google Form (managed by the User Research folk) in a new browser tab. If the user clicks on this button, we record that in the Signon database and we never show them the banner again. If the user clicks on the "Hide this" link, then we hide the banner for the duration of the current browser session, but it will be displayed to the user in their next browser session.

@chrisroos Wondered whether there's a better way to style the "Hide this" button as a link? But I haven't found any information about doing that, so I've left it as it was.

I've the following changes to @chrisroos' original work

* Open Google form in a new browser tab
* Use GOV.UK Design System responsive spacing helpers
* Add padding to button group to balance the bottom of the banner with the top
* Improve the vertical alignment of the "Sign up..." & "Hide this" buttons
* Change button text -> "Find out more" based on content design feedback

As per [these recommendations](https://www.gov.uk/service-manual/technology/designing-for-different-browsers-and-devices#browsers-to-test-in-from-june-2022), I've tested against the following devices/browsers (using BrowserStack):

* [x] Windows 11
  * [x] Edge 115
  * [x] Chrome 115
  * [x] Firefox 116
* [x] MacOS 13.4.1
  * [x] Firefox 115
  * [x] Chrome 115
  * [x] Safari 16.5.2
* [x] iPhone SE 2022 v15.4
  * [x] Safari
  * [x] Chrome
* iPhone 14 iOS 16
  * [x] Safari
* [x] Galaxy S23 Android 13
  * [x] Chrome
  * [x] Samsung Internet

### Desktop
![Screen Shot 2023-08-08 at 12 23 34](https://github.com/alphagov/signon/assets/3169/dc5b8aec-13e0-4f1c-aa5e-dc85a06ed2f6)

### iPad
![Screen Shot 2023-08-08 at 12 24 10](https://github.com/alphagov/signon/assets/3169/d0a5ef97-b1d0-429b-82f1-503264214d2e)

### iPhone
![Screen Shot 2023-08-08 at 12 24 46](https://github.com/alphagov/signon/assets/3169/01482556-7d06-4e45-8a47-3459a176d202)
