### PR TITLE
Prevent new users being created with non-governmental email addresses

### DIFF
--- a/app/models/batch_invitation_user.rb
+++ b/app/models/batch_invitation_user.rb
@@ -2,6 +2,7 @@ class BatchInvitationUser < ApplicationRecord
   belongs_to :batch_invitation
 
   validates :email, presence: true, format: { with: Devise.email_regexp }
+  validates :email, reject_non_governmental_email_addresses: true, on: :create
 
   validates :outcome, inclusion: { in: [nil, "success", "failed", "skipped"] }
 

--- a/app/models/reject_non_governmental_email_addresses_validator.rb
+++ b/app/models/reject_non_governmental_email_addresses_validator.rb
@@ -1,0 +1,25 @@
+class RejectNonGovernmentalEmailAddressesValidator < ActiveModel::EachValidator
+  NON_GOVERNMENTAL_EMAIL_DOMAIN_KEYWORDS = %w[
+    aol btinternet gmail hotmail outlook yahoo
+  ].freeze
+
+  MESSAGE = "not accepted. Please enter a workplace email to continue.".freeze
+
+  def validate_each(record, attribute, value)
+    return if value.blank?
+
+    domain_part = value.split("@").last
+
+    return if domain_part.blank?
+
+    if keyword_matchers.any? { |keyword| keyword.match?(domain_part) }
+      record.errors.add(attribute, (options[:message] || MESSAGE))
+    end
+  end
+
+private
+
+  def keyword_matchers
+    NON_GOVERNMENTAL_EMAIL_DOMAIN_KEYWORDS.map { |keyword| /\b#{keyword}\b/ }
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,6 +34,7 @@ class User < ApplicationRecord
   encrypts :otp_secret_key
 
   validates :name, presence: true
+  validates :email, reject_non_governmental_email_addresses: true, on: :create
   validates :reason_for_suspension, presence: true, if: proc { |u| u.suspended? }
   validate :user_can_be_exempted_from_2sv
   validate :organisation_admin_belongs_to_organisation

--- a/test/models/batch_invitation_user_test.rb
+++ b/test/models/batch_invitation_user_test.rb
@@ -16,6 +16,22 @@ class BatchInvitationUserTest < ActiveSupport::TestCase
       assert_not user.valid?
       assert_equal ["is invalid"], user.errors[:email]
     end
+
+    should "prevent user being created with a known non-government email address" do
+      user = build(:batch_invitation_user, email: "piers.quinn@yahoo.co.uk")
+
+      assert_not user.valid?
+      assert_equal ["not accepted. Please enter a workplace email to continue."],
+                   user.errors[:email]
+    end
+
+    should "still allow user to be updated with a known non-government email address" do
+      user = create(:batch_invitation_user, email: "alexia.statham@department.gov.uk")
+
+      user.email = "alexia.statham@yahoo.co.uk"
+
+      assert user.valid?
+    end
   end
 
   context "invite" do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -304,6 +304,22 @@ class UserTest < ActiveSupport::TestCase
       end
     end
 
+    should "prevent user being created with a known non-government email address" do
+      user = build(:user, email: "piers.quinn@yahoo.co.uk")
+
+      assert_not user.valid?
+      assert_equal ["not accepted. Please enter a workplace email to continue."],
+                   user.errors[:email]
+    end
+
+    should "still allow user to be updated with a known non-government email address" do
+      user = create(:batch_invitation_user, email: "alexia.statham@department.gov.uk")
+
+      user.email = "alexia.statham@yahoo.co.uk"
+
+      assert user.valid?
+    end
+
     should "reject emails with invalid domain parts" do
       user = build(:user)
       [

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -423,7 +423,7 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test "it discourages weak passwords which reuse parts of the email" do
-    u = build(:user, email: "sleuth@gmail.com", password: "sherlock holmes baker street")
+    u = build(:user, email: "sleuth@detective.com", password: "sherlock holmes baker street")
     assert u.valid?
 
     u = build(:user, email: "sherlock.holmes@bakerstreet.com", password: "sherlock holmes baker street")


### PR DESCRIPTION
https://trello.com/c/gME44pGU/210-prevent-new-users-with-being-created-with-non-governmental-email-addresses

Right now, a user can be created in Signon with any email address at
all. For example, you can create (and evidently people have created) new
users with `gmail.com` addresses.

This openness presents a number of potential security risks.

Here we use a custom validator to reject email addresses that match any of
a short list of well known email providers' domains.

Including these validation rules in `BatchInvitationUser` as well as
`User` means that the email addresses included in CSV uploads will be
verified, too. (Note that batch uploads encountering this new validation
error will still only see our generic "One or more emails were invalid"
error message for now. But the more specific error will be available to
us when we get to work on our upcoming improvements to that page.)

:pray: Please help me out with the error message content! As I've got it,
it says, "Email is not a workplace-provided address".