### PR TITLE
Refactor Roles

### DIFF
--- a/app/helpers/user_filter_helper.rb
+++ b/app/helpers/user_filter_helper.rb
@@ -35,7 +35,7 @@ module UserFilterHelper
             when :status
               User::USER_STATUSES
             when :organisation
-              if is_super_org_admin?
+              if current_user.super_organisation_admin?
                 current_user.organisation.subtree.order(:name).joins(:users).uniq.map { |org| [org.id, org.name_with_abbreviation] }
               else
                 Organisation.order(:name).joins(:users).uniq.map { |org| [org.id, org.name_with_abbreviation] }

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -20,7 +20,7 @@ module UsersHelper
   end
 
   def organisation_select_options
-    { include_blank: is_org_admin? || is_super_org_admin? ? false : "None" }
+    { include_blank: is_org_admin? || current_user.super_organisation_admin? ? false : "None" }
   end
 
   def user_email_tokens(user = current_user)
@@ -37,10 +37,6 @@ module UsersHelper
 
   def is_org_admin?
     current_user.organisation_admin?
-  end
-
-  def is_super_org_admin?
-    current_user.super_organisation_admin?
   end
 
   def sync_needed?(permissions)

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -20,7 +20,7 @@ module UsersHelper
   end
 
   def organisation_select_options
-    { include_blank: is_org_admin? || current_user.super_organisation_admin? ? false : "None" }
+    { include_blank: current_user.organisation_admin? || current_user.super_organisation_admin? ? false : "None" }
   end
 
   def user_email_tokens(user = current_user)
@@ -33,10 +33,6 @@ module UsersHelper
 
   def edit_user_path_by_user_type(user)
     user.api_user? ? edit_api_user_path(user) : edit_user_path(user)
-  end
-
-  def is_org_admin?
-    current_user.organisation_admin?
   end
 
   def sync_needed?(permissions)

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -20,7 +20,7 @@ module UsersHelper
   end
 
   def organisation_select_options
-    { include_blank: current_user.organisation_admin? || current_user.super_organisation_admin? ? false : "None" }
+    { include_blank: current_user.publishing_manager? ? false : "None" }
   end
 
   def user_email_tokens(user = current_user)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -271,7 +271,7 @@ class User < ApplicationRecord
   def set_2sv_for_admin_roles
     return unless GovukEnvironment.production?
 
-    self.require_2sv = true if role_changed? && (govuk_admin? || organisation_admin? || super_organisation_admin?)
+    self.require_2sv = true if role_changed? && (govuk_admin? || publishing_manager?)
   end
 
   def reset_2sv_exemption_reason

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -271,7 +271,7 @@ class User < ApplicationRecord
   def set_2sv_for_admin_roles
     return unless GovukEnvironment.production?
 
-    self.require_2sv = true if role_changed? && (admin? || superadmin? || organisation_admin? || super_organisation_admin?)
+    self.require_2sv = true if role_changed? && (govuk_admin? || organisation_admin? || super_organisation_admin?)
   end
 
   def reset_2sv_exemption_reason

--- a/app/policies/batch_invitation_policy.rb
+++ b/app/policies/batch_invitation_policy.rb
@@ -1,6 +1,6 @@
 class BatchInvitationPolicy < BasePolicy
   def new?
-    return true if current_user.superadmin? || current_user.admin?
+    return true if current_user.govuk_admin?
 
     false
   end
@@ -8,6 +8,6 @@ class BatchInvitationPolicy < BasePolicy
   alias_method :show?, :new?
 
   def assign_organisation_from_csv?
-    current_user.superadmin? || current_user.admin?
+    current_user.govuk_admin?
   end
 end

--- a/app/policies/bulk_grant_permission_set_policy.rb
+++ b/app/policies/bulk_grant_permission_set_policy.rb
@@ -1,6 +1,6 @@
 class BulkGrantPermissionSetPolicy < BasePolicy
   def new?
-    return true if current_user.superadmin? || current_user.admin?
+    return true if current_user.govuk_admin?
 
     false
   end

--- a/app/policies/organisation_policy.rb
+++ b/app/policies/organisation_policy.rb
@@ -1,10 +1,10 @@
 class OrganisationPolicy < BasePolicy
   def index?
-    current_user.superadmin? || current_user.admin?
+    current_user.govuk_admin?
   end
 
   def can_assign?
-    return true if current_user.superadmin? || current_user.admin?
+    return true if current_user.govuk_admin?
 
     false
   end
@@ -15,7 +15,7 @@ class OrganisationPolicy < BasePolicy
 
   class Scope < ::BasePolicy::Scope
     def resolve
-      if current_user.admin? || current_user.superadmin?
+      if current_user.govuk_admin?
         scope.all
       else
         scope.none

--- a/app/policies/supported_permission_policy.rb
+++ b/app/policies/supported_permission_policy.rb
@@ -1,9 +1,7 @@
 class SupportedPermissionPolicy < BasePolicy
   class Scope < ::BasePolicy::Scope
     def resolve
-      if current_user.superadmin?
-        scope.all
-      elsif current_user.admin?
+      if current_user.govuk_admin?
         scope.all
       elsif current_user.super_organisation_admin?
         app_ids = Pundit.policy_scope(current_user, :user_permission_manageable_application).pluck(:id)

--- a/app/policies/supported_permission_policy.rb
+++ b/app/policies/supported_permission_policy.rb
@@ -3,10 +3,7 @@ class SupportedPermissionPolicy < BasePolicy
     def resolve
       if current_user.govuk_admin?
         scope.all
-      elsif current_user.super_organisation_admin?
-        app_ids = Pundit.policy_scope(current_user, :user_permission_manageable_application).pluck(:id)
-        scope.joins(:application).where(oauth_applications: { id: app_ids })
-      elsif current_user.organisation_admin?
+      elsif current_user.publishing_manager?
         app_ids = Pundit.policy_scope(current_user, :user_permission_manageable_application).pluck(:id)
         scope.joins(:application).where(oauth_applications: { id: app_ids })
       else

--- a/app/policies/user_permission_manageable_application_policy.rb
+++ b/app/policies/user_permission_manageable_application_policy.rb
@@ -19,9 +19,7 @@ class UserPermissionManageableApplicationPolicy
     end
 
     def resolve
-      if current_user.superadmin?
-        applications
-      elsif current_user.admin?
+      if current_user.govuk_admin?
         applications
       elsif current_user.super_organisation_admin?
         applications.can_signin(current_user).with_signin_delegatable

--- a/app/policies/user_permission_manageable_application_policy.rb
+++ b/app/policies/user_permission_manageable_application_policy.rb
@@ -21,9 +21,7 @@ class UserPermissionManageableApplicationPolicy
     def resolve
       if current_user.govuk_admin?
         applications
-      elsif current_user.super_organisation_admin?
-        applications.can_signin(current_user).with_signin_delegatable
-      elsif current_user.organisation_admin?
+      elsif current_user.publishing_manager?
         applications.can_signin(current_user).with_signin_delegatable
       else
         applications.none

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -59,7 +59,7 @@ class UserPolicy < BasePolicy
 
   def exempt_from_two_step_verification?
     current_user.belongs_to_gds? &&
-      (current_user.superadmin? || current_user.admin?) &&
+      current_user.govuk_admin? &&
       record.normal? &&
       !record.api_user
   end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -16,7 +16,7 @@ class UserPolicy < BasePolicy
 
   def edit?
     case current_user.role
-    when "superadmin"
+    when Roles::Superadmin.role_name
       true
     when "admin"
       can_manage?

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -20,7 +20,7 @@ class UserPolicy < BasePolicy
       true
     when Roles::Admin.role_name
       can_manage?
-    when "super_organisation_admin"
+    when Roles::SuperOrganisationAdmin.role_name
       allow_self_only || (can_manage? && (record_in_own_organisation? || record_in_child_organisation?))
     when "organisation_admin"
       allow_self_only || (can_manage? && record_in_own_organisation?)

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -18,7 +18,7 @@ class UserPolicy < BasePolicy
     case current_user.role
     when Roles::Superadmin.role_name
       true
-    when "admin"
+    when Roles::Admin.role_name
       can_manage?
     when "super_organisation_admin"
       allow_self_only || (can_manage? && (record_in_own_organisation? || record_in_child_organisation?))

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -22,7 +22,7 @@ class UserPolicy < BasePolicy
       can_manage?
     when Roles::SuperOrganisationAdmin.role_name
       allow_self_only || (can_manage? && (record_in_own_organisation? || record_in_child_organisation?))
-    when "organisation_admin"
+    when Roles::OrganisationAdmin.role_name
       allow_self_only || (can_manage? && record_in_own_organisation?)
     else # 'normal'
       false

--- a/app/views/users/_form_fields.html.erb
+++ b/app/views/users/_form_fields.html.erb
@@ -95,10 +95,10 @@
   </p>
 <% end %>
 
-<h2 class="add-vertical-margins"> <%= "Editable " if (current_user.organisation_admin? || current_user.super_organisation_admin? ) %>Permissions</h2>
+<h2 class="add-vertical-margins"> <%= "Editable " if (current_user.publishing_manager? ) %>Permissions</h2>
 <%= render partial: "shared/user_permissions", locals: { user_object: f.object }%>
 
-<% if current_user.organisation_admin? || current_user.super_organisation_admin? %>
+<% if current_user.publishing_manager? %>
     <h2 class="add-vertical-margins">All Permissions for this user</h2>
     <%= render partial: "app_permissions", locals: { user_object: f.object }%>
 <% end %>

--- a/app/views/users/_form_fields.html.erb
+++ b/app/views/users/_form_fields.html.erb
@@ -95,10 +95,10 @@
   </p>
 <% end %>
 
-<h2 class="add-vertical-margins"> <%= "Editable " if (is_org_admin? || is_super_org_admin?) %>Permissions</h2>
+<h2 class="add-vertical-margins"> <%= "Editable " if (is_org_admin? || current_user.super_organisation_admin? ) %>Permissions</h2>
 <%= render partial: "shared/user_permissions", locals: { user_object: f.object }%>
 
-<% if is_org_admin? || is_super_org_admin? %>
+<% if is_org_admin? || current_user.super_organisation_admin? %>
     <h2 class="add-vertical-margins">All Permissions for this user</h2>
     <%= render partial: "app_permissions", locals: { user_object: f.object }%>
 <% end %>

--- a/app/views/users/_form_fields.html.erb
+++ b/app/views/users/_form_fields.html.erb
@@ -95,10 +95,10 @@
   </p>
 <% end %>
 
-<h2 class="add-vertical-margins"> <%= "Editable " if (is_org_admin? || current_user.super_organisation_admin? ) %>Permissions</h2>
+<h2 class="add-vertical-margins"> <%= "Editable " if (current_user.organisation_admin? || current_user.super_organisation_admin? ) %>Permissions</h2>
 <%= render partial: "shared/user_permissions", locals: { user_object: f.object }%>
 
-<% if is_org_admin? || current_user.super_organisation_admin? %>
+<% if current_user.organisation_admin? || current_user.super_organisation_admin? %>
     <h2 class="add-vertical-margins">All Permissions for this user</h2>
     <%= render partial: "app_permissions", locals: { user_object: f.object }%>
 <% end %>

--- a/app/views/users/_user_filter.html.erb
+++ b/app/views/users/_user_filter.html.erb
@@ -27,7 +27,7 @@
         <%= render partial: 'user_filter_group', locals: {filter_type: :role} %>
         <%= render partial: 'user_filter_group', locals: {filter_type: :permission} %>
         <%= render partial: 'user_filter_group', locals: {filter_type: :status} %>
-        <% if is_org_admin? %>
+        <% if current_user.organisation_admin? %>
           <li class="nav-pill-text text-muted"><%= current_user.organisation.name %></li>
         <% else %>
           <%= render partial: 'user_filter_group', locals: {filter_type: :organisation} %>

--- a/lib/roles.rb
+++ b/lib/roles.rb
@@ -36,4 +36,8 @@ module Roles
   def govuk_admin?
     [Roles::Superadmin.role_name, Roles::Admin.role_name].include? role
   end
+
+  def publishing_manager?
+    [Roles::SuperOrganisationAdmin.role_name, Roles::OrganisationAdmin.role_name].include? role
+  end
 end

--- a/lib/roles.rb
+++ b/lib/roles.rb
@@ -32,4 +32,8 @@ module Roles
       role_classes.sort_by(&:level).map(&:role_name)
     end
   end
+
+  def govuk_admin?
+    [Roles::Superadmin.role_name, Roles::Admin.role_name].include? role
+  end
 end

--- a/lib/tasks/permission_promoter.rake
+++ b/lib/tasks/permission_promoter.rake
@@ -12,7 +12,7 @@ namespace :permissions_promoter do
     puts "user ids to update are #{users_to_update.map(&:id)}"
 
     users_to_update.each do |user|
-      user.update(role: "organisation_admin")
+      user.update(role: Roles::OrganisationAdmin.role_name)
     end
   end
 end

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -186,7 +186,7 @@ namespace :users do
 
   desc "Sets 2sv on all organisation admin and organisation superadmin users"
   task set_2sv_for_org_admins: :environment do
-    org_admin_users = User.where(role: "organisation_admin")
+    org_admin_users = User.where(role: Roles::OrganisationAdmin.role_name)
     super_org_admin_users = User.where(role: Roles::SuperOrganisationAdmin.role_name)
 
     users_to_update = org_admin_users + super_org_admin_users

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -187,7 +187,7 @@ namespace :users do
   desc "Sets 2sv on all organisation admin and organisation superadmin users"
   task set_2sv_for_org_admins: :environment do
     org_admin_users = User.where(role: "organisation_admin")
