### PR TITLE
Add user research recruitment banner v3

### DIFF
--- a/app/assets/stylesheets/_user_research_recruitment_banner.scss
+++ b/app/assets/stylesheets/_user_research_recruitment_banner.scss
@@ -1,0 +1,22 @@
+.user-research-recruitment-banner {
+  background-color: $govuk-brand-colour;
+  @include govuk-responsive-padding(8, "top");
+}
+
+.user-research-recruitment-banner__divider {
+  border-bottom: 1px solid govuk-colour("white");
+}
+
+.user-research-recruitment-banner__title {
+  color: govuk-colour("white");
+  @include govuk-responsive-margin(5, "bottom");
+}
+
+.user-research-recruitment-banner__intro {
+  color: govuk-colour("white");
+}
+
+.user-research-recruitment-banner__buttons {
+  @include govuk-responsive-padding(6, "bottom");
+  align-items: center;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,4 +1,5 @@
 @import "govuk_publishing_components/all_components";
+@import "user_research_recruitment_banner";
 
 // TODO: move into component
 .gem-c-success-alert,

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -14,4 +14,11 @@ class RootController < ApplicationController
   def signin_required
     @application = ::Doorkeeper::Application.find_by(id: session.delete(:signin_missing_for_application))
   end
+
+private
+
+  def show_user_research_recruitment_banner?
+    !cookies[:dismiss_user_research_recruitment_banner]
+  end
+  helper_method :show_user_research_recruitment_banner?
 end

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -18,7 +18,7 @@ class RootController < ApplicationController
 private
 
   def show_user_research_recruitment_banner?
-    !cookies[:dismiss_user_research_recruitment_banner]
+    !cookies[:dismiss_user_research_recruitment_banner] && !current_user.user_research_recruitment_banner_hidden?
   end
   helper_method :show_user_research_recruitment_banner?
 end

--- a/app/controllers/user_research_recruitment_controller.rb
+++ b/app/controllers/user_research_recruitment_controller.rb
@@ -1,9 +1,15 @@
 class UserResearchRecruitmentController < ApplicationController
+  USER_RESEARCH_RECRUITMENT_FORM_URL = "https://docs.google.com/forms/d/1Bdu_GqOrSR4j6mbuzXkFTQg6FRktRMQc8Y-q879Mny8/viewform".freeze
+
   before_action :authenticate_user!
   skip_after_action :verify_authorized
 
   def update
-    if params[:choice] == "dismiss-banner"
+    case params[:choice]
+    when "participate"
+      current_user.update!(user_research_recruitment_banner_hidden: true)
+      redirect_to USER_RESEARCH_RECRUITMENT_FORM_URL, allow_other_host: true
+    when "dismiss-banner"
       cookies[:dismiss_user_research_recruitment_banner] = true
       redirect_to root_path
     end

--- a/app/controllers/user_research_recruitment_controller.rb
+++ b/app/controllers/user_research_recruitment_controller.rb
@@ -1,0 +1,11 @@
+class UserResearchRecruitmentController < ApplicationController
+  before_action :authenticate_user!
+  skip_after_action :verify_authorized
+
+  def update
+    if params[:choice] == "dismiss-banner"
+      cookies[:dismiss_user_research_recruitment_banner] = true
+      redirect_to root_path
+    end
+  end
+end

--- a/app/views/layouts/admin_layout.html.erb
+++ b/app/views/layouts/admin_layout.html.erb
@@ -11,6 +11,8 @@
     navigation_items: navigation_items,
   }%>
 
+  <%= yield(:user_research_recruitment_banner) %>
+
   <div class="govuk-width-container">
     <% if yield(:back_link).present? %>
       <%= render "govuk_publishing_components/components/back_link", href: yield(:back_link) %>

--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -1,5 +1,28 @@
 <% content_for :title, "Your applications" %>
 
+  <% content_for :user_research_recruitment_banner do %>
+    <section class="user-research-recruitment-banner">
+      <div class="govuk-width-container">
+        <hr class="user-research-recruitment-banner__divider govuk-section-break govuk-section-break--l govuk-!-margin-top-0">
+        <h1 class="user-research-recruitment-banner__title govuk-heading-xl">Help us improve GOV.UK Publishing</h1>
+        <p class="user-research-recruitment-banner__intro govuk-body">We're holding research sessions to make Publishing work better.</p>
+        <%= form_tag "#" do %>
+          <div class="user-research-recruitment-banner__buttons govuk-button-group">
+            <button class="govuk-!-font-size-24 govuk-!-font-weight-bold govuk-button govuk-button--start govuk-button--inverse" type="submit">
+              <span>Find out more</span>
+              <svg class="govuk-button__start-icon govuk-!-display-none-print" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" focusable="false" aria-hidden="true">
+                <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"></path>
+              </svg>
+            </button>
+            <button class="govuk-button govuk-button--inverse" type="submit">
+              Hide this
+            </button>
+          </div>
+        <% end %>
+      </div>
+    </section>
+  <% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 

