### PR TITLE
Break batch invitations creation into two steps

### DIFF
--- a/app/controllers/batch_invitation_permissions_controller.rb
+++ b/app/controllers/batch_invitation_permissions_controller.rb
@@ -26,7 +26,7 @@ private
   end
 
   def authorise_to_manage_permissions
-    authorize @batch_invitation
+    authorize @batch_invitation, :manage_permissions?
   end
 
   def grant_default_permissions(batch_invitation)

--- a/app/controllers/batch_invitation_permissions_controller.rb
+++ b/app/controllers/batch_invitation_permissions_controller.rb
@@ -1,0 +1,37 @@
+class BatchInvitationPermissionsController < ApplicationController
+  include UserPermissionsControllerMethods
+  before_action :authenticate_user!
+  before_action :load_batch_invitation
+  before_action :authorise_to_manage_permissions
+
+  helper_method :applications_and_permissions
+
+  def new; end
+
+  def create
+    @batch_invitation.supported_permission_ids = params[:user][:supported_permission_ids] if params[:user]
+    grant_default_permissions(@batch_invitation)
+
+    @batch_invitation.save!
+
+    @batch_invitation.enqueue
+    flash[:notice] = "Scheduled invitation of #{@batch_invitation.batch_invitation_users.count} users"
+    redirect_to batch_invitation_path(@batch_invitation)
+  end
+
+private
+
+  def load_batch_invitation
+    @batch_invitation = current_user.batch_invitations.find(params[:batch_invitation_id])
+  end
+
+  def authorise_to_manage_permissions
+    authorize @batch_invitation
+  end
+
+  def grant_default_permissions(batch_invitation)
+    SupportedPermission.default.each do |default_permission|
+      batch_invitation.grant_permission(default_permission)
+    end
+  end
+end

--- a/app/controllers/batch_invitation_permissions_controller.rb
+++ b/app/controllers/batch_invitation_permissions_controller.rb
@@ -3,6 +3,7 @@ class BatchInvitationPermissionsController < ApplicationController
   before_action :authenticate_user!
   before_action :load_batch_invitation
   before_action :authorise_to_manage_permissions
+  before_action :prevent_updating
 
   helper_method :applications_and_permissions
 
@@ -27,6 +28,13 @@ private
 
   def authorise_to_manage_permissions
     authorize @batch_invitation, :manage_permissions?
+  end
+
+  def prevent_updating
+    if @batch_invitation.has_permissions?
+      flash[:alert] = "Permissions have already been set for this batch of users"
+      redirect_to batch_invitation_path(@batch_invitation)
+    end
   end
 
   def grant_default_permissions(batch_invitation)

--- a/app/controllers/batch_invitations_controller.rb
+++ b/app/controllers/batch_invitations_controller.rb
@@ -1,10 +1,8 @@
 require "csv"
 
 class BatchInvitationsController < ApplicationController
-  include UserPermissionsControllerMethods
   before_action :authenticate_user!
 
-  helper_method :applications_and_permissions
   helper_method :recent_batch_invitations
 
   layout "admin_layout", only: %w[show]
@@ -16,8 +14,6 @@ class BatchInvitationsController < ApplicationController
 
   def create
     @batch_invitation = BatchInvitation.new(user: current_user, organisation_id: params[:batch_invitation][:organisation_id])
-    @batch_invitation.supported_permission_ids = params[:user][:supported_permission_ids] if params[:user]
-    grant_default_permissions(@batch_invitation)
     authorize @batch_invitation
 
     unless file_uploaded?
@@ -64,9 +60,7 @@ class BatchInvitationsController < ApplicationController
 
     @batch_invitation.save!
 
-    @batch_invitation.enqueue
-    flash[:notice] = "Scheduled invitation of #{@batch_invitation.batch_invitation_users.count} users"
-    redirect_to batch_invitation_path(@batch_invitation)
+    redirect_to new_batch_invitation_permissions_path(@batch_invitation)
   end
 
   def show
@@ -88,12 +82,6 @@ private
       false
     else
       true
-    end
-  end
-
-  def grant_default_permissions(batch_invitation)
-    SupportedPermission.default.each do |default_permission|
-      batch_invitation.grant_permission(default_permission)
     end
   end
 

