### PR TITLE
Add documentation about environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ bundle exec rake
 ## Further documentation
 
 - [Usage documentation]
+- [Environment variables]
 - [Mass password reset]
 - [Troubleshooting]
 
@@ -36,5 +37,6 @@ bundle exec rake
 [Doorkeeper]: https://github.com/applicake/doorkeeper
 [auth]: docs/oauth.md
 [Usage documentation]: docs/usage.md
+[Environment variables]: docs/environment-variables.md
 [Mass password reset]: docs/mass_password_reset.md
 [Troubleshooting]: docs/troubleshooting.md

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -1,0 +1,52 @@
+# Environment variables
+
+## ActiveRecord Encryption
+
+Used by ActiveRecord to encrypt values in the database e.g. `User#otp_secret_key`.
+
+* `ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT`
+* `ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY`
+
+## Devise
+
+Used by Devise and/or its extensions to encrypt values in the database e.g. `User#password`.
+
+* `DEVISE_PEPPER`
+* `DEVISE_SECRET_KEY`
+
+## GOV.UK Notify
+
+Used to configure Mail::Notify for use by ActionMailer in sending emails.
+
+* `GOVUK_NOTIFY_API_KEY`
+* `GOVUK_NOTIFY_TEMPLATE_ID`
+
+## Rewrite URIs for OAuth Applications
+
+Used by `Doorkeeper::Application#substituted_uri`.
+
+* `SIGNON_APPS_URI_SUB_PATTERN`
+* `SIGNON_APPS_URI_SUB_REPLACEMENT`
+
+## GOV.UK app domain
+
+Used to configure Google Analytics in the new `app/views/layouts/admin_layout.html.erb`.
+
+* `GOVUK_APP_DOMAIN`
+
+## GOV.UK environment names
+
+Used to configure `GovukAdminTemplate` and in `Healthcheck::ApiTokens#expiring_tokens`.
+
+* `GOVUK_ENVIRONMENT_NAME`
+
+Used in various bits of logic to detect the production instance of the app and used to display various environment-specific strings.
+
+* `INSTANCE_NAME`
+
+## Splunk
+
+Used to stream event logs to Splunk for analysis of Signon usage patterns and anomalies.
+
+* `SPLUNK_EVENT_LOG_ENDPOINT_HEC_TOKEN`
+* `SPLUNK_EVENT_LOG_ENDPOINT_URL`


### PR DESCRIPTION
While I was working on https://github.com/alphagov/signon/pull/2311, I thought it would be useful to document the environment-variables used in the app. I think these are all the environment variables that are specific to this app or at least have an app-specific use in this app, but I might have missed some.

It would be nice to work out which ones are required in which environments, but that's a non-trivial amount of work, because the app doesn't seem to fail fast for at least some of the required ones.

Note that I haven't included env vars which are used as arguments to rake tasks or scripts.