### PR TITLE
A heading for the right-hand section of dashboard

### DIFF
--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -55,16 +55,23 @@
   </div>
 
   <div class="govuk-grid-column-one-third">
-    <ul class="govuk-list app-dashboard-side">
-      <li>
-        <%= link_to "Change your email or password", edit_email_or_password_user_path(current_user), class: "govuk-link" %>
-      </li>
+    <div class="app-dashboard-side">
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "Actions and settings",
+        padding: true,
+        margin_bottom: 3,
+      } %>
+      <ul class="govuk-list">
+        <li>
+          <%= link_to "Change your email or password", edit_email_or_password_user_path(current_user), class: "govuk-link" %>
+        </li>
 
-      <% if current_user.has_2sv? %>
-        <li><%= link_to "Change your 2-step verification phone", two_step_verification_path, class: "govuk-link" %></li>
-      <% else %>
-        <li><%= link_to "Set up 2-step verification", two_step_verification_path, class: "govuk-link" %></li>
-      <% end %>
-    </ul>
+        <% if current_user.has_2sv? %>
+          <li><%= link_to "Change your 2-step verification phone", two_step_verification_path, class: "govuk-link" %></li>
+        <% else %>
+          <li><%= link_to "Set up 2-step verification", two_step_verification_path, class: "govuk-link" %></li>
+        <% end %>
+      </ul>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
https://trello.com/c/1AarwGE2/266-add-a-actions-and-settings-title-on-the-right-side-of-the-dashboard

Based on feedback from user research, without a heading, this section doesn't really look like anything at all.

Our page layout code isn't compatible with the specific layout suggested in the mock up (in the Trello card), so I've taken some cues from [this example Housing and local services page](https://www.gov.uk/get-help-energy-bills), putting the heading below the line.

### How it looks
![Screenshot from 2023-09-29 17-24-39](https://github.com/alphagov/signon/assets/141013432/793d5d87-21bd-4686-8cb0-718b275c3e0d)