--- a/app/helpers/batch_invitations_helper.rb
+++ b/app/helpers/batch_invitations_helper.rb
@@ -1,4 +1,12 @@
 module BatchInvitationsHelper
+  def batch_invite_status_link(batch_invitation, &block)
+    if !batch_invitation.has_permissions?
+      link_to(new_batch_invitation_permissions_path(batch_invitation), alt: "Edit this batch's permissions", &block)
+    else
+      link_to(batch_invitation_path(batch_invitation), alt: "View this batch", &block)
+    end
+  end
+
   def batch_invite_status_message(batch_invitation)
     if batch_invitation.in_progress?
       "In progress. " \

--- a/app/helpers/batch_invitations_helper.rb
+++ b/app/helpers/batch_invitations_helper.rb
@@ -7,6 +7,8 @@ module BatchInvitationsHelper
         "users processed."
     elsif batch_invitation.all_successful?
       "#{batch_invitation.batch_invitation_users.count} users processed."
+    elsif !batch_invitation.has_permissions?
+      "Batch invitation doesn't have any permissions yet."
     else
       "#{pluralize(batch_invitation.batch_invitation_users.failed.count, 'error')} out of " \
         "#{batch_invitation.batch_invitation_users.count} " \

--- a/app/models/batch_invitation.rb
+++ b/app/models/batch_invitation.rb
@@ -17,7 +17,7 @@ class BatchInvitation < ApplicationRecord
   end
 
   def in_progress?
-    outcome.nil?
+    outcome.nil? && has_permissions?
   end
 
   def all_successful?

--- a/app/models/batch_invitation.rb
+++ b/app/models/batch_invitation.rb
@@ -12,6 +12,10 @@ class BatchInvitation < ApplicationRecord
   validates :outcome, inclusion: { in: [nil, "success", "fail"] }
   validates :user_id, presence: true
 
+  def has_permissions?
+    batch_invitation_application_permissions.exists?
+  end
+
   def in_progress?
     outcome.nil?
   end

--- a/app/models/batch_invitation.rb
+++ b/app/models/batch_invitation.rb
@@ -17,7 +17,7 @@ class BatchInvitation < ApplicationRecord
   end
 
   def all_successful?
-    batch_invitation_users.failed.count.zero?
+    !outcome.nil? && batch_invitation_users.failed.count.zero?
   end
 
   def enqueue

--- a/app/policies/batch_invitation_policy.rb
+++ b/app/policies/batch_invitation_policy.rb
@@ -6,6 +6,7 @@ class BatchInvitationPolicy < BasePolicy
   end
   alias_method :create?, :new?
   alias_method :show?, :new?
+  alias_method :manage_permissions?, :new?
 
   def assign_organisation_from_csv?
     current_user.govuk_admin?

--- a/app/views/batch_invitation_permissions/new.html.erb
+++ b/app/views/batch_invitation_permissions/new.html.erb
@@ -1,0 +1,13 @@
+<% content_for :title, "Manage permissions for new users" %>
+
+<div class="page-title">
+  <h1>Manage permissions for new users</h1>
+</div>
+
+<div class="well">
+  <%= form_for @batch_invitation, url: :batch_invitation_permissions, method: :post do |f| %>
+    <%= render partial: "shared/user_permissions", locals: { user_object: User.new } %>
+
+    <%= f.submit "Create users and send emails", :class => 'btn btn-success' %>
+  <% end %>
+</div>

--- a/app/views/batch_invitations/new.html.erb
+++ b/app/views/batch_invitations/new.html.erb
@@ -66,10 +66,6 @@ Winston Churchill,winston@example.com
       <% end %>
     </div>
 
-    <h2>Permissions for the users</h2>
-
-    <%= render partial: "shared/user_permissions", locals: { user_object: User.new } %>
-
-    <%= f.submit "Create users and send emails", :class => 'btn btn-success' %>
+    <%= f.submit "Manage permissions for new users", :class => 'btn btn-success' %>
   <% end %>
 </div>

--- a/app/views/batch_invitations/new.html.erb
+++ b/app/views/batch_invitations/new.html.erb
@@ -17,7 +17,7 @@
       <% recent_batch_invitations.each do |batch_invitation| %>
         <tr>
           <td>
