### PR TITLE
Update suspension and unlock email text

### DIFF
--- a/app/mailers/mailer_helper.rb
+++ b/app/mailers/mailer_helper.rb
@@ -4,11 +4,7 @@ module MailerHelper
   end
 
   def app_name
-    if GovukEnvironment.production?
-      I18n.t("mailer.app_name.no_instance")
-    else
-      I18n.t("mailer.app_name.instance", instance_name: GovukEnvironment.name)
-    end
+    I18n.t("mailer.app_name.instance", instance_name: GovukEnvironment.name)
   end
 
   def email_from_address

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -119,11 +119,7 @@ private
   end
 
   def account_name
-    if GovukEnvironment.production?
-      "account"
-    else
-      "#{GovukEnvironment.name} account"
-    end
+    "#{GovukEnvironment.name} account"
   end
 
   def subject_for(key)

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -115,7 +115,11 @@ private
   end
 
   def unlock_time
-    (@user.locked_at + 1.hour).to_fs(:govuk_date)
+    t = (@user.locked_at + User.unlock_in)
+    time_part = t.to_fs(:govuk_time)
+    date_part = t.to_date.to_fs(:govuk_date)
+
+    "#{time_part} UK time on #{date_part}"
   end
 
   def account_name

--- a/app/views/user_mailer/suspension_notification.text.erb
+++ b/app/views/user_mailer/suspension_notification.text.erb
@@ -1,15 +1,13 @@
-<%= t('department.name') %> Signon accounts are suspended after <%= User::SUSPENSION_THRESHOLD_PERIOD.inspect %> of inactivity.
+Your <%= t('department.name') %> Signon <%= account_name %> for <%= @user.email %> is now suspended.
 
-Your <%= t('department.name') %> Signon <%= account_name %>, for <%= @user.email %>, has now been suspended and you won't be able to access any <%= t('department.name') %> <%= account_name %> publishing applications.
+^ Please do not reply to this email.
 
-<% unless GovukEnvironment.production? %>
-<%= account_name.humanize %> suspensions do not suspend production accounts or remove access to <%= t('department.name') %> production applications.
-<% end %>
+## How to reactive your account
 
-If you don't need the account you can ignore this email.
+Contact your managing editor or user manager ‒ they can unsuspend your account.
 
-If you do still need the account you will have to contact a managing <%= t('department.name') %> editor in your organisation (or your parent organisation). They can use the support form (<%= t('support.url') %>) to get help from the <%= t('department.name') %> team.
+## If you’re a managing editor or user manager
 
-Read our blog post about suspending unused <%= t('department.name') %> accounts:
+Contact another managing editor or user manager and ask them to unsuspend you.
 
-https://insidegovuk.blog.gov.uk/2014/08/21/suspending-unused-gov-uk-accounts
+Please note that managing editors in an arm's length body may not have this authority.

--- a/app/views/user_mailer/suspension_reminder.text.erb
+++ b/app/views/user_mailer/suspension_reminder.text.erb
@@ -1,19 +1,24 @@
-<%= t('department.name') %> Signon accounts are suspended after <%= User::SUSPENSION_THRESHOLD_PERIOD.inspect %> of inactivity.
+Your <%= t('department.name') %> Signon <%= account_name %>, for <%= @user.email %> will be suspended <%= suspension_time %>.
 
-Your <%= t('department.name') %> Signon <%= account_name %>, for <%= @user.email %>, will be suspended <%= suspension_time %>. After suspension you won't be able to access any <%= t('department.name') %> <%= account_name %> publishing applications.
-
-<% unless GovukEnvironment.production? %>
-<%= account_name.humanize %> suspensions do not suspend production accounts or remove access to <%= t('department.name') %> production applications.
+<% if GovukEnvironment.production? %>
+If this happens you won’t be able to access any of your publishing apps from this account, including Whitehall and Publisher.
+<% else %>
+If this happens you won’t be able to do any training from this account.
 <% end %>
 
-If you don't need the account you can ignore these emails.
+## How to stop suspension
 
-To stop your account suspension you will need to sign in:
+^ Please do not reply to this email.
 
+To stop your account being suspended, all you have to do is sign in:
 <%= new_user_session_url(protocol: 'https') %>
 
-If you’ve forgotten your password, you can request a new one from the sign in screen.
+<%= t('department.name') %> Signon accounts are automatically suspended after <%= User::SUSPENSION_THRESHOLD_PERIOD.inspect %> of inactivity.
 
-Read our blog post about suspending unused <%= t('department.name') %> accounts:
+<% unless GovukEnvironment.production? %>
+Please note that Integration account suspensions do not suspend Production accounts.
 
