### PR TITLE
Trim API Users table

### DIFF
--- a/app/views/api_users/edit.html.erb
+++ b/app/views/api_users/edit.html.erb
@@ -4,6 +4,7 @@
 
 <p class="suspenders">
   User <strong><%= @api_user.status %></strong> &bull;
+  Created <%= time_ago_in_words(@api_user.created_at) %> ago &bull;
   <%= link_to "Account access log", event_logs_user_path(@api_user) %> &bull;
   <%= link_to "#{@api_user.suspended? ? "Uns" : "S"}uspend user", edit_suspension_path(@api_user) %>
 </p>

--- a/app/views/api_users/index.html.erb
+++ b/app/views/api_users/index.html.erb
@@ -23,10 +23,6 @@
       text: "Apps",
     },
     {
-      text: "Sign‑ins",
-      format: "numeric"
-    },
-    {
       text: "Created",
     },
     {
@@ -43,10 +39,6 @@
       },
       {
         text: permissions_by_application(user),
-      },
-      {
-        text: user.sign_in_count,
-        format: "numeric"
       },
       {
         text: "#{time_ago_in_words(user.created_at)} ago",

--- a/app/views/api_users/index.html.erb
+++ b/app/views/api_users/index.html.erb
@@ -23,9 +23,6 @@
       text: "Apps",
     },
     {
-      text: "Role",
-    },
-    {
       text: "Sign‑ins",
       format: "numeric"
     },
@@ -46,9 +43,6 @@
       },
       {
         text: permissions_by_application(user),
-      },
-      {
-        text: user.role.humanize,
       },
       {
         text: user.sign_in_count,

--- a/app/views/api_users/index.html.erb
+++ b/app/views/api_users/index.html.erb
@@ -23,9 +23,6 @@
       text: "Apps",
     },
     {
-      text: "Created",
-    },
-    {
       text: "Suspended?",
     },
   ],
@@ -39,9 +36,6 @@
       },
       {
         text: permissions_by_application(user),
-      },
-      {
-        text: "#{time_ago_in_words(user.created_at)} ago",
       },
       {
         text: user.suspended? ? "Yes" : "No",

--- a/test/integration/manage_api_users_test.rb
+++ b/test/integration/manage_api_users_test.rb
@@ -18,7 +18,6 @@ class ManageApiUsersTest < ActionDispatch::IntegrationTest
     should "be able to view a list of API users alongwith their authorised applications" do
       assert page.has_selector?("td", text: @api_user.name)
       assert page.has_selector?("td", text: @api_user.email)
-      assert page.has_selector?("td", text: "Normal")
 
       assert page.has_selector?("abbr", text: @application.name)
       assert page.has_selector?("td:last-child", text: "No") # suspended?


### PR DESCRIPTION
https://trello.com/c/dggyhTVY/62-api-users-page-fix-and-iterate-how-this-page-is-displayed

I'm making improvements to the API Users index page and these are the first and most straightforward bits.

The only users I've spoken to about these changes are Sean and Chris from the Platform Engineering team, who have had to make a lot of use of this page while working across multiple apps (particularly intensively while replatforming GOV.UK).

Is it OK to conclude that shipping this change will shed more light on any use cases that I haven't considered?

Before:
![Screenshot from 2023-09-04 12-14-39](https://github.com/alphagov/signon/assets/141013432/d685fc06-fc0f-4a37-9c5d-a6ad4c09b841)

After:
![Screenshot from 2023-09-04 12-14-53](https://github.com/alphagov/signon/assets/141013432/59d06d42-94f1-4197-b211-bba6ee5e6a58)