-    super_org_admin_users = User.where(role: "super_organisation_admin")
+    super_org_admin_users = User.where(role: Roles::SuperOrganisationAdmin.role_name)
 
     users_to_update = org_admin_users + super_org_admin_users
 

--- a/test/controllers/api_users_controller_test.rb
+++ b/test/controllers/api_users_controller_test.rb
@@ -10,15 +10,13 @@ class ApiUsersControllerTest < ActionController::TestCase
     should "not be able to access API user's list" do
       get :index
 
-      assert_redirected_to root_path
-      assert_equal "You do not have permission to perform this action.", flash[:alert]
+      assert_not_authorised
     end
 
     should "not be able to view API user create form" do
       get :new
 
-      assert_redirected_to root_path
-      assert_equal "You do not have permission to perform this action.", flash[:alert]
+      assert_not_authorised
     end
   end
 

--- a/test/controllers/authorisations_controller_test.rb
+++ b/test/controllers/authorisations_controller_test.rb
@@ -14,8 +14,7 @@ class AuthorisationsControllerTest < ActionController::TestCase
     should "not be able to authorise API users" do
       get :new, params: { api_user_id: @api_user.id }
 
-      assert_redirected_to root_path
-      assert_equal "You do not have permission to perform this action.", flash[:alert]
+      assert_not_authorised
     end
 
     should "not be able to revoke API user's authorisations" do
@@ -23,8 +22,7 @@ class AuthorisationsControllerTest < ActionController::TestCase
 
       get :revoke, params: { api_user_id: @api_user.id, id: access_token.id }
 
-      assert_redirected_to root_path
-      assert_equal "You do not have permission to perform this action.", flash[:alert]
+      assert_not_authorised
     end
   end
 

--- a/test/controllers/batch_invitations_controller_test.rb
+++ b/test/controllers/batch_invitations_controller_test.rb
@@ -68,7 +68,7 @@ class BatchInvitationsControllerTest < ActionController::TestCase
     end
 
     should "store organisation info from the uploaded CSV when logged in as an admin" do
-      @user.update!(role: "admin")
+      @user.update!(role: Roles::Admin.role_name)
       post :create,
            params: { user: { supported_permission_ids: [] },
                      batch_invitation: { user_names_and_emails: users_csv("users_with_orgs.csv"), organisation_id: 3 } }

--- a/test/controllers/batch_invitations_controller_test.rb
+++ b/test/controllers/batch_invitations_controller_test.rb
@@ -83,7 +83,7 @@ class BatchInvitationsControllerTest < ActionController::TestCase
     end
 
     should "store organisation info from the uploaded CSV when logged in as a superadmin" do
-      @user.update!(role: "superadmin")
+      @user.update!(role: Roles::Superadmin.role_name)
       post :create,
            params: { user: { supported_permission_ids: [] },
                      batch_invitation: { user_names_and_emails: users_csv("users_with_orgs.csv"), organisation_id: 3 } }

--- a/test/controllers/doorkeeper_applications_controller_test.rb
+++ b/test/controllers/doorkeeper_applications_controller_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class DoorkeeperApplicationsControllerTest < ActionController::TestCase
   setup do
-    @user = create(:user, role: "superadmin")
+    @user = create(:superadmin_user)
     sign_in @user
   end
 

--- a/test/controllers/invitations_controller_test.rb
+++ b/test/controllers/invitations_controller_test.rb
@@ -92,7 +92,7 @@ class InvitationsControllerTest < ActionController::TestCase
     should "not render 2SV form and saves user when user is an admin" do
       organisation = create(:organisation, require_2sv: false)
 
-      post :create, params: { user: { name: "User Name", email: "person@gov.uk", organisation_id: organisation.id, role: "admin" } }
+      post :create, params: { user: { name: "User Name", email: "person@gov.uk", organisation_id: organisation.id, role: Roles::Admin.role_name } }
 
       assert_redirected_to users_path
       assert_equal "User Name", User.last.name

--- a/test/controllers/invitations_controller_test.rb
+++ b/test/controllers/invitations_controller_test.rb
@@ -15,7 +15,7 @@ class InvitationsControllerTest < ActionController::TestCase
     end
 
     should "disallow access to organisation admins" do
-      @user.update!(role: "organisation_admin", organisation_id: create(:organisation).id)
+      @user.update!(role: Roles::OrganisationAdmin.role_name, organisation_id: create(:organisation).id)
       get :new
       assert_redirected_to root_path
     end
@@ -50,7 +50,7 @@ class InvitationsControllerTest < ActionController::TestCase
     end
 
     should "disallow access to organisation admins" do
-      @user.update!(role: "organisation_admin", organisation_id: create(:organisation).id)
+      @user.update!(role: Roles::OrganisationAdmin.role_name, organisation_id: create(:organisation).id)
       post :create, params: { user: { name: "Testing Org Admins", email: "testing_org_admins@example.com" } }
       assert_redirected_to root_path
     end
@@ -102,7 +102,7 @@ class InvitationsControllerTest < ActionController::TestCase
     should "not render 2SV form and saves user when user is an organisation admin" do
       organisation = create(:organisation, require_2sv: false)
 
-      post :create, params: { user: { name: "User Name", email: "person@gov.uk", organisation_id: organisation.id, role: "organisation_admin" } }
+      post :create, params: { user: { name: "User Name", email: "person@gov.uk", organisation_id: organisation.id, role: Roles::OrganisationAdmin.role_name } }
 
       assert_redirected_to users_path
       assert_equal "User Name", User.last.name
@@ -129,7 +129,7 @@ class InvitationsControllerTest < ActionController::TestCase
     end
 
     should "disallow access to organisation admins" do
-      @user.update!(role: "organisation_admin", organisation_id: create(:organisation).id)
+      @user.update!(role: Roles::OrganisationAdmin.role_name, organisation_id: create(:organisation).id)
       user_to_resend_for = create(:user)
       post :resend, params: { id: user_to_resend_for.id }
       assert_redirected_to root_path

--- a/test/controllers/invitations_controller_test.rb
+++ b/test/controllers/invitations_controller_test.rb
@@ -21,7 +21,7 @@ class InvitationsControllerTest < ActionController::TestCase
     end
 
     should "disallow access to super organisation admins" do
-      @user.update!(role: "super_organisation_admin", organisation_id: create(:organisation).id)
+      @user.update!(role: Roles::SuperOrganisationAdmin.role_name, organisation_id: create(:organisation).id)
       get :new
       assert_redirected_to root_path
     end
@@ -56,7 +56,7 @@ class InvitationsControllerTest < ActionController::TestCase
     end
 
     should "disallow access to super organisation admins" do
-      @user.update!(role: "super_organisation_admin", organisation_id: create(:organisation).id)
+      @user.update!(role: Roles::SuperOrganisationAdmin.role_name, organisation_id: create(:organisation).id)
       post :create, params: { user: { name: "Testing Org Admins", email: "testing_org_admins@example.com" } }
       assert_redirected_to root_path
     end
@@ -112,7 +112,7 @@ class InvitationsControllerTest < ActionController::TestCase
     should "not render 2SV form and saves user when user is an super organisation admin" do
       organisation = create(:organisation, require_2sv: false)
 
-      post :create, params: { user: { name: "User Name", email: "person@gov.uk", organisation_id: organisation.id, role: "super_organisation_admin" } }
+      post :create, params: { user: { name: "User Name", email: "person@gov.uk", organisation_id: organisation.id, role: Roles::SuperOrganisationAdmin.role_name } }
 
       assert_redirected_to users_path
       assert_equal "User Name", User.last.name
@@ -136,7 +136,7 @@ class InvitationsControllerTest < ActionController::TestCase
     end
 
     should "disallow access to super organisation admins" do
-      @user.update!(role: "super_organisation_admin", organisation_id: create(:organisation).id)
+      @user.update!(role: Roles::SuperOrganisationAdmin.role_name, organisation_id: create(:organisation).id)
       user_to_resend_for = create(:user)
       post :resend, params: { id: user_to_resend_for.id }
       assert_redirected_to root_path

--- a/test/controllers/invitations_controller_test.rb
+++ b/test/controllers/invitations_controller_test.rb
@@ -82,7 +82,7 @@ class InvitationsControllerTest < ActionController::TestCase
     should "not render 2SV form and saves user when user is a superadmin" do
       organisation = create(:organisation, require_2sv: false)
 
-      post :create, params: { user: { name: "User Name", email: "person@gov.uk", organisation_id: organisation.id, role: "superadmin" } }
+      post :create, params: { user: { name: "User Name", email: "person@gov.uk", organisation_id: organisation.id, role: Roles::Superadmin.role_name } }
 
       assert_redirected_to users_path
       assert_equal "User Name", User.last.name

--- a/test/controllers/organisations_controller_test.rb
+++ b/test/controllers/organisations_controller_test.rb
@@ -47,14 +47,14 @@ class OrganisationsControllerTest < ActionController::TestCase
       should "not be allowed to set require 2sv to true" do
         organisation = create(:organisation, name: "Ministry of Funk")
         put :update, params: { id: organisation.id, organisation: { require_2sv: "1" } }
-        assert_equal "You do not have permission to perform this action.", flash[:alert]
+        assert_not_authorised
         assert_not organisation.reload.require_2sv?
       end
 
       should "not be allowed to set require 2sv to false" do
         organisation = create(:organisation, name: "Ministry of Funk", require_2sv: true)
         put :update, params: { id: organisation.id }
-        assert_equal "You do not have permission to perform this action.", flash[:alert]
+        assert_not_authorised
         assert organisation.reload.require_2sv?
       end
     end

--- a/test/controllers/supported_permissions_controller_test.rb
+++ b/test/controllers/supported_permissions_controller_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class SupportedPermissionsControllerTest < ActionController::TestCase
   setup do
-    @user = create(:user, role: "superadmin")
+    @user = create(:superadmin_user)
     sign_in @user
   end
 

--- a/test/controllers/suspensions_controller_test.rb
+++ b/test/controllers/suspensions_controller_test.rb
@@ -26,7 +26,7 @@ class SuspensionsControllerTest < ActionController::TestCase
   context "super organisation admin" do
     should "be unable to control suspension of a user outside their organisation subtree" do
       user = create(:suspended_user, reason_for_suspension: "Negligence")
-      super_org_admin = create(:super_org_admin)
+      super_org_admin = create(:super_organisation_admin_user)
       sign_in super_org_admin
 
       put :update, params: { id: user.id, user: { suspended: "0" } }
@@ -35,7 +35,7 @@ class SuspensionsControllerTest < ActionController::TestCase
     end
 
     should "be able to control suspension of a user within their organisation" do
-      super_org_admin = create(:super_org_admin)
+      super_org_admin = create(:super_organisation_admin_user)
       sign_in super_org_admin
       user = create(:suspended_user, reason_for_suspension: "Negligence", organisation: super_org_admin.organisation)
 
@@ -45,7 +45,7 @@ class SuspensionsControllerTest < ActionController::TestCase
     end
 
     should "be able to control suspension of a user within child organisations" do
-      super_org_admin = create(:super_org_admin)
+      super_org_admin = create(:super_organisation_admin_user)
       child_org = create(:organisation, parent: super_org_admin.organisation)
 
       sign_in super_org_admin

--- a/test/controllers/suspensions_controller_test.rb
+++ b/test/controllers/suspensions_controller_test.rb
@@ -4,7 +4,7 @@ class SuspensionsControllerTest < ActionController::TestCase
   context "organisation admin" do
     should "be unable to control suspension of a user outside their organisation" do
       user = create(:suspended_user, reason_for_suspension: "Negligence")
-      organisation_admin = create(:organisation_admin)
+      organisation_admin = create(:organisation_admin_user)
       sign_in organisation_admin
 
       put :update, params: { id: user.id, user: { suspended: "0" } }
@@ -13,7 +13,7 @@ class SuspensionsControllerTest < ActionController::TestCase
     end
 
     should "be able to control suspension of a user within their organisation" do
-      organisation_admin = create(:organisation_admin)
+      organisation_admin = create(:organisation_admin_user)
       sign_in organisation_admin
       user = create(:suspended_user, reason_for_suspension: "Negligence", organisation: organisation_admin.organisation)
 

--- a/test/controllers/two_step_verification_exemptions_controller_test.rb
+++ b/test/controllers/two_step_verification_exemptions_controller_test.rb
@@ -90,7 +90,7 @@ class TwoStepVerificationExemptionsControllerTest < ActionController::TestCase
 
       put :update, params: { id: user.id, exemption: { reason: reason_for_exemption, expiry_date: expiry_date_params } }
 
-      assert_equal "You do not have permission to perform this action.", flash[:alert]
+      assert_not_authorised
       assert_nil user.reason_for_2sv_exemption
     end
   end

--- a/test/controllers/two_step_verification_exemptions_controller_test.rb
+++ b/test/controllers/two_step_verification_exemptions_controller_test.rb
@@ -51,7 +51,7 @@ class TwoStepVerificationExemptionsControllerTest < ActionController::TestCase
       end
     end
 
-    users_without_exemption_permissions = %i[super_org_admin organisation_admin user]
+    users_without_exemption_permissions = %i[super_organisation_admin_user organisation_admin user]
 
     users_without_exemption_permissions.each do |user_type_without_exemption_permission|
       should "not be able to exempt a user when a #{user_type_without_exemption_permission}" do
@@ -96,7 +96,7 @@ class TwoStepVerificationExemptionsControllerTest < ActionController::TestCase
   end
 
   context "non-gds users" do
-    user_types = %i[superadmin_user admin_user super_org_admin organisation_admin user]
+    user_types = %i[superadmin_user admin_user super_organisation_admin_user organisation_admin user]
 
     user_types.each do |user_type|
       should "not be able to exempt a user from any organisation when logged in as a non-gds #{user_type}" do

