### PR TITLE
Fix use of INSTANCE_NAME to determine environment-specific behaviour

### DIFF
--- a/app/helpers/two_step_verification_helper.rb
+++ b/app/helpers/two_step_verification_helper.rb
@@ -28,8 +28,8 @@ private
 
   def otp_secret_key_uri(user:, otp_secret_key:)
     issuer = I18n.t("devise.issuer")
-    if Rails.application.config.instance_name
-      issuer = "#{Rails.application.config.instance_name.titleize} #{issuer}"
+    if GovukEnvironment.name
+      issuer = "#{GovukEnvironment.name.titleize} #{issuer}"
     end
 
     issuer = ERB::Util.url_encode(issuer)

--- a/app/helpers/two_step_verification_helper.rb
+++ b/app/helpers/two_step_verification_helper.rb
@@ -28,7 +28,7 @@ private
 
   def otp_secret_key_uri(user:, otp_secret_key:)
     issuer = I18n.t("devise.issuer")
-    if GovukEnvironment.name
+    unless GovukEnvironment.production?
       issuer = "#{GovukEnvironment.name.titleize} #{issuer}"
     end
 

--- a/app/mailers/mailer_helper.rb
+++ b/app/mailers/mailer_helper.rb
@@ -8,10 +8,10 @@ module MailerHelper
   end
 
   def email_from_address
-    if GovukEnvironment.name.present?
-      I18n.t("mailer.email_from_address.instance", instance_name: GovukEnvironment.name.parameterize)
-    else
+    if GovukEnvironment.production?
       I18n.t("mailer.email_from_address.no-instance")
+    else
+      I18n.t("mailer.email_from_address.instance", instance_name: GovukEnvironment.name.parameterize)
     end
   end
 end

--- a/app/mailers/mailer_helper.rb
+++ b/app/mailers/mailer_helper.rb
@@ -16,6 +16,6 @@ module MailerHelper
   end
 
   def instance_name
-    Rails.application.config.instance_name
+    GovukEnvironment.name
   end
 end

--- a/app/mailers/mailer_helper.rb
+++ b/app/mailers/mailer_helper.rb
@@ -4,7 +4,11 @@ module MailerHelper
   end
 
   def app_name
-    I18n.t("mailer.app_name", instance_name: GovukEnvironment.name)
+    if GovukEnvironment.production?
+      I18n.t("mailer.app_name.no_instance")
+    else
+      I18n.t("mailer.app_name.instance", instance_name: GovukEnvironment.name)
+    end
   end
 
   def email_from_address

--- a/app/mailers/mailer_helper.rb
+++ b/app/mailers/mailer_helper.rb
@@ -4,18 +4,14 @@ module MailerHelper
   end
 
   def app_name
-    I18n.t("mailer.app_name", instance_name:)
+    I18n.t("mailer.app_name", instance_name: GovukEnvironment.name)
   end
 
   def email_from_address
-    if instance_name.present?
-      I18n.t("mailer.email_from_address.instance", instance_name: instance_name.parameterize)
+    if GovukEnvironment.name.present?
+      I18n.t("mailer.email_from_address.instance", instance_name: GovukEnvironment.name.parameterize)
     else
       I18n.t("mailer.email_from_address.no-instance")
     end
-  end
-
-  def instance_name
-    GovukEnvironment.name
   end
 end

--- a/app/mailers/mailer_helper.rb
+++ b/app/mailers/mailer_helper.rb
@@ -9,7 +9,7 @@ module MailerHelper
 
   def email_from_address
     if GovukEnvironment.production?
-      I18n.t("mailer.email_from_address.no-instance")
+      I18n.t("mailer.email_from_address.no_instance")
     else
       I18n.t("mailer.email_from_address.instance", instance_name: GovukEnvironment.name.parameterize)
     end

--- a/app/mailers/noisy_batch_invitation.rb
+++ b/app/mailers/noisy_batch_invitation.rb
@@ -10,7 +10,7 @@ class NoisyBatchInvitation < ApplicationMailer
 
     user_count = batch_invitation.batch_invitation_users.count
     subject = "[SIGNON] #{@user.name} created a batch of #{user_count} users"