--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -1,12 +1,13 @@
 <% content_for :title, "Your applications" %>
 
+<% if show_user_research_recruitment_banner? %>
   <% content_for :user_research_recruitment_banner do %>
     <section class="user-research-recruitment-banner">
       <div class="govuk-width-container">
         <hr class="user-research-recruitment-banner__divider govuk-section-break govuk-section-break--l govuk-!-margin-top-0">
         <h1 class="user-research-recruitment-banner__title govuk-heading-xl">Help us improve GOV.UK Publishing</h1>
         <p class="user-research-recruitment-banner__intro govuk-body">We're holding research sessions to make Publishing work better.</p>
-        <%= form_tag "#" do %>
+        <%= form_tag user_research_recruitment_update_path, method: :put do %>
           <div class="user-research-recruitment-banner__buttons govuk-button-group">
             <button class="govuk-!-font-size-24 govuk-!-font-weight-bold govuk-button govuk-button--start govuk-button--inverse" type="submit">
               <span>Find out more</span>
@@ -14,7 +15,7 @@
                 <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"></path>
               </svg>
             </button>
-            <button class="govuk-button govuk-button--inverse" type="submit">
+            <button class="govuk-button govuk-button--inverse" type="submit" name="choice" value="dismiss-banner">
               Hide this
             </button>
           </div>
@@ -22,6 +23,7 @@
       </div>
     </section>
   <% end %>
+<% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -9,7 +9,7 @@
         <p class="user-research-recruitment-banner__intro govuk-body">We're holding research sessions to make Publishing work better.</p>
         <%= form_tag user_research_recruitment_update_path, method: :put do %>
           <div class="user-research-recruitment-banner__buttons govuk-button-group">
-            <button class="govuk-!-font-size-24 govuk-!-font-weight-bold govuk-button govuk-button--start govuk-button--inverse" type="submit" name="choice" value="participate">
+            <button class="govuk-!-font-size-24 govuk-!-font-weight-bold govuk-button govuk-button--start govuk-button--inverse" type="submit" name="choice" value="participate" formtarget="_blank">
               <span>Find out more</span>
               <svg class="govuk-button__start-icon govuk-!-display-none-print" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" focusable="false" aria-hidden="true">
                 <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"></path>

--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -9,7 +9,7 @@
         <p class="user-research-recruitment-banner__intro govuk-body">We're holding research sessions to make Publishing work better.</p>
         <%= form_tag user_research_recruitment_update_path, method: :put do %>
           <div class="user-research-recruitment-banner__buttons govuk-button-group">
-            <button class="govuk-!-font-size-24 govuk-!-font-weight-bold govuk-button govuk-button--start govuk-button--inverse" type="submit">
+            <button class="govuk-!-font-size-24 govuk-!-font-weight-bold govuk-button govuk-button--start govuk-button--inverse" type="submit" name="choice" value="participate">
               <span>Find out more</span>
               <svg class="govuk-button__start-icon govuk-!-display-none-print" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" focusable="false" aria-hidden="true">
                 <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"></path>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -77,4 +77,6 @@ Rails.application.routes.draw do
   get "/signin-required" => "root#signin_required"
 
   root to: "root#index"
+
+  put "/user-research-recruitment/update" => "user_research_recruitment#update"
 end

--- a/db/migrate/20230804094159_add_user_research_recruitment_banner_hidden_to_users.rb
+++ b/db/migrate/20230804094159_add_user_research_recruitment_banner_hidden_to_users.rb
@@ -1,0 +1,5 @@
+class AddUserResearchRecruitmentBannerHiddenToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :user_research_recruitment_banner_hidden, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_02_095323) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_04_094159) do
   create_table "batch_invitation_application_permissions", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "batch_invitation_id", null: false
     t.integer "supported_permission_id", null: false
@@ -209,6 +209,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_02_095323) do
     t.boolean "require_2sv", default: false, null: false
     t.string "reason_for_2sv_exemption"
     t.date "expiry_date_for_2sv_exemption"
