### PR TITLE
Fixes for batch invitations

### DIFF
--- a/app/controllers/batch_invitations_controller.rb
+++ b/app/controllers/batch_invitations_controller.rb
@@ -15,7 +15,7 @@ class BatchInvitationsController < ApplicationController
     authorize @batch_invitation
 
     unless file_uploaded?
-      flash[:alert] = "You must upload a file"
+      flash.now[:alert] = "You must upload a file"
       render :new
       return
     end
@@ -23,16 +23,16 @@ class BatchInvitationsController < ApplicationController
     begin
       csv = CSV.parse(params[:batch_invitation][:user_names_and_emails].read, headers: true)
     rescue CSV::MalformedCSVError => e
-      flash[:alert] = "Couldn't understand that file: #{e.message}"
+      flash.now[:alert] = "Couldn't understand that file: #{e.message}"
       render :new
       return
     end
     if csv.empty?
-      flash[:alert] = "CSV had no rows."
+      flash.now[:alert] = "CSV had no rows."
       render :new
       return
     elsif %w[Name Email].any? { |required_header| csv.headers.exclude?(required_header) }
-      flash[:alert] = "CSV must have headers including 'Name' and 'Email'"
+      flash.now[:alert] = "CSV must have headers including 'Name' and 'Email'"
       render :new
       return
     end
@@ -47,7 +47,7 @@ class BatchInvitationsController < ApplicationController
       batch_user = BatchInvitationUser.new(batch_user_args)
 
       unless batch_user.valid?
-        flash[:alert] = batch_users_error_message(batch_user)
+        flash.now[:alert] = batch_users_error_message(batch_user)
         return render :new
       end
 

--- a/app/models/batch_invitation_user.rb
+++ b/app/models/batch_invitation_user.rb
@@ -103,7 +103,7 @@ private
   end
 
   def strip_whitespace_from_email
-    email.strip!
+    email&.strip!
   end
 
   def strip_whitespace_from_organisation_slug

--- a/app/models/batch_invitation_user.rb
+++ b/app/models/batch_invitation_user.rb
@@ -8,6 +8,7 @@ class BatchInvitationUser < ApplicationRecord
 
   before_save :strip_whitespace_from_name
   before_validation :strip_whitespace_from_email
+  before_save :strip_whitespace_from_organisation_slug
 
   scope :processed, -> { where.not(outcome: nil) }
   scope :unprocessed, -> { where(outcome: nil) }
@@ -103,5 +104,9 @@ private
 
   def strip_whitespace_from_email
     email.strip!
+  end
+
+  def strip_whitespace_from_organisation_slug
+    organisation_slug&.strip!
   end
 end

--- a/app/models/batch_invitation_user.rb
+++ b/app/models/batch_invitation_user.rb
@@ -7,6 +7,7 @@ class BatchInvitationUser < ApplicationRecord
   validates :outcome, inclusion: { in: [nil, "success", "failed", "skipped"] }
 
   before_save :strip_whitespace_from_name
+  before_validation :strip_whitespace_from_email
 
   scope :processed, -> { where.not(outcome: nil) }
   scope :unprocessed, -> { where(outcome: nil) }
@@ -98,5 +99,9 @@ private
 
   def strip_whitespace_from_name
     name.strip!
+  end
+
+  def strip_whitespace_from_email
+    email.strip!
   end
 end

--- a/test/controllers/batch_invitations_controller_test.rb
+++ b/test/controllers/batch_invitations_controller_test.rb
@@ -89,7 +89,7 @@ class BatchInvitationsControllerTest < ActionController::TestCase
         post :create, params: { batch_invitation: { user_names_and_emails: nil } }
 
         assert_template :new
-        assert_match(/You must upload a file/i, flash[:alert])
+        assert_match(/You must upload a file/i, flash.now[:alert])
       end
     end
 
@@ -98,7 +98,7 @@ class BatchInvitationsControllerTest < ActionController::TestCase
         post :create, params: { batch_invitation: { user_names_and_emails: users_csv("users_with_non_valid_emails.csv") } }
 
         assert_template :new
-        assert_match(/One or more emails were invalid/i, flash[:alert])
+        assert_match(/One or more emails were invalid/i, flash.now[:alert])
       end
     end
 
@@ -117,7 +117,7 @@ class BatchInvitationsControllerTest < ActionController::TestCase
         post :create, params: { batch_invitation: { user_names_and_emails: users_csv("empty_users.csv") } }
 
         assert_template :new
-        assert_match(/no rows/i, flash[:alert])
+        assert_match(/no rows/i, flash.now[:alert])
       end
     end
 