-    subject << " in #{GovukEnvironment.name}" if GovukEnvironment.name
+    subject << " in #{GovukEnvironment.name}" unless GovukEnvironment.production?
     view_mail(template_id, subject:)
   end
 end

--- a/app/mailers/noisy_batch_invitation.rb
+++ b/app/mailers/noisy_batch_invitation.rb
@@ -10,7 +10,7 @@ class NoisyBatchInvitation < ApplicationMailer
 
     user_count = batch_invitation.batch_invitation_users.count
     subject = "[SIGNON] #{@user.name} created a batch of #{user_count} users"
-    subject << " in #{instance_name}" if instance_name
+    subject << " in #{GovukEnvironment.name}" if GovukEnvironment.name
     view_mail(template_id, subject:)
   end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -4,7 +4,7 @@ class UserMailer < Devise::Mailer
 
   default from: proc { email_from }
 
-  helper_method :suspension_time, :account_name, :instance_name, :locked_time, :unlock_time, :production?
+  helper_method :suspension_time, :account_name, :locked_time, :unlock_time
 
   def two_step_reset(user)
     @user = user
@@ -17,7 +17,7 @@ class UserMailer < Devise::Mailer
   end
 
   def two_step_enabled(user)
-    prefix = "[#{GovukEnvironment.name.titleize}] " unless production?
+    prefix = "[#{GovukEnvironment.name.titleize}] " if GovukEnvironment.name.present?
     @user = user
     view_mail(template_id, to: @user.email, subject: "#{prefix}2-step verification set up")
   end
@@ -119,8 +119,8 @@ private
   end
 
   def account_name
-    if instance_name.present?
-      "#{instance_name} account"
+    if GovukEnvironment.name.present?
+      "#{GovukEnvironment.name} account"
     else
       "account"
     end
@@ -133,9 +133,5 @@ private
       default: [:subject, key.to_s.humanize],
       app_name:,
     )
-  end
-
-  def production?
-    GovukEnvironment.name.blank?
   end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -17,7 +17,7 @@ class UserMailer < Devise::Mailer
   end
 
   def two_step_enabled(user)
-    prefix = "[#{Rails.application.config.instance_name.titleize}] " unless production?
+    prefix = "[#{GovukEnvironment.name.titleize}] " unless production?
     @user = user
     view_mail(template_id, to: @user.email, subject: "#{prefix}2-step verification set up")
   end
@@ -136,6 +136,6 @@ private
   end
 
   def production?
-    Rails.application.config.instance_name.blank?
+    GovukEnvironment.name.blank?
   end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -17,7 +17,7 @@ class UserMailer < Devise::Mailer
   end
 
   def two_step_enabled(user)
-    prefix = "[#{GovukEnvironment.name.titleize}] " if GovukEnvironment.name.present?
+    prefix = "[#{GovukEnvironment.name.titleize}] " unless GovukEnvironment.production?
     @user = user
     view_mail(template_id, to: @user.email, subject: "#{prefix}2-step verification set up")
   end
@@ -119,10 +119,10 @@ private
   end
 
   def account_name
-    if GovukEnvironment.name.present?
-      "#{GovukEnvironment.name} account"
-    else
+    if GovukEnvironment.production?
       "account"
+    else
+      "#{GovukEnvironment.name} account"
     end
   end
 

--- a/app/models/govuk_environment.rb
+++ b/app/models/govuk_environment.rb
@@ -1,0 +1,9 @@
+class GovukEnvironment
+  def self.name
+    if Rails.env.development? || Rails.env.test?
+      "development"
+    else
+      ENV["INSTANCE_NAME"]
+    end
+  end
+end

--- a/app/models/govuk_environment.rb
+++ b/app/models/govuk_environment.rb
@@ -8,6 +8,6 @@ class GovukEnvironment
   end
 
   def self.production?
-    name.blank?
+    name == "production"
   end
 end

--- a/app/models/govuk_environment.rb
+++ b/app/models/govuk_environment.rb
@@ -6,4 +6,8 @@ class GovukEnvironment
       ENV["INSTANCE_NAME"]
     end
   end
+
+  def self.production?
+    name.blank?
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -258,7 +258,7 @@ class User < ApplicationRecord
   end
 
   def set_2sv_for_admin_roles