--- a/test/controllers/two_step_verification_exemptions_controller_test.rb
+++ b/test/controllers/two_step_verification_exemptions_controller_test.rb
@@ -51,7 +51,7 @@ class TwoStepVerificationExemptionsControllerTest < ActionController::TestCase
       end
     end
 
-    users_without_exemption_permissions = %i[super_organisation_admin_user organisation_admin user]
+    users_without_exemption_permissions = %i[super_organisation_admin_user organisation_admin_user user]
 
     users_without_exemption_permissions.each do |user_type_without_exemption_permission|
       should "not be able to exempt a user when a #{user_type_without_exemption_permission}" do
@@ -82,7 +82,7 @@ class TwoStepVerificationExemptionsControllerTest < ActionController::TestCase
     end
 
     should "not be able to exempt an admin user" do
-      user = create(:organisation_admin, organisation: create(:organisation))
+      user = create(:organisation_admin_user, organisation: create(:organisation))
       admin = create(:superadmin_user, organisation: @gds)
       sign_in admin
       reason_for_exemption = "accessibility reasons"
@@ -96,7 +96,7 @@ class TwoStepVerificationExemptionsControllerTest < ActionController::TestCase
   end
 
   context "non-gds users" do
-    user_types = %i[superadmin_user admin_user super_organisation_admin_user organisation_admin user]
+    user_types = %i[superadmin_user admin_user super_organisation_admin_user organisation_admin_user user]
 
     user_types.each do |user_type|
       should "not be able to exempt a user from any organisation when logged in as a non-gds #{user_type}" do

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -421,7 +421,7 @@ class UsersControllerTest < ActionController::TestCase
 
       context "as superadmin" do
         should "not list api users" do
-          @user.update_column(:role, "superadmin")
+          @user.update_column(:role, Roles::Superadmin.role_name)
           create(:api_user, email: "api_user@email.com")
 
           get :index
@@ -763,7 +763,7 @@ class UsersControllerTest < ActionController::TestCase
 
       context "you are a superadmin" do
         setup do
-          @user.update_column(:role, "superadmin")
+          @user.update_column(:role, Roles::Superadmin.role_name)
         end
 
         should "let you set the role" do
@@ -819,7 +819,7 @@ class UsersControllerTest < ActionController::TestCase
 
       context "changing a role" do
         should "log an event" do
-          @user.update_column(:role, "superadmin")
+          @user.update_column(:role, Roles::Superadmin.role_name)
           another_user = create(:admin_user)
           put :update, params: { id: another_user.id, user: { role: "normal" } }
 

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -820,7 +820,7 @@ class UsersControllerTest < ActionController::TestCase
       context "changing a role" do
         should "log an event" do
           @user.update_column(:role, "superadmin")
-          another_user = create(:user, role: "admin")
+          another_user = create(:admin_user)
           put :update, params: { id: another_user.id, user: { role: "normal" } }
 
           assert_equal 1, EventLog.where(event_id: EventLog::ROLE_CHANGED.id, uid: another_user.uid, initiator_id: @user.id).count

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -373,7 +373,7 @@ class UsersControllerTest < ActionController::TestCase
         should "scope filtered list of users by role" do
           create(:organisation_admin_user, email: "xyz@gov.uk")
 
-          get :index, params: { filter: "admin", role: "admin" }
+          get :index, params: { filter: "admin", role: Roles::Admin.role_name }
 
           assert_select "tbody tr", count: 1
           assert_select "td.email", /admin@gov.uk/
@@ -401,10 +401,10 @@ class UsersControllerTest < ActionController::TestCase
       end
 
       should "scope list of users by status and role" do
-        create(:suspended_user, email: "suspended_user@gov.uk", role: "admin")
+        create(:suspended_user, email: "suspended_user@gov.uk", role: Roles::Admin.role_name)
         create(:suspended_user, email: "normal_suspended_user@gov.uk")
 
-        get :index, params: { status: "suspended", role: "admin" }
+        get :index, params: { status: "suspended", role: Roles::Admin.role_name }
 
         assert_select "tbody tr", count: 1
         assert_select "td.email", /suspended_user@gov.uk/
@@ -757,7 +757,7 @@ class UsersControllerTest < ActionController::TestCase
 
       should "not let you set the role" do
         not_an_admin = create(:user)
-        put :update, params: { id: not_an_admin.id, user: { role: "admin" } }
+        put :update, params: { id: not_an_admin.id, user: { role: Roles::Admin.role_name } }
         assert_equal "normal", not_an_admin.reload.role
       end
 
@@ -768,8 +768,8 @@ class UsersControllerTest < ActionController::TestCase
 
         should "let you set the role" do
           not_an_admin = create(:user)
-          put :update, params: { id: not_an_admin.id, user: { role: "admin" } }
-          assert_equal "admin", not_an_admin.reload.role
+          put :update, params: { id: not_an_admin.id, user: { role: Roles::Admin.role_name } }
+          assert_equal Roles::Admin.role_name, not_an_admin.reload.role
         end
       end
 

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -291,7 +291,7 @@ class UsersControllerTest < ActionController::TestCase
 
       should "show user roles" do
         create(:user, email: "user@email.com")
-        create(:super_org_admin, email: "superorgadmin@email.com")
+        create(:super_organisation_admin_user, email: "superorgadmin@email.com")
         create(:organisation_admin, email: "orgadmin@email.com")
 
         get :index
@@ -577,7 +577,7 @@ class UsersControllerTest < ActionController::TestCase
 
       context "super organisation admin" do
         should "not be able to assign organisations" do
-          super_org_admin = create(:super_org_admin)
+          super_org_admin = create(:super_organisation_admin_user)
           outside_organisation = create(:organisation)
           sign_in super_org_admin
 
@@ -595,7 +595,7 @@ class UsersControllerTest < ActionController::TestCase
           delegatable_no_access_to_app = create(:application, with_delegatable_supported_permissions: %w[signin])
           non_delegatable_no_access_to_app = create(:application, with_supported_permissions: %w[signin])
 
-          super_org_admin = create(:super_org_admin, with_signin_permissions_for: [delegatable_app, non_delegatable_app])
+          super_org_admin = create(:super_organisation_admin_user, with_signin_permissions_for: [delegatable_app, non_delegatable_app])
 
           sign_in super_org_admin
 
@@ -621,7 +621,7 @@ class UsersControllerTest < ActionController::TestCase
           delegatable_no_access_to_app = create(:application, with_delegatable_supported_permissions: ["signin", "GDS Editor"])
           non_delegatable_no_access_to_app = create(:application, with_supported_permissions: ["signin", "Import CSVs"])
 
-          super_org_admin = create(:super_org_admin, with_signin_permissions_for: [delegatable_app, non_delegatable_app])
+          super_org_admin = create(:super_organisation_admin_user, with_signin_permissions_for: [delegatable_app, non_delegatable_app])
 
           sign_in super_org_admin
 
@@ -740,7 +740,7 @@ class UsersControllerTest < ActionController::TestCase
 
       context "super organisation admin" do
         should "redisplay the form if save fails" do
-          admin = create(:super_org_admin)
+          admin = create(:super_organisation_admin_user)
           sign_in admin
 
           put :update, params: { id: admin.id, user: { name: "" } }

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -292,7 +292,7 @@ class UsersControllerTest < ActionController::TestCase
       should "show user roles" do
         create(:user, email: "user@email.com")
         create(:super_organisation_admin_user, email: "superorgadmin@email.com")
-        create(:organisation_admin, email: "orgadmin@email.com")
+        create(:organisation_admin_user, email: "orgadmin@email.com")
 
         get :index
 
@@ -371,7 +371,7 @@ class UsersControllerTest < ActionController::TestCase
         end
 
         should "scope filtered list of users by role" do
-          create(:organisation_admin, email: "xyz@gov.uk")
+          create(:organisation_admin_user, email: "xyz@gov.uk")
 
           get :index, params: { filter: "admin", role: "admin" }
 
@@ -495,7 +495,7 @@ class UsersControllerTest < ActionController::TestCase
 
       context "organisation admin" do
         should "not be able to assign organisations" do
-          organisation_admin = create(:organisation_admin)
+          organisation_admin = create(:organisation_admin_user)
           create(:organisation)
           sign_in organisation_admin
 
@@ -512,7 +512,7 @@ class UsersControllerTest < ActionController::TestCase
           delegatable_no_access_to_app = create(:application, with_delegatable_supported_permissions: %w[signin])
           non_delegatable_no_access_to_app = create(:application, with_supported_permissions: %w[signin])
 
-          organisation_admin = create(:organisation_admin, with_signin_permissions_for: [delegatable_app, non_delegatable_app])
+          organisation_admin = create(:organisation_admin_user, with_signin_permissions_for: [delegatable_app, non_delegatable_app])
 
           sign_in organisation_admin
 
@@ -538,7 +538,7 @@ class UsersControllerTest < ActionController::TestCase
           delegatable_no_access_to_app = create(:application, with_delegatable_supported_permissions: ["signin", "GDS Editor"])
           non_delegatable_no_access_to_app = create(:application, with_supported_permissions: ["signin", "Import CSVs"])
 
-          organisation_admin = create(:organisation_admin, with_signin_permissions_for: [delegatable_app, non_delegatable_app])
+          organisation_admin = create(:organisation_admin_user, with_signin_permissions_for: [delegatable_app, non_delegatable_app])
 
           sign_in organisation_admin
 
@@ -715,7 +715,7 @@ class UsersControllerTest < ActionController::TestCase
 
       context "organisation admin" do
         should "not be able to assign organisation ids" do
-          admin = create(:organisation_admin)
+          admin = create(:organisation_admin_user)
           sub_organisation = create(:organisation, parent: admin.organisation)
           sign_in admin
 
@@ -729,7 +729,7 @@ class UsersControllerTest < ActionController::TestCase
         end
 
         should "redisplay the form if save fails" do
-          admin = create(:organisation_admin)
+          admin = create(:organisation_admin_user)
           sign_in admin
 
           put :update, params: { id: admin.id, user: { name: "" } }
@@ -918,7 +918,7 @@ class UsersControllerTest < ActionController::TestCase
 
   context "as Organisation Admin" do
     setup do
-      @user = create(:organisation_admin)
+      @user = create(:organisation_admin_user)
       sign_in @user
     end
 

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -39,7 +39,7 @@ FactoryBot.define do
     otp_secret_key { "Sssshh" }
   end
 
-  factory :two_step_enabled_organisation_admin, parent: :organisation_admin do
+  factory :two_step_enabled_organisation_admin, parent: :organisation_admin_user do
     require_2sv { true }
     otp_secret_key { "Sssshh" }
   end
@@ -79,7 +79,7 @@ FactoryBot.define do
     role { "super_organisation_admin" }
   end
 
-  factory :organisation_admin, parent: :user_in_organisation do
+  factory :organisation_admin_user, parent: :user_in_organisation do
     role { "organisation_admin" }
   end
 

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -72,7 +72,7 @@ FactoryBot.define do
 
   factory :admin_user, parent: :user do
     sequence(:email) { |n| "admin#{n}@example.com" }
-    role { "admin" }
+    role { Roles::Admin.role_name }
   end
 
   factory :super_organisation_admin_user, parent: :user_in_organisation do

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -75,7 +75,7 @@ FactoryBot.define do
     role { "admin" }
   end
 
-  factory :super_org_admin, parent: :user_in_organisation do
+  factory :super_organisation_admin_user, parent: :user_in_organisation do
     role { "super_organisation_admin" }
   end
 

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -80,7 +80,7 @@ FactoryBot.define do
   end
 
   factory :organisation_admin_user, parent: :user_in_organisation do
-    role { "organisation_admin" }
+    role { Roles::OrganisationAdmin.role_name }
   end
 
   factory :suspended_user, parent: :user do

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -67,7 +67,7 @@ FactoryBot.define do
 
   factory :superadmin_user, parent: :user do
     sequence(:email) { |n| "superadmin#{n}@example.com" }
-    role { "superadmin" }
+    role { Roles::Superadmin.role_name }
   end
 
   factory :admin_user, parent: :user do

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -76,7 +76,7 @@ FactoryBot.define do
   end
 
   factory :super_organisation_admin_user, parent: :user_in_organisation do
-    role { "super_organisation_admin" }
+    role { Roles::SuperOrganisationAdmin.role_name }
   end
 
   factory :organisation_admin_user, parent: :user_in_organisation do

--- a/test/helpers/bulk_grant_permission_sets_helper_test.rb
+++ b/test/helpers/bulk_grant_permission_sets_helper_test.rb
@@ -22,7 +22,7 @@ class BulkGrantPermissionSetsHelperTest < ActionView::TestCase
 
     context "for an admin" do
       setup do
-        @current_user = create(:user, role: "admin")
+        @current_user = create(:admin_user)
       end
 
       should "return all non-retired applications in alphabetical order" do

--- a/test/helpers/bulk_grant_permission_sets_helper_test.rb
+++ b/test/helpers/bulk_grant_permission_sets_helper_test.rb
@@ -12,7 +12,7 @@ class BulkGrantPermissionSetsHelperTest < ActionView::TestCase
 
     context "for a superadmin" do
       setup do
-        @current_user = create(:user, role: "superadmin")
+        @current_user = create(:superadmin_user)
       end
 
       should "return all non-retired applications in alphabetical order" do

--- a/test/integration/batch_inviting_users_test.rb
+++ b/test/integration/batch_inviting_users_test.rb
@@ -47,7 +47,7 @@ class BatchInvitingUsersTest < ActionDispatch::IntegrationTest
 
   context "for organisation admins" do
     setup do