-            <%= link_to(batch_invitation_path(batch_invitation), alt: "View this batch") do %>
+            <%= batch_invite_status_link(batch_invitation) do %>
               <%= batch_invitation.batch_invitation_users.count %> users by <%= batch_invitation.user.name %> at <%= batch_invitation.created_at.to_fs(:govuk_date) %>
             <% end %>
           </td>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,7 +54,12 @@ Rails.application.routes.draw do
     resources :applications, only: [:index]
   end
 
-  resources :batch_invitations, only: %i[new create show]
+  resources :batch_invitations, only: %i[new create show] do
+    resource :permissions,
+             only: %i[new create],
+             controller: :batch_invitation_permissions
+  end
+
   resources :bulk_grant_permission_sets, only: %i[new create show]
   resources :organisations, only: %i[index edit update]
   resources :suspensions, only: %i[edit update]

--- a/test/controllers/batch_invitation_permissions_controller_test.rb
+++ b/test/controllers/batch_invitation_permissions_controller_test.rb
@@ -1,0 +1,83 @@
+require "test_helper"
+
+class BatchInvitationPermissionsControllerTest < ActionController::TestCase
+  include ActiveJob::TestHelper
+
+  setup do
+    @user = create(:admin_user)
+    sign_in @user
+
+    @app = create(:application, name: "Profound Publisher")
+
+    @batch_invitation = create(:batch_invitation, user: @user)
+    create(
+      :batch_invitation_user,
+      name: "Darayavaush Ayers",
+      email: "darayavaush.ayers@department.gov.uk",
+      batch_invitation: @batch_invitation,
+    )
+    create(
+      :batch_invitation_user,
+      name: "Precious Kumar",
+      email: "precious.kumar@department.gov.uk",
+      batch_invitation: @batch_invitation,
+    )
+  end
+
+  context "GET new" do
+    should "allow selection of application permissions to grant to users" do
+      get :new, params: { batch_invitation_id: @batch_invitation.id }
+
+      assert_select "table#editable-permissions" do
+        assert_select "td", "Has access to Profound Publisher?"
+        assert_select "td", "Permissions for Profound Publisher"
+      end
+    end
+  end
+
+  context "POST create" do
+    should "grant selected permissions and default permissions to BatchInvitation" do
+      support_app = create(:application, name: "Support")
+      support_app.signin_permission.update!(default: true)
+
+      post :create, params: {
+        batch_invitation_id: @batch_invitation.id,
+        user: { supported_permission_ids: [@app.signin_permission.id] },
+      }
+
+      assert_equal [@app.signin_permission, support_app.signin_permission],
+                   @batch_invitation.supported_permissions
+    end
+
+    context "with no permissions selected" do
+      should "still grant default permissions to BatchInvitation" do
+        support_app = create(:application, name: "Support")
+        support_app.signin_permission.update!(default: true)
+
+        post :create, params: { batch_invitation_id: @batch_invitation.id }
+
+        assert_equal [support_app.signin_permission],
+                     @batch_invitation.supported_permissions
+      end
+    end
+
+    should "send an email to signon-alerts" do
+      perform_enqueued_jobs do
+        post :create, params: { batch_invitation_id: @batch_invitation.id }
+
+        email = ActionMailer::Base.deliveries.detect do |m|
+          m.to.any? { |to| to =~ /signon-alerts@.*\.gov\.uk/ }
+        end
+        assert_not_nil email
+        assert_equal "[SIGNON] #{@user.name} created a batch of 2 users in development", email.subject
+      end
+    end
+
+    should "redirect to the batch invitation page and show a flash message" do
+      post :create, params: { batch_invitation_id: @batch_invitation.id }
+
+      assert_match(/Scheduled invitation of 2 users/i, flash[:notice])
+      assert_redirected_to "/batch_invitations/#{@batch_invitation.id}"
+    end
+  end
+end

--- a/test/controllers/batch_invitation_permissions_controller_test.rb
+++ b/test/controllers/batch_invitation_permissions_controller_test.rb
@@ -25,6 +25,16 @@ class BatchInvitationPermissionsControllerTest < ActionController::TestCase
   end
 
   context "GET new" do