-    return if GovukEnvironment.name.present?
+    return unless GovukEnvironment.production?
 
     self.require_2sv = true if role_changed? && (admin? || superadmin? || organisation_admin? || super_organisation_admin?)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -258,7 +258,7 @@ class User < ApplicationRecord
   end
 
   def set_2sv_for_admin_roles
-    return if Rails.application.config.instance_name.present?
+    return if GovukEnvironment.name.present?
 
     self.require_2sv = true if role_changed? && (admin? || superadmin? || organisation_admin? || super_organisation_admin?)
   end

--- a/app/views/user_mailer/notify_reset_password_disallowed_due_to_suspension.text.erb
+++ b/app/views/user_mailer/notify_reset_password_disallowed_due_to_suspension.text.erb
@@ -1,7 +1,7 @@
 
 Your <%= t('department.name') %> Signon <%= account_name %>, for <%= @user.email %>, is suspended. You can't request a password reset on a suspended account.
 
-<% if instance_name.present? %>
+<% if GovukEnvironment.name.present? %>
 <%= account_name.humanize %> suspensions do not suspend production accounts.
 <% end %>
 

--- a/app/views/user_mailer/notify_reset_password_disallowed_due_to_suspension.text.erb
+++ b/app/views/user_mailer/notify_reset_password_disallowed_due_to_suspension.text.erb
@@ -1,7 +1,7 @@
 
 Your <%= t('department.name') %> Signon <%= account_name %>, for <%= @user.email %>, is suspended. You can't request a password reset on a suspended account.
 
-<% if GovukEnvironment.name.present? %>
+<% unless GovukEnvironment.production? %>
 <%= account_name.humanize %> suspensions do not suspend production accounts.
 <% end %>
 

--- a/app/views/user_mailer/suspension_notification.text.erb
+++ b/app/views/user_mailer/suspension_notification.text.erb
@@ -2,7 +2,7 @@
 
 Your <%= t('department.name') %> Signon <%= account_name %>, for <%= @user.email %>, has now been suspended and you won't be able to access any <%= t('department.name') %> <%= account_name %> publishing applications.
 
-<% if instance_name.present? %>
+<% if GovukEnvironment.name.present? %>
 <%= account_name.humanize %> suspensions do not suspend production accounts or remove access to <%= t('department.name') %> production applications.
 <% end %>
 

--- a/app/views/user_mailer/suspension_notification.text.erb
+++ b/app/views/user_mailer/suspension_notification.text.erb
@@ -2,7 +2,7 @@
 
 Your <%= t('department.name') %> Signon <%= account_name %>, for <%= @user.email %>, has now been suspended and you won't be able to access any <%= t('department.name') %> <%= account_name %> publishing applications.
 
-<% if GovukEnvironment.name.present? %>
+<% unless GovukEnvironment.production? %>
 <%= account_name.humanize %> suspensions do not suspend production accounts or remove access to <%= t('department.name') %> production applications.
 <% end %>
 

--- a/app/views/user_mailer/suspension_reminder.text.erb
+++ b/app/views/user_mailer/suspension_reminder.text.erb
@@ -2,7 +2,7 @@
 
 Your <%= t('department.name') %> Signon <%= account_name %>, for <%= @user.email %>, will be suspended <%= suspension_time %>. After suspension you won't be able to access any <%= t('department.name') %> <%= account_name %> publishing applications.
 
-<% if GovukEnvironment.name.present? %>
+<% unless GovukEnvironment.production? %>
 <%= account_name.humanize %> suspensions do not suspend production accounts or remove access to <%= t('department.name') %> production applications.
 <% end %>
 

--- a/app/views/user_mailer/suspension_reminder.text.erb
+++ b/app/views/user_mailer/suspension_reminder.text.erb
@@ -2,7 +2,7 @@
 
 Your <%= t('department.name') %> Signon <%= account_name %>, for <%= @user.email %>, will be suspended <%= suspension_time %>. After suspension you won't be able to access any <%= t('department.name') %> <%= account_name %> publishing applications.
 
-<% if instance_name.present? %>
+<% if GovukEnvironment.name.present? %>
 <%= account_name.humanize %> suspensions do not suspend production accounts or remove access to <%= t('department.name') %> production applications.
 <% end %>
 

