### PR TITLE
Add a feature flag (disabled) for the user research banner

### DIFF
--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -20,7 +20,9 @@ class RootController < ApplicationController
 private
 
   def show_user_research_recruitment_banner?
-    !cookies[:dismiss_user_research_recruitment_banner] && !current_user.user_research_recruitment_banner_hidden?
+    Rails.application.config.show_user_research_recruitment_banner &&
+      !cookies[:dismiss_user_research_recruitment_banner] &&
+      !current_user.user_research_recruitment_banner_hidden?
   end
   helper_method :show_user_research_recruitment_banner?
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -97,5 +97,7 @@ module Signon
 
       cookies.rotate :encrypted, secret
     end
+
+    config.show_user_research_recruitment_banner = false
   end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -65,4 +65,6 @@ Rails.application.configure do
 
   config.logger = Logger.new($stdout)
   config.log_level = :fatal
+
+  config.show_user_research_recruitment_banner = true
 end


### PR DESCRIPTION
Trello: https://trello.com/c/cOsB2851

We've decided to disable the user research recruitment banner for now. I considered removing all of the relevant code but after talking to Joseph and Chris it seems likely that we'll want to bring this back in a month or two *and* retain the user's preference for hiding it.

I couldn't think of a great way of retaining the data in the `user_research_recruitment_banner_hidden` column on `users` and remind our future selves that we should use this data if we restore the banner from the git history. So instead I've decided to add a feature flag, turned off in production and development, but enabled in test (so we can retain the current test code too).

I'm not 100% convinced that keeping dead code around is a good idea, but based on what I know now this seems ok. If it turns out that we don't reinstate the banner in a couple of months I think the code and data should be deleted.

