### PR TITLE
Fix and prevent unnecessary whitespace in organisation names

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -10,6 +10,8 @@ class Organisation < ApplicationRecord
   validates :name, presence: true
   validates :organisation_type, presence: true
 
+  before_save :strip_whitespace_from_name
+
   def name_with_abbreviation
     return_value = if abbreviation.present? && abbreviation != name
                      "#{name} – #{abbreviation}"
@@ -20,5 +22,11 @@ class Organisation < ApplicationRecord
     return_value += " (closed)" if closed?
 
     return_value
+  end
+
+private
+
+  def strip_whitespace_from_name
+    name.strip!
   end
 end

--- a/db/migrate/20230911092404_strip_whitespace_from_organisation_names.rb
+++ b/db/migrate/20230911092404_strip_whitespace_from_organisation_names.rb
@@ -1,0 +1,9 @@
+class StripWhitespaceFromOrganisationNames < ActiveRecord::Migration[7.0]
+  NAME_HAS_LEADING_OR_TRAILING_SPACE = "name REGEXP('^\s+') OR name REGEXP('\s+$')".freeze
+
+  def up
+    Organisation.where(NAME_HAS_LEADING_OR_TRAILING_SPACE).each(&:save!)
+  end
+
+  def down; end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_16_164936) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_11_092404) do
   create_table "batch_invitation_application_permissions", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "batch_invitation_id", null: false
     t.integer "supported_permission_id", null: false

--- a/test/models/organisation_test.rb
+++ b/test/models/organisation_test.rb
@@ -17,6 +17,12 @@ class OrganisationTest < ActiveSupport::TestCase
     end
   end
 
+  test "strips unwanted whitespace from name" do
+    organisation = create(:organisation, name: "  An organisation ")
+
+    assert_equal "An organisation", organisation.name
+  end
+
   context "displaying name with abbreviation" do
     should "use abbreviation when it is not the same as name" do
       organisation = build(:organisation, name: "An Organisation", abbreviation: "ABBR")


### PR DESCRIPTION
Trello: https://trello.com/c/rbUCwjHg

This commit removes and prevents unnecessary whitespace being added to `Organisation` `name` in a similar way to #2291 (for `User`). This only affects 1 record in integration and none in production, but it creates confusing ordering when we sort alphabetically by name. 