-      @user = create(:organisation_admin)
+      @user = create(:organisation_admin_user)
       @user.grant_application_permission(@application, %w[signin])
     end
 

--- a/test/integration/batch_inviting_users_test.rb
+++ b/test/integration/batch_inviting_users_test.rb
@@ -62,7 +62,7 @@ class BatchInvitingUsersTest < ActionDispatch::IntegrationTest
 
   context "for super organisation admins" do
     setup do
-      @user = create(:super_org_admin)
+      @user = create(:super_organisation_admin_user)
       @user.grant_application_permission(@application, %w[signin])
     end
 

--- a/test/integration/bulk_granting_permisions_test.rb
+++ b/test/integration/bulk_granting_permisions_test.rb
@@ -5,7 +5,7 @@ class BulkGrantingPermissionsTest < ActionDispatch::IntegrationTest
 
   setup do
     @users = create_list(:user, 2)
-    @org_admins = create_list(:organisation_admin, 2)
+    @org_admins = create_list(:organisation_admin_user, 2)
     @admins = create_list(:admin_user, 2)
     @superadmins = create_list(:superadmin_user, 2)
 
@@ -35,7 +35,7 @@ class BulkGrantingPermissionsTest < ActionDispatch::IntegrationTest
   end
 
   should "organisation admin user can not grant multiple permissions to all users in one go" do
-    user = create(:organisation_admin)
+    user = create(:organisation_admin_user)
 
     visit root_path
     signin_with(user)

--- a/test/integration/bulk_granting_permisions_test.rb
+++ b/test/integration/bulk_granting_permisions_test.rb
@@ -25,7 +25,7 @@ class BulkGrantingPermissionsTest < ActionDispatch::IntegrationTest
   end
 
   should "super organisation admin user can not grant multiple permissions to all users in one go" do
-    user = create(:super_org_admin)
+    user = create(:super_organisation_admin_user)
 
     visit root_path
     signin_with(user)

--- a/test/integration/event_log_page_test.rb
+++ b/test/integration/event_log_page_test.rb
@@ -40,7 +40,7 @@ class EventLogPageIntegrationTest < ActionDispatch::IntegrationTest
   end
 
   test "super organisation admins have permission to view access logs of users belonging to their organisation" do
-    super_org_admin = create(:super_org_admin)
+    super_org_admin = create(:super_organisation_admin_user)
     user = create(:user_in_organisation, organisation: super_org_admin.organisation)
     user.lock_access!
 
@@ -53,7 +53,7 @@ class EventLogPageIntegrationTest < ActionDispatch::IntegrationTest
   end
 
   test "super organisation admins have permission to view access logs of users belonging to child organisations" do
-    super_org_admin = create(:super_org_admin)
+    super_org_admin = create(:super_organisation_admin_user)
     child_org = create(:organisation, parent: super_org_admin.organisation)
     user = create(:user_in_organisation, organisation: child_org)
     user.lock_access!
@@ -67,7 +67,7 @@ class EventLogPageIntegrationTest < ActionDispatch::IntegrationTest
   end
 
   test "super organisation admins don't have permission to view access logs of users belonging to another organisation" do
-    super_org_admin = create(:super_org_admin)
+    super_org_admin = create(:super_organisation_admin_user)
 
     visit root_path
     signin_with(super_org_admin)

--- a/test/integration/event_log_page_test.rb
+++ b/test/integration/event_log_page_test.rb
@@ -77,7 +77,7 @@ class EventLogPageIntegrationTest < ActionDispatch::IntegrationTest
   end
 
   test "organisation admins have permission to view access logs of users belonging to their organisation" do
-    organisation_admin = create(:organisation_admin)
+    organisation_admin = create(:organisation_admin_user)
     user = create(:user_in_organisation, organisation: organisation_admin.organisation)
     user.lock_access!
 
@@ -90,7 +90,7 @@ class EventLogPageIntegrationTest < ActionDispatch::IntegrationTest
   end
 
   test "organisation admins don't have permission to view access logs of users belonging to another organisation" do
-    organisation_admin = create(:organisation_admin)
+    organisation_admin = create(:organisation_admin_user)
 
     visit root_path
     signin_with(organisation_admin)

--- a/test/integration/granting_permissions_test.rb
+++ b/test/integration/granting_permissions_test.rb
@@ -91,7 +91,7 @@ class GrantingPermissionsTest < ActionDispatch::IntegrationTest
 
   context "as a super organisation admin" do
     setup do
-      @super_org_admin = create(:super_org_admin)
+      @super_org_admin = create(:super_organisation_admin_user)
       @user = create(:user, organisation: @super_org_admin.organisation)
 
       visit root_path

--- a/test/integration/granting_permissions_test.rb
+++ b/test/integration/granting_permissions_test.rb
@@ -177,7 +177,7 @@ class GrantingPermissionsTest < ActionDispatch::IntegrationTest
 
   context "as an organisation admin" do
     setup do
-      @organisation_admin = create(:organisation_admin)
+      @organisation_admin = create(:organisation_admin_user)
       @user = create(:user, organisation: @organisation_admin.organisation)
 
       visit root_path

--- a/test/integration/inviting_users_test.rb
+++ b/test/integration/inviting_users_test.rb
@@ -246,10 +246,10 @@ class InvitingUsersTest < ActionDispatch::IntegrationTest
           select "Test Organisation without 2SV", from: "Organisation"
           click_button "Create user and send email"
 
-          assert_not_nil User.where(email: "fred@example.com", role: "superadmin").last
+          assert_not_nil User.where(email: "fred@example.com", role: Roles::Superadmin.role_name).last
           assert_equal "fred@example.com", last_email.to[0]
           assert_match "Please confirm your account", last_email.subject
-          assert User.where(email: "fred@example.com", role: "superadmin").last.require_2sv?
+          assert User.where(email: "fred@example.com", role: Roles::Superadmin.role_name).last.require_2sv?
         end
       end
 
@@ -284,10 +284,10 @@ class InvitingUsersTest < ActionDispatch::IntegrationTest
           select "Test Organisation without 2SV", from: "Organisation"
           click_button "Create user and send email"
 
-          assert_not_nil User.where(email: "fred@example.com", role: "superadmin").last
+          assert_not_nil User.where(email: "fred@example.com", role: Roles::Superadmin.role_name).last
           assert_equal "fred@example.com", last_email.to[0]
           assert_match "Please confirm your account", last_email.subject
-          assert User.where(email: "fred@example.com", role: "superadmin").last.require_2sv?
+          assert User.where(email: "fred@example.com", role: Roles::Superadmin.role_name).last.require_2sv?
         end
       end
 

--- a/test/integration/inviting_users_test.rb
+++ b/test/integration/inviting_users_test.rb
@@ -44,7 +44,7 @@ class InvitingUsersTest < ActionDispatch::IntegrationTest
 
   context "as an admin" do
     setup do
-      admin = create(:user, role: "admin")
+      admin = create(:admin_user)
       visit root_path
       signin_with(admin)
     end
@@ -356,7 +356,7 @@ class InvitingUsersTest < ActionDispatch::IntegrationTest
 
   context "Notify service is using an allowlist or is in trial mode" do
     setup do
-      admin = create(:user, role: "admin")
+      admin = create(:admin_user)
       visit root_path
       signin_with(admin)
     end

--- a/test/integration/inviting_users_test.rb
+++ b/test/integration/inviting_users_test.rb
@@ -196,7 +196,7 @@ class InvitingUsersTest < ActionDispatch::IntegrationTest
 
   context "as a superadmin" do
     setup do
-      superadmin = create(:user, role: "superadmin")
+      superadmin = create(:superadmin_user)
       visit root_path
       signin_with(superadmin)
     end

--- a/test/integration/inviting_users_test.rb
+++ b/test/integration/inviting_users_test.rb
@@ -262,10 +262,10 @@ class InvitingUsersTest < ActionDispatch::IntegrationTest
           select "Test Organisation without 2SV", from: "Organisation"
           click_button "Create user and send email"
 
-          assert_not_nil User.where(email: "fred@example.com", role: "admin").last
+          assert_not_nil User.where(email: "fred@example.com", role: Roles::Admin.role_name).last
           assert_equal "fred@example.com", last_email.to[0]
           assert_match "Please confirm your account", last_email.subject
-          assert User.where(email: "fred@example.com", role: "admin").last.require_2sv?
+          assert User.where(email: "fred@example.com", role: Roles::Admin.role_name).last.require_2sv?
         end
       end
     end
@@ -300,10 +300,10 @@ class InvitingUsersTest < ActionDispatch::IntegrationTest
           select "Test Organisation without 2SV", from: "Organisation"
           click_button "Create user and send email"
 
-          assert_not_nil User.where(email: "fred@example.com", role: "admin").last
+          assert_not_nil User.where(email: "fred@example.com", role: Roles::Admin.role_name).last
           assert_equal "fred@example.com", last_email.to[0]
           assert_match "Please confirm your account", last_email.subject
-          assert User.where(email: "fred@example.com", role: "admin").last.require_2sv?
+          assert User.where(email: "fred@example.com", role: Roles::Admin.role_name).last.require_2sv?
         end
       end
     end

--- a/test/integration/managing_two_step_verification_test.rb
+++ b/test/integration/managing_two_step_verification_test.rb
@@ -108,7 +108,7 @@ class ManagingTwoStepVerificationTest < ActionDispatch::IntegrationTest
 
     context "when logged in as an organisation admin" do
       setup do
-        @org_admin = create(:organisation_admin, organisation: @user.organisation)
+        @org_admin = create(:organisation_admin_user, organisation: @user.organisation)
       end
 
       should "be able to send a notification to a user to set up 2SV" do
@@ -144,7 +144,7 @@ class ManagingTwoStepVerificationTest < ActionDispatch::IntegrationTest
 
     context "when a user has already had 2sv mandated" do
       setup do
-        @org_admin = create(:organisation_admin, organisation: @organisation)
+        @org_admin = create(:organisation_admin_user, organisation: @organisation)
       end
 
       should "be able to see an appropriate message reflecting the user's 2sv status when enabled but not set up" do

--- a/test/integration/managing_two_step_verification_test.rb
+++ b/test/integration/managing_two_step_verification_test.rb
@@ -74,7 +74,7 @@ class ManagingTwoStepVerificationTest < ActionDispatch::IntegrationTest
 
     context "when logged in as a super organisation admin" do
       setup do
-        @super_org_admin = create(:super_org_admin, organisation: @user.organisation)
+        @super_org_admin = create(:super_organisation_admin_user, organisation: @user.organisation)
       end
 
       should "be able to send a notification to a user to set up 2SV" do

--- a/test/integration/user_locking_test.rb
+++ b/test/integration/user_locking_test.rb
@@ -35,7 +35,7 @@ class UserLockingTest < ActionDispatch::IntegrationTest
   end
 
   should "be reversible by admins" do
-    admin = create(:user, role: "admin")
+    admin = create(:admin_user)
     user = create(:user)
     user.lock_access!
 
@@ -50,7 +50,7 @@ class UserLockingTest < ActionDispatch::IntegrationTest
   end
 
   should "be reversible from the user edit page" do
-    admin = create(:user, role: "admin")
+    admin = create(:admin_user)
     user = create(:user)
     user.lock_access!
 

--- a/test/integration/user_suspension_test.rb
+++ b/test/integration/user_suspension_test.rb
@@ -14,7 +14,7 @@ class UserSuspensionTest < ActionDispatch::IntegrationTest
   end
 
   should "show the suspension reason to admins" do
-    admin = create(:user, role: "admin")
+    admin = create(:admin_user)
     visit new_user_session_path
     signin_with(admin)
 

--- a/test/lib/numbers/numbers_csv_test.rb
+++ b/test/lib/numbers/numbers_csv_test.rb
@@ -38,7 +38,7 @@ class NumbersCsvTest < ActiveSupport::TestCase
   end
 
   test "csv contains admin and superadmin user names" do
-    create(:admin_user, email: "maggie@gov.uk", name: "Margaret", role: "superadmin")
+    create(:superadmin_user, email: "maggie@gov.uk", name: "Margaret")
     create(:admin_user, email: "dave@gov.uk", name: "David", role: "admin")
 
     Numbers::NumbersCsv.generate

--- a/test/lib/numbers/numbers_csv_test.rb
+++ b/test/lib/numbers/numbers_csv_test.rb
@@ -44,7 +44,7 @@ class NumbersCsvTest < ActiveSupport::TestCase
     Numbers::NumbersCsv.generate
 
     assert numbers_csv.include? ["Active admin user names", "admin", "David <dave@gov.uk>, Winston <admin_user@admin.example.com>"]
-    assert numbers_csv.include? ["Active admin user names", "superadmin", "Margaret <maggie@gov.uk>"]
+    assert numbers_csv.include? ["Active admin user names", Roles::Superadmin.role_name, "Margaret <maggie@gov.uk>"]
   end
 
   test "csv contains counts by application access" do

--- a/test/lib/numbers/numbers_csv_test.rb
+++ b/test/lib/numbers/numbers_csv_test.rb
@@ -39,7 +39,7 @@ class NumbersCsvTest < ActiveSupport::TestCase
 
   test "csv contains admin and superadmin user names" do
     create(:superadmin_user, email: "maggie@gov.uk", name: "Margaret")
-    create(:admin_user, email: "dave@gov.uk", name: "David", role: "admin")
+    create(:admin_user, email: "dave@gov.uk", name: "David")
 
     Numbers::NumbersCsv.generate
 

--- a/test/lib/numbers/numbers_csv_test.rb
+++ b/test/lib/numbers/numbers_csv_test.rb
@@ -33,7 +33,7 @@ class NumbersCsvTest < ActiveSupport::TestCase
 
   test "csv contains counts by role" do
     Numbers::NumbersCsv.generate