+    should "not allow access if batch invitation already has permissions" do
+      @batch_invitation.supported_permission_ids = [@app.signin_permission.id]
+      @batch_invitation.save!
+
+      get :new, params: { batch_invitation_id: @batch_invitation.id }
+
+      assert_match(/Permissions have already been set for this batch of users/, flash[:alert])
+      assert_redirected_to "/batch_invitations/#{@batch_invitation.id}"
+    end
+
     should "allow selection of application permissions to grant to users" do
       get :new, params: { batch_invitation_id: @batch_invitation.id }
 
@@ -36,6 +46,16 @@ class BatchInvitationPermissionsControllerTest < ActionController::TestCase
   end
 
   context "POST create" do
+    should "not accept submission if batch invitation already has permissions" do
+      @batch_invitation.supported_permission_ids = [@app.signin_permission.id]
+      @batch_invitation.save!
+
+      post :create, params: { batch_invitation_id: @batch_invitation.id }
+
+      assert_match(/Permissions have already been set for this batch of users/, flash[:alert])
+      assert_redirected_to "/batch_invitations/#{@batch_invitation.id}"
+    end
+
     should "grant selected permissions and default permissions to BatchInvitation" do
       support_app = create(:application, name: "Support")
       support_app.signin_permission.update!(default: true)

--- a/test/controllers/batch_invitations_controller_test.rb
+++ b/test/controllers/batch_invitations_controller_test.rb
@@ -228,5 +228,23 @@ class BatchInvitationsControllerTest < ActionController::TestCase
         assert_select "head meta[http-equiv=refresh]", count: 0
       end
     end
+
+    context "batch invitation doesn't have any permissions yet" do
+      setup do
+        @bi = create(:batch_invitation)
+        create(:batch_invitation_user, name: "A", email: "a@m.com", batch_invitation: @bi)
+        create(:batch_invitation_user, name: "B", email: "b@m.com", batch_invitation: @bi)
+        get :show, params: { id: @bi.id }
+      end
+
+      should "explain the problem with the batch invitation" do
+        assert_select "div.gem-c-error-alert",
+                      /Batch invitation doesn't have any permissions yet./
+      end
+
+      should "not include the meta refresh" do
+        assert_select "head meta[http-equiv=refresh]", count: 0
+      end
+    end
   end
 end

--- a/test/controllers/batch_invitations_controller_test.rb
+++ b/test/controllers/batch_invitations_controller_test.rb
@@ -179,40 +179,44 @@ class BatchInvitationsControllerTest < ActionController::TestCase
   end
 
   context "GET show" do
-    setup do
-      @bi = create(:batch_invitation, :in_progress)
-      @user1 = create(:batch_invitation_user, name: "A", email: "a@m.com", batch_invitation: @bi)
-      @user2 = create(:batch_invitation_user, name: "B", email: "b@m.com", batch_invitation: @bi)
-    end
+    context "processing in progress" do
+      setup do
+        @bi = create(:batch_invitation, :in_progress)
+        @user1 = create(:batch_invitation_user, name: "A", email: "a@m.com", batch_invitation: @bi)
+        @user2 = create(:batch_invitation_user, name: "B", email: "b@m.com", batch_invitation: @bi)
+      end
 
-    should "list the users being created" do
-      get :show, params: { id: @bi.id }
-      assert_select "table tbody tr", 2
-      assert_select "table td", "a@m.com"
-      assert_select "table td", "b@m.com"
-    end
+      should "list the users being created" do
+        get :show, params: { id: @bi.id }
+        assert_select "table tbody tr", 2
+        assert_select "table td", "a@m.com"
+        assert_select "table td", "b@m.com"
+      end
 
-    should "include a meta refresh" do
-      get :show, params: { id: @bi.id }
-      assert_select 'head meta[http-equiv=refresh][content="3"]'
-    end
+      should "include a meta refresh" do
+        get :show, params: { id: @bi.id }
+        assert_select 'head meta[http-equiv=refresh][content="3"]'
+      end
 