-https://insidegovuk.blog.gov.uk/2014/08/21/suspending-unused-gov-uk-accounts
+Find about more about the two kinds of accounts on the [How to Publish on GOV.UK page](https://www.gov.uk/guidance/how-to-publish-on-gov-uk/introduction-and-access-to-whitehall-publisher).
+<% end %>
+
+If you no longer need this account, please ignore these instructions.

--- a/app/views/user_mailer/unlock_instructions.text.erb
+++ b/app/views/user_mailer/unlock_instructions.text.erb
@@ -1,7 +1,13 @@
-Your <%= t('department.name') %> Signon <%= account_name %>, for <%= @user.email %>, was locked at <%= locked_time %> because the wrong sign on details were entered too many times.
+Your <%= t('department.name') %> Signon <%= account_name %>, for <%= @user.email %> has been locked.
 
-<% unless GovukEnvironment.production? %>
-  <%= account_name.humanize %> locks do not lock production accounts.
-<% end %>
+This has happened because the wrong sign in details were entered too many times.
 
-Your account will be unlocked at <%= unlock_time %>. If you need your account unlocked sooner, please contact a managing <%= t('department.name') %> editor in your organisation (or your parent organisation). They can use the support form (<%= t('support.url') %>) to get help from the <%= t('department.name') %> team.
+## What happens now
+
+Your account will be unlocked at <%= unlock_time %> UK time.
+
+## If you need your account to be unlocked immediately
+
+Please contact a GOV.UK managing editor or user manager in your organisation (or parent organisation) for further assistance.
+
+Please note that managing editors in an arm’s length body may not have the authority to unlock.

--- a/test/models/noisy_batch_invitation_test.rb
+++ b/test/models/noisy_batch_invitation_test.rb
@@ -53,6 +53,7 @@ class NoisyBatchInvitationTest < ActionMailer::TestCase
   context "work correctly in production environment" do
     setup do
       GovukEnvironment.stubs(:production?).returns(true)
+      GovukEnvironment.stubs(:name).returns("production")
 
       user = create(:user, name: "Bob Loblaw")
       @batch_invitation = create(:batch_invitation, user:)
@@ -61,7 +62,7 @@ class NoisyBatchInvitationTest < ActionMailer::TestCase
     end
 
     should "from address should not include the environment name" do
-      assert_match(/".* Signon" <noreply-signon@.*\.gov\.uk>/, @email[:from].to_s)
+      assert_match(/".* Signon production" <noreply-signon@.*\.gov\.uk>/, @email[:from].to_s)
     end
   end
 end

--- a/test/models/user_mailer_test.rb
+++ b/test/models/user_mailer_test.rb
@@ -166,16 +166,8 @@ class UserMailerTest < ActionMailer::TestCase
       assert_body_includes "for user@example.com"
     end
 
-    should "state when the account was locked" do
-      assert_body_includes "was locked at #{@the_time.to_fs(:govuk_date)}"
-    end
-
     should "state when the account will be unlocked" do
       assert_body_includes "Your account will be unlocked at #{(@the_time + 1.hour).to_fs(:govuk_date)}"
-    end
-
-    should "include correct support links" do
-      assert_support_present_in_text "support form"
     end
   end
 

--- a/test/models/user_mailer_test.rb
+++ b/test/models/user_mailer_test.rb
@@ -133,10 +133,6 @@ class UserMailerTest < ActionMailer::TestCase
     should "say 'suspended' in the body" do
       assert_body_includes "suspended"
     end
-
-    should "include support links" do
-      assert_support_present_in_text "support form"
-    end
   end
 
   context "on a non-production Signon instance" do

--- a/test/models/user_mailer_test.rb
+++ b/test/models/user_mailer_test.rb
@@ -156,7 +156,7 @@ class UserMailerTest < ActionMailer::TestCase
     setup do
       GovukEnvironment.stubs(:production?).returns(false)
       GovukEnvironment.stubs(:name).returns("test")
-      @the_time = Time.zone.now
+      @the_time = Time.zone.parse("2023-10-31 02:00:00")
       user = User.new(name: "User", email: "user@example.com", locked_at: @the_time)
       @email = UserMailer.unlock_instructions(user, "afaketoken")
     end
@@ -167,7 +167,7 @@ class UserMailerTest < ActionMailer::TestCase
     end
 
     should "state when the account will be unlocked" do
-      assert_body_includes "Your account will be unlocked at #{(@the_time + 1.hour).to_fs(:govuk_date)}"
+      assert_body_includes "Your account will be unlocked at 3:00am UK time on 31 October 2023"
     end
   end
 


### PR DESCRIPTION
Trello: https://trello.com/c/0oTag1bi

This PR updates the content of the suspension reminder, suspension notification and unlock instruction emails following [some user research we did on their content](https://docs.google.com/document/d/1kIedI1QlYwf6RNjbVR3l4HApeRFmoHooShZNrDy7NNk/edit?pli=1). 
