### PR TITLE
Require user to sign in after accepting invitation

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -116,6 +116,11 @@ Devise.setup do |config|
   # Default: false
   config.validate_on_invite = true
 
+  # Auto-login after the user accepts the invite. If this is false,
+  # the user will need to manually log in after accepting the invite.
+  # Default: true
+  config.allow_insecure_sign_in_after_accept = false
+
   # ==> Configuration for :confirmable
   # A period that the user is allowed to access the website even without
   # confirming their account. For instance, if set to 2.days, the user will be

--- a/test/integration/email_change_test.rb
+++ b/test/integration/email_change_test.rb
@@ -1,8 +1,6 @@
 require "test_helper"
-require "support/user_account_helpers"
 
 class EmailChangeTest < ActionDispatch::IntegrationTest
-  include UserAccountHelpers
   include ActiveJob::TestHelper
 
   context "by an admin" do

--- a/test/integration/inviting_users_test.rb
+++ b/test/integration/inviting_users_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class InvitingUsersTest < ActionDispatch::IntegrationTest
   include ActiveJob::TestHelper
 
-  should "send the user an invitation token" do
+  should "ask the invited user to set a password" do
     user = User.invite!(name: "Jim", email: "jim@web.com")
     visit accept_user_invitation_path(invitation_token: user.raw_invitation_token)
 

--- a/test/integration/inviting_users_test.rb
+++ b/test/integration/inviting_users_test.rb
@@ -11,7 +11,24 @@ class InvitingUsersTest < ActionDispatch::IntegrationTest
     fill_in "Confirm new password", with: "this 1s 4 v3333ry s3cur3 p4ssw0rd.!Z"
     click_button "Save password"
 
-    assert_response_contains("You are now signed in")
+    assert_response_contains("Your password was set successfully.")
+  end
+
+  should "require the invited user to sign in after setting their password" do
+    user = User.invite!(name: "Neptuno Keighley", email: "neptuno.keighley@office.gov.uk")
+
+    accept_invitation(
+      invitation_token: user.raw_invitation_token,
+      password: "pretext annoying headpiece waviness header slinky",
+    )
+
+    assert_response_contains("Sign in to GOV.UK")
+
+    fill_in "Email", with: "neptuno.keighley@office.gov.uk"
+    fill_in "Password", with: "pretext annoying headpiece waviness header slinky"
+    click_button "Sign in"
+
+    assert_response_contains("Make your account more secure by setting up 2‑step verification.")
   end
 
   should "not send invitation token to Google Analytics" do

--- a/test/integration/inviting_users_test.rb
+++ b/test/integration/inviting_users_test.rb
@@ -1,7 +1,6 @@
 require "test_helper"
 
 class InvitingUsersTest < ActionDispatch::IntegrationTest
-  include EmailHelpers
   include ActiveJob::TestHelper
 
   should "send the user an invitation token" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -73,6 +73,7 @@ require "support/email_helpers"
 require "support/managing_two_sv_helpers"
 require "support/analytics_helpers"
 require "support/html_table_helpers"
+require "support/user_account_helpers"
 
 class ActiveRecord::Base
   mattr_accessor :shared_connection
@@ -94,6 +95,7 @@ class ActionDispatch::IntegrationTest
   include EmailHelpers
   include ConfirmationTokenHelpers
   include AnalyticsHelpers
+  include UserAccountHelpers
 
   def assert_response_contains(content)
     assert page.has_content?(content), "Expected to find '#{content}' in:\n#{page.text}"


### PR DESCRIPTION
https://trello.com/c/SWVUwQHc/101-consider-requiring-users-to-sign-in-after-accepting-invitation

To mitigate the security risk posed by leaked invitation tokens, we're
no longer automatically signing a user in when they accept an
invitation.

This is a feature of Devise's Invitable module, so not a lot of work on
our part (to enable or disable).