### PR TITLE
Handle nil name in BatchInvitationUser#strip_whitespace_from_name

### DIFF
--- a/app/models/batch_invitation_user.rb
+++ b/app/models/batch_invitation_user.rb
@@ -99,7 +99,7 @@ private
   end
 
   def strip_whitespace_from_name
-    name.strip!
+    name&.strip!
   end
 
   def strip_whitespace_from_email

--- a/test/models/batch_invitation_user_test.rb
+++ b/test/models/batch_invitation_user_test.rb
@@ -20,6 +20,12 @@ class BatchInvitationUserTest < ActiveSupport::TestCase
 
       assert_equal "cabinet-office", user.organisation_slug
     end
+
+    should "strip unwanted whitespace from organisation_slug before persisting even if name is nil" do
+      user = create(:batch_invitation_user, organisation_slug: "  cabinet-office ", name: nil)
+
+      assert_equal "cabinet-office", user.organisation_slug
+    end
   end
 
   context "validations" do


### PR DESCRIPTION
This was causing [a migration][1] to fail in integration with:

    NoMethodError: undefined method `strip!' for nil:NilClass

This makes sense from the point of view that there is no validation on BatchInvitationUser#name and so there's nothing forcing it to be present.

I've added a unit test to force me to fix the problem.

[1]: https://github.com/alphagov/signon/blob/afe562d1905c90def59e80a5e483375538fa0935/db/migrate/20230925093143_strip_whitespace_from_batch_invitation_user_organisation_slug.rb
