### PR TITLE
Provide fallback for GovukAdminTemplate.environment_label

### DIFF
--- a/config/initializers/govuk_admin_template.rb
+++ b/config/initializers/govuk_admin_template.rb
@@ -8,5 +8,5 @@ GovukAdminTemplate.configure do |c|
   c.disable_google_analytics = false
 end
 
-GovukAdminTemplate.environment_label = GovukEnvironment.name.titleize
+GovukAdminTemplate.environment_label = (GovukEnvironment.name || "development").titleize
 GovukAdminTemplate.environment_style = GovukEnvironment.production? ? "production" : "preview"


### PR DESCRIPTION
It turns out that the `GOVUK_ENVIRONMENT_NAME` env var is not defined and the Rails env is not development or test during the GH action job which builds the image for deployment. This means that `GovukEnvironment.name` is `nil` and we see [the following exception][1]:

    NoMethodError: undefined method `titleize' for nil:NilClass

I considered setting `GOVUK_ENVIRONMENT_NAME` in the GH action, but there didn't seem to be any precendent for doing that.

I also considered providing a fallback within the implementation of `GovukEnvironment.name`. However, I thought that might have other undesirable consequences.

So I've implemented the fallback in `config/initializers/govuk_admin_template.rb` which is a bit ugly, but hopefully it won't be too long before we get rid of `GovukAdminTemplate` altogether!

[1]: https://github.com/alphagov/signon/actions/runs/5940071624/job/16107859623#step:7:609
