### PR TITLE
Publish /privacy-notice page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,6 +1,9 @@
 @import "govuk_publishing_components/all_components";
 @import "user_research_recruitment_banner";
 
+// Components from this application
+@import "components/*";
+
 // TODO: move into component
 .gem-c-success-alert,
 .gem-c-error-alert {

--- a/app/assets/stylesheets/components/_contact-details.scss
+++ b/app/assets/stylesheets/components/_contact-details.scss
@@ -1,0 +1,13 @@
+.app-c-contact-details {
+  @include govuk-font($size: 19);
+  @include govuk-text-colour;
+  padding-left: govuk-spacing(3);
+  // Margin top intended to collapse
+  // This adds an additional 10px to the paragraph above
+  @include govuk-responsive-margin(6, "top");
+  @include govuk-responsive-margin(6, "bottom");
+
+  clear: both;
+
+  border-left: 1px solid $govuk-border-colour;
+}

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -2,7 +2,7 @@ class RootController < ApplicationController
   layout "admin_layout"
 
   include UserPermissionsControllerMethods
-  before_action :authenticate_user!
+  before_action :authenticate_user!, except: :privacy_notice
   skip_after_action :verify_authorized
 
   def index
@@ -14,6 +14,8 @@ class RootController < ApplicationController
   def signin_required
     @application = ::Doorkeeper::Application.find_by(id: session.delete(:signin_missing_for_application))
   end
+
+  def privacy_notice; end
 
 private
 

--- a/app/views/components/_contact_details.html.erb
+++ b/app/views/components/_contact_details.html.erb
@@ -1,0 +1,7 @@
+<div class="app-c-contact-details">
+  <% if defined? text %>
+    <%= text %>
+  <% elsif block_given? %>
+    <%= yield %>
+  <% end %>
+</div>

--- a/app/views/components/docs/contact_details.yml
+++ b/app/views/components/docs/contact_details.yml
@@ -1,0 +1,19 @@
+name: Contact Details
+description: Use the contact details component to differentiate a line or block of contact details from the surrounding content.
+body: |
+  Optional markdown providing further detail about the component
+accessibility_criteria: |
+  All text must have a contrast ratio higher than 4.5:1 against the background colour to meet [WCAG AA](https://www.w3.org/TR/WCAG20/#visual-audio-contrast-contrast)
+examples:
+  default:
+    data:
+      text: "contact@info.gov.uk"
+
+  with_block:
+    description: |
+      Note that the component applies no formatting to the contents passed to it. There are guidelines covering the use of various types of contact details in [the Style guide](https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style).
+    data:
+      block: |
+        Address Line 1
+        <br>
+        Address Line 2

--- a/app/views/layouts/admin_layout.html.erb
+++ b/app/views/layouts/admin_layout.html.erb
@@ -38,7 +38,13 @@
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
           <span class="govuk-caption-l"><%= yield(:context) %></span>
-          <h1 class="govuk-heading-l"><%= yield(:title) %></h1>
+          <h1 class="govuk-heading-l">
+            <% if yield(:page_heading).present? %>
+              <%= yield(:page_heading) %>
+            <% else %>
+              <%= yield(:title) %>
+            <% end %>
+          </h1>
         </div>
       </div>
       <%= yield %>

--- a/app/views/layouts/admin_layout.html.erb
+++ b/app/views/layouts/admin_layout.html.erb
@@ -65,6 +65,10 @@
           {
             href: "https://www.gov.uk/government/content-publishing",
             text: "How to write, publish, and improve content",
+          },
+          {
+            href: privacy_notice_path,
+            text: "Privacy notice",
           }
         ].compact
       }