--- a/app/views/user_mailer/two_step_enabled.text.erb
+++ b/app/views/user_mailer/two_step_enabled.text.erb
@@ -1,5 +1,5 @@
 You’ve successfully set up 2-step verification. This will make your Signon account more secure. Next time you sign in, you’ll need the phone you used during set up.
 
-<% unless GovukEnvironment.name.blank? %>
+<% unless GovukEnvironment.production? %>
 You’ll have to set up 2-step verification separately for your Production account.
 <% end %>

--- a/app/views/user_mailer/two_step_enabled.text.erb
+++ b/app/views/user_mailer/two_step_enabled.text.erb
@@ -1,5 +1,5 @@
 You’ve successfully set up 2-step verification. This will make your Signon account more secure. Next time you sign in, you’ll need the phone you used during set up.
 
-<% unless production? %>
+<% unless GovukEnvironment.name.blank? %>
 You’ll have to set up 2-step verification separately for your Production account.
 <% end %>

--- a/app/views/user_mailer/unlock_instructions.text.erb
+++ b/app/views/user_mailer/unlock_instructions.text.erb
@@ -1,6 +1,6 @@
 Your <%= t('department.name') %> Signon <%= account_name %>, for <%= @user.email %>, was locked at <%= locked_time %> because the wrong sign on details were entered too many times.
 
-<% if instance_name.present? %>
+<% if GovukEnvironment.name.present? %>
   <%= account_name.humanize %> locks do not lock production accounts.
 <% end %>
 

--- a/app/views/user_mailer/unlock_instructions.text.erb
+++ b/app/views/user_mailer/unlock_instructions.text.erb
@@ -1,6 +1,6 @@
 Your <%= t('department.name') %> Signon <%= account_name %>, for <%= @user.email %>, was locked at <%= locked_time %> because the wrong sign on details were entered too many times.
 
-<% if GovukEnvironment.name.present? %>
+<% unless GovukEnvironment.production? %>
   <%= account_name.humanize %> locks do not lock production accounts.
 <% end %>
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,5 +1,4 @@
 require "govuk_app_config"
-require_relative "instance_name"
 
 devise_config = Rails.application.config_for(:devise).symbolize_keys
 

--- a/config/initializers/instance_name.rb
+++ b/config/initializers/instance_name.rb
@@ -3,5 +3,5 @@
 Rails.application.config.instance_name = if Rails.env.development? || Rails.env.test?
                                            "development"
                                          else
-                                           ENV.fetch("INSTANCE_NAME", nil)
+                                           ENV["INSTANCE_NAME"]
                                          end

--- a/config/initializers/instance_name.rb
+++ b/config/initializers/instance_name.rb
@@ -1,7 +1,0 @@
-# Human-friendly name for this signon instance. This is used when generating
-# reminder emails that need to disambiguate between instances.
-Rails.application.config.instance_name = if Rails.env.development? || Rails.env.test?
-                                           "development"
-                                         else
-                                           ENV["INSTANCE_NAME"]
-                                         end

--- a/config/locales/department_specific.en.yml
+++ b/config/locales/department_specific.en.yml
@@ -6,7 +6,9 @@ en:
   devise:
     issuer: "GOV.UK Signon"
   mailer:
-    app_name: "GOV.UK Signon %{instance_name}"
+    app_name:
+      instance: "GOV.UK Signon %{instance_name}"
+      no_instance: "GOV.UK Signon"
     email_from_address:
       instance: "noreply-signon-%{instance_name}@digital.cabinet-office.gov.uk"
       no_instance: "noreply-signon@digital.cabinet-office.gov.uk"

--- a/config/locales/department_specific.en.yml
+++ b/config/locales/department_specific.en.yml
@@ -9,7 +9,7 @@ en:
     app_name: "GOV.UK Signon %{instance_name}"
     email_from_address:
       instance: "noreply-signon-%{instance_name}@digital.cabinet-office.gov.uk"
-      no-instance: "noreply-signon@digital.cabinet-office.gov.uk"
+      no_instance: "noreply-signon@digital.cabinet-office.gov.uk"
 
   noisy_batch_invitation_mailer:
     to: "signon-alerts@digital.cabinet-office.gov.uk"

