### PR TITLE
Missing validation on new/edit application permission page

### DIFF
--- a/app/models/supported_permission.rb
+++ b/app/models/supported_permission.rb
@@ -2,7 +2,7 @@ class SupportedPermission < ApplicationRecord
   belongs_to :application, class_name: "Doorkeeper::Application"
   has_many :user_application_permissions, dependent: :destroy, inverse_of: :supported_permission
 
-  validates :name, presence: true
+  validates :name, presence: true, uniqueness: { scope: :application_id }
   validate :signin_permission_name_not_changed
 
   default_scope { order(:name) }

--- a/test/models/supported_permission_test.rb
+++ b/test/models/supported_permission_test.rb
@@ -17,6 +17,15 @@ class SupportedPermissionTest < ActiveSupport::TestCase
     end
   end
 
+  test "name of permission must be unique" do
+    application = create(:application)
+    create(:supported_permission, name: "writer", application:)
+    copy_cat_permission = build(:supported_permission, name: "writer", application:)
+
+    assert_not copy_cat_permission.valid?
+    assert_includes copy_cat_permission.errors[:name], "has already been taken"
+  end
+
   test "associated user application permissions are destroyed when supported permissions are destroyed" do
     user = create(:user)
     application = create(:application, with_supported_permissions: %w[managing_editor])


### PR DESCRIPTION
https://trello.com/c/kgyjym0j/212-missing-validation-on-new-edit-application-permission-page

This pull request adds a validation rule that results in a more helpful error message if a user attempts to give 2 permissions the same name for a single application.

![Screenshot_2023-08-08_10-29-37](https://github.com/alphagov/signon/assets/141013432/6ce4b515-bb0e-496e-9f8b-683c3d7b0438)
