### PR TITLE
Improve db seeds

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,10 +8,37 @@ gds = Organisation.create!(
 )
 
 User.create!(
+  name: "Test Superadmin",
+  email: "test.superadmin@gov.uk",
+  password: "6fe552ca-d406-4c54-b7a6-041ed1ade6cd",
+  role: :superadmin,
+  confirmed_at: Time.zone.now,
+  organisation: gds,
+)
+
+User.create!(
   name: "Test Admin",
   email: "test.admin@gov.uk",
   password: "6fe552ca-d406-4c54-b7a6-041ed1ade6cd",
-  role: :superadmin,
+  role: :admin,
+  confirmed_at: Time.zone.now,
+  organisation: gds,
+)
+
+User.create!(
+  name: "Test Super Organisation Admin",
+  email: "test.super-organisation-admin@gov.uk",
+  password: "6fe552ca-d406-4c54-b7a6-041ed1ade6cd",
+  role: :super_organisation_admin,
+  confirmed_at: Time.zone.now,
+  organisation: gds,
+)
+
+User.create!(
+  name: "Test Organisation Admin",
+  email: "test.organisation-admin@gov.uk",
+  password: "6fe552ca-d406-4c54-b7a6-041ed1ade6cd",
+  role: :organisation_admin,
   confirmed_at: Time.zone.now,
   organisation: gds,
 )

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -11,7 +11,7 @@ User.create!(
   name: "Test Superadmin",
   email: "test.superadmin@gov.uk",
   password: "6fe552ca-d406-4c54-b7a6-041ed1ade6cd",
-  role: :superadmin,
+  role: Roles::Superadmin.role_name,
   confirmed_at: Time.zone.now,
   organisation: gds,
 )
@@ -20,7 +20,7 @@ User.create!(
   name: "Test Admin",
   email: "test.admin@gov.uk",
   password: "6fe552ca-d406-4c54-b7a6-041ed1ade6cd",
-  role: :admin,
+  role: Roles::Admin.role_name,
   confirmed_at: Time.zone.now,
   organisation: gds,
 )
@@ -29,7 +29,7 @@ User.create!(
   name: "Test Super Organisation Admin",
   email: "test.super-organisation-admin@gov.uk",
   password: "6fe552ca-d406-4c54-b7a6-041ed1ade6cd",
-  role: :super_organisation_admin,
+  role: Roles::SuperOrganisationAdmin.role_name,
   confirmed_at: Time.zone.now,
   organisation: gds,
 )
@@ -38,7 +38,7 @@ User.create!(
   name: "Test Organisation Admin",
   email: "test.organisation-admin@gov.uk",
   password: "6fe552ca-d406-4c54-b7a6-041ed1ade6cd",
-  role: :organisation_admin,
+  role: Roles::OrganisationAdmin.role_name,
   confirmed_at: Time.zone.now,
   organisation: gds,
 )
@@ -63,7 +63,7 @@ User.create!(
   name: "Test User",
   email: "test.user@gov.uk",
   password: "6fe552ca-d406-4c54-b7a6-041ed1ade6cd",
-  role: :normal,
+  role: Roles::Normal.role_name,
   confirmed_at: Time.zone.now,
   organisation: test_organisation_without_2sv,
 )
@@ -99,7 +99,7 @@ User.create!(
   name: "Test User with 2SV enabled",
   email: "test.user.2sv@gov.uk",
   password: "6fe552ca-d406-4c54-b7a6-041ed1ade6cd",
-  role: :normal,
+  role: Roles::Normal.role_name,
   confirmed_at: Time.zone.now,
   organisation: test_organisation_without_2sv,
   require_2sv: true,
@@ -110,7 +110,7 @@ User.create!(
   name: "Test User from organisation with mandatory 2SV",
   email: "test.user.2sv.organisation@gov.uk",
   password: "6fe552ca-d406-4c54-b7a6-041ed1ade6cd",
-  role: :normal,
+  role: Roles::Normal.role_name,
   confirmed_at: Time.zone.now,
   organisation: test_organisation_with_2sv,
   require_2sv: true,
@@ -122,7 +122,7 @@ User.create!(
   api_user: true,
   email: "test.apiuser@gov.uk",
   password: "6fe552ca-d406-4c54-b7a6-041ed1ade6cd",
-  role: :normal,
+  role: Roles::Normal.role_name,
   confirmed_at: Time.zone.now,
   require_2sv: false,
 )


### PR DESCRIPTION
This PR adds the following users to db/seeds to complement the existing test.admin@gov.uk user:

- test.superadmin@gov.uk
- test.super-organisation-admin@gov.uk
- test.organisation-admin@gov.uk

I found the addition of these users useful while playing with the app in development.

I've also removed some duplication by using `Role::<role>#role_name` instead of hardcoded strings.