### PR TITLE
Users page improvements

### DIFF
--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,8 +1,4 @@
 module UsersHelper
-  def two_step_abbr_tag
-    tag.abbr("2SV", title: "Two step verification")
-  end
-
   def two_step_status(user)
     user.two_step_status.humanize.capitalize
   end

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -48,7 +48,7 @@
           { text: "Email" },
           { text: "Role" },
           { text: "Status" },
-          { text: "#{two_step_abbr_tag} Status".html_safe },
+          { text: "2SV Status" },
         ],
         rows: @users.map do |user|
           [

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -25,7 +25,7 @@
       <%= render "govuk_publishing_components/components/button", {
         text: "Upload a batch of users",
         href: new_batch_invitation_path,
-        secondary: true,
+        secondary_quiet: true,
         margin_bottom: 4,
       } %>
     <% end %>


### PR DESCRIPTION
Trello: https://trello.com/c/zNFNt7Oj

Two small improvements to the /users index page: 
- using a secondary quiet button for "upload a batch of users"
- removing the `2SV` `<abbr>` tag in the table header