-    assert numbers_csv.include? ["Active accounts count by role", "admin", "1"]
+    assert numbers_csv.include? ["Active accounts count by role", Roles::Admin.role_name, "1"]
     assert numbers_csv.include? ["Active accounts count by role", "normal", "3"]
   end
 
@@ -43,7 +43,7 @@ class NumbersCsvTest < ActiveSupport::TestCase
 
     Numbers::NumbersCsv.generate
 
-    assert numbers_csv.include? ["Active admin user names", "admin", "David <dave@gov.uk>, Winston <admin_user@admin.example.com>"]
+    assert numbers_csv.include? ["Active admin user names", Roles::Admin.role_name, "David <dave@gov.uk>, Winston <admin_user@admin.example.com>"]
     assert numbers_csv.include? ["Active admin user names", Roles::Superadmin.role_name, "Margaret <maggie@gov.uk>"]
   end
 

--- a/test/lib/roles_test.rb
+++ b/test/lib/roles_test.rb
@@ -90,4 +90,28 @@ class RolesTest < ActiveSupport::TestCase
       end
     end
   end
+
+  context "#publishing_manager?" do
+    setup do
+      @subject = Subject.new
+    end
+
+    should "be true if the role is super_organisation_admin" do
+      @subject.role = Roles::SuperOrganisationAdmin.role_name
+      assert @subject.publishing_manager?
+    end
+
+    should "be true if role is organisation_admin" do
+      @subject.role = Roles::OrganisationAdmin.role_name
+      assert @subject.publishing_manager?
+    end
+
+    should "be false if role is anything else" do
+      other_role_classes = Subject.role_classes - [Roles::SuperOrganisationAdmin, Roles::OrganisationAdmin]
+      other_role_classes.each do |role_class|
+        @subject.role = role_class.role_name
+        assert_not @subject.publishing_manager?
+      end
+    end
+  end
 end

--- a/test/lib/roles_test.rb
+++ b/test/lib/roles_test.rb
@@ -66,4 +66,28 @@ class RolesTest < ActiveSupport::TestCase
       end
     end
   end
+
+  context "#govuk_admin?" do
+    setup do
+      @subject = Subject.new
+    end
+
+    should "be true if the role is superadmin" do
+      @subject.role = Roles::Superadmin.role_name
+      assert @subject.govuk_admin?
+    end
+
+    should "be true if role is admin" do
+      @subject.role = Roles::Admin.role_name
+      assert @subject.govuk_admin?
+    end
+
+    should "be false if role is anything else" do
+      other_role_classes = Subject.role_classes - [Roles::Superadmin, Roles::Admin]
+      other_role_classes.each do |role_class|
+        @subject.role = role_class.role_name
+        assert_not @subject.govuk_admin?
+      end
+    end
+  end
 end

--- a/test/lib/roles_test.rb
+++ b/test/lib/roles_test.rb
@@ -1,0 +1,69 @@
+require "test_helper"
+
+class RolesTest < ActiveSupport::TestCase
+  class Subject
+    include ActiveModel::Validations
+    include Roles
+
+    attr_accessor :role
+  end
+
+  context ".role_classes" do
+    should "include all role classes" do
+      expected_role_classes = [
+        Roles::Normal,
+        Roles::Admin,
+        Roles::Superadmin,
+        Roles::OrganisationAdmin,
+        Roles::SuperOrganisationAdmin,
+      ]
+
+      assert_same_elements expected_role_classes, Subject.role_classes
+    end
+  end
+
+  context ".admin_role_classes" do
+    should "only include admin role classes" do
+      expected_role_classes = [
+        Roles::Admin,
+        Roles::Superadmin,
+        Roles::OrganisationAdmin,
+        Roles::SuperOrganisationAdmin,
+      ]
+
+      assert_same_elements expected_role_classes, Subject.admin_role_classes
+    end
+  end
+
+  context ".roles" do
+    should "order roles by their level" do
+      expected_ordered_roles = %w[
+        superadmin
+        admin
+        super_organisation_admin
+        organisation_admin
+        normal
+      ]
+
+      assert_equal expected_ordered_roles, Subject.roles
+    end
+  end
+
+  Subject.roles.each do |role|
+    context "##{role}?" do
+      setup do
+        @subject = Subject.new
+      end
+
+      should "return true if subject has the #{role} role" do
+        @subject.role = role
+        assert @subject.send("#{role}?")
+      end
+
+      should "return false if subject does not have #{role} role" do
+        @subject.role = "not-#{role}"
+        assert_not @subject.send("#{role}?")
+      end
+    end
+  end
+end

--- a/test/lib/tasks/permissions_promoter_test.rb
+++ b/test/lib/tasks/permissions_promoter_test.rb
@@ -44,7 +44,7 @@ class PermissionsPromoterTest < ActiveSupport::TestCase
 
     @task.invoke
 
-    assert admin_user.reload.role == "admin"
+    assert admin_user.reload.role == Roles::Admin.role_name
   end
 
   should "not update a non-GDS user who is suspended" do

--- a/test/lib/tasks/permissions_promoter_test.rb
+++ b/test/lib/tasks/permissions_promoter_test.rb
@@ -26,7 +26,7 @@ class PermissionsPromoterTest < ActiveSupport::TestCase
       users = [first_non_gds_user, second_non_gds_user].each(&:reload)
 
       assert users.all? do |user|
-        user.role == "organisation_admin"
+        user.role == Roles::OrganisationAdmin.role_name
       end
     end
   end

--- a/test/lib/tasks/users_test.rb
+++ b/test/lib/tasks/users_test.rb
@@ -5,7 +5,7 @@ class UsersTaskTest < ActiveSupport::TestCase
     Signon::Application.load_tasks if Rake::Task.tasks.empty?
     $stdout.stubs(:write)
 
-    @user_types = %i[user superadmin_user admin_user organisation_admin super_org_admin]
+    @user_types = %i[user superadmin_user admin_user organisation_admin super_organisation_admin_user]
   end
 
   context "#set_2sv_by_org" do
@@ -67,7 +67,7 @@ class UsersTaskTest < ActiveSupport::TestCase
     end
 
     should "require 2SV for an super organisation admin" do
-      user = create(:super_org_admin)
+      user = create(:super_organisation_admin_user)
 
       @task.invoke
 

--- a/test/lib/tasks/users_test.rb
+++ b/test/lib/tasks/users_test.rb
@@ -5,7 +5,7 @@ class UsersTaskTest < ActiveSupport::TestCase
     Signon::Application.load_tasks if Rake::Task.tasks.empty?
     $stdout.stubs(:write)
 
-    @user_types = %i[user superadmin_user admin_user organisation_admin super_organisation_admin_user]
+    @user_types = %i[user superadmin_user admin_user organisation_admin_user super_organisation_admin_user]
   end
 
   context "#set_2sv_by_org" do
@@ -59,7 +59,7 @@ class UsersTaskTest < ActiveSupport::TestCase
     end
 
     should "require 2SV for an organisation admin" do
-      user = create(:organisation_admin)
+      user = create(:organisation_admin_user)
 
       @task.invoke
 

--- a/test/lib/user_permissions_exporter_test.rb
+++ b/test/lib/user_permissions_exporter_test.rb
@@ -14,7 +14,7 @@ class UserPermissionsExporterTest < ActionView::TestCase
       reason_for_suspension: "Left Chips.org",
     )
     @anne = create(:superadmin_user, name: "Anne", email: "anne@anne.com", organisation: @ketchup_org)
-    @mary = create(:user, name: "Mary", email: "mary@mary.com", role: "admin", organisation: @brown_sauce_org)
+    @mary = create(:admin_user, name: "Mary", email: "mary@mary.com", organisation: @brown_sauce_org)
 
     @tmpfile = Tempfile.new(%w[user_permissions_exporter_test_example csv])
     UserPermissionsExporter.any_instance.stubs(:file_path).returns(@tmpfile.path)

--- a/test/lib/user_permissions_exporter_test.rb
+++ b/test/lib/user_permissions_exporter_test.rb
@@ -67,7 +67,7 @@ class UserPermissionsExporterTest < ActionView::TestCase
     csv_data = CSV.read(@tmpfile.path)
 
     assert_equal ["Name", "Email", "Organisation", "Role", "Suspended at"], csv_data[0]
-    assert_equal ["Anne", "anne@anne.com", "Ministry of ketchup", "superadmin", ""], csv_data[1]
+    assert_equal ["Anne", "anne@anne.com", "Ministry of ketchup", Roles::Superadmin.role_name, ""], csv_data[1]
     assert_equal ["Bill", "bill@bill.com", "Ministry of chips", "normal", "2000-01-01 00:00:00 +0000"], csv_data[2]
     assert_equal ["Mary", "mary@mary.com", "Ministry of brown sauce", "admin", ""], csv_data[3]
   end

--- a/test/lib/user_permissions_exporter_test.rb
+++ b/test/lib/user_permissions_exporter_test.rb
@@ -13,7 +13,7 @@ class UserPermissionsExporterTest < ActionView::TestCase
       suspended_at: Date.parse("2000-01-01"),
       reason_for_suspension: "Left Chips.org",
     )
-    @anne = create(:user, name: "Anne", email: "anne@anne.com", role: "superadmin", organisation: @ketchup_org)
+    @anne = create(:superadmin_user, name: "Anne", email: "anne@anne.com", organisation: @ketchup_org)
     @mary = create(:user, name: "Mary", email: "mary@mary.com", role: "admin", organisation: @brown_sauce_org)
 
     @tmpfile = Tempfile.new(%w[user_permissions_exporter_test_example csv])

--- a/test/lib/user_permissions_exporter_test.rb
+++ b/test/lib/user_permissions_exporter_test.rb
@@ -69,6 +69,6 @@ class UserPermissionsExporterTest < ActionView::TestCase
     assert_equal ["Name", "Email", "Organisation", "Role", "Suspended at"], csv_data[0]
     assert_equal ["Anne", "anne@anne.com", "Ministry of ketchup", Roles::Superadmin.role_name, ""], csv_data[1]
     assert_equal ["Bill", "bill@bill.com", "Ministry of chips", "normal", "2000-01-01 00:00:00 +0000"], csv_data[2]
-    assert_equal ["Mary", "mary@mary.com", "Ministry of brown sauce", "admin", ""], csv_data[3]
+    assert_equal ["Mary", "mary@mary.com", "Ministry of brown sauce", Roles::Admin.role_name, ""], csv_data[3]
   end
 end

--- a/test/lib/user_suspensions_exporter_test.rb
+++ b/test/lib/user_suspensions_exporter_test.rb
@@ -51,7 +51,7 @@ class UserSuspensionsExporterTest < ActionView::TestCase
     csv_data = CSV.read(@tmpfile.path)
 
     assert_equal ["Name", "Email", "Organisation", "Role", "Created at", "Auto-suspended at", "Unsuspended at", "Unsuspended by"], csv_data[0]
-    assert_equal ["Mary", "mary@mary.com", "Ministry of brown sauce", "admin", "2000-01-01 00:00:00 +0000", "2018-03-05 00:00:00 +0000", "", ""], csv_data[1]
+    assert_equal ["Mary", "mary@mary.com", "Ministry of brown sauce", Roles::Admin.role_name, "2000-01-01 00:00:00 +0000", "2018-03-05 00:00:00 +0000", "", ""], csv_data[1]
     assert_equal 2, csv_data.count
   end
 
@@ -62,7 +62,7 @@ class UserSuspensionsExporterTest < ActionView::TestCase
 
     assert_equal ["Name", "Email", "Organisation", "Role", "Created at", "Auto-suspended at", "Unsuspended at", "Unsuspended by"], csv_data[0]
     assert_equal ["Anne", "anne@anne.com", "Ministry of ketchup", Roles::Superadmin.role_name, "2010-10-10 00:00:00 +0100", "2018-02-01 00:00:00 +0000", "", ""], csv_data[1]
-    assert_equal ["Mary", "mary@mary.com", "Ministry of brown sauce", "admin", "2000-01-01 00:00:00 +0000", "2018-03-05 00:00:00 +0000", "", ""], csv_data[2]
+    assert_equal ["Mary", "mary@mary.com", "Ministry of brown sauce", Roles::Admin.role_name, "2000-01-01 00:00:00 +0000", "2018-03-05 00:00:00 +0000", "", ""], csv_data[2]
     assert_equal 3, csv_data.count
   end
 
@@ -87,7 +87,7 @@ class UserSuspensionsExporterTest < ActionView::TestCase
     assert_equal ["Bill", "bill@bill.com", "Ministry of chips", "normal", "2010-10-10 00:00:00 +0100", "2018-01-01 00:00:00 +0000", "2018-01-15 00:00:00 +0000", "anne@anne.com"], csv_data[1]
     assert_equal ["Bill", "bill@bill.com", "Ministry of chips", "normal", "2010-10-10 00:00:00 +0100", "2018-01-16 00:00:00 +0000", "2018-01-31 00:00:00 +0000", "mary@mary.com"], csv_data[2]
     assert_equal ["Anne", "anne@anne.com", "Ministry of ketchup", Roles::Superadmin.role_name, "2010-10-10 00:00:00 +0100", "2018-02-01 00:00:00 +0000", "", ""], csv_data[3]
-    assert_equal ["Mary", "mary@mary.com", "Ministry of brown sauce", "admin", "2000-01-01 00:00:00 +0000", "2018-03-05 00:00:00 +0000", "", ""], csv_data[4]
+    assert_equal ["Mary", "mary@mary.com", "Ministry of brown sauce", Roles::Admin.role_name, "2000-01-01 00:00:00 +0000", "2018-03-05 00:00:00 +0000", "", ""], csv_data[4]
     assert_equal 5, csv_data.count
   end
 end

