### PR TITLE
Avoid queueing job if Splunk-related functionality is disabled

### DIFF
--- a/app/models/event_log.rb
+++ b/app/models/event_log.rb
@@ -119,7 +119,9 @@ class EventLog < ApplicationRecord
 
     event_log_entry = EventLog.create!(attributes)
 
-    SplunkLogStreamingJob.perform_later(event_log_entry.id)
+    if splunk_endpoint_enabled?
+      SplunkLogStreamingJob.perform_later(event_log_entry.id)
+    end
 
     event_log_entry
   end

--- a/app/models/event_log.rb
+++ b/app/models/event_log.rb
@@ -86,7 +86,7 @@ class EventLog < ApplicationRecord
   end
 
   def send_to_splunk(*)
-    return unless ENV["SPLUNK_EVENT_LOG_ENDPOINT_URL"] && ENV["SPLUNK_EVENT_LOG_ENDPOINT_HEC_TOKEN"]
+    return unless self.class.splunk_endpoint_enabled?
 
     event = {
       timestamp: created_at.utc,
@@ -153,6 +153,10 @@ class EventLog < ApplicationRecord
       # IPv4 address
       IPAddr.new(integer, Socket::AF_INET).to_s
     end
+  end
+
+  def self.splunk_endpoint_enabled?
+    ENV["SPLUNK_EVENT_LOG_ENDPOINT_URL"] && ENV["SPLUNK_EVENT_LOG_ENDPOINT_HEC_TOKEN"]
   end
 
 private

--- a/test/factories/event_log.rb
+++ b/test/factories/event_log.rb
@@ -1,3 +1,6 @@
 FactoryBot.define do
-  factory :event_log
+  factory :event_log do
+    event_id { EventLog::NO_SUCH_ACCOUNT_LOGIN.id }
+    uid { create(:user).uid }
+  end
 end

--- a/test/integration/user_locking_test.rb
+++ b/test/integration/user_locking_test.rb
@@ -25,10 +25,12 @@ class UserLockingTest < ActionDispatch::IntegrationTest
     user = create(:user)
     visit root_path
 
-    # One job is enqueued to send the email, 9 jobs are enqueued to stream log entries
-    # for each incorrect login attempt and the email sending
-    assert_enqueued_jobs(10) do
-      8.times { signin_with(email: user.email, password: "wrong password") }
+    assert_no_enqueued_emails do
+      (User.maximum_attempts - 1).times { signin_with(email: user.email, password: "wrong password") }
+    end
+
+    assert_enqueued_emails(1) do
+      signin_with(email: user.email, password: "wrong password")
     end
   end
 

--- a/test/models/event_log_test.rb
+++ b/test/models/event_log_test.rb
@@ -136,6 +136,28 @@ class EventLogTest < ActiveSupport::TestCase
       EventLog.stubs(:splunk_endpoint_enabled?).returns(true)
     end
 
+    should "queue job to send event to Splunk endpoint" do
+      SplunkLogStreamingJob.expects(:perform_later)
+      EventLog.record_event(build(:user), EventLog::SUCCESSFUL_LOGIN)
+    end
+  end
+
+  context "when Splunk endpoint disabled" do
+    setup do
+      EventLog.stubs(:splunk_endpoint_enabled?).returns(false)
+    end
+
+    should "not queue job to send event to Splunk endpoint" do
+      SplunkLogStreamingJob.expects(:perform_later).never
+      EventLog.record_event(build(:user), EventLog::SUCCESSFUL_LOGIN)
+    end
+  end
+
+  context "when Splunk endpoint enabled" do
+    setup do
+      EventLog.stubs(:splunk_endpoint_enabled?).returns(true)
+    end
+
     should "send event to Splunk endpoint" do
       ClimateControl.modify(
         SPLUNK_EVENT_LOG_ENDPOINT_URL: "http://example.com/splunk",

--- a/test/models/event_log_test.rb
+++ b/test/models/event_log_test.rb
@@ -130,4 +130,57 @@ class EventLogTest < ActiveSupport::TestCase
     assert_equal admin, event_log.initiator
     assert_equal EventLog::ACCOUNT_INVITED, event_log.entry
   end
+
+  context "when Splunk endpoint enabled" do
+    setup do
+      EventLog.stubs(:splunk_endpoint_enabled?).returns(true)
+    end
+
+    should "send event to Splunk endpoint" do
+      ClimateControl.modify(
+        SPLUNK_EVENT_LOG_ENDPOINT_URL: "http://example.com/splunk",
+        SPLUNK_EVENT_LOG_ENDPOINT_HEC_TOKEN: "hec-token",
+      ) do
+        request = stub_request(:post, "http://example.com/splunk")
+        event_log = create(:event_log)
+        event_log.send_to_splunk
+        assert_requested request
+      end
+    end
+  end
+
+  context "when Splunk endpoint disabled" do
+    setup do
+      EventLog.stubs(:splunk_endpoint_enabled?).returns(false)
+    end
+
+    should "not send event to Splunk endpoint" do
+      request = stub_request(:post, "http://example.com/splunk")
+      event_log = create(:event_log)
+      event_log.send_to_splunk
+      assert_not_requested request
+    end
+  end
+
+  context "when Splunk-related env vars are defined" do
+    should "return true for splunk_endpoint_enabled?" do
+      ClimateControl.modify(
+        SPLUNK_EVENT_LOG_ENDPOINT_URL: "url",
+        SPLUNK_EVENT_LOG_ENDPOINT_HEC_TOKEN: "hec-token",
+      ) do
+        assert EventLog.splunk_endpoint_enabled?
+      end
+    end
+  end
+
+  context "when Splunk-related env vars are not defined" do
+    should "return false for splunk_endpoint_enabled?" do
+      ClimateControl.modify(
+        SPLUNK_EVENT_LOG_ENDPOINT_URL: nil,
+        SPLUNK_EVENT_LOG_ENDPOINT_HEC_TOKEN: nil,
+      ) do
+        assert_not EventLog.splunk_endpoint_enabled?
+      end
+    end
+  end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/q1B1HKBy

Currently the Splunk-related functionality is effectively disabled, because neither of the relevant env vars are defined in any environment. See [this Trello card][1] for more details.

Prior to this commit, we were always queueing up a Sidekiq job whenever `EventLog.record_event` was called even though, as soon as that `SplunkLogStreamingJob` was executed, the first thing we did was give up if both the relevant env vars were not set.

Now we only queue up the job in the first place if the relevant env vars are defined. I've left the original check in `EventLog#send_to_splunk` in place, because there's a small chance the state of the env vars could change between the job being queued and the job being executed.

[1]: https://trello.com/c/Zp23Kd6c