+    t.boolean "user_research_recruitment_banner_hidden", default: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["invitation_token"], name: "index_users_on_invitation_token"
     t.index ["invited_by_id"], name: "index_users_on_invited_by_id"

--- a/test/controllers/user_research_recruitment_controller_test.rb
+++ b/test/controllers/user_research_recruitment_controller_test.rb
@@ -4,15 +4,15 @@ class UserResearchRecruitmentControllerTest < ActionController::TestCase
   attr_reader :choice
 
   context "#update" do
+    should "require users to be signed in" do
+      put :update
+
+      assert_redirected_to new_user_session_path
+    end
+
     context "when user clicks the button to dismiss the banner" do
       setup do
         @choice = "dismiss-banner"
-      end
-
-      should "require signed in users" do
-        put :update, params: { choice: }
-
-        assert_redirected_to new_user_session_path
       end
 
       should "set session cookie" do
@@ -29,6 +29,29 @@ class UserResearchRecruitmentControllerTest < ActionController::TestCase
         put :update, params: { choice: }
 
         assert_redirected_to root_path
+      end
+    end
+
+    context "when user clicks the button to participate in user research" do
+      setup do
+        @choice = "participate"
+      end
+
+      should "set user_research_recruitment_banner_hidden to true for the current_user" do
+        user = create(:user)
+        sign_in user
+
+        put :update, params: { choice: }
+
+        assert user.user_research_recruitment_banner_hidden?
+      end
+
+      should "redirect to the Google Form" do
+        sign_in create(:user)
+
+        put :update, params: { choice: }
+
+        assert_redirected_to UserResearchRecruitmentController::USER_RESEARCH_RECRUITMENT_FORM_URL
       end
     end
   end

--- a/test/controllers/user_research_recruitment_controller_test.rb
+++ b/test/controllers/user_research_recruitment_controller_test.rb
@@ -1,0 +1,35 @@
+require "test_helper"
+
+class UserResearchRecruitmentControllerTest < ActionController::TestCase
+  attr_reader :choice
+
+  context "#update" do
+    context "when user clicks the button to dismiss the banner" do
+      setup do
+        @choice = "dismiss-banner"
+      end
+
+      should "require signed in users" do
+        put :update, params: { choice: }
+
+        assert_redirected_to new_user_session_path
+      end
+
+      should "set session cookie" do
+        sign_in create(:user)
+
+        put :update, params: { choice: }
+
+        assert cookies[:dismiss_user_research_recruitment_banner]
+      end
+
+      should "redirect to root path" do
+        sign_in create(:user)
+
+        put :update, params: { choice: }
+
+        assert_redirected_to root_path
+      end
+    end
+  end
+end

--- a/test/integration/user_research_recruitment_banner_test.rb
+++ b/test/integration/user_research_recruitment_banner_test.rb
@@ -26,6 +26,32 @@ class UserResearchRecruitmentBannerTest < ActionDispatch::IntegrationTest
     assert_not has_content?(user_research_recruitment_banner_title)
   end
 
+  should "hide the banner until the next session" do
+    user = create(:user, name: "user-name", email: "user@example.com")
+
+    using_session("Session 1") do
+      visit new_user_session_path
+      signin_with(user)
+
+      assert has_content?(user_research_recruitment_banner_title)
+
+      within ".user-research-recruitment-banner" do
+        click_on "Hide this"
+      end
+
+      visit root_path
+
+      assert_not has_content?(user_research_recruitment_banner_title)
+    end
+
+    using_session("Session 2") do
+      visit new_user_session_path
+      signin_with(user)
+
+      assert has_content?(user_research_recruitment_banner_title)
+    end
+  end
+
 private
 
   def user_research_recruitment_banner_title

--- a/test/integration/user_research_recruitment_banner_test.rb
+++ b/test/integration/user_research_recruitment_banner_test.rb
@@ -13,7 +13,7 @@ class UserResearchRecruitmentBannerTest < ActionDispatch::IntegrationTest
     signin_with(user)
 
     assert has_content?(user_research_recruitment_banner_title)
-    assert has_css?("form", text: "Find out more")
+    assert has_css?("form[action='#{user_research_recruitment_update_path}']", text: "Find out more")
   end
 
   should "not display the banner on any page other than the dashboard" do