--- a/test/lib/user_suspensions_exporter_test.rb
+++ b/test/lib/user_suspensions_exporter_test.rb
@@ -7,7 +7,7 @@ class UserSuspensionsExporterTest < ActionView::TestCase
     @ketchup_org = create(:organisation, name: "Ministry of ketchup")
     @brown_sauce_org = create(:organisation, name: "Ministry of brown sauce")
     @bill = create(:user, name: "Bill", email: "bill@bill.com", role: "normal", organisation: @chips_org, created_at: Date.new(2010, 10, 10))
-    @anne = create(:user, name: "Anne", email: "anne@anne.com", role: "superadmin", organisation: @ketchup_org, created_at: Date.new(2010, 10, 10))
+    @anne = create(:superadmin_user, name: "Anne", email: "anne@anne.com", organisation: @ketchup_org, created_at: Date.new(2010, 10, 10))
     @mary = create(:user, name: "Mary", email: "mary@mary.com", role: "admin", organisation: @brown_sauce_org, created_at: Date.new(2000, 1, 1))
 
     # give bill multiple suspensions

--- a/test/lib/user_suspensions_exporter_test.rb
+++ b/test/lib/user_suspensions_exporter_test.rb
@@ -8,7 +8,7 @@ class UserSuspensionsExporterTest < ActionView::TestCase
     @brown_sauce_org = create(:organisation, name: "Ministry of brown sauce")
     @bill = create(:user, name: "Bill", email: "bill@bill.com", role: "normal", organisation: @chips_org, created_at: Date.new(2010, 10, 10))
     @anne = create(:superadmin_user, name: "Anne", email: "anne@anne.com", organisation: @ketchup_org, created_at: Date.new(2010, 10, 10))
-    @mary = create(:user, name: "Mary", email: "mary@mary.com", role: "admin", organisation: @brown_sauce_org, created_at: Date.new(2000, 1, 1))
+    @mary = create(:admin_user, name: "Mary", email: "mary@mary.com", organisation: @brown_sauce_org, created_at: Date.new(2000, 1, 1))
 
     # give bill multiple suspensions
     create(:event_log, uid: @bill.uid, event_id: EventLog::ACCOUNT_AUTOSUSPENDED.id, created_at: Date.new(2018, 1, 1))

--- a/test/lib/user_suspensions_exporter_test.rb
+++ b/test/lib/user_suspensions_exporter_test.rb
@@ -61,7 +61,7 @@ class UserSuspensionsExporterTest < ActionView::TestCase
     csv_data = CSV.read(@tmpfile.path)
 
     assert_equal ["Name", "Email", "Organisation", "Role", "Created at", "Auto-suspended at", "Unsuspended at", "Unsuspended by"], csv_data[0]
-    assert_equal ["Anne", "anne@anne.com", "Ministry of ketchup", "superadmin", "2010-10-10 00:00:00 +0100", "2018-02-01 00:00:00 +0000", "", ""], csv_data[1]
+    assert_equal ["Anne", "anne@anne.com", "Ministry of ketchup", Roles::Superadmin.role_name, "2010-10-10 00:00:00 +0100", "2018-02-01 00:00:00 +0000", "", ""], csv_data[1]
     assert_equal ["Mary", "mary@mary.com", "Ministry of brown sauce", "admin", "2000-01-01 00:00:00 +0000", "2018-03-05 00:00:00 +0000", "", ""], csv_data[2]
     assert_equal 3, csv_data.count
   end
@@ -74,7 +74,7 @@ class UserSuspensionsExporterTest < ActionView::TestCase
     assert_equal ["Name", "Email", "Organisation", "Role", "Created at", "Auto-suspended at", "Unsuspended at", "Unsuspended by"], csv_data[0]
     assert_equal ["Bill", "bill@bill.com", "Ministry of chips", "normal", "2010-10-10 00:00:00 +0100", "2018-01-01 00:00:00 +0000", "2018-01-15 00:00:00 +0000", "anne@anne.com"], csv_data[1]
     assert_equal ["Bill", "bill@bill.com", "Ministry of chips", "normal", "2010-10-10 00:00:00 +0100", "2018-01-16 00:00:00 +0000", "2018-01-31 00:00:00 +0000", "mary@mary.com"], csv_data[2]
-    assert_equal ["Anne", "anne@anne.com", "Ministry of ketchup", "superadmin", "2010-10-10 00:00:00 +0100", "2018-02-01 00:00:00 +0000", "", ""], csv_data[3]
+    assert_equal ["Anne", "anne@anne.com", "Ministry of ketchup", Roles::Superadmin.role_name, "2010-10-10 00:00:00 +0100", "2018-02-01 00:00:00 +0000", "", ""], csv_data[3]
     assert_equal 4, csv_data.count
   end
 
@@ -86,7 +86,7 @@ class UserSuspensionsExporterTest < ActionView::TestCase
     assert_equal ["Name", "Email", "Organisation", "Role", "Created at", "Auto-suspended at", "Unsuspended at", "Unsuspended by"], csv_data[0]
     assert_equal ["Bill", "bill@bill.com", "Ministry of chips", "normal", "2010-10-10 00:00:00 +0100", "2018-01-01 00:00:00 +0000", "2018-01-15 00:00:00 +0000", "anne@anne.com"], csv_data[1]
     assert_equal ["Bill", "bill@bill.com", "Ministry of chips", "normal", "2010-10-10 00:00:00 +0100", "2018-01-16 00:00:00 +0000", "2018-01-31 00:00:00 +0000", "mary@mary.com"], csv_data[2]
-    assert_equal ["Anne", "anne@anne.com", "Ministry of ketchup", "superadmin", "2010-10-10 00:00:00 +0100", "2018-02-01 00:00:00 +0000", "", ""], csv_data[3]
+    assert_equal ["Anne", "anne@anne.com", "Ministry of ketchup", Roles::Superadmin.role_name, "2010-10-10 00:00:00 +0100", "2018-02-01 00:00:00 +0000", "", ""], csv_data[3]
     assert_equal ["Mary", "mary@mary.com", "Ministry of brown sauce", "admin", "2000-01-01 00:00:00 +0000", "2018-03-05 00:00:00 +0000", "", ""], csv_data[4]
     assert_equal 5, csv_data.count
   end

--- a/test/models/bulk_grant_permission_set_test.rb
+++ b/test/models/bulk_grant_permission_set_test.rb
@@ -52,7 +52,7 @@ class BulkGrantPermissionSetTest < ActiveSupport::TestCase
       user = create(:user)
       admin_user = create(:admin_user)
       superadmin_user = create(:superadmin_user)
-      orgadmin_user = create(:organisation_admin)
+      orgadmin_user = create(:organisation_admin_user)
 
       @permission_set.perform
 

--- a/test/models/doorkeeper_application_test.rb
+++ b/test/models/doorkeeper_application_test.rb
@@ -49,13 +49,13 @@ class ::Doorkeeper::ApplicationTest < ActiveSupport::TestCase
 
     should "only show permissions that organisation admins themselves have" do
       app = create(:application, with_delegatable_supported_permissions: %w[write approve])
-      organisation_admin = create(:organisation_admin, with_permissions: { app => %w[write] })
+      organisation_admin = create(:organisation_admin_user, with_permissions: { app => %w[write] })
 
       assert_equal %w[write], app.supported_permission_strings(organisation_admin)
     end
 
     should "only show delegatable permissions to organisation admins" do
-      user = create(:organisation_admin)
+      user = create(:organisation_admin_user)
       app = create(:application, with_delegatable_supported_permissions: %w[write], with_supported_permissions: %w[approve])
       user.grant_application_permissions(app, %w[write approve])
 

--- a/test/models/doorkeeper_application_test.rb
+++ b/test/models/doorkeeper_application_test.rb
@@ -34,13 +34,13 @@ class ::Doorkeeper::ApplicationTest < ActiveSupport::TestCase
 
     should "only show permissions that super organisation admins themselves have" do
       app = create(:application, with_delegatable_supported_permissions: %w[write approve])
-      super_org_admin = create(:super_org_admin, with_permissions: { app => %w[write] })
+      super_org_admin = create(:super_organisation_admin_user, with_permissions: { app => %w[write] })
 
       assert_equal %w[write], app.supported_permission_strings(super_org_admin)
     end
 
     should "only show delegatable permissions to super organisation admins" do
-      super_org_admin = create(:super_org_admin)
+      super_org_admin = create(:super_organisation_admin_user)
       app = create(:application, with_delegatable_supported_permissions: %w[write], with_supported_permissions: %w[approve])
       super_org_admin.grant_application_permissions(app, %w[write approve])
 

--- a/test/models/event_log_test.rb
+++ b/test/models/event_log_test.rb
@@ -70,7 +70,7 @@ class EventLogTest < ActiveSupport::TestCase
   test "records role changes with the details of the roles" do
     user = create(:user, email: "new@example.com")
     admin = create(:admin_user)
-    event_log = EventLog.record_role_change(user, "admin", "superadmin", admin)
+    event_log = EventLog.record_role_change(user, "admin", Roles::Superadmin.role_name, admin)
 
     assert_equal "from admin to superadmin", event_log.trailing_message
   end

--- a/test/models/event_log_test.rb
+++ b/test/models/event_log_test.rb
@@ -70,7 +70,7 @@ class EventLogTest < ActiveSupport::TestCase
   test "records role changes with the details of the roles" do
     user = create(:user, email: "new@example.com")
     admin = create(:admin_user)
-    event_log = EventLog.record_role_change(user, "admin", Roles::Superadmin.role_name, admin)
+    event_log = EventLog.record_role_change(user, Roles::Admin.role_name, Roles::Superadmin.role_name, admin)
 
     assert_equal "from admin to superadmin", event_log.trailing_message
   end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -36,13 +36,13 @@ class UserTest < ActiveSupport::TestCase
 
     should "default to true when a user is promoted to superadmin" do
       user = create(:user)
-      user.update!(role: "superadmin")
+      user.update!(role: Roles::Superadmin.role_name)
       assert user.require_2sv?
     end
 
     should "default to true when an admin is promoted to superadmin" do
       user = create(:admin_user)
-      user.update!(role: "superadmin")
+      user.update!(role: Roles::Superadmin.role_name)
       assert user.require_2sv?
     end
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -60,7 +60,7 @@ class UserTest < ActiveSupport::TestCase
 
     should "default to true when a user is promoted to super organisation admin" do
       user = create(:user_in_organisation)
-      user.update!(role: "super_organisation_admin")
+      user.update!(role: Roles::SuperOrganisationAdmin.role_name)
       assert user.require_2sv?
     end
 
@@ -529,7 +529,7 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test "super organisation admin must belong to an organisation" do
-    user = build(:user, role: "super_organisation_admin", organisation_id: nil)
+    user = build(:user, role: Roles::SuperOrganisationAdmin.role_name, organisation_id: nil)
 
     assert_not user.valid?
     assert_equal "can't be 'None' for Super Organisation Admin", user.errors[:organisation_id].first

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -30,7 +30,7 @@ class UserTest < ActiveSupport::TestCase
 
     should "default to true when a user is promoted to admin" do
       user = create(:user)
-      user.update!(role: "admin")
+      user.update!(role: Roles::Admin.role_name)
       assert user.require_2sv?
     end
 
@@ -119,7 +119,7 @@ class UserTest < ActiveSupport::TestCase
 
       context "when promoting a user" do
         should "be true" do
-          @user.update!(role: "admin")
+          @user.update!(role: Roles::Admin.role_name)
 
           assert @user.send_two_step_mandated_notification?
         end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -54,7 +54,7 @@ class UserTest < ActiveSupport::TestCase
 
     should "default to true when a user is promoted to organisation admin" do
       user = create(:user_in_organisation)
-      user.update!(role: "organisation_admin")
+      user.update!(role: Roles::OrganisationAdmin.role_name)
       assert user.require_2sv?
     end
 
@@ -522,7 +522,7 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test "organisation admin must belong to an organisation" do
-    user = build(:user, role: "organisation_admin", organisation_id: nil)
+    user = build(:user, role: Roles::OrganisationAdmin.role_name, organisation_id: nil)
 
     assert_not user.valid?
     assert_equal "can't be 'None' for Organisation Admin", user.errors[:organisation_id].first

--- a/test/policies/api_user_policy_test.rb
+++ b/test/policies/api_user_policy_test.rb
@@ -10,7 +10,7 @@ class ApiUserPolicyTest < ActiveSupport::TestCase
         assert permit?(create(:superadmin_user), User, permission_name)
 
         assert forbid?(create(:admin_user), User, permission_name)
-        assert forbid?(create(:super_org_admin), User, permission_name)
+        assert forbid?(create(:super_organisation_admin_user), User, permission_name)
         assert forbid?(create(:organisation_admin), User, permission_name)
         assert forbid?(create(:user), User, permission_name)
       end

--- a/test/policies/api_user_policy_test.rb
+++ b/test/policies/api_user_policy_test.rb
@@ -11,7 +11,7 @@ class ApiUserPolicyTest < ActiveSupport::TestCase
 
         assert forbid?(create(:admin_user), User, permission_name)
         assert forbid?(create(:super_organisation_admin_user), User, permission_name)
-        assert forbid?(create(:organisation_admin), User, permission_name)
+        assert forbid?(create(:organisation_admin_user), User, permission_name)
         assert forbid?(create(:user), User, permission_name)
       end
     end

--- a/test/policies/application_policy_test.rb
+++ b/test/policies/application_policy_test.rb
@@ -11,7 +11,7 @@ class ApplicationPolicyTest < ActiveSupport::TestCase
 
         assert forbid?(create(:admin_user), User, permission_name)
         assert forbid?(create(:super_organisation_admin_user), User, permission_name)
