### PR TITLE
Set autocomplete attribute on input elements appropriately

### DIFF
--- a/app/views/api_users/_form_fields.html.erb
+++ b/app/views/api_users/_form_fields.html.erb
@@ -10,10 +10,10 @@
 
 <p class="form-group">
   <%= f.label :name %>
-  <%= f.text_field :name, autofocus: true, class: 'form-control input-md-6', required: true %>
+  <%= f.text_field :name, autofocus: true, autocomplete: "off", class: 'form-control input-md-6', required: true %>
 </p>
 
 <p class="form-group">
   <%= f.label :email %>
-  <%= f.text_field :email, class: 'form-control input-md-6', required: true %>
+  <%= f.text_field :email, autocomplete: "off", class: 'form-control input-md-6', required: true %>
 </p>

--- a/app/views/api_users/new.html.erb
+++ b/app/views/api_users/new.html.erb
@@ -24,6 +24,7 @@
         id: "api_user_name",
         error_items: @api_user.errors.full_messages_for(:name).map {|message| { text: message } },
         value: @api_user.name,
+        autocomplete: "off",
         } %>
 
       <%= render "govuk_publishing_components/components/input", {
@@ -35,6 +36,7 @@
         type: "email",
         error_items: @api_user.errors.full_messages_for(:email).map {|message| { text: message } },
         value: @api_user.email,
+        autocomplete: "off",
         } %>
 
       <%= render "govuk_publishing_components/components/button", {

--- a/app/views/devise/confirmations/show.html.erb
+++ b/app/views/devise/confirmations/show.html.erb
@@ -15,7 +15,8 @@
           text: "Your password"
         },
         name: "user[password]",
-        type: "password"
+        type: "password",
+        autocomplete: "current-password"
       } %>
 
       <%= render "govuk_publishing_components/components/button", {

--- a/app/views/devise/passwords/_change_password_panel.html.erb
+++ b/app/views/devise/passwords/_change_password_panel.html.erb
@@ -5,7 +5,8 @@
         text: "Current password"
       },
       name: "user[current_password]",
-      type: "password"
+      type: "password",
+      autocomplete: "current-password"
     } %>
   <% end %>
 
@@ -17,6 +18,7 @@
       hint: "Passwords must be at least 10 characters, shouldn’t include part of your email address and must be complex. Consider using whole sentences (with spaces), lyrics or phrases to make your password more memorable.",
       name: "user[password]",
       type: "password",
+      autocomplete: "new-password",
       data: {
         'email-parts': user_email_tokens(user).join(","),
         'min-password-length': minimum_password_length
@@ -31,6 +33,7 @@
       },
       name: "user[password_confirmation]",
       type: "password",
+      autocomplete: "new-password"
     } %>
   </div>
 

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -13,7 +13,8 @@
           text: "Email address"
         },
         name: "user[email]",
-        type: "email"
+        type: "email",
+        autocomplete: "email"
       } %>
 
       <%= render "govuk_publishing_components/components/button", {

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -10,7 +10,8 @@
         name: "user[email]",
         type: "email",
         autofocus: true,
-        tabindex: 0
+        tabindex: 0,
+        autocomplete: "email",
       } %>
 
       <%= render "govuk_publishing_components/components/input", {
@@ -18,7 +19,8 @@
           text: "Password"
         },
         name: "user[password]",
-        type: "password"
+        type: "password",
+        autocomplete: "current-password"
       } %>
 
       <%= render "govuk_publishing_components/components/button", {

--- a/app/views/doorkeeper_applications/edit.html.erb
+++ b/app/views/doorkeeper_applications/edit.html.erb
@@ -29,6 +29,7 @@
         name: "doorkeeper_application[name]",
         type: "text",
         value: @application.name,
+        autocomplete: "off"
       } %>
 
 
@@ -39,6 +40,7 @@
         name: "doorkeeper_application[description]",
         type: "text",
         value: @application.description,
+        autocomplete: "off"
       } %>
 
       <%= render "govuk_publishing_components/components/input", {
@@ -49,6 +51,7 @@
         type: "text",
         hint: "Used to link to the app on the dashboard",
         value: @application.home_uri,
+        autocomplete: "off"
       } %>
 
       <%= render "govuk_publishing_components/components/input", {
@@ -59,6 +62,7 @@
         type: "text",
         hint: "The app should expect this URI. Used in the signin redirect dance.",
         value: @application.redirect_uri,
+        autocomplete: "off"
       } %>
 
       <%= render "govuk_publishing_components/components/input", {
@@ -69,6 +73,7 @@
         type: "text",
         hint: "The app has a copy of this. Used in the signin redirect dance.",
         value: @application.uid,
+        autocomplete: "off"
       } %>
 
       <%= render "govuk_publishing_components/components/input", {
@@ -79,6 +84,7 @@
         type: "text",
         hint: "The app has a copy of this. Used in the signin redirect dance.",
         value: @application.secret,
+        autocomplete: "off"
       } %>
 
       <%# TODO: use a checkbox component for this %>