@@ -126,7 +126,7 @@ class BatchInvitationsControllerTest < ActionController::TestCase
         post :create, params: { batch_invitation: { user_names_and_emails: users_csv("invalid_users.csv") } }
 
         assert_template :new
-        assert_match(/Couldn't understand that file/i, flash[:alert])
+        assert_match(/Couldn't understand that file/i, flash.now[:alert])
       end
     end
 
@@ -135,7 +135,7 @@ class BatchInvitationsControllerTest < ActionController::TestCase
         post :create, params: { batch_invitation: { user_names_and_emails: users_csv("no_headers_users.csv") } }
 
         assert_template :new
-        assert_match(/must have headers/i, flash[:alert])
+        assert_match(/must have headers/i, flash.now[:alert])
       end
     end
   end

--- a/test/integration/batch_inviting_users_test.rb
+++ b/test/integration/batch_inviting_users_test.rb
@@ -25,6 +25,28 @@ class BatchInvitingUsersTest < ActionDispatch::IntegrationTest
       assert_user_created_and_invited("lara@example.com", @application, organisation: @cabinet_office)
       assert_user_not_created("emma@example.com")
     end
+
+    should "only display flash alert once on validation error" do
+      visit root_path
+      signin_with(@user)
+
+      visit new_batch_invitation_path
+      click_button "Manage permissions for new users"
+
+      assert_response_contains "You must upload a file"
+
+      path = Rails.root.join("test/fixtures/users.csv")
+      attach_file("Upload a CSV file", path)
+      click_button "Manage permissions for new users"
+
+      batch_invitation = BatchInvitation.last
+      assert batch_invitation.present?
+
+      invited_user = batch_invitation.batch_invitation_users.last
+      assert_equal "fred@example.com", invited_user.email
+
+      refute_response_contains "You must upload a file"
+    end
   end
 
   context "for admin users" do

--- a/test/models/batch_invitation_user_test.rb
+++ b/test/models/batch_invitation_user_test.rb
@@ -23,19 +23,25 @@ class BatchInvitationUserTest < ActiveSupport::TestCase
   end
 
   context "validations" do
-    should "validate email address" do
+    should "validate presence of email address" do
+      user = build(:batch_invitation_user, email: nil)
+
+      assert_not user.valid?
+      assert_includes user.errors[:email], "can't be blank"
+    end
+
+    should "validate format of email address" do
       user = build(:batch_invitation_user, email: "@gov.uk")
 
       assert_not user.valid?
-      assert_equal ["is invalid"], user.errors[:email]
+      assert_includes user.errors[:email], "is invalid"
     end
 
     should "prevent user being created with a known non-government email address" do
       user = build(:batch_invitation_user, email: "piers.quinn@yahoo.co.uk")
 
       assert_not user.valid?
-      assert_equal ["not accepted. Please enter a workplace email to continue."],
-                   user.errors[:email]
+      assert_includes user.errors[:email], "not accepted. Please enter a workplace email to continue."
     end
 
     should "not allow user to be updated with a known non-government email address" do

--- a/test/models/batch_invitation_user_test.rb
+++ b/test/models/batch_invitation_user_test.rb
@@ -7,6 +7,13 @@ class BatchInvitationUserTest < ActiveSupport::TestCase
 
       assert_equal "Ailean Millard", user.name
     end
+
+    should "strip unwanted whitespace from email before validating" do
+      user = build(:batch_invitation_user, email: "  foo@example.com ")
+      user.valid?
+
+      assert_equal "foo@example.com", user.email
+    end
   end
 
   context "validations" do

--- a/test/models/batch_invitation_user_test.rb
+++ b/test/models/batch_invitation_user_test.rb
@@ -14,6 +14,12 @@ class BatchInvitationUserTest < ActiveSupport::TestCase
 
       assert_equal "foo@example.com", user.email
     end
+
+    should "strip unwanted whitespace from organisation_slug before persisting" do
+      user = create(:batch_invitation_user, organisation_slug: "  cabinet-office ")
+
+      assert_equal "cabinet-office", user.organisation_slug
+    end
   end
 
   context "validations" do


### PR DESCRIPTION
Trello: https://trello.com/c/aO4nVCZT

* Avoid displaying validation errors on successful processing of file. Previously if a validation error was displayed and then corrected, the error was incorrectly displayed again on the success page.
* Strip leading & trailing whitespace from `BatchInvitationUser#email` before validation to avoid unnecessarily confusing validation errors.
* Strip leading & trailing whitespace from `BatchInvitationUser#organisation_slug` before save to avoid the potential for failing organisation lookups.
* Improve test coverage of `BatchInvitationUser#email` validation.
