### PR TITLE
Use GOVUK_ENVIRONMENT_NAME vs INSTANCE_NAME env var

### DIFF
--- a/app/models/govuk_environment.rb
+++ b/app/models/govuk_environment.rb
@@ -3,7 +3,7 @@ class GovukEnvironment
     if Rails.env.development? || Rails.env.test?
       "development"
     else
-      ENV["INSTANCE_NAME"]
+      ENV["GOVUK_ENVIRONMENT_NAME"]
     end
   end
 

--- a/config/initializers/govuk_admin_template.rb
+++ b/config/initializers/govuk_admin_template.rb
@@ -1,3 +1,5 @@
+require "govuk_environment"
+
 # We were setting app_title here, but we needed to use the department.name from
 # localisations, which aren't available in initializers. Our solution was to move
 # it to app/views/application.html.erb.
@@ -6,5 +8,5 @@ GovukAdminTemplate.configure do |c|
   c.disable_google_analytics = false
 end
 
-GovukAdminTemplate.environment_label = ENV.fetch("GOVUK_ENVIRONMENT_NAME", "development").titleize
-GovukAdminTemplate.environment_style = ENV["GOVUK_ENVIRONMENT_NAME"] == "production" ? "production" : "preview"
+GovukAdminTemplate.environment_label = GovukEnvironment.name.titleize
+GovukAdminTemplate.environment_style = GovukEnvironment.production? ? "production" : "preview"

--- a/test/models/govuk_environment_test.rb
+++ b/test/models/govuk_environment_test.rb
@@ -28,11 +28,11 @@ class GovukEnvironmentTest < ActionMailer::TestCase
       setup do
         Rails.env.stubs(:development?).returns(false)
         Rails.env.stubs(:test?).returns(false)
-        ENV.stubs(:[]).with("INSTANCE_NAME").returns("instance-name")
+        ENV.stubs(:[]).with("GOVUK_ENVIRONMENT_NAME").returns("govuk-environment-name")
       end
 
-      should "return value of INSTANCE_NAME env var" do
-        assert_equal "instance-name", GovukEnvironment.name
+      should "return value of GOVUK_ENVIRONMENT_NAME env var" do
+        assert_equal "govuk-environment-name", GovukEnvironment.name
       end
     end
   end


### PR DESCRIPTION
This follows on from [this PR][1].

The `GOVUK_ENVIRONMENT_NAME` env var is [made available to all apps][2] and is already being used in this app, e.g. to configure `GovukAdminTemplate`:

https://github.com/alphagov/signon/blob/2b935d7441b62545cb527e571312d709a33d0bba/config/initializers/govuk_admin_template.rb#L9-L10

The `GOVUK_ENVIRONMENT_NAME` env var has the same values as the `INSTANCE_NAME` env var in the different environments, i.e.

* ["integration"][3]
* ["staging"][4]
* ["production"][5]

So using `GOVUK_ENVIRONMENT_NAME` shouldn't change the behaviour of the app in any way.

We should look to remove the `INSTANCE_NAME` variable from `govuk-helm-charts` for the Signon app once this change has been deployed, because it will no longer be needed by this app.

I've also removed a bit of duplication where we were using `GOVUK_ENVIRONMENT_NAME` directly to configure `GovukAdminTemplate`; we can now use `GovukEnvironment` methods.

There is still one direct usage of `GOVUK_ENVIRONMENT_NAME` in the query in `Healthcheck::ApiTokens#expiring_tokens`, but it's not so obvious that we can/should replace this with calls to `GovukEnvironment` methods, so I've left it for now. I've separately made a note to see whether that functionality is even being used.
 
[1]: https://github.com/alphagov/signon/pull/2311
[2]: https://github.com/alphagov/govuk-helm-charts/blob/f117fcbc4bf103431f73a8d66b6dda086939e1b1/charts/app-config/templates/env-configmap.yaml#L22
[3]: https://github.com/alphagov/govuk-helm-charts/blob/f117fcbc4bf103431f73a8d66b6dda086939e1b1/charts/app-config/values-integration.yaml#L4
[4]: https://github.com/alphagov/govuk-helm-charts/blob/f117fcbc4bf103431f73a8d66b6dda086939e1b1/charts/app-config/values-staging.yaml#L4
[5]: https://github.com/alphagov/govuk-helm-charts/blob/f117fcbc4bf103431f73a8d66b6dda086939e1b1/charts/app-config/values-production.yaml#L4