--- a/test/helpers/two_step_verification_helper_test.rb
+++ b/test/helpers/two_step_verification_helper_test.rb
@@ -18,12 +18,7 @@ class TwoStepVerificationHelperTest < ActionView::TestCase
 
     context "in production" do
       setup do
-        @old_instance_name = Rails.application.config.instance_name
-        Rails.application.config.instance_name = nil
-      end
-
-      teardown do
-        Rails.application.config.instance_name = @old_instance_name
+        GovukEnvironment.stubs(:name).returns(nil)
       end
 
       should "not include the environment name" do

--- a/test/helpers/two_step_verification_helper_test.rb
+++ b/test/helpers/two_step_verification_helper_test.rb
@@ -18,7 +18,7 @@ class TwoStepVerificationHelperTest < ActionView::TestCase
 
     context "in production" do
       setup do
-        GovukEnvironment.stubs(:name).returns(nil)
+        GovukEnvironment.stubs(:production?).returns(true)
       end
 
       should "not include the environment name" do

--- a/test/models/govuk_environment_test.rb
+++ b/test/models/govuk_environment_test.rb
@@ -36,4 +36,26 @@ class GovukEnvironmentTest < ActionMailer::TestCase
       end
     end
   end
+
+  context ".production?" do
+    context "when name is blank" do
+      setup do
+        GovukEnvironment.stubs(:name).returns("")
+      end
+
+      should "return truthy" do
+        assert GovukEnvironment.production?
+      end
+    end
+
+    context "when name is not blank" do
+      setup do
+        GovukEnvironment.stubs(:name).returns("not-blank")
+      end
+
+      should "return falsey" do
+        assert_not GovukEnvironment.production?
+      end
+    end
+  end
 end

--- a/test/models/govuk_environment_test.rb
+++ b/test/models/govuk_environment_test.rb
@@ -1,0 +1,39 @@
+require "test_helper"
+
+class GovukEnvironmentTest < ActionMailer::TestCase
+  context ".name" do
+    context "when in Rails development environment" do
+      setup do
+        Rails.env.stubs(:development?).returns(true)
+        Rails.env.stubs(:test?).returns(false)
+      end
+
+      should "return 'development'" do
+        assert_equal "development", GovukEnvironment.name
+      end
+    end
+
+    context "when in Rails test environment" do
+      setup do
+        Rails.env.stubs(:development?).returns(false)
+        Rails.env.stubs(:test?).returns(true)
+      end
+
+      should "return 'development'" do
+        assert_equal "development", GovukEnvironment.name
+      end
+    end
+
+    context "when not in Rails development or test environment" do
+      setup do
+        Rails.env.stubs(:development?).returns(false)
+        Rails.env.stubs(:test?).returns(false)
+        ENV.stubs(:[]).with("INSTANCE_NAME").returns("instance-name")
+      end
+
+      should "return value of INSTANCE_NAME env var" do
+        assert_equal "instance-name", GovukEnvironment.name
+      end
+    end
+  end
+end

--- a/test/models/govuk_environment_test.rb
+++ b/test/models/govuk_environment_test.rb
@@ -38,9 +38,9 @@ class GovukEnvironmentTest < ActionMailer::TestCase
   end
 
   context ".production?" do
-    context "when name is blank" do
+    context "when name is 'production'" do
       setup do
-        GovukEnvironment.stubs(:name).returns("")
+        GovukEnvironment.stubs(:name).returns("production")
       end
 
       should "return truthy" do
@@ -48,9 +48,9 @@ class GovukEnvironmentTest < ActionMailer::TestCase
       end
     end
 
-    context "when name is not blank" do
+    context "when name is not 'production'" do
       setup do
-        GovukEnvironment.stubs(:name).returns("not-blank")
+        GovukEnvironment.stubs(:name).returns("not-production")
       end
 
       should "return falsey" do

--- a/test/models/noisy_batch_invitation_test.rb
+++ b/test/models/noisy_batch_invitation_test.rb
@@ -36,7 +36,7 @@ class NoisyBatchInvitationTest < ActionMailer::TestCase
 
   context "make_noise when instance_name has been set" do
     setup do
