### PR TITLE
Strip whitespace from BatchInvitationUser email & organisation_slug

### DIFF
--- a/db/migrate/20230925093142_strip_whitespace_from_batch_invitation_user_email.rb
+++ b/db/migrate/20230925093142_strip_whitespace_from_batch_invitation_user_email.rb
@@ -1,0 +1,7 @@
+class StripWhitespaceFromBatchInvitationUserEmail < ActiveRecord::Migration[7.0]
+  def change
+    BatchInvitationUser.where("email REGEXP ? OR email REGEXP ?", "^\\s+", "\\s+$").each do |biu|
+      biu.update_attribute(:email, biu.email&.strip) # rubocop:disable Rails/SkipsModelValidations
+    end
+  end
+end

--- a/db/migrate/20230925093143_strip_whitespace_from_batch_invitation_user_organisation_slug.rb
+++ b/db/migrate/20230925093143_strip_whitespace_from_batch_invitation_user_organisation_slug.rb
@@ -1,0 +1,7 @@
+class StripWhitespaceFromBatchInvitationUserOrganisationSlug < ActiveRecord::Migration[7.0]
+  def change
+    BatchInvitationUser.where("organisation_slug REGEXP ? OR organisation_slug REGEXP ?", "^\\s+", "\\s+$").each do |biu|
+      biu.update_attribute(:organisation_slug, biu.organisation_slug&.strip) # rubocop:disable Rails/SkipsModelValidations
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_18_141453) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_25_093142) do
   create_table "batch_invitation_application_permissions", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "batch_invitation_id", null: false
     t.integer "supported_permission_id", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_25_093142) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_25_093143) do
   create_table "batch_invitation_application_permissions", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "batch_invitation_id", null: false
     t.integer "supported_permission_id", null: false


### PR DESCRIPTION
Trello: https://trello.com/c/aO4nVCZT

I forgot to do this as part of #2371.

I've constructed the query in the migration slightly differently to similar previous migrations, because I noticed the whitespace character in the regular expression wasn't working as intended. I plan to add new migrations for the columns we've already updated using the flawed query in a separate PR.

I've had to use `ActiveRecord::Persistence#update_attribute` in order to skip model validation, because some of the existing `BatchInvitationUser` records are invalid for other reasons.

I did consider writing the migration as a SQL `UPDATE`, but generating a `TRIM` expression that is exactly equivalent to `String#strip` isn't as trivial as it sounds!

