### PR TITLE
Prevent users changing their email addresses to non-governmental ones

### DIFF
--- a/app/models/batch_invitation_user.rb
+++ b/app/models/batch_invitation_user.rb
@@ -2,7 +2,7 @@ class BatchInvitationUser < ApplicationRecord
   belongs_to :batch_invitation
 
   validates :email, presence: true, format: { with: Devise.email_regexp }
-  validates :email, reject_non_governmental_email_addresses: true, on: :create
+  validates :email, reject_non_governmental_email_addresses: true
 
   validates :outcome, inclusion: { in: [nil, "success", "failed", "skipped"] }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -48,7 +48,7 @@ class User < ApplicationRecord
   encrypts :otp_secret_key
 
   validates :name, presence: true
-  validates :email, reject_non_governmental_email_addresses: true, on: :create
+  validates :email, reject_non_governmental_email_addresses: true
   validates :reason_for_suspension, presence: true, if: proc { |u| u.suspended? }
   validate :user_can_be_exempted_from_2sv
   validate :organisation_admin_belongs_to_organisation

--- a/test/models/batch_invitation_user_test.rb
+++ b/test/models/batch_invitation_user_test.rb
@@ -25,12 +25,12 @@ class BatchInvitationUserTest < ActiveSupport::TestCase
                    user.errors[:email]
     end
 
-    should "still allow user to be updated with a known non-government email address" do
+    should "not allow user to be updated with a known non-government email address" do
       user = create(:batch_invitation_user, email: "alexia.statham@department.gov.uk")
 
       user.email = "alexia.statham@yahoo.co.uk"
 
-      assert user.valid?
+      assert_not user.valid?
     end
   end
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -284,12 +284,12 @@ class UserTest < ActiveSupport::TestCase
                    user.errors[:email]
     end
 
-    should "still allow user to be updated with a known non-government email address" do
+    should "not allow user to be updated with a known non-government email address" do
       user = create(:batch_invitation_user, email: "alexia.statham@department.gov.uk")
 
       user.email = "alexia.statham@yahoo.co.uk"
 
-      assert user.valid?
+      assert_not user.valid?
     end
 
     should "reject emails with invalid domain parts" do


### PR DESCRIPTION
Trello: https://trello.com/c/dp3QzDlq

We've now chased up all users who were using one of our identified "non-governmental" email domains, so we can enforce this validation rule for all User accounts, not just new ones. This strengthens the validation we introduced in 00e93e9570.