-      Rails.application.config.stubs(:instance_name).returns("Test Fools")
+      GovukEnvironment.stubs(:name).returns("Test Fools")
 
       user = create(:user, name: "Bob Loblaw")
       @batch_invitation = create(:batch_invitation, user:)
@@ -51,7 +51,7 @@ class NoisyBatchInvitationTest < ActionMailer::TestCase
 
   context "work correctly when no instance name is set" do
     setup do
-      Rails.application.config.stubs(:instance_name).returns(nil)
+      GovukEnvironment.stubs(:name).returns(nil)
 
       user = create(:user, name: "Bob Loblaw")
       @batch_invitation = create(:batch_invitation, user:)

--- a/test/models/noisy_batch_invitation_test.rb
+++ b/test/models/noisy_batch_invitation_test.rb
@@ -34,8 +34,9 @@ class NoisyBatchInvitationTest < ActionMailer::TestCase
     end
   end
 
-  context "make_noise when instance_name has been set" do
+  context "make_noise in non-production environment" do
     setup do
+      GovukEnvironment.stubs(:production?).returns(false)
       GovukEnvironment.stubs(:name).returns("Test Fools")
 
       user = create(:user, name: "Bob Loblaw")
@@ -44,14 +45,14 @@ class NoisyBatchInvitationTest < ActionMailer::TestCase
       @email = NoisyBatchInvitation.make_noise(@batch_invitation).deliver_now
     end
 
-    should "from address should include the instance name" do
+    should "from address should include the environment name" do
       assert_match(/".* Signon Test Fools" <noreply-signon-test-fools@.*\.gov\.uk>/, @email[:from].to_s)
     end
   end
 
-  context "work correctly when no instance name is set" do
+  context "work correctly in production environment" do
     setup do
-      GovukEnvironment.stubs(:name).returns(nil)
+      GovukEnvironment.stubs(:production?).returns(true)
 
       user = create(:user, name: "Bob Loblaw")
       @batch_invitation = create(:batch_invitation, user:)
@@ -59,7 +60,7 @@ class NoisyBatchInvitationTest < ActionMailer::TestCase
       @email = NoisyBatchInvitation.make_noise(@batch_invitation).deliver_now
     end
 
-    should "from address should include the instance name" do
+    should "from address should not include the environment name" do
       assert_match(/".* Signon" <noreply-signon@.*\.gov\.uk>/, @email[:from].to_s)
     end
   end

--- a/test/models/user_mailer_test.rb
+++ b/test/models/user_mailer_test.rb
@@ -22,7 +22,7 @@ class UserMailerTest < ActionMailer::TestCase
 
     context "in a non-production environment" do
       setup do
-        Rails.application.config.stubs(instance_name: "foobar")
+        GovukEnvironment.stubs(:name).returns("foobar")
       end
 
       should "include the environment in the subject" do
@@ -36,7 +36,7 @@ class UserMailerTest < ActionMailer::TestCase
 
     context "in the production environment" do
       setup do
-        Rails.application.config.stubs(instance_name: nil)
+        GovukEnvironment.stubs(:name).returns(nil)
       end
 
       should "not include the environment in the subject" do
@@ -119,7 +119,7 @@ class UserMailerTest < ActionMailer::TestCase
 
   context "email a user to notify of suspension" do
     setup do
-      Rails.application.config.stubs(:instance_name).returns("test")
+      GovukEnvironment.stubs(:name).returns("test")
       stub_user = stub(name: "User", email: "user@example.com")
       @email = UserMailer.suspension_notification(stub_user)
     end
@@ -139,7 +139,7 @@ class UserMailerTest < ActionMailer::TestCase
 
   context "on a named Signon instance" do
     setup do
-      Rails.application.config.stubs(:instance_name).returns("test")
+      GovukEnvironment.stubs(:name).returns("test")
       stub_user = stub(name: "User", email: "user@example.com")
       @email = UserMailer.suspension_reminder(stub_user, 3)
     end
@@ -155,7 +155,7 @@ class UserMailerTest < ActionMailer::TestCase
 
   context "emailing a user to explain why their account is locked" do
     setup do
-      Rails.application.config.stubs(:instance_name).returns("test")
+      GovukEnvironment.stubs(:name).returns("test")
       @the_time = Time.zone.now
       user = User.new(name: "User", email: "user@example.com", locked_at: @the_time)
       @email = UserMailer.unlock_instructions(user, "afaketoken")

