### PR TITLE
Remove <abbr> tag from API Users table

### DIFF
--- a/app/helpers/api_users_helper.rb
+++ b/app/helpers/api_users_helper.rb
@@ -8,15 +8,13 @@ module ApiUsersHelper
     user.suspended? ? content_tag(:del, anchor_tag) : anchor_tag
   end
 
-  def permissions_by_application(user)
+  def application_list(user)
     content_tag(:ul, class: "govuk-list") do
       safe_join(
         visible_applications(user).map do |application|
           next unless user.permissions_for(application).any?
 
-          content_tag(:li) do
-            content_tag(:abbr, application.name, title: "Permissions: #{user.permissions_for(application).to_sentence}")
-          end
+          content_tag(:li, application.name)
         end,
       )
     end

--- a/app/views/api_users/index.html.erb
+++ b/app/views/api_users/index.html.erb
@@ -36,7 +36,7 @@
         text: user.email,
       },
       {
-        text: permissions_by_application(user),
+        text: application_list(user),
       },
       {
         text: user.suspended? ? "Yes" : "No",

--- a/test/integration/manage_api_users_test.rb
+++ b/test/integration/manage_api_users_test.rb
@@ -19,7 +19,7 @@ class ManageApiUsersTest < ActionDispatch::IntegrationTest
       assert page.has_selector?("td", text: @api_user.name)
       assert page.has_selector?("td", text: @api_user.email)
 
-      assert page.has_selector?("abbr", text: @application.name)
+      assert page.has_selector?("td", text: @application.name)
       assert page.has_selector?("td:last-child", text: "No") # suspended?
     end
 
@@ -54,16 +54,26 @@ class ManageApiUsersTest < ActionDispatch::IntegrationTest
       select "Managing Editor", from: "Permissions for Whitehall"
       click_button "Update API user"
 
-      assert page.has_selector?("abbr[title='Permissions: Managing Editor and signin']", text: "Whitehall")
-
       click_link @api_user.name
+
+      within "table#editable-permissions" do
+        # The existence of the <tr> indicates that the API User has "singin"
+        # permission for Whitehall
+        assert has_selector?("tr", text: "Whitehall")
+      end
+      assert has_select?("Permissions for Whitehall", selected: ["Managing Editor"])
 
       unselect "Managing Editor", from: "Permissions for Whitehall"
       click_button "Update API user"
 
-      assert page.has_selector?("abbr[title='Permissions: signin']", text: "Whitehall")
-
       click_link @api_user.name
+
+      within "table#editable-permissions" do
+        # The existence of the <tr> indicates that the API User has "singin"
+        # permission for Whitehall
+        assert has_selector?("tr", text: "Whitehall")
+      end
+
       click_link "Account access log"
       assert page.has_text?("Access token generated for Whitehall by #{@superadmin.name}")
     end

--- a/test/integration/manage_api_users_test.rb
+++ b/test/integration/manage_api_users_test.rb
@@ -56,23 +56,15 @@ class ManageApiUsersTest < ActionDispatch::IntegrationTest
 
       click_link @api_user.name
 
-      within "table#editable-permissions" do
-        # The existence of the <tr> indicates that the API User has "singin"
-        # permission for Whitehall
-        assert has_selector?("tr", text: "Whitehall")
-      end
-      assert has_select?("Permissions for Whitehall", selected: ["Managing Editor"])
+      assert_has_signin_permission_for("Whitehall")
+      assert_has_other_permissions("Whitehall", ["Managing Editor"])
 
       unselect "Managing Editor", from: "Permissions for Whitehall"
       click_button "Update API user"
 
       click_link @api_user.name
 
-      within "table#editable-permissions" do
-        # The existence of the <tr> indicates that the API User has "singin"
-        # permission for Whitehall
-        assert has_selector?("tr", text: "Whitehall")
-      end
+      assert_has_signin_permission_for("Whitehall")
 
       click_link "Account access log"
       assert page.has_text?("Access token generated for Whitehall by #{@superadmin.name}")
@@ -120,5 +112,17 @@ class ManageApiUsersTest < ActionDispatch::IntegrationTest
 
       assert page.has_selector?(".alert-success", text: "#{@api_user.email} is now active.")
     end
+  end
+
+  def assert_has_signin_permission_for(application_name)
+    within "table#editable-permissions" do
+      # The existence of the <tr> indicates that the API User has "singin"
+      # permission for the application
+      assert has_selector?("tr", text: application_name)
+    end
+  end
+
+  def assert_has_other_permissions(application_name, permission_names)
+    assert has_select?("Permissions for #{application_name}", selected: permission_names)
   end
 end


### PR DESCRIPTION
https://trello.com/c/dggyhTVY/62-api-users-page-fix-and-iterate-how-this-page-is-displayed

This tooltip was on our list of things that don't seem like they'd
comply with the design system.

So far I haven't found anybody who uses this feature.

Used to look like this:
![Screenshot from 2023-09-06 16-19-31](https://github.com/alphagov/signon/assets/141013432/87e1e073-39b9-4b40-89da-de9d480586b7)

Now it doesn't:
![Screenshot from 2023-09-06 16-20-51](https://github.com/alphagov/signon/assets/141013432/2bb17488-ff64-434e-b1be-03f6371d489b)