@@ -52,9 +52,43 @@ class UserResearchRecruitmentBannerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  should "hide the banner permanently if the user clicks the button to participate in user research" do
+    user = create(:user, name: "user-name", email: "user@example.com")
+
+    using_session("Session 1") do
+      visit new_user_session_path
+      signin_with(user)
+
+      assert has_content?(user_research_recruitment_banner_title)
+
+      within ".user-research-recruitment-banner" do
+        allowing_request_to_user_research_recruitment_google_form do
+          click_on "Find out more"
+        end
+      end
+
+      visit root_path
+
+      assert_not has_content?(user_research_recruitment_banner_title)
+    end
+
+    using_session("Session 2") do
+      visit new_user_session_path
+      signin_with(user)
+
+      assert_not has_content?(user_research_recruitment_banner_title)
+    end
+  end
+
 private
 
   def user_research_recruitment_banner_title
     "Help us improve GOV.UK Publishing"
+  end
+
+  def allowing_request_to_user_research_recruitment_google_form
+    yield
+  rescue ActionController::RoutingError
+    raise unless current_url == UserResearchRecruitmentController::USER_RESEARCH_RECRUITMENT_FORM_URL
   end
 end

--- a/test/integration/user_research_recruitment_banner_test.rb
+++ b/test/integration/user_research_recruitment_banner_test.rb
@@ -1,0 +1,34 @@
+require "test_helper"
+
+class UserResearchRecruitmentBannerTest < ActionDispatch::IntegrationTest
+  should "not display the banner on the login page" do
+    visit new_user_session_path
+
+    assert_not has_content?(user_research_recruitment_banner_title)
+  end
+
+  should "display the banner on the dashboard" do
+    user = create(:user, name: "user-name", email: "user@example.com")
+    visit new_user_session_path
+    signin_with(user)
+
+    assert has_content?(user_research_recruitment_banner_title)
+    assert has_css?("form", text: "Find out more")
+  end
+
+  should "not display the banner on any page other than the dashboard" do
+    user = create(:user, name: "user-name", email: "user@example.com")
+    visit new_user_session_path
+    signin_with(user)
+
+    click_on "Change your email or password"
+
+    assert_not has_content?(user_research_recruitment_banner_title)
+  end
+
+private
+
+  def user_research_recruitment_banner_title
+    "Help us improve GOV.UK Publishing"
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/yGMU3sR2

Supersedes #2301.

This adds a "sticky" banner on the Signon home page to recruit user research participants for GOV.UK Publishing. The "Find out more" button opens a Google Form (managed by the User Research folk) in a new browser tab. If the user clicks on this button, we record that in the Signon database and we never show them the banner again. If the user clicks on the "Hide this" button then we hide the banner for the duration of the current browser session, but it will be displayed to the user in their next browser session.

This is a reworked version of #2301 where I've addressed the issue that Calum spotted where the buttons in the banner were not full width on mobile screen widths. I've solved this by using a single form wrapped around the button group with each button having a different value and combining the two controller actions into one switching on the button value. Previously we were using the Rails `button_to` helper method which was generating two forms within the button group and this was upsetting the button layout on mobiles. For now the buttons are defined using plain HTML which is what the GOV.UK Components button would generate if it supported the `govuk-button--inverse` CSS class. Our intention is to open a PR against the GOV.UK Components repo to add support for this class at which point we can address the duplication in this button HTML.

One thing I'm not 100% sure about is that I've had to use the `formtarget` attribute on the "Find out more" button in order to open the Google Form in another tab - however, it seems to be well supported in modern browsers.

As per [these recommendations](https://www.gov.uk/service-manual/technology/designing-for-different-browsers-and-devices#browsers-to-test-in-from-june-2022), I've tested these changes against the following devices/browsers (using BrowserStack):

* Windows 11
  * [x] Edge 115
  * [x] Firefox 116
  * [x] Chrome 115
* MacOS 13.4.1
  * [x] Firefox 115
  * [x] Chrome 115
  * [x] Safari 16.5.2
* iPhone SE 2022 v15.4
  * [x] Safari
  * [x] Chrome
* iPhone 14 iOS 16
  * [x] Safari
* Galaxy S23 Android 13
  * [x] Chrome
  * [x] Samsung Internet

### Desktop
![Screen Shot 2023-08-10 at 11 00 51](https://github.com/alphagov/signon/assets/3169/c2af2103-bd46-41f3-8201-d83a4b9407cb)

### iPad
![Screen Shot 2023-08-10 at 11 00 37](https://github.com/alphagov/signon/assets/3169/954330ca-813f-43fc-993b-fc7716fd908a)

### iPhone
![Screen Shot 2023-08-10 at 11 00 26](https://github.com/alphagov/signon/assets/3169/29e28012-1d6a-48c5-a01e-965a615185c6)