--- a/test/models/user_mailer_test.rb
+++ b/test/models/user_mailer_test.rb
@@ -22,6 +22,7 @@ class UserMailerTest < ActionMailer::TestCase
 
     context "in a non-production environment" do
       setup do
+        GovukEnvironment.stubs(:production?).returns(false)
         GovukEnvironment.stubs(:name).returns("foobar")
       end
 
@@ -36,7 +37,7 @@ class UserMailerTest < ActionMailer::TestCase
 
     context "in the production environment" do
       setup do
-        GovukEnvironment.stubs(:name).returns(nil)
+        GovukEnvironment.stubs(:production?).returns(true)
       end
 
       should "not include the environment in the subject" do
@@ -119,6 +120,7 @@ class UserMailerTest < ActionMailer::TestCase
 
   context "email a user to notify of suspension" do
     setup do
+      GovukEnvironment.stubs(:production?).returns(false)
       GovukEnvironment.stubs(:name).returns("test")
       stub_user = stub(name: "User", email: "user@example.com")
       @email = UserMailer.suspension_notification(stub_user)
@@ -137,8 +139,9 @@ class UserMailerTest < ActionMailer::TestCase
     end
   end
 
-  context "on a named Signon instance" do
+  context "on a non-production Signon instance" do
     setup do
+      GovukEnvironment.stubs(:production?).returns(false)
       GovukEnvironment.stubs(:name).returns("test")
       stub_user = stub(name: "User", email: "user@example.com")
       @email = UserMailer.suspension_reminder(stub_user, 3)
@@ -155,6 +158,7 @@ class UserMailerTest < ActionMailer::TestCase
 
   context "emailing a user to explain why their account is locked" do
     setup do
+      GovukEnvironment.stubs(:production?).returns(false)
       GovukEnvironment.stubs(:name).returns("test")
       @the_time = Time.zone.now
       user = User.new(name: "User", email: "user@example.com", locked_at: @the_time)

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -5,7 +5,7 @@ class UserTest < ActiveSupport::TestCase
   include ActiveJob::TestHelper
 
   def setup
-    GovukEnvironment.stubs(:name).returns(nil)
+    GovukEnvironment.stubs(:production?).returns(true)
 
     @user = create(:user)
   end
@@ -21,6 +21,7 @@ class UserTest < ActiveSupport::TestCase
     end
 
     should "default to false for admins and superadmins in non-production" do
+      GovukEnvironment.stubs(:production?).returns(false)
       GovukEnvironment.stubs(:name).returns("foobar")
 
       assert_not create(:admin_user).require_2sv?

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -5,7 +5,7 @@ class UserTest < ActiveSupport::TestCase
   include ActiveJob::TestHelper
 
   def setup
-    Rails.application.config.stubs(instance_name: nil)
+    GovukEnvironment.stubs(:name).returns(nil)
 
     @user = create(:user)
   end
@@ -21,7 +21,7 @@ class UserTest < ActiveSupport::TestCase
     end
 
     should "default to false for admins and superadmins in non-production" do
-      Rails.application.config.stubs(instance_name: "foobar")
+      GovukEnvironment.stubs(:name).returns("foobar")
 
       assert_not create(:admin_user).require_2sv?
       assert_not create(:superadmin_user).require_2sv?


### PR DESCRIPTION
Trello: https://trello.com/c/8HOXkVAT

## Summary

Since the replatforming to k8s (a few months ago?), some application logic has not been correctly identifying the production environment. This has affected logic in the following functionality (see below for more details about each one):

* Mandating 2SV for users promoted to any admin role
* 2SV QR code issuer
* Automated email subject line, content & from address

## Problem

Previously the implementation relied on the `INSTANCE_NAME` environment variable not being set in the production environment. However, since the replatforming to k8s, that environment variable has been [incorrectly set][1] to "production".

That means that since the replatforming a bunch of logic in the app has been working _incorrectly_. This was highlighted by some non-sensical text in an automated email sent to a user whose account had been locked:

> Production account locks do not lock production accounts.

However, the problem has actually been a lot more widespread, because we've never been recognising we're in a production environment.