-    should "show the state of the processing" do
-      @user1.update_column(:outcome, "failed")
-      get :show, params: { id: @bi.id }
-      assert_select "section.gem-c-notice", /In progress/i
-      assert_select "section.gem-c-notice", /1 of 2 users processed/i
-    end
+      should "show the state of the processing" do
+        @user1.update_column(:outcome, "failed")
+        get :show, params: { id: @bi.id }
+        assert_select "section.gem-c-notice", /In progress/i
+        assert_select "section.gem-c-notice", /1 of 2 users processed/i
+      end
 
-    should "show the outcome for each user" do
-      @user1.update_column(:outcome, "failed")
-      get :show, params: { id: @bi.id }
-      assert_select "td", /Failed/i
+      should "show the outcome for each user" do
+        @user1.update_column(:outcome, "failed")
+        get :show, params: { id: @bi.id }
+        assert_select "td", /Failed/i
+      end
     end
 
     context "processing complete" do
       setup do
-        @bi.update_column(:outcome, "success")
+        @bi = create(:batch_invitation, outcome: "success")
+        create(:batch_invitation_user, name: "A", email: "a@m.com", batch_invitation: @bi)
+        create(:batch_invitation_user, name: "B", email: "b@m.com", batch_invitation: @bi)
         get :show, params: { id: @bi.id }
       end
 

--- a/test/controllers/batch_invitations_controller_test.rb
+++ b/test/controllers/batch_invitations_controller_test.rb
@@ -21,7 +21,7 @@ class BatchInvitationsControllerTest < ActionController::TestCase
 
     context "some batches created recently" do
       setup do
-        @bi = create(:batch_invitation)
+        @bi = create(:batch_invitation, :in_progress)
         create(:batch_invitation_user, batch_invitation: @bi)
       end
 
@@ -180,7 +180,7 @@ class BatchInvitationsControllerTest < ActionController::TestCase
 
   context "GET show" do
     setup do
-      @bi = create(:batch_invitation)
+      @bi = create(:batch_invitation, :in_progress)
       @user1 = create(:batch_invitation_user, name: "A", email: "a@m.com", batch_invitation: @bi)
       @user2 = create(:batch_invitation_user, name: "B", email: "b@m.com", batch_invitation: @bi)
     end

--- a/test/factories/batch_invitation.rb
+++ b/test/factories/batch_invitation.rb
@@ -4,5 +4,20 @@ FactoryBot.define do
     trait :with_organisation do
       association :organisation, factory: :organisation
     end
+
+    trait :in_progress do
+      outcome { nil }
+
+      has_permissions
+    end
+
+    trait :has_permissions do
+      after(:create) do |batch_invitation|
+        unless batch_invitation.has_permissions?
+          batch_invitation.supported_permissions << create(:supported_permission)
+          batch_invitation.save!
+        end
+      end
+    end
   end
 end

--- a/test/helpers/batch_invitations_helper_test.rb
+++ b/test/helpers/batch_invitations_helper_test.rb
@@ -14,7 +14,11 @@ class BatchInvitationsHelperTest < ActionView::TestCase
     end
 
     should "state number of users processed when all were successful" do
-      batch_invitation = create(:batch_invitation, outcome: "success")
+      batch_invitation = create(
+        :batch_invitation,
+        :has_permissions,
+        outcome: "success",
+      )
       create(:batch_invitation_user, outcome: "skipped", batch_invitation:)
       create(:batch_invitation_user, outcome: "success", batch_invitation:)
 
@@ -23,12 +27,23 @@ class BatchInvitationsHelperTest < ActionView::TestCase
     end
 
     should "state number of failures if any users have failed to process" do
-      batch_invitation = create(:batch_invitation, outcome: "success")
+      batch_invitation = create(
+        :batch_invitation,
+        :has_permissions,
+        outcome: "success",
+      )
       create(:batch_invitation_user, outcome: "failed", batch_invitation:)
       create(:batch_invitation_user, outcome: "skipped", batch_invitation:)
       create(:batch_invitation_user, outcome: "success", batch_invitation:)
 
       assert_equal "1 error out of 3 users processed.",
+                   batch_invite_status_message(batch_invitation)
+    end
+
+    should "explain the problem for a batch invitation that has no permissions" do
+      batch_invitation = create(:batch_invitation)
+
+      assert_equal "Batch invitation doesn't have any permissions yet.",
                    batch_invite_status_message(batch_invitation)
     end
   end

