### PR TITLE
Delete non-API users who were invited 90+ days ago and have never signed in

### DIFF
--- a/app/models/event_log.rb
+++ b/app/models/event_log.rb
@@ -47,6 +47,7 @@ class EventLog < ApplicationRecord
     TWO_STEP_MANDATED = LogEntry.new(id: 42, description: "2-step verification setup mandated at next login", require_uid: true, require_initiator: true),
     ACCESS_GRANTS_DELETED = LogEntry.new(id: 43, description: "Access grants deleted", require_uid: true),
     ACCESS_TOKENS_DELETED = LogEntry.new(id: 44, description: "Access tokens deleted", require_uid: true),
+    ACCOUNT_DELETED = LogEntry.new(id: 45, description: "Account deleted", require_uid: true),
 
     # We no longer expire passwords, but we keep this event for history purposes
     PASSWORD_EXPIRED = LogEntry.new(id: 6, description: "Password expired"),

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -45,7 +45,7 @@ class User < ApplicationRecord
   validate :organisation_has_mandatory_2sv, on: :create
 
   has_many :authorisations, class_name: "Doorkeeper::AccessToken", foreign_key: :resource_owner_id
-  has_many :application_permissions, class_name: "UserApplicationPermission", inverse_of: :user
+  has_many :application_permissions, class_name: "UserApplicationPermission", inverse_of: :user, dependent: :destroy
   has_many :supported_permissions, through: :application_permissions
   has_many :batch_invitations
   belongs_to :organisation

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,8 @@ class User < ApplicationRecord
 
   self.include_root_in_json = true
 
+  NEVER_SIGNED_IN_EXPIRY_PERIOD = 90.days
+
   SUSPENSION_THRESHOLD_PERIOD = 45.days
   UNSUSPENSION_GRACE_PERIOD = 7.days
 
@@ -66,6 +68,8 @@ class User < ApplicationRecord
   scope :last_signed_in_on, ->(date) { web_users.not_suspended.where("date(current_sign_in_at) = date(?)", date) }
   scope :last_signed_in_before, ->(date) { web_users.not_suspended.where("date(current_sign_in_at) < date(?)", date) }
   scope :last_signed_in_after, ->(date) { web_users.not_suspended.where("date(current_sign_in_at) >= date(?)", date) }
+  scope :never_signed_in, -> { web_users.where(current_sign_in_at: nil) }
+  scope :expired_never_signed_in, -> { never_signed_in.where("invitation_sent_at < ?", NEVER_SIGNED_IN_EXPIRY_PERIOD.ago) }
   scope :not_recently_unsuspended, -> { where(["unsuspended_at IS NULL OR unsuspended_at < ?", UNSUSPENSION_GRACE_PERIOD.ago]) }
   scope :with_access_to_application, ->(application) { UsersWithAccess.new(self, application).users }
   scope :with_2sv_enabled,

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -1,0 +1,2 @@
+Date::DATE_FORMATS[:short_ordinal] = "%d %B %Y"
+Time::DATE_FORMATS[:short_ordinal] = "%d %B %Y"

--- a/lib/expired_not_signed_in_user_deleter.rb
+++ b/lib/expired_not_signed_in_user_deleter.rb
@@ -1,0 +1,20 @@
+class ExpiredNotSignedInUserDeleter
+  def delete
+    User.expired_never_signed_in.find_each do |user|
+      EventLog.record_event(
+        user,
+        EventLog::ACCOUNT_DELETED,
+        trailing_message: log_message(user),
+      )
+
+      user.destroy!
+    end
+  end
+
+private
+
+  def log_message(user)
+    "#{user.email} was invited on " \
+      "#{user.invitation_sent_at.to_fs(:short_ordinal)} and never signed in"
+  end
+end

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -193,4 +193,9 @@ namespace :users do
 
     users_to_update.each { |user| user.update(require_2sv: true) }
   end
+
+  desc "Deletes all web users who've never signed in and were invited at least 90 days ago"
+  task delete_expired_never_signed_in: :environment do
+    ExpiredNotSignedInUserDeleter.new.delete
+  end
 end

--- a/test/lib/expired_not_signed_in_user_deleter_test.rb
+++ b/test/lib/expired_not_signed_in_user_deleter_test.rb
@@ -1,0 +1,51 @@
+require "test_helper"
+
+class ExpiredNotSignedInUserDeleterTest < ActiveSupport::TestCase
+  test "deletes web users who've never signed in and were invited over 90 days ago" do
+    create(:user).tap(&:invite!)
+    has_signed_in = create(:user, current_sign_in_at: 1.day.ago).tap(&:invite!)
+
+    Timecop.travel(91.days)
+
+    more_recently_invited = create(:user).tap(&:invite!)
+
+    ExpiredNotSignedInUserDeleter.new.delete
+
+    assert_equal [has_signed_in, more_recently_invited], User.all
+  end
+
+  test "creates an activity log entry for each deleted user" do
+    user = create(:user, email: "landon.leonardsson@dept.gov.uk").tap(&:invite!)
+
+    Timecop.travel(91.days)
+
+    ExpiredNotSignedInUserDeleter.new.delete
+
+    event_logs = user.event_logs(event: EventLog::ACCOUNT_DELETED)
+    assert_equal(1, event_logs.count)
+    assert_match(/landon\.leonardsson@dept\.gov\.uk.*never signed in/,
+                 event_logs.first.trailing_message)
+  end
+
+  test "doesn't delete users who've been re-invited within the past 90 days" do
+    user = create(:user).tap(&:invite!)
+
+    Timecop.travel(91.days)
+
+    user.invite!
+
+    ExpiredNotSignedInUserDeleter.new.delete
+
+    assert_equal [user], User.all
+  end
+
+  test "doesn't delete API users" do
+    api_user = create(:api_user).tap(&:invite!)
+
+    Timecop.travel(91.days)
+
+    ExpiredNotSignedInUserDeleter.new.delete
+
+    assert_equal [api_user], ApiUser.all
+  end
+end


### PR DESCRIPTION
https://trello.com/c/hgj1pe57/243-delete-all-accounts-that-never-signed-in

1. Delete non-API users who were invited 90+ days ago and have never signed in.
2. Add a rake task so that a cron job can perform this action regularly.