-        assert forbid?(create(:organisation_admin), User, permission_name)
+        assert forbid?(create(:organisation_admin_user), User, permission_name)
         assert forbid?(create(:user), User, permission_name)
       end
     end

--- a/test/policies/application_policy_test.rb
+++ b/test/policies/application_policy_test.rb
@@ -10,7 +10,7 @@ class ApplicationPolicyTest < ActiveSupport::TestCase
         assert permit?(create(:superadmin_user), User, permission_name)
 
         assert forbid?(create(:admin_user), User, permission_name)
-        assert forbid?(create(:super_org_admin), User, permission_name)
+        assert forbid?(create(:super_organisation_admin_user), User, permission_name)
         assert forbid?(create(:organisation_admin), User, permission_name)
         assert forbid?(create(:user), User, permission_name)
       end

--- a/test/policies/batch_invitation_policy_test.rb
+++ b/test/policies/batch_invitation_policy_test.rb
@@ -28,7 +28,7 @@ class BatchInvitationPolicyTest < ActiveSupport::TestCase
       assert permit?(create(:superadmin_user), User, :assign_organisation_from_csv)
       assert permit?(create(:admin_user), User, :assign_organisation_from_csv)
 
-      assert forbid?(create(:super_org_admin), User, :assign_organisation_from_csv)
+      assert forbid?(create(:super_organisation_admin_user), User, :assign_organisation_from_csv)
       assert forbid?(create(:organisation_admin), User, :assign_organisation_from_csv)
       assert forbid?(create(:user), User, :assign_organisation_from_csv)
     end

--- a/test/policies/batch_invitation_policy_test.rb
+++ b/test/policies/batch_invitation_policy_test.rb
@@ -11,7 +11,7 @@ class BatchInvitationPolicyTest < ActiveSupport::TestCase
     end
 
     should "forbid organisation admins to create new batch uploads even within their organisation subtree" do
-      organisation_admin = create(:organisation_admin)
+      organisation_admin = create(:organisation_admin_user)
 
       assert forbid?(organisation_admin, BatchInvitation.new, :new)
       assert forbid?(organisation_admin, BatchInvitation.new(organisation_id: create(:organisation).id), :new)
@@ -29,7 +29,7 @@ class BatchInvitationPolicyTest < ActiveSupport::TestCase
       assert permit?(create(:admin_user), User, :assign_organisation_from_csv)
 
       assert forbid?(create(:super_organisation_admin_user), User, :assign_organisation_from_csv)
-      assert forbid?(create(:organisation_admin), User, :assign_organisation_from_csv)
+      assert forbid?(create(:organisation_admin_user), User, :assign_organisation_from_csv)
       assert forbid?(create(:user), User, :assign_organisation_from_csv)
     end
   end

--- a/test/policies/bulk_grant_permission_set_policy_test.rb
+++ b/test/policies/bulk_grant_permission_set_policy_test.rb
@@ -9,7 +9,7 @@ class BulkGrantPermissionSetPolicyTest < ActiveSupport::TestCase
       assert permit?(create(:superadmin_user), User, :new)
       assert permit?(create(:admin_user), User, :new)
 
-      assert forbid?(create(:super_org_admin), User, :new)
+      assert forbid?(create(:super_organisation_admin_user), User, :new)
       assert forbid?(create(:organisation_admin), User, :new)
       assert forbid?(create(:user), User, :new)
     end

--- a/test/policies/bulk_grant_permission_set_policy_test.rb
+++ b/test/policies/bulk_grant_permission_set_policy_test.rb
@@ -10,7 +10,7 @@ class BulkGrantPermissionSetPolicyTest < ActiveSupport::TestCase
       assert permit?(create(:admin_user), User, :new)
 
       assert forbid?(create(:super_organisation_admin_user), User, :new)
-      assert forbid?(create(:organisation_admin), User, :new)
+      assert forbid?(create(:organisation_admin_user), User, :new)
       assert forbid?(create(:user), User, :new)
     end
   end

--- a/test/policies/organisation_policy_scope_test.rb
+++ b/test/policies/organisation_policy_scope_test.rb
@@ -40,7 +40,7 @@ class OrganisationPolicyScopeTest < ActiveSupport::TestCase
     end
 
     should "is empty for organisation admins" do
-      user = create(:organisation_admin, organisation: @parent_organisation)
+      user = create(:organisation_admin_user, organisation: @parent_organisation)
       resolved_scope = OrganisationPolicy::Scope.new(user, Organisation.all).resolve
       assert_empty resolved_scope
     end

--- a/test/policies/organisation_policy_scope_test.rb
+++ b/test/policies/organisation_policy_scope_test.rb
@@ -34,7 +34,7 @@ class OrganisationPolicyScopeTest < ActiveSupport::TestCase
     end
 
     should "is empty for super organisation admins" do
-      user = create(:super_org_admin, organisation: @parent_organisation)
+      user = create(:super_organisation_admin_user, organisation: @parent_organisation)
       resolved_scope = OrganisationPolicy::Scope.new(user, Organisation.all).resolve
       assert_empty resolved_scope
     end

--- a/test/policies/organisation_policy_test.rb
+++ b/test/policies/organisation_policy_test.rb
@@ -10,7 +10,7 @@ class OrganisationPolicyTest < ActiveSupport::TestCase
       assert permit?(create(:admin_user), User, :index)
 
       assert forbid?(create(:super_organisation_admin_user), User, :index)
-      assert forbid?(create(:organisation_admin), User, :index)
+      assert forbid?(create(:organisation_admin_user), User, :index)
       assert forbid?(create(:user), User, :index)
     end
   end
@@ -21,7 +21,7 @@ class OrganisationPolicyTest < ActiveSupport::TestCase
 
       assert forbid?(create(:admin_user), User, :edit)
       assert forbid?(create(:super_organisation_admin_user), User, :edit)
-      assert forbid?(create(:organisation_admin), User, :edit)
+      assert forbid?(create(:organisation_admin_user), User, :edit)
       assert forbid?(create(:user), User, :edit)
     end
   end
@@ -46,7 +46,7 @@ class OrganisationPolicyTest < ActiveSupport::TestCase
     end
 
     should "forbid for organisation admins" do
-      organisation_admin = create(:organisation_admin)
+      organisation_admin = create(:organisation_admin_user)
       admins_organisation = organisation_admin.organisation
       child_organisation = create(:organisation, parent_id: admins_organisation.id)
 

--- a/test/policies/organisation_policy_test.rb
+++ b/test/policies/organisation_policy_test.rb
@@ -9,7 +9,7 @@ class OrganisationPolicyTest < ActiveSupport::TestCase
       assert permit?(create(:superadmin_user), User, :index)
       assert permit?(create(:admin_user), User, :index)
 
-      assert forbid?(create(:super_org_admin), User, :index)
+      assert forbid?(create(:super_organisation_admin_user), User, :index)
       assert forbid?(create(:organisation_admin), User, :index)
       assert forbid?(create(:user), User, :index)
     end
@@ -20,7 +20,7 @@ class OrganisationPolicyTest < ActiveSupport::TestCase
       assert permit?(create(:superadmin_user), User, :edit)
 
       assert forbid?(create(:admin_user), User, :edit)
-      assert forbid?(create(:super_org_admin), User, :edit)
+      assert forbid?(create(:super_organisation_admin_user), User, :edit)
       assert forbid?(create(:organisation_admin), User, :edit)
       assert forbid?(create(:user), User, :edit)
     end
@@ -33,7 +33,7 @@ class OrganisationPolicyTest < ActiveSupport::TestCase
     end
 
     should "forbid for super organisation admins" do
-      super_org_admin = create(:super_org_admin)
+      super_org_admin = create(:super_organisation_admin_user)
       admins_organisation = super_org_admin.organisation
       child_organisation = create(:organisation, parent_id: admins_organisation.id)
 

--- a/test/policies/organisation_policy_test.rb
+++ b/test/policies/organisation_policy_test.rb
@@ -28,7 +28,7 @@ class OrganisationPolicyTest < ActiveSupport::TestCase
 
   context "can_assign" do
     should "allow superadmins and admins to assign a user to any organisation" do
-      assert permit?(create(:user_in_organisation, role: "superadmin"), build(:organisation), :can_assign)
+      assert permit?(create(:user_in_organisation, role: Roles::Superadmin.role_name), build(:organisation), :can_assign)
       assert permit?(create(:user_in_organisation, role: "admin"), build(:organisation), :can_assign)
     end
 

--- a/test/policies/organisation_policy_test.rb
+++ b/test/policies/organisation_policy_test.rb
@@ -29,7 +29,7 @@ class OrganisationPolicyTest < ActiveSupport::TestCase
   context "can_assign" do
     should "allow superadmins and admins to assign a user to any organisation" do
       assert permit?(create(:user_in_organisation, role: Roles::Superadmin.role_name), build(:organisation), :can_assign)
-      assert permit?(create(:user_in_organisation, role: "admin"), build(:organisation), :can_assign)
+      assert permit?(create(:user_in_organisation, role: Roles::Admin.role_name), build(:organisation), :can_assign)
     end
 
     should "forbid for super organisation admins" do

--- a/test/policies/supported_permission_policy_scope_test.rb
+++ b/test/policies/supported_permission_policy_scope_test.rb
@@ -70,7 +70,7 @@ class SupportedPermissionPolicyScopeTest < ActiveSupport::TestCase
 
     context "super organisation admins" do
       setup do
-        user = create(:super_org_admin).tap do |u|
+        user = create(:super_organisation_admin_user).tap do |u|
           u.grant_application_permission(@app_one, "signin")
           u.grant_application_permission(@app_two, "signin")
         end

--- a/test/policies/supported_permission_policy_scope_test.rb
+++ b/test/policies/supported_permission_policy_scope_test.rb
@@ -103,7 +103,7 @@ class SupportedPermissionPolicyScopeTest < ActiveSupport::TestCase
 
     context "organisation admins" do
       setup do
-        user = create(:organisation_admin).tap do |u|
+        user = create(:organisation_admin_user).tap do |u|
           u.grant_application_permission(@app_one, "signin")
           u.grant_application_permission(@app_two, "signin")
         end

--- a/test/policies/user_permission_manageable_application_policy_scope_test.rb
+++ b/test/policies/user_permission_manageable_application_policy_scope_test.rb
@@ -34,7 +34,7 @@ class UserPermissionManageableApplicationPolicyScopeTest < ActiveSupport::TestCa
 
     context "super organisation admins" do
       setup do
-        user = create(:super_org_admin).tap do |u|
+        user = create(:super_organisation_admin_user).tap do |u|
           u.grant_application_permission(@app_one, "signin")
           u.grant_application_permission(@app_two, "signin")
         end

--- a/test/policies/user_permission_manageable_application_policy_scope_test.rb
+++ b/test/policies/user_permission_manageable_application_policy_scope_test.rb
@@ -58,7 +58,7 @@ class UserPermissionManageableApplicationPolicyScopeTest < ActiveSupport::TestCa
 
     context "for organisation admins" do
       setup do
-        user = create(:organisation_admin).tap do |u|
+        user = create(:organisation_admin_user).tap do |u|
           u.grant_application_permission(@app_one, "signin")
           u.grant_application_permission(@app_two, "signin")
         end

--- a/test/policies/user_policy_scope_test.rb
+++ b/test/policies/user_policy_scope_test.rb
@@ -9,19 +9,19 @@ class UserPolicyScopeTest < ActiveSupport::TestCase
     @super_admin_in_org = create(:superadmin_user, organisation: @parent_organisation)
     @admin_in_org = create(:admin_user, organisation: @parent_organisation)
     @super_org_admin_in_org = create(:super_organisation_admin_user, organisation: @parent_organisation)
-    @org_admin_in_org = create(:organisation_admin, organisation: @parent_organisation)
+    @org_admin_in_org = create(:organisation_admin_user, organisation: @parent_organisation)
     @normal_user_in_org = create(:user_in_organisation, organisation: @parent_organisation)
 
     @super_admin_in_child_org = create(:superadmin_user, organisation: @child_organisation)
     @admin_in_child_org = create(:admin_user, organisation: @child_organisation)
     @super_org_admin_in_child_org = create(:super_organisation_admin_user, organisation: @child_organisation)
-    @org_admin_in_child_org = create(:organisation_admin, organisation: @child_organisation)
+    @org_admin_in_child_org = create(:organisation_admin_user, organisation: @child_organisation)
     @normal_user_in_child_org = create(:user_in_organisation, organisation: @child_organisation)
 
     @super_admin_in_other_org = create(:superadmin_user, organisation: @other_organisation)
     @admin_in_other_org = create(:admin_user, organisation: @other_organisation)
     @super_org_admin_in_other_org = create(:super_organisation_admin_user, organisation: @other_organisation)
-    @org_admin_in_other_org = create(:organisation_admin, organisation: @other_organisation)
+    @org_admin_in_other_org = create(:organisation_admin_user, organisation: @other_organisation)
     @normal_user_in_other_org = create(:user_in_organisation, organisation: @other_organisation)
 
     @api_user = create(:api_user)
@@ -142,7 +142,7 @@ class UserPolicyScopeTest < ActiveSupport::TestCase
 
   context "organisation admins" do
     should "includes users of similar permission or below belonging to their organisation" do
-      user = create(:organisation_admin, organisation: @parent_organisation)
+      user = create(:organisation_admin_user, organisation: @parent_organisation)
       resolved_scope = UserPolicy::Scope.new(user, User.all).resolve
 
       assert_not_includes resolved_scope, @super_admin_in_org
@@ -153,7 +153,7 @@ class UserPolicyScopeTest < ActiveSupport::TestCase
     end
 
     should "does not include users of similar permission or below belonging to a child organisation" do