--- a/test/helpers/batch_invitations_helper_test.rb
+++ b/test/helpers/batch_invitations_helper_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class BatchInvitationsHelperTest < ActionView::TestCase
   context "#batch_invite_status_message" do
     should "state number of users processed so far when still in progress" do
-      batch_invitation = create(:batch_invitation, outcome: nil)
+      batch_invitation = create(:batch_invitation, :in_progress)
       create(:batch_invitation_user, outcome: "failed", batch_invitation:)
       create(:batch_invitation_user, outcome: "skipped", batch_invitation:)
       create(:batch_invitation_user, outcome: "success", batch_invitation:)

--- a/test/helpers/batch_invitations_helper_test.rb
+++ b/test/helpers/batch_invitations_helper_test.rb
@@ -1,6 +1,38 @@
 require "test_helper"
 
 class BatchInvitationsHelperTest < ActionView::TestCase
+  context "#batch_invite_status_message" do
+    should "state number of users processed so far when still in progress" do
+      batch_invitation = create(:batch_invitation, outcome: nil)
+      create(:batch_invitation_user, outcome: "failed", batch_invitation:)
+      create(:batch_invitation_user, outcome: "skipped", batch_invitation:)
+      create(:batch_invitation_user, outcome: "success", batch_invitation:)
+      create(:batch_invitation_user, outcome: nil, batch_invitation:)
+
+      assert_equal "In progress. 3 of 4 users processed.",
+                   batch_invite_status_message(batch_invitation)
+    end
+
+    should "state number of users processed when all were successful" do
+      batch_invitation = create(:batch_invitation, outcome: "success")
+      create(:batch_invitation_user, outcome: "skipped", batch_invitation:)
+      create(:batch_invitation_user, outcome: "success", batch_invitation:)
+
+      assert_equal "2 users processed.",
+                   batch_invite_status_message(batch_invitation)
+    end
+
+    should "state number of failures if any users have failed to process" do
+      batch_invitation = create(:batch_invitation, outcome: "success")
+      create(:batch_invitation_user, outcome: "failed", batch_invitation:)
+      create(:batch_invitation_user, outcome: "skipped", batch_invitation:)
+      create(:batch_invitation_user, outcome: "success", batch_invitation:)
+
+      assert_equal "1 error out of 3 users processed.",
+                   batch_invite_status_message(batch_invitation)
+    end
+  end
+
   context "#batch_invite_organisation_for_user" do
     context "when the batch invitation user raises an invalid slug error when asked for organisation_id" do
       setup do

--- a/test/helpers/batch_invitations_helper_test.rb
+++ b/test/helpers/batch_invitations_helper_test.rb
@@ -93,4 +93,18 @@ class BatchInvitationsHelperTest < ActionView::TestCase
       end
     end
   end
+
+  context "#batch_invite_status_link" do
+    should "link to show the batch when it has permissions" do
+      batch_invitation = create(:batch_invitation, :has_permissions, outcome: "success")
+
+      assert_includes batch_invite_status_link(batch_invitation) {}, batch_invitation_path(batch_invitation)
+    end
+
+    should "link to show edit the permissions when it has no permissions" do
+      batch_invitation = create(:batch_invitation)
+
+      assert_includes batch_invite_status_link(batch_invitation) {}, new_batch_invitation_permissions_path(batch_invitation)
+    end
+  end
 end

--- a/test/integration/batch_inviting_users_test.rb
+++ b/test/integration/batch_inviting_users_test.rb
@@ -88,6 +88,8 @@ class BatchInvitingUsersTest < ActionDispatch::IntegrationTest
       visit new_batch_invitation_path
       path = Rails.root.join("test/fixtures/users.csv")
       attach_file("Choose a CSV file of users with names and email addresses", path)
+      click_button "Manage permissions for new users"
+
       uncheck "Has access to #{support_app.name}?"
       check "Has access to #{@application.name}?"
       unselect "reader", from: "Permissions for #{@application.name}"
@@ -124,11 +126,12 @@ class BatchInvitingUsersTest < ActionDispatch::IntegrationTest
       visit new_batch_invitation_path
       path = Rails.root.join("test/fixtures", fixture_file)
       attach_file("Choose a CSV file of users with names and email addresses", path)
