### PR TITLE
Give batch uploading users more information when an email address in their batch is invalid

### DIFF
--- a/app/controllers/batch_invitations_controller.rb
+++ b/app/controllers/batch_invitations_controller.rb
@@ -43,8 +43,6 @@ class BatchInvitationsController < ApplicationController
       return
     end
 
-    @batch_invitation.save!
-
     csv.each do |row|
       batch_user_args = {
         batch_invitation: @batch_invitation,
@@ -54,8 +52,13 @@ class BatchInvitationsController < ApplicationController
       if policy(@batch_invitation).assign_organisation_from_csv?
         batch_user_args[:organisation_slug] = row["Organisation"]
       end
-      BatchInvitationUser.create!(batch_user_args)
+      batch_user = BatchInvitationUser.new(batch_user_args)
+
+      @batch_invitation.batch_invitation_users << batch_user
     end
+
+    @batch_invitation.save!
+
     @batch_invitation.enqueue
     flash[:notice] = "Scheduled invitation of #{@batch_invitation.batch_invitation_users.count} users"
     redirect_to batch_invitation_path(@batch_invitation)

--- a/app/controllers/batch_invitations_controller.rb
+++ b/app/controllers/batch_invitations_controller.rb
@@ -54,6 +54,11 @@ class BatchInvitationsController < ApplicationController
       end
       batch_user = BatchInvitationUser.new(batch_user_args)
 
+      unless batch_user.valid?
+        flash[:alert] = batch_users_error_message(batch_user)
+        return render :new
+      end
+
       @batch_invitation.batch_invitation_users << batch_user
     end
 
@@ -89,6 +94,16 @@ private
   def grant_default_permissions(batch_invitation)
     SupportedPermission.default.each do |default_permission|
       batch_invitation.grant_permission(default_permission)
+    end
+  end
+
+  def batch_users_error_message(batch_user)
+    e = batch_user.errors.first
+
+    if e.attribute == :email
+      "One or more emails were invalid"
+    else
+      e.full_message
     end
   end
 end

--- a/app/models/batch_invitation_user.rb
+++ b/app/models/batch_invitation_user.rb
@@ -1,6 +1,8 @@
 class BatchInvitationUser < ApplicationRecord
   belongs_to :batch_invitation
 
+  validates :email, presence: true, format: { with: Devise.email_regexp }
+
   validates :outcome, inclusion: { in: [nil, "success", "failed", "skipped"] }
 
   before_save :strip_whitespace_from_name

--- a/test/controllers/batch_invitations_controller_test.rb
+++ b/test/controllers/batch_invitations_controller_test.rb
@@ -131,6 +131,15 @@ class BatchInvitationsControllerTest < ActionController::TestCase
       end
     end
 
+    context "the CSV contains one or more email addresses that aren't valid" do
+      should "redisplay the form and show a flash message" do
+        post :create, params: { batch_invitation: { user_names_and_emails: users_csv("users_with_non_valid_emails.csv") }, user: { supported_permission_ids: [] } }
+
+        assert_template :new
+        assert_match(/One or more emails were invalid/i, flash[:alert])
+      end
+    end
+
     context "the CSV has all the fields, but not in the expected order" do
       should "process the fields by name" do
         post :create, params: { batch_invitation: { user_names_and_emails: users_csv("reversed_users.csv") }, user: { supported_permission_ids: [] } }

--- a/test/controllers/fixtures/users_with_non_valid_emails.csv
+++ b/test/controllers/fixtures/users_with_non_valid_emails.csv
@@ -1,0 +1,5 @@
+Name,Email
+Raphael Gupta,raphael@example.gov.uk
+Bolormaa Śniegowski,@bolo
+Flora Gao,f.gao@example.gov.uk
+Aureliusz Clemente,aureliusz@examplegovuk

--- a/test/models/batch_invitation_user_test.rb
+++ b/test/models/batch_invitation_user_test.rb
@@ -9,6 +9,15 @@ class BatchInvitationUserTest < ActiveSupport::TestCase
     end
   end
 
+  context "validations" do
+    should "validate email address" do
+      user = build(:batch_invitation_user, email: "@gov.uk")
+
+      assert_not user.valid?
+      assert_equal ["is invalid"], user.errors[:email]
+    end
+  end
+
   context "invite" do
     setup do
       @inviting_user = create(:admin_user)
@@ -78,7 +87,8 @@ class BatchInvitationUserTest < ActiveSupport::TestCase
 
     context "the user could not be saved (eg email is blank)" do
       should "record it as a failure" do
-        user = create(:batch_invitation_user, batch_invitation: @batch_invitation, email: nil)
+        user = create(:batch_invitation_user, batch_invitation: @batch_invitation)
+        user.email = nil
         user.invite(@inviting_user, [])
 
         assert_equal "failed", user.reload.outcome
@@ -87,7 +97,8 @@ class BatchInvitationUserTest < ActiveSupport::TestCase
       should "log the error" do
         GovukError.expects(:notify).once
 
-        user = create(:batch_invitation_user, batch_invitation: @batch_invitation, email: nil)
+        user = create(:batch_invitation_user, batch_invitation: @batch_invitation)
+        user.email = nil
         user.invite(@inviting_user, [])
       end
     end


### PR DESCRIPTION
https://trello.com/c/HOwVtQLy/184-give-batch-uploading-users-more-information-when-an-email-address-in-their-batch-is-invalid

Until now, one invalid email address in a batch upload (CSV) would raise
an ambiguous error and give the user no information about what went
wrong.

Now, if the batch encounters a validation problem, it returns to the
original form as before but also displays a more helpful error message.

Though, as I've implemented it, the message could be more helpful. But see for yourself:

![Screenshot_2023-08-07_09-07-32](https://github.com/alphagov/signon/assets/141013432/f42fa3bd-7120-410a-a6e4-7449c1c4c7da)