## Solution

I _could_ have fixed the problem by simply removing the value of `INSTANCE_NAME` in the production environment. However, I can see why the mistake was made and it looks as if it has already had to be rectified [once before][2] in the replatforming to AWS! So instead I've chosen to leave the value of `INSTANCE_NAME` as "production" and change the
implementation to check for this value.

I've performed a bunch of preparatory refactoring to make the change easier and to clarify what functionality will be affected by the change. The bug is only actually *fixed* in the final commit.

This PR will fix a bunch of issues:

### Mandating 2SV for users promoted to any admin role

Users promoted to any admin role in production will now be required to setup 2SV. Since we now mandate 2SV for most users in production, this is unlikely to be causing a security lapse, but it would be worth checking that no users have slipped through the cracks while this bug existed.

### 2SV QR code issuer

The issuer in the 2SV QR code will now be set to "GOV.UK Signon" rather than "Production GOV.UK Signon" in production. The issuer is used by Authenticator Apps to identify which website the secret belongs to. There _might_ be some confusion for people who originally setup 2SV while this bug existed who now come back to reset 2SV, but I plan to investigate that before I merge the changes.

### Email subject line

In production, the subject line of the automated email for 2SV enabled will now be "2-step verification set up" instead of "[Production] 2-step verification set up". It's not clear to me why this particular email is singled out in this way and unfortunately the [commit note][3] & [PR][4] where it was originally introduced doesn't shed any light on the matter. I've written up [this Trello card](https://trello.com/c/0uCDE6Kd/108-should-the-subject-line-of-all-automated-emails-have-an-env-specific-prefix) to consider using the same prefix for all automated emails.

In production, the subject line of the automated email for batches of
user invitations will now be:

> [SIGNON] Serena Williams created a batch of 37 users

instead of:

> [SIGNON] Serena Williams created a batch of 37 users in production

### Email content

In production, the content for the following automated email types will no longer include content which was originally only intended to be displayed in non-production environments. This will resolve the specific issue which drew our attention to the bug.
    * Suspension reminder
    * Suspension notification
    * Notify reset password disallowed due to suspension
    * 2SV enabled
    * Unlock instructions

In production, automated emails will now refer to "your GOV.UK Signon account" rather than "your production GOV.UK account".

### Email from address

The from address in all automated emails sent from the production environment will now be:

> GOV.UK Signon <noreply-signon@digital.cabinet-office.gov.uk>

versus:

> GOV.UK Signon production <noreply-signon-production@digital.cabinet-office.gov.uk>

Note that the reply-to address will not change, so there should NOT be any need to check that we can actually receive emails at the new from address.

## Suggested further work

* Consider using `GOVUK_ENVIRONMENT` or `GOVUK_ENVIRONMENT_NAME` which [both seem](https://github.com/alphagov/govuk-helm-charts/blob/4b330aa6e254f60d771b1452f85237ff8f8a1c02/charts/app-config/templates/env-configmap.yaml#L21-L22) to make the relevant environment-specific strings available to *ALL* GOV.UK apps. We could then remove `INSTANCE_NAME` altogether.
    * Note that we're already using `GOVUK_ENVIRONMENT_NAME` for [something similar](https://github.com/alphagov/signon/blob/db485c293839257e737b05b3c9b8fe5d3f45a5ef/config/initializers/govuk_admin_template.rb#L9-L10) and for [something else similar](https://github.com/alphagov/signon/blob/db485c293839257e737b05b3c9b8fe5d3f45a5ef/lib/healthcheck/api_tokens.rb#L22).
* Document all environment variables - I don't know if there is a recommended way to do this?
* Contact the team that's responsible for the Short URL Manager app which seems to be the only other app that uses an `INSTANCE_NAME` env var in case there is a similar bug in that app.

[1]: https://github.com/alphagov/govuk-helm-charts/blob/d9a542872a009363f9251d8276e98f1c94c6cd16/charts/app-config/values-production.yaml#L2289-L2290
[2]: https://github.com/alphagov/govuk-puppet/pull/7432
[3]: https://github.com/alphagov/signon/commit/89d2801d54afc778663bc4703c30cf47d3b1e3b5
[4]: https://github.com/alphagov/signon/pull/425