### PR TITLE
Enable OAuth2 PKCE extension in Doorkeeper

### DIFF
--- a/db/migrate/20230814160809_enable_pkce.rb
+++ b/db/migrate/20230814160809_enable_pkce.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class EnablePkce < ActiveRecord::Migration[7.0]
+  def change
+    change_table :oauth_access_grants, bulk: true do |t|
+      t.column :code_challenge, :string, null: true
+      t.column :code_challenge_method, :string, null: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -81,6 +81,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_16_164936) do
     t.datetime "created_at", precision: nil, null: false
     t.datetime "revoked_at", precision: nil
     t.string "scopes", default: "", null: false
+    t.string "code_challenge"
+    t.string "code_challenge_method"
     t.index ["token"], name: "index_oauth_access_grants_on_token", unique: true
   end
 

--- a/test/integration/doorkeeper_integration_test.rb
+++ b/test/integration/doorkeeper_integration_test.rb
@@ -6,4 +6,58 @@ class DoorkeeperIntegrationTest < ActionDispatch::IntegrationTest
   rescue ActionController::RoutingError => e
     assert_equal 'No route matches [GET] "/oauth/applications"', e.message
   end
+
+  test "oauth2 authorization code grant type" do
+    without_csrf_protection do
+      app = create(:application)
+      password = SecureRandom.urlsafe_base64
+      user = create(:user, with_signin_permissions_for: [app], password:)
+
+      sign_in user.email, password
+
+      auth_code = request_authorization_code(app)
+
+      reset!
+
+      access_token = request_access_token(app, auth_code)
+
+      user_data = request_user_data(app, access_token)
+      assert_equal user.uid, user_data["user"]["uid"]
+    end
+  end
+
+private
+
+  def without_csrf_protection
+    original_value = ActionController::Base.allow_forgery_protection
+    ActionController::Base.allow_forgery_protection = false
+    yield
+  ensure
+    ActionController::Base.allow_forgery_protection = original_value
+  end
+
+  def sign_in(email, password)
+    post user_session_path, params: { user: { email:, password: } }
+    assert_redirected_to root_path
+  end
+
+  def request_authorization_code(app)
+    get oauth_authorization_path, params: { response_type: "code", client_id: app.uid, redirect_uri: app.redirect_uri }
+    assert_response :redirect
+    Rack::Utils.parse_query(URI.parse(response.location).query)["code"]
+  end
+
+  def request_access_token(app, auth_code)
+    http_basic_auth = ActionController::HttpAuthentication::Basic.encode_credentials(app.uid, app.secret)
+    post oauth_token_path, params: { grant_type: "authorization_code", code: auth_code, redirect_uri: app.redirect_uri },
+                           headers: { Authorization: http_basic_auth }
+    assert_response :success
+    JSON.parse(response.body)["access_token"]
+  end
+
+  def request_user_data(app, access_token)
+    get "/user.json", params: { client_id: app.uid }, headers: { Authorization: "Bearer #{access_token}" }
+    assert_response :success
+    JSON.parse(response.body)
+  end
 end

--- a/test/integration/doorkeeper_integration_test.rb
+++ b/test/integration/doorkeeper_integration_test.rb
@@ -26,6 +26,27 @@ class DoorkeeperIntegrationTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "oauth2 authorization code grant type with pkce extension" do
+    without_csrf_protection do
+      app = create(:application)
+      password = SecureRandom.urlsafe_base64
+      user = create(:user, with_signin_permissions_for: [app], password:)
+
+      sign_in user.email, password
+
+      pkce = PKCE.new
+
+      auth_code = request_authorization_code(app, code_challenge_method: pkce.code_challenge_method, code_challenge: pkce.code_challenge)
+
+      reset!
+
+      access_token = request_access_token(app, auth_code, code_verifier: pkce.code_verifier)
+
+      user_data = request_user_data(app, access_token)
+      assert_equal user.uid, user_data["user"]["uid"]
+    end
+  end
+
 private
 
   def without_csrf_protection
@@ -41,15 +62,15 @@ private
     assert_redirected_to root_path
   end
 
-  def request_authorization_code(app)
-    get oauth_authorization_path, params: { response_type: "code", client_id: app.uid, redirect_uri: app.redirect_uri }
+  def request_authorization_code(app, code_challenge_method: nil, code_challenge: nil)
+    get oauth_authorization_path, params: { response_type: "code", client_id: app.uid, redirect_uri: app.redirect_uri, code_challenge_method:, code_challenge: }
     assert_response :redirect
     Rack::Utils.parse_query(URI.parse(response.location).query)["code"]
   end
 
-  def request_access_token(app, auth_code)
+  def request_access_token(app, auth_code, code_verifier: nil)
     http_basic_auth = ActionController::HttpAuthentication::Basic.encode_credentials(app.uid, app.secret)
-    post oauth_token_path, params: { grant_type: "authorization_code", code: auth_code, redirect_uri: app.redirect_uri },
+    post oauth_token_path, params: { grant_type: "authorization_code", code: auth_code, redirect_uri: app.redirect_uri, code_verifier: },
                            headers: { Authorization: http_basic_auth }
     assert_response :success
     JSON.parse(response.body)["access_token"]
@@ -59,5 +80,20 @@ private
     get "/user.json", params: { client_id: app.uid }, headers: { Authorization: "Bearer #{access_token}" }
     assert_response :success
     JSON.parse(response.body)
+  end
+
+  class PKCE
+    attr_reader :code_verifier, :code_challenge_method, :code_challenge
+
+    def initialize
+      # From https://github.com/omniauth/omniauth-oauth2/blob/3e7ee11c84153e6f0c19d38a5e63cda550f6925c/lib/omniauth/strategies/oauth2.rb#L108
+      @code_verifier = SecureRandom.hex(64)
+
+      # From https://github.com/omniauth/omniauth-oauth2/blob/3e7ee11c84153e6f0c19d38a5e63cda550f6925c/lib/omniauth/strategies/oauth2.rb#L41
+      @code_challenge_method = "S256"
+
+      # From https://github.com/omniauth/omniauth-oauth2/blob/3e7ee11c84153e6f0c19d38a5e63cda550f6925c/lib/omniauth/strategies/oauth2.rb#L35-L40
+      @code_challenge = Base64.urlsafe_encode64(Digest::SHA2.digest(@code_verifier), padding: false)
+    end
   end
 end


### PR DESCRIPTION
https://trello.com/c/59EBweBx

Signon utilises the [OAuth 2.0 Authorization Code Grant type][1] to enable users to authorize client applications to act on their behalf. That page includes:

> It is recommended that all clients use the [PKCE](https://oauth.net/2/pkce/) extension with this flow as well to provide better security.

This PR enables the PKCE extension in Doorkeeper. We're not yet mandating Signon clients to use PKCE but it will be used if the client supplies a `code_challenge` and `code_challenge_method` in the request for the Authorization Code.

We hope to mandate the use of PKCE once we're confident all Signon clients are using it.

[1]: https://oauth.net/2/grant-types/authorization-code/