-      user = create(:organisation_admin, organisation: @parent_organisation)
+      user = create(:organisation_admin_user, organisation: @parent_organisation)
       resolved_scope = UserPolicy::Scope.new(user, User.all).resolve
 
       assert_not_includes resolved_scope, @super_admin_in_child_org
@@ -164,7 +164,7 @@ class UserPolicyScopeTest < ActiveSupport::TestCase
     end
 
     should "does not include users of similar permission or below belonging to another organisation" do
-      user = create(:organisation_admin, organisation: @parent_organisation)
+      user = create(:organisation_admin_user, organisation: @parent_organisation)
       resolved_scope = UserPolicy::Scope.new(user, User.all).resolve
 
       assert_not_includes resolved_scope, @super_admin_in_other_org
@@ -175,7 +175,7 @@ class UserPolicyScopeTest < ActiveSupport::TestCase
     end
 
     should "does not include api users" do
-      user = create(:organisation_admin, organisation: @parent_organisation)
+      user = create(:organisation_admin_user, organisation: @parent_organisation)
       resolved_scope = UserPolicy::Scope.new(user, User.all).resolve
       assert_not_includes resolved_scope, @api_user
     end

--- a/test/policies/user_policy_scope_test.rb
+++ b/test/policies/user_policy_scope_test.rb
@@ -8,19 +8,19 @@ class UserPolicyScopeTest < ActiveSupport::TestCase
 
     @super_admin_in_org = create(:superadmin_user, organisation: @parent_organisation)
     @admin_in_org = create(:admin_user, organisation: @parent_organisation)
-    @super_org_admin_in_org = create(:super_org_admin, organisation: @parent_organisation)
+    @super_org_admin_in_org = create(:super_organisation_admin_user, organisation: @parent_organisation)
     @org_admin_in_org = create(:organisation_admin, organisation: @parent_organisation)
     @normal_user_in_org = create(:user_in_organisation, organisation: @parent_organisation)
 
     @super_admin_in_child_org = create(:superadmin_user, organisation: @child_organisation)
     @admin_in_child_org = create(:admin_user, organisation: @child_organisation)
-    @super_org_admin_in_child_org = create(:super_org_admin, organisation: @child_organisation)
+    @super_org_admin_in_child_org = create(:super_organisation_admin_user, organisation: @child_organisation)
     @org_admin_in_child_org = create(:organisation_admin, organisation: @child_organisation)
     @normal_user_in_child_org = create(:user_in_organisation, organisation: @child_organisation)
 
     @super_admin_in_other_org = create(:superadmin_user, organisation: @other_organisation)
     @admin_in_other_org = create(:admin_user, organisation: @other_organisation)
-    @super_org_admin_in_other_org = create(:super_org_admin, organisation: @other_organisation)
+    @super_org_admin_in_other_org = create(:super_organisation_admin_user, organisation: @other_organisation)
     @org_admin_in_other_org = create(:organisation_admin, organisation: @other_organisation)
     @normal_user_in_other_org = create(:user_in_organisation, organisation: @other_organisation)
 
@@ -101,7 +101,7 @@ class UserPolicyScopeTest < ActiveSupport::TestCase
 
   context "super organisation admins" do
     should "includes users of similar permission or below belonging to their organisation" do
-      user = create(:super_org_admin, organisation: @parent_organisation)
+      user = create(:super_organisation_admin_user, organisation: @parent_organisation)
       resolved_scope = UserPolicy::Scope.new(user, User.all).resolve
 
       assert_not_includes resolved_scope, @super_admin_in_org
@@ -112,7 +112,7 @@ class UserPolicyScopeTest < ActiveSupport::TestCase
     end
 
     should "includes users of similar permission or below belonging to a child organisation" do
-      user = create(:super_org_admin, organisation: @parent_organisation)
+      user = create(:super_organisation_admin_user, organisation: @parent_organisation)
       resolved_scope = UserPolicy::Scope.new(user, User.all).resolve
 
       assert_not_includes resolved_scope, @super_admin_in_child_org
@@ -123,7 +123,7 @@ class UserPolicyScopeTest < ActiveSupport::TestCase
     end
 
     should "does not include users of similar permission or below belonging to another organisation" do
-      user = create(:super_org_admin, organisation: @parent_organisation)
+      user = create(:super_organisation_admin_user, organisation: @parent_organisation)
       resolved_scope = UserPolicy::Scope.new(user, User.all).resolve
 
       assert_not_includes resolved_scope, @super_admin_in_other_org
@@ -134,7 +134,7 @@ class UserPolicyScopeTest < ActiveSupport::TestCase
     end
 
     should "does not include api users" do
-      user = create(:super_org_admin, organisation: @parent_organisation)
+      user = create(:super_organisation_admin_user, organisation: @parent_organisation)
       resolved_scope = UserPolicy::Scope.new(user, User.all).resolve
       assert_not_includes resolved_scope, @api_user
     end

--- a/test/policies/user_policy_test.rb
+++ b/test/policies/user_policy_test.rb
@@ -7,7 +7,7 @@ class UserPolicyTest < ActiveSupport::TestCase
   setup do
     @parent_organisation = create :organisation
     @child_organisation = create(:organisation, parent: @parent_organisation)
-    @super_org_admin = create(:super_org_admin, organisation: @parent_organisation)
+    @super_org_admin = create(:super_organisation_admin_user, organisation: @parent_organisation)
     @organisation_admin = create(:organisation_admin, organisation: @parent_organisation)
     @gds = create(:organisation, name: "Government Digital Services", content_id: Organisation::GDS_ORG_CONTENT_ID)
   end
@@ -39,7 +39,7 @@ class UserPolicyTest < ActiveSupport::TestCase
 
         assert permit?(user, build(:user), permission)
         assert permit?(user, build(:organisation_admin), permission)
-        assert permit?(user, build(:super_org_admin), permission)
+        assert permit?(user, build(:super_organisation_admin_user), permission)
         assert permit?(user, build(:admin_user), permission)
         assert permit?(user, build(:superadmin_user), permission)
       end
@@ -91,7 +91,7 @@ class UserPolicyTest < ActiveSupport::TestCase
 
         assert permit?(user, build(:user), permission)
         assert permit?(user, build(:organisation_admin), permission)
-        assert permit?(user, build(:super_org_admin), permission)
+        assert permit?(user, build(:super_organisation_admin_user), permission)
         assert permit?(user, build(:admin_user), permission)
         assert forbid?(user, build(:superadmin_user), permission)
       end
@@ -123,16 +123,16 @@ class UserPolicyTest < ActiveSupport::TestCase
 
   context "super organisation admins" do
     should "allow for index" do
-      assert permit?(build(:super_org_admin), User, :index)
+      assert permit?(build(:super_organisation_admin_user), User, :index)
     end
 
     should "not allow for create" do
-      assert forbid?(build(:super_org_admin), User, :create)
+      assert forbid?(build(:super_organisation_admin_user), User, :create)
     end
 
     primary_management_actions.each do |permission|
       should "not allow for #{permission}" do
-        assert forbid?(build(:super_org_admin), User, permission)
+        assert forbid?(build(:super_organisation_admin_user), User, permission)
       end
     end
 
@@ -140,7 +140,7 @@ class UserPolicyTest < ActiveSupport::TestCase
       should "allow for #{permission} and users of similar permissions or below from within their own organisation" do
         assert permit?(@super_org_admin, build(:user_in_organisation, organisation: @super_org_admin.organisation), permission)
         assert permit?(@super_org_admin, build(:organisation_admin, organisation: @super_org_admin.organisation), permission)
-        assert permit?(@super_org_admin, build(:super_org_admin, organisation: @super_org_admin.organisation), permission)
+        assert permit?(@super_org_admin, build(:super_organisation_admin_user, organisation: @super_org_admin.organisation), permission)
 
         assert forbid?(@super_org_admin, build(:superadmin_user), permission)
         assert forbid?(@super_org_admin, build(:admin_user), permission)
@@ -149,7 +149,7 @@ class UserPolicyTest < ActiveSupport::TestCase
       should "allow for #{permission} and users of similar permissions or below from within their own organisation's subtree" do
         assert permit?(@super_org_admin, build(:user_in_organisation, organisation: @child_organisation), permission)
         assert permit?(@super_org_admin, build(:organisation_admin, organisation: @child_organisation), permission)
-        assert permit?(@super_org_admin, build(:super_org_admin, organisation: @child_organisation), permission)
+        assert permit?(@super_org_admin, build(:super_organisation_admin_user, organisation: @child_organisation), permission)
 
         assert forbid?(@super_org_admin, build(:superadmin_user, organisation: @child_organisation), permission)
         assert forbid?(@super_org_admin, build(:admin_user, organisation: @child_organisation), permission)
@@ -157,7 +157,7 @@ class UserPolicyTest < ActiveSupport::TestCase
 
       should "not allow for #{permission} and users from other organisations" do
         assert forbid?(@super_org_admin, build(:organisation_admin), permission)
-        assert forbid?(@super_org_admin, build(:super_org_admin), permission)
+        assert forbid?(@super_org_admin, build(:super_organisation_admin_user), permission)
         assert forbid?(@super_org_admin, build(:admin_user), permission)
         assert forbid?(@super_org_admin, build(:superadmin_user), permission)
         assert forbid?(@super_org_admin, build(:user_in_organisation), permission)
@@ -166,14 +166,14 @@ class UserPolicyTest < ActiveSupport::TestCase
 
     superadmin_actions.each do |permission|
       should "not allow for #{permission}" do
-        assert forbid?(create(:super_org_admin), User, permission)
+        assert forbid?(create(:super_organisation_admin_user), User, permission)
       end
     end
 
     two_step_verification_exemption_actions.each do |permission|
       should "not allow for #{permission}" do
-        user = create(:super_org_admin)
-        assert forbid?(create(:super_org_admin), user, permission)
+        user = create(:super_organisation_admin_user)
+        assert forbid?(create(:super_organisation_admin_user), user, permission)
       end
     end
   end
@@ -198,7 +198,7 @@ class UserPolicyTest < ActiveSupport::TestCase
         assert permit?(@organisation_admin, build(:user_in_organisation, organisation: @organisation_admin.organisation), permission)
         assert permit?(@organisation_admin, build(:organisation_admin, organisation: @organisation_admin.organisation), permission)
 
-        assert forbid?(@organisation_admin, build(:super_org_admin, organisation: @organisation_admin.organisation), permission)
+        assert forbid?(@organisation_admin, build(:super_organisation_admin_user, organisation: @organisation_admin.organisation), permission)
         assert forbid?(@organisation_admin, build(:superadmin_user), permission)
         assert forbid?(@organisation_admin, build(:admin_user), permission)
       end
@@ -206,14 +206,14 @@ class UserPolicyTest < ActiveSupport::TestCase
       should "allow for #{permission} and users of similar permissions or below from within their own organisation's subtree" do
         assert forbid?(@organisation_admin, build(:user_in_organisation, organisation: @child_organisation), permission)
         assert forbid?(@organisation_admin, build(:organisation_admin, organisation: @child_organisation), permission)
-        assert forbid?(@organisation_admin, build(:super_org_admin, organisation: @child_organisation), permission)
+        assert forbid?(@organisation_admin, build(:super_organisation_admin_user, organisation: @child_organisation), permission)
         assert forbid?(@organisation_admin, build(:superadmin_user, organisation: @child_organisation), permission)
         assert forbid?(@organisation_admin, build(:admin_user, organisation: @child_organisation), permission)
       end
 
       should "not allow for #{permission} and users from other organisations" do
         assert forbid?(@organisation_admin, build(:organisation_admin), permission)
-        assert forbid?(@organisation_admin, build(:super_org_admin), permission)
+        assert forbid?(@organisation_admin, build(:super_organisation_admin_user), permission)
         assert forbid?(@organisation_admin, build(:admin_user), permission)
         assert forbid?(@organisation_admin, build(:superadmin_user), permission)
         assert forbid?(@organisation_admin, build(:user_in_organisation), permission)
@@ -250,7 +250,7 @@ class UserPolicyTest < ActiveSupport::TestCase
         user = create(:user)
         assert forbid?(user, build(:user), permission)
         assert forbid?(user, build(:organisation_admin), permission)
-        assert forbid?(user, build(:super_org_admin), permission)
+        assert forbid?(user, build(:super_organisation_admin_user), permission)
         assert forbid?(user, build(:admin_user), permission)
         assert forbid?(user, build(:superadmin_user), permission)
       end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -47,6 +47,11 @@ class ActionController::TestCase
     warden.unstub(:session)
     @controller.unstub(:current_user)
   end
+
+  def assert_not_authorised
+    assert_redirected_to root_path
+    assert_equal "You do not have permission to perform this action.", flash[:alert]
+  end
 end
 
 # Capybara.server = :webrick


### PR DESCRIPTION
I made these refactoring changes while working on #2334. I think they're useful in their own right so I'm opening them as a separate PR.

See the individual commits for more detail but in summary:

- Extract `Roles#govuk_admin?` to encapsulate the concept of a user with either of the `superadmin` or `admin` roles.
- Extract `Roles#publishing_manager?` to encapsulate the concept of a user with either of the `super_organisation_admin` or `organisation_admin` roles.
- Rename `super_org_admin` and `organisation_admin` User factories, to `super_organisation_admin_user` and `organisation_admin_user` respectively, so that they're consistent with the naming of the `superadmin_user` and `admin_user` factories.
- Use the role-specific User factories instead of setting the role manually in the tests (e.g. `create(:super_admin_user)` instead of `create(user, role: 'superadmin')`.
- Use the `Role::<role>#role_name` method to avoid duplicating strings all over the code.