### PR TITLE
Fix `<h1>` wrapping

### DIFF
--- a/app/views/layouts/admin_layout.html.erb
+++ b/app/views/layouts/admin_layout.html.erb
@@ -36,7 +36,7 @@
       <%= yield(:error_summary) %>
 
       <div class="govuk-grid-row">
-        <div class="<%= yield(:top_right) ? 'govuk-grid-column-one-third' : 'govuk-grid-column-two-thirds' %>">
+        <div class="<%= yield(:top_right).present? ? 'govuk-grid-column-one-third' : 'govuk-grid-column-two-thirds' %>">
           <h1 class="govuk-heading-l">
             <% if yield(:page_heading).present? %>
               <%= yield(:page_heading) %>
@@ -45,7 +45,7 @@
             <% end %>
           </h1>
         </div>
-        <% if yield(:top_right) %>
+        <% if yield(:top_right).present? %>
           <div class="govuk-grid-column-two-thirds">
             <%= yield(:top_right) %>
           </div>


### PR DESCRIPTION
Without `#present?`, `yield` seems to generate a false positive. I guess it could be returning an empty string by default.

That false positive was squashing all of our page's `<h1>`s into a one-third column, forcing even fairly short page headings to wrap

### Before
![Screenshot from 2023-09-20 11-50-19](https://github.com/alphagov/signon/assets/141013432/1a69009e-9352-44f2-ba23-10d381e18230)
![Screenshot from 2023-09-20 11-57-01](https://github.com/alphagov/signon/assets/141013432/00d9276e-020e-4d40-9ff4-9220cade0af4)

### After
![Screenshot from 2023-09-20 12-09-09](https://github.com/alphagov/signon/assets/141013432/eed11b34-198c-425b-aea7-b488c79f8732)
![Screenshot from 2023-09-20 12-08-19](https://github.com/alphagov/signon/assets/141013432/009525b4-951a-4ebd-8646-17cc72988d46)