--- a/app/views/root/privacy_notice.html.erb
+++ b/app/views/root/privacy_notice.html.erb
@@ -1,0 +1,319 @@
+<% content_for :title, "Privacy notice and cookie policy" %>
+<% content_for :page_heading, "GOV.UK Publisher Signon ‒ Privacy Notice and Cookie Policy" %>
+
+<p class="govuk-body">GOV.UK Publisher Signon is provided by the <%= link_to "Government Digital Service", "https://www.gov.uk/government/organisations/government-digital-service", class: "govuk-link" %> (GDS), part of the Cabinet Office.</p>
+
+<p class="govuk-body">The Cabinet Office is the data controller for GOV.UK Publisher Signon.</p>
+
+<p class="govuk-body">A data controller determines how and why personal data is processed. For more information, read the Cabinet Office’s entry in the <%= link_to "Data Protection Public Register", "https://ico.org.uk/ESDWebPages/Entry/Z7414053", class: "govuk-link" %>.</p>
+
+<%= render "govuk_publishing_components/components/heading", {
+  text: "What data we collect",
+  padding: true,
+} %>
+
+<p class="govuk-body">The information we collect when you create and use a GOV.UK Publisher account includes:</p>
+
+<%= render "govuk_publishing_components/components/list", {
+  visible_counters: true,
+  items: [
+    "basic personal information needed to set up and authenticate your account, including your name, work email address and department / organisation",
+    "information on how you use your GOV.UK Publisher account, which is collected in the system logs, and by Google Analytics cookies ‒ the Cookies section provides more information about this",
+    "online identifiers, such as your Internet Protocol (IP) address, and technical information about the device you use, including the model, web browser and operating system",
+  ]
+} %>
+
+<p class="govuk-body">This is automatically collected in system logs when you use your GOV.UK Publisher account.</p>
+
+<p class="govuk-body">When you create an account, it will automatically generate a unique account identifier.</p>
+
+<%= render "govuk_publishing_components/components/heading", {
+  text: "Cookies",
+  padding: true,
+} %>
+
+<%= render "govuk_publishing_components/components/heading", {
+  text: "Non-essential cookies",
+  padding: true,
+  heading_level: 3,
+  font_size: "s",
+} %>
+
+<p class="govuk-body">We may use a variety of non-essential cookies to record your preferences as you’re using GOV.UK Publisher Signon, in order to give you a consistent experience. For example, we might use a cookie to record your preference not to see a recurring banner whenever you sign in.</p>
+
+<p class="govuk-body">We also use the Google Analytics cookies detailed in the <%= link_to "GOV.UK Cookie Policy", "https://www.gov.uk/help/cookie-details", class: "govuk-link" %> to collect information about:</p>
+
+<%= render "govuk_publishing_components/components/list", {
+  visible_counters: true,
+  items: [
+    "the pages you visit",
+    "how long you spend on each page",
+    "how you got to the site",
+    "what you click on while you’re visiting the site",
+    "technical information about your device such as your IP address",
+  ]
+} %>
+
+<p class="govuk-body">We minimise the amount of personal data we send to Google Analytics by using <%= link_to "Google Analytics’ IP address anonymisation", "https://support.google.com/analytics/answer/2763052", class: "govuk-link" %> feature and by removing any other personal data from the titles or URLs of the pages you visit.</p>
+
+<p class="govuk-body">We do not combine analytics information with other data sets in a way that would enable us to establish users’ identities. We do not allow Google to use or share this data for their own purposes.</p>
+
+<%= render "govuk_publishing_components/components/heading", {
+  text: "Essential cookies",
+  padding: true,
+  heading_level: 3,
+  font_size: "s",
+} %>
+
+<p class="govuk-body">We also set the following essential cookies:</p>
+
+<%= render "govuk_publishing_components/components/table", {
+  head: [
+    {
+      text: "Name",
+    },
+    {
+      text: "Purpose",
+    },
+    {
+      text: "Expires",
+    }
+  ],
+  rows: [
+    [
+      {
+        text: "remember_2sv_session",
+      },
+      {
+        text: "This sets automatically when a user successfully authenticates using the two-step verification (2SV) 6 digit code. Once set, the user won’t be prompted to enter a 2SV 6 digit code for 30 days as long as the login occurs from the same browser where the cookie was set.",
+      },
+      {
+        text: "30 days",
+      }
+    ],
+    [
+      {
+        text: "_signonotron2_session",
+      },
+      {
+        text: "To remember a user’s logged in session.",
+      },
+      {
+        text: "At the end of the user’s session",
+      }
+    ]
+  ]
+} %>
+
+<%= render "govuk_publishing_components/components/heading", {
+  text: "Why we need your data",
+  padding: true,
+} %>
+
+<p class="govuk-body">We collect your personal information to:</p>
+
+<%= render "govuk_publishing_components/components/list", {
+  visible_counters: true,
+  items: [
+    "provide you with a GOV.UK Publisher account so that you can use it to access GOV.UK publishing tools",
+    "keep your account secure (using your email address, password and system logs)",
+    "contact you about any planned interruptions, problems or changes that may affect your account (using your email address)",
+    "monitor use of the site to identify security threats",
+  ]
+} %>
+
+<p class="govuk-body">We use the information we collect through Google Analytics to understand how users use GOV.UK Publisher Signon. We do this to help make sure the service is meeting the needs of its users and to make improvements.</p>
+
+<p class="govuk-body">We may also use your information to produce anonymised reports about GOV.UK Publisher Signon. This helps us understand where we can make improvements.</p>
+
+<%= render "govuk_publishing_components/components/heading", {
+  text: "Our legal basis for processing your data",
+  padding: true,
+} %>
+
+<p class="govuk-body">The legal basis for processing personal data in relation to site security is our legitimate interests, in ensuring the security and integrity of GOV.UK.</p>
+
+<p class="govuk-body">The legal basis for processing all other personal data is that it’s necessary:</p>
+
+<%= render "govuk_publishing_components/components/list", {
+  visible_counters: true,
+  items: [
+    "to perform a task in the public interest",
+    "in the exercise of our functions as a government department",
+  ]
+} %>
+
+<%= render "govuk_publishing_components/components/heading", {
+  text: "What we do with your data",
+  padding: true,
+} %>
+
+<p class="govuk-body">The data we collect may be shared with other government departments, agencies and public bodies. It may also be shared with our technology suppliers, for example our hosting provider.</p>
+
+<p class="govuk-body">We will share your data if we are required to do so by law - for example, by court order, or to prevent fraud or other crime.</p>
+
+<%= render "govuk_publishing_components/components/heading", {
+  text: "How long we keep your data",
+  padding: true,
+} %>
+
+<p class="govuk-body">We will only retain your personal data for as long as it is needed for the purposes set out in this document or for as long as the law requires us to.</p>
+
+<p class="govuk-body">We will:</p>
+
+<%= render "govuk_publishing_components/components/list", {
+  visible_counters: true,
+  items: [
+    "delete access log data after 2 years",
+    "delete Google Analytics data after 26 months",
+  ]
+} %>
+
+<%= render "govuk_publishing_components/components/heading", {
+  text: "Children’s privacy protection",
+  padding: true,
+} %>
+
+<p class="govuk-body">Our services are not designed for, or intentionally targeted at, children 13 years of age or younger. We do not intentionally collect or maintain data about anyone under the age of 13.</p>
+
+<%= render "govuk_publishing_components/components/heading", {
+  text: "Where your data is processed and stored",
+  padding: true,
+} %>
+
+<p class="govuk-body">GOV.UK Signon data is stored in the <%= link_to "European Economic Area", "https://www.gov.uk/eu-eea", class: "govuk-link" %> (EEA). Some third party services, such as Google Analytics, may involve transferring data outside the EEA for processing. In these situations we implement appropriate safeguards, such as contractual clauses, to ensure an adequate level of protection.</p>
+
+<%= render "govuk_publishing_components/components/heading", {
+  text: "How we protect your data and keep it secure",
+  padding: true,
+} %>
+
+<p class="govuk-body">We are committed to doing all that we can to keep your data secure. We have set up systems and processes to prevent unauthorised access or disclosure of your data ‒ for example, we protect your data using varying levels of encryption. We also make sure that any third parties that we deal with keep all personal data they process on our behalf secure.</p>
+
+<%= render "govuk_publishing_components/components/heading", {
+  text: "Your rights",
+  padding: true,
+} %>
+
+<p class="govuk-body">You have the right to request:</p>
+
+<%= render "govuk_publishing_components/components/list", {
+  visible_counters: true,
+  items: [
+    "information about how your personal data is processed",
+    "a copy of that personal data",
+    "that anything inaccurate in your personal data is corrected immediately",
+  ]
+} %>
+
+<p class="govuk-body">You can also:</p>
+
+<%= render "govuk_publishing_components/components/list", {
+  visible_counters: true,
+  items: [
+    "raise an objection about how your personal data is processed",
+    "request that your personal data is erased if there is no longer a justification for it",
+    "ask that the processing of your personal data is restricted in certain circumstances",
+  ]
+} %>
+
+<p class="govuk-body">If you have any of these requests, get in contact with our Privacy Team ‒ see the Contact us section for their email address.</p>
+
+<%= render "govuk_publishing_components/components/heading", {
+  text: "Contact us or make a complaint",
+  padding: true,
+} %>
+
+<p class="govuk-body">Contact the Privacy Team if you:</p>
+
+<%= render "govuk_publishing_components/components/list", {
+  visible_counters: true,
+  items: [
+    "have a question about anything in this privacy notice",
+    "think that your personal data has been misused or mishandled",
+  ]
+} %>
+
+<%= render "govuk_publishing_components/components/heading", {
+  text: "Privacy Team",
+  padding: true,
+  heading_level: 3,
+  font_size: "s",
+} %>
+
+<p class="govuk-body">Email our Privacy Team at:</p>
+
+<%= render "components/contact_details", {
+  text: mail_to("gds-privacy-office@digital.cabinet-office.gov.uk", class: "govuk-link")
+} %>
+
+<%= render "govuk_publishing_components/components/heading", {
+  text: "Data Protection Officer",
+  padding: true,
+  heading_level: 3,
+  font_size: "s",
+} %>
+
+<p class="govuk-body">You can also contact our Data Protection Officer (DPO) in writing at:</p>
+
+<%= render "components/contact_details", {} do %>
+  Data Protection Officer
+  <br>
+  <%= mail_to "DPO@cabinetoffice.gov.uk", class: "govuk-link" %>
+  <br>
+  Cabinet Office
+  <br>
+  70 Whitehall
+  <br>
+  London
+  <br>
+  SW1A 2AS
+<% end %>
+
+<p class="govuk-body">The DPO provides independent advice and monitoring of our use of personal information.</p>
+
+<p class="govuk-body">You can also make a complaint to the Information Commissioner, who is an independent regulator.</p>
+
+<%= render "govuk_publishing_components/components/heading", {
+  text: "Information Commissioner",
+  padding: true,
+  heading_level: 3,
+  font_size: "s",
+} %>
+
+<p class="govuk-body">Contact the Information Commissioner at:</p>
+
+<%= render "components/contact_details", {} do %>
+  <%= mail_to "casework@ico.org.uk", class: "govuk-link" %>
+  <br>
+  Telephone: 0303 123 1113
+  <br>
+  Textphone: 01625 545860
+  <br>
+  Monday to Friday, 9am to 4:30pm
+  <br>
+  <%= link_to "Find out about call charges", "https://www.gov.uk/call-charges", class: "govuk-link" %>
+<% end %>
+
+<%= render "components/contact_details", {} do %>
+  Information Commissioner’s Office
+  <br>
+  Wycliffe House
+  <br>
+  Water Lane
+  <br>
+  Wilmslow
+  <br>
+  Cheshire SK9 5AF
+<% end %>
+
+<%= render "govuk_publishing_components/components/heading", {
+  text: "Changes to this policy",
+  padding: true,
+} %>
+
+<p class="govuk-body">We may change this privacy policy. In that case, the ‘last updated’ date at the bottom of this page will also change. Any changes to this privacy policy will apply to you and your data immediately.</p>
+
+<p class="govuk-body">If these changes affect how your personal data is processed, GDS will take reasonable steps to let you know.</p>
+
+<p class="govuk-body-s">Last updated 23 August 2023</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -75,6 +75,7 @@ Rails.application.routes.draw do
   match "/suspensions/:id" => redirect("/users/%{id}/edit"), via: :get
 
   get "/signin-required" => "root#signin_required"
+  get "/privacy-notice" => "root#privacy_notice"
 
   root to: "root#index"
 


### PR DESCRIPTION
https://trello.com/c/AgYOfi7y/239-publish-the-signon-privacy-notice-and-link-to-it-in-signon-page

To meet one of the requirements of our Data Protection Impact Assessment, we're publishing this privacy notice and cookie policy for users of Signon.

I've had one eye on the styling of https://www.gov.uk/help/privacy-notice while working on this. Though, since that's a public facing page, I don't really know how similar this needs to be :confused: 

There's a suggestion on the Trello card about explaining what the page is for when linking to it. I haven't found an appropriate place to do that, since I've followed the convention of just including the link in the site's footer.

Things I'm still wondering:
- should the page heading have fewer capital letters in it?
- should the URL and footer link text include "cookie policy" in them?