-      check "Has access to #{application.name}?"
       if organisation
         select organisation.name, from: "Organisation"
       end
+      click_button "Manage permissions for new users"
 
+      check "Has access to #{application.name}?"
       click_button "Create users and send emails"
 
       assert_response_contains("Creating a batch of users")

--- a/test/models/batch_invitation_test.rb
+++ b/test/models/batch_invitation_test.rb
@@ -26,6 +26,39 @@ class BatchInvitationTest < ActiveSupport::TestCase
     @bi.save!
   end
 
+  context "#all_successful?" do
+    should "be false when at least one BatchInvitationUser has failed" do
+      @bi.update_column(:outcome, "success")
+      @user_a.update_column(:outcome, "failed")
+
+      assert_not @bi.all_successful?
+    end
+
+    should "be true when no BatchInvitationUsers have failed" do
+      @bi.update_column(:outcome, "success")
+      @user_a.update_column(:outcome, "success")
+      @user_b.update_column(:outcome, "success")
+
+      assert @bi.all_successful?
+    end
+
+    should "be true even if outcome is 'fail' as long as no BatchInvitationUsers have failed" do
+      @bi.update_column(:outcome, "fail")
+      @user_a.update_column(:outcome, "success")
+      @user_b.update_column(:outcome, "success")
+
+      assert @bi.all_successful?
+    end
+
+    should "be false when BatchInvitation is still in progress" do
+      @bi.update_column(:outcome, nil)
+      @user_a.update_column(:outcome, "success")
+      @user_b.update_column(:outcome, "success")
+
+      assert_not @bi.all_successful?
+    end
+  end
+
   context "perform" do
     should "create the users and assign them permissions" do
       @bi.reload.perform

--- a/test/models/batch_invitation_test.rb
+++ b/test/models/batch_invitation_test.rb
@@ -40,6 +40,26 @@ class BatchInvitationTest < ActiveSupport::TestCase
     end
   end
 
+  context "#in_progress?" do
+    should "be false when BatchInvitation has an outcome" do
+      @bi.update_column(:outcome, "success")
+
+      assert_not @bi.in_progress?
+    end
+
+    should "be true when BatchInvitation does not have an outcome yet" do
+      @bi.update_column(:outcome, nil)
+
+      assert @bi.in_progress?
+    end
+
+    should "be false when BatchInvitation does not have any permissions yet" do
+      invitation = create(:batch_invitation, outcome: nil)
+
+      assert_not invitation.in_progress?
+    end
+  end
+
   context "#all_successful?" do
     should "be false when at least one BatchInvitationUser has failed" do
       @bi.update_column(:outcome, "success")

--- a/test/models/batch_invitation_test.rb
+++ b/test/models/batch_invitation_test.rb
@@ -26,6 +26,20 @@ class BatchInvitationTest < ActiveSupport::TestCase
     @bi.save!
   end
 
+  context "#has_permissions?" do
+    should "be false when BatchInvitation has no batch_invitation_application_permissions" do
+      invitation = create(:batch_invitation)
+
+      assert_not invitation.has_permissions?
+    end
+
+    should "be true when BatchInvitation has any batch_invitation_application_permissions at all" do
+      invitation = create(:batch_invitation, supported_permissions: [@app.signin_permission])
+
+      assert invitation.has_permissions?
+    end
+  end
+
   context "#all_successful?" do
     should "be false when at least one BatchInvitationUser has failed" do
       @bi.update_column(:outcome, "success")


### PR DESCRIPTION
https://trello.com/c/FzaiUjkY/127-break-batchinvitations-new-into-two-separate-steps-to-prepare-for-migrating-to-the-design-system

This is the first step of moving `batch_invitations#new` to the design system. It breaks the large single page form into two separate steps across their own pages:
  1. Upload user info
  2. Manage permissions

The second step is implemented in its own controller.

## Step 1.
![Screenshot from 2023-09-08 20-25-48](https://github.com/alphagov/signon/assets/141013432/64260ee2-0a5d-4ea4-957d-83013b0f91e4)

## Step 2.
![Screenshot from 2023-09-08 20-26-37](https://github.com/alphagov/signon/assets/141013432/23045107-ca4a-4913-b3fe-feec044b571a)