--- a/app/views/suspensions/edit.html.erb
+++ b/app/views/suspensions/edit.html.erb
@@ -58,6 +58,7 @@
     },
     name: "user[reason_for_suspension]",
     value: @suspension.reason_for_suspension,
+    autocomplete: "off",
     error_items: @suspension.errors.full_messages_for(:reason_for_suspension).map {|message| { text: message } },
   } %>
 

--- a/app/views/two_step_verification_exemptions/edit.html.erb
+++ b/app/views/two_step_verification_exemptions/edit.html.erb
@@ -55,6 +55,7 @@
       Please provide a reason for granting this exemption above.
       Please note - the reason you enter will be visible to the user, and any admins who have the ability to edit the user.
     },
+    autocomplete: "off",
     error_items: @exemption.errors.full_messages_for(:reason).map { |message| { text: message } }
   } %>
 

--- a/app/views/users/_form_fields.html.erb
+++ b/app/views/users/_form_fields.html.erb
@@ -1,11 +1,11 @@
 <p class="form-group">
   <%= f.label :name %>
-  <%= f.text_field :name, autofocus: true, class: 'form-control input-md-6 ' %>
+  <%= f.text_field :name, autofocus: true, autocomplete: "off", class: 'form-control input-md-6 ' %>
 </p>
 
 <p class="form-group">
   <%= f.label :email %>
-  <%= f.text_field :email, class: 'form-control input-md-6 add-label-margin' %>
+  <%= f.text_field :email, autocomplete: "off", class: 'form-control input-md-6 add-label-margin' %>
   <% if f.object.persisted? %>
     <% if f.object.invited_but_not_yet_accepted? %>
       <span class="help-block">Changes will trigger a new signup email.</span>

--- a/app/views/users/_user_filter.html.erb
+++ b/app/views/users/_user_filter.html.erb
@@ -17,7 +17,7 @@
           <%= hidden_field_tag :organisation, params[:organisation] if params[:organisation] %>
           <%= hidden_field_tag :two_step_status, params[:two_step_status] if params[:two_step_status] %>
           <%= label_tag 'filter', 'Name or email', class: 'add-right-margin sr-only' %>
-          <%= text_field_tag "filter", params[:filter], placeholder: "Name or email", class: 'form-control filter-by-name-field' %>
+          <%= text_field_tag "filter", params[:filter], placeholder: "Name or email", autocomplete: "off", class: 'form-control filter-by-name-field' %>
           <%= submit_tag "Filter", class: "btn btn-default" %>
           <% end %>
         </li>

--- a/app/views/users/_user_filter_group.html.erb
+++ b/app/views/users/_user_filter_group.html.erb
@@ -23,7 +23,7 @@
       <li class="list-filter">
         <form>
           <label for="organisation-list-filter" class="rm">Search organisations</label>
-          <input id="organisation-list-filter" type="text" class="list-filter-input form-control js-filter-list-input" placeholder="Search organisations">
+          <input id="organisation-list-filter" type="text" class="list-filter-input form-control js-filter-list-input" placeholder="Search organisations" autocomplete="off">
         </form>
       </li>
     <% end %>
@@ -31,7 +31,7 @@
       <li class="list-filter">
         <form>
           <label for="permission-list-filter" class="rm">Search permissions</label>
-          <input id="permission-list-filter" type="text" class="list-filter-input form-control js-filter-list-input" placeholder="Search permissions">
+          <input id="permission-list-filter" type="text" class="list-filter-input form-control js-filter-list-input" placeholder="Search permissions" autocomplete="off">
         </form>
       </li>
     <% end %>

--- a/app/views/users/edit_email_or_password.html.erb
+++ b/app/views/users/edit_email_or_password.html.erb
@@ -27,7 +27,8 @@
         type: "email",
         id: "user_email",
         value: current_user.email,
-        hint: "Changing your email address doesn’t take effect until you follow the link in a confirmation email sent to the new address."
+        hint: "Changing your email address doesn’t take effect until you follow the link in a confirmation email sent to the new address.",
+        autocomplete: "email"
       } %>
       <%= render "govuk_publishing_components/components/button", {
         text: "Change email"


### PR DESCRIPTION
Trello: https://trello.com/c/WHsgcFDz

This explicitly sets the autocomplete attribute to "off" on all input elements unless there is [a specificly suitable value][1], e.g. "name", "email", "current-password", "new-password". Note that these values must apply for the current user and not for another user, e.g. when a user is editing the details of another user, autocomplete should be set to "off" for the "name" & "email" fields.

The original motivation behind this was that some password managers were filling in the "name" and "email" fields on the edit user page. This was because autocomplete was not set on the fields, the password manager heuristics decided that they were legitimate "name" & "email" fields, and (since there was only one matching item for the domain) the password manager filled the field with the current user's name and email address. This should no longer happen, because we are now setting autocomplete to "off" for those two fields.

I have manually tested all the affected pages in Chrome on MacOS.

[1]: https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete#values
