### PR TITLE
Tidy InvitationsController

### DIFF
--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -20,7 +20,7 @@ class InvitationsController < Devise::InvitationsController
     authorize User
 
     all_params = invite_params
-    all_params[:require_2sv] = new_user_requires_2sv(all_params.symbolize_keys)
+    all_params[:require_2sv] = invitee_requires_2sv(all_params.symbolize_keys)
 
     self.resource = resource_class.invite!(all_params, current_inviter)
     if resource.errors.empty?
@@ -60,7 +60,7 @@ class InvitationsController < Devise::InvitationsController
 private
 
   def after_invite_path_for(_resource)
-    if new_user_requires_2sv(resource)
+    if invitee_requires_2sv(resource)
       users_path
     else
       require_2sv_user_path(resource)
@@ -77,7 +77,7 @@ private
     Organisation.find_by(id: params[:organisation_id])
   end
 
-  def new_user_requires_2sv(params)
+  def invitee_requires_2sv(params)
     organisation(params)&.require_2sv? || User.admin_roles.include?(params[:role])
   end
 

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -78,8 +78,7 @@ private
   end
 
   def new_user_requires_2sv(params)
-    organisation(params)&.require_2sv? ||
-      %w[superadmin admin organisation_admin super_organisation_admin].include?(params[:role])
+    organisation(params)&.require_2sv? || User.admin_roles.include?(params[:role])
   end
 
   def redirect_if_invitee_already_exists

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -17,12 +17,10 @@ class InvitationsController < Devise::InvitationsController
   end
 
   def create
-    # workaround for invitatable not providing a build_invitation which could be authorised before saving
+    authorize User
+
     all_params = invite_params
     all_params[:require_2sv] = new_user_requires_2sv(all_params.symbolize_keys)
-
-    user = User.new(all_params)
-    authorize user
 
     self.resource = resource_class.invite!(all_params, current_inviter)
     if resource.errors.empty?

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -14,8 +14,6 @@ class InvitationsController < Devise::InvitationsController
   end
 
   def create
-    # Prevent an error when devise_invitable invites/updates an existing user,
-    # and accepts_nested_attributes_for tries to create duplicate permissions.
     if (self.resource = User.find_by(email: params[:user][:email]))
       authorize resource
       flash[:alert] = "User already invited. If you want to, you can click 'Resend signup email'."

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -29,13 +29,12 @@ class InvitationsController < Devise::InvitationsController
       self.resource = resource_class.invite!(all_params, current_inviter)
       if resource.errors.empty?
         grant_default_permissions(resource)
+        EventLog.record_account_invitation(@user, current_user)
         set_flash_message :notice, :send_instructions, email: resource.email
         respond_with resource, location: after_invite_path_for(resource)
       else
         respond_with_navigational(resource) { render :new }
       end
-
-      EventLog.record_account_invitation(@user, current_user)
     end
   end
 

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -88,7 +88,7 @@ private
   end
 
   def current_user_role
-    current_user.try(:role).try(:to_sym) || :normal
+    (current_user || User.new).role.to_sym
   end
 
   def invitation_token

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -73,8 +73,12 @@ private
     end
   end
 
+  def organisation(params)
+    Organisation.find_by(id: params[:organisation_id])
+  end
+
   def new_user_requires_2sv(params)
-    (params[:organisation_id].present? && Organisation.find(params[:organisation_id]).require_2sv?) ||
+    organisation(params)&.require_2sv? ||
       %w[superadmin admin organisation_admin super_organisation_admin].include?(params[:role])
   end
 

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -1,7 +1,7 @@
 # https://raw.github.com/scambra/devise_invitable/master/app/controllers/devise/invitations_controller.rb
 class InvitationsController < Devise::InvitationsController
   before_action :authenticate_user!
-  after_action :verify_authorized, except: %i[edit update] # rubocop:disable Rails/LexicallyScopedActionFilter
+  after_action :verify_authorized, except: %i[edit update]
   layout "admin_layout", only: %i[edit update]
 
   include UserPermissionsControllerMethods
@@ -40,6 +40,21 @@ class InvitationsController < Devise::InvitationsController
       EventLog.record_account_invitation(@user, current_user)
     end
   end
+
+  # rubocop:disable Lint/UselessMethodDefinition
+  # Renders app/views/devise/invitations/edit.html.erb
+  def edit
+    super
+  end
+
+  def update
+    super
+  end
+
+  def destroy
+    super
+  end
+  # rubocop:enable Lint/UselessMethodDefinition
 
   def resend
     user = User.find(params[:id])

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -87,17 +87,6 @@ private
     ).to_h
   end
 
-  # NOTE: `current_user` doesn't exist for `#edit` and `#update` actions as
-  # implemented in our current (out-of-date) versions of Devise
-  # (https://github.com/plataformatec/devise/blob/v2.2/app/controllers/devise_controller.rb#L117)
-  # and DeviseInvitable
-  # (https://github.com/scambra/devise_invitable/blob/v1.1.5/app/controllers/devise/invitations_controller.rb#L5)
-  #
-  # With the old attr_accessible approach, this would fall back to the
-  # default whitelist (i.e. equivalent to the `:normal` role) and this
-  # this preserves that behaviour. In fact, a user accepting an invitation
-  # only needs to modify `password` and `password_confirmation` so we could
-  # only permit those two params for the `edit` and `update` actions.
   def current_user_role
     current_user.try(:role).try(:to_sym) || :normal
   end

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -17,7 +17,7 @@ class InvitationsController < Devise::InvitationsController
 
   def create
     # workaround for invitatable not providing a build_invitation which could be authorised before saving
-    all_params = resource_params
+    all_params = invite_params
     all_params[:require_2sv] = new_user_requires_2sv(all_params.symbolize_keys)
 
     user = User.new(all_params)
@@ -68,17 +68,11 @@ private
     end
   end
 
-  def resource_params
-    sanitised_params = UserParameterSanitiser.new(
+  def invite_params
+    UserParameterSanitiser.new(
       user_params: unsanitised_user_params,
       current_user_role:,
-    ).sanitise
-
-    if params[:action] == "update"
-      sanitised_params.to_h.merge(invitation_token:)
-    else
-      sanitised_params.to_h
-    end
+    ).sanitise.to_h
   end
 
   def unsanitised_user_params
@@ -97,14 +91,6 @@ private
 
   def current_user_role
     (current_user || User.new).role.to_sym
-  end
-
-  def invitation_token
-    unsanitised_user_params.fetch(:invitation_token, {})
-  end
-
-  def update_resource_params
-    resource_params
   end
 
   def grant_default_permissions(user)

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -60,12 +60,6 @@ private
     end
   end
 
-  # TODO: remove this method when we're on a version of devise_invitable which
-  # no longer expects it to exist (v1.2.1 onwards)
-  def build_resource
-    self.resource = resource_class.new(resource_params)
-  end
-
   def resource_params
     sanitised_params = UserParameterSanitiser.new(
       user_params: unsanitised_user_params,

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -73,14 +73,6 @@ private
     end
   end
 
-  # TODO: once we've upgraded Devise and DeviseInvitable, `resource_params`
-  # hopefully won't be being called for actions like `#new` anymore and we
-  # can change the following `params.fetch(:user)` to
-  # `params.require(:user)`. See
-  # https://github.com/scambra/devise_invitable/blob/v1.1.5/app/controllers/devise/invitations_controller.rb#L10
-  # and
-  # https://github.com/plataformatec/devise/blob/v2.2/app/controllers/devise_controller.rb#L99
-  # for details :)
   def unsanitised_user_params
     params.require(:user).permit(
       :name,

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -1,7 +1,8 @@
 # https://raw.github.com/scambra/devise_invitable/master/app/controllers/devise/invitations_controller.rb
 class InvitationsController < Devise::InvitationsController
-  before_action :authenticate_user!
-  after_action :verify_authorized, except: %i[edit update]
+  before_action :authenticate_inviter!, only: %i[new create resend]
+  after_action :verify_authorized, only: %i[new create resend]
+
   layout "admin_layout", only: %i[edit update]
 
   include UserPermissionsControllerMethods

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -20,7 +20,7 @@ class InvitationsController < Devise::InvitationsController
     authorize User
 
     all_params = invite_params
-    all_params[:require_2sv] = invitee_requires_2sv(all_params.symbolize_keys)
+    all_params[:require_2sv] = invitee_requires_2sv(all_params)
 
     self.resource = resource_class.invite!(all_params, current_inviter)
     if resource.errors.empty?

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -24,7 +24,6 @@ class InvitationsController < Devise::InvitationsController
       all_params[:require_2sv] = new_user_requires_2sv(all_params.symbolize_keys)
 
       user = User.new(all_params)
-      user.organisation_id = all_params[:organisation_id]
       authorize user
 
       self.resource = resource_class.invite!(all_params, current_inviter)

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -59,7 +59,7 @@ class InvitationsController < Devise::InvitationsController
 
 private
 
-  def after_invite_path_for(_resource)
+  def after_invite_path_for(_)
     if invitee_requires_2sv(resource)
       users_path
     else

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -25,7 +25,7 @@ class InvitationsController < Devise::InvitationsController
     self.resource = resource_class.invite!(all_params, current_inviter)
     if resource.errors.empty?
       grant_default_permissions(resource)
-      EventLog.record_account_invitation(@user, current_user)
+      EventLog.record_account_invitation(resource, current_user)
       set_flash_message :notice, :send_instructions, email: resource.email
       respond_with resource, location: after_invite_path_for(resource)
     else

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -10,9 +10,7 @@ class UserPolicy < BasePolicy
   alias_method :assign_organisations?, :new?
 
   # invitations#create
-  def create?
-    current_user.superadmin? || (current_user.admin? && !record.superadmin?)
-  end
+  alias_method :create?, :new?
 
   def edit?
     return false if current_user == record

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -15,19 +15,21 @@
     <%= f.text_field :email, autocomplete: "off", class: 'form-control input-md-6 add-label-margin' %>
   </p>
 
-  <% if policy(User).assign_role? && f.object.reason_for_2sv_exemption.blank? %>
-    <p class="form-group">
-      <%= f.label :role %><br />
-      <%= f.select :role, options_for_select(assignable_user_roles.map(&:humanize).zip(assignable_user_roles), f.object.role), {}, class: "chosen-select form-control", 'data-module' => 'chosen' %>
-      <span class="help-block">
-        <strong>Superadmins</strong> can create and edit all user types and edit applications.<br />
-        <strong>Admins</strong> can create and edit normal users.<br />
-        <strong>Super Organisation Admins</strong> can unlock and unsuspend their organisation and related organisation accounts.<br />
-        <strong>Organisation Admins</strong> can unlock and unsuspend their organisation accounts.
-      </span>
-    </p>
-  <% elsif policy(User).assign_role? %>
-    <p>This user's role is set to <%= f.object.role %>. They are currently exempted from 2-step verification, meaning that their role cannot be changed as admins are required to have 2-step verification.</p>
+  <% if policy(User).assign_role? %>
+    <% if f.object.reason_for_2sv_exemption.blank? %>
+      <p class="form-group">
+        <%= f.label :role %><br />
+        <%= f.select :role, options_for_select(assignable_user_roles.map(&:humanize).zip(assignable_user_roles), f.object.role), {}, class: "chosen-select form-control", 'data-module' => 'chosen' %>
+        <span class="help-block">
+          <strong>Superadmins</strong> can create and edit all user types and edit applications.<br />
+          <strong>Admins</strong> can create and edit normal users.<br />
+          <strong>Super Organisation Admins</strong> can unlock and unsuspend their organisation and related organisation accounts.<br />
+          <strong>Organisation Admins</strong> can unlock and unsuspend their organisation accounts.
+        </span>
+      </p>
+    <% else %>
+      <p>This user's role is set to <%= f.object.role %>. They are currently exempted from 2-step verification, meaning that their role cannot be changed as admins are required to have 2-step verification.</p>
+    <% end %>
   <% end %>
 
   <% if policy(User).assign_organisations? %>

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -15,18 +15,6 @@
     <%= f.text_field :email, autocomplete: "off", class: 'form-control input-md-6 add-label-margin' %>
   </p>
 
-  <% if f.object.unconfirmed_email.present? %>
-    <p class="form-group">
-      <%= f.label :unconfirmed_email, "Pending email" %>
-      <%= f.text_field :unconfirmed_email, readonly: "readonly", disabled: "disabled", class: 'form-control' %>
-
-      <div class="help-block add-bottom-margin">
-        <%= link_to "Resend confirmation email", resend_email_change_user_path(f.object), :method => :put, :class => "btn btn-primary add-right-margin" %>
-        <%= link_to "Cancel change", cancel_email_change_user_path(f.object), :method => :delete, :class => "btn btn-danger" %>
-      </div>
-    </p>
-  <% end %>
-
   <% if policy(User).assign_role? && f.object.reason_for_2sv_exemption.blank? %>
     <p class="form-group">
       <%= f.label :role %><br />

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -5,7 +5,110 @@
 <%= form_for resource, :as => resource_name, :url => invitation_path(resource_name), :html => {:method => :post, :class => 'well'} do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
-  <%= render partial: "users/form_fields", locals: { f: f } %>
+  <p class="form-group">
+    <%= f.label :name %>
+    <%= f.text_field :name, autofocus: true, autocomplete: "off", class: 'form-control input-md-6 ' %>
+  </p>
+
+  <p class="form-group">
+    <%= f.label :email %>
+    <%= f.text_field :email, autocomplete: "off", class: 'form-control input-md-6 add-label-margin' %>
+    <% if f.object.persisted? %>
+      <% if f.object.invited_but_not_yet_accepted? %>
+        <span class="help-block">Changes will trigger a new signup email.</span>
+      <% end %>
+    <% end %>
+  </p>
+
+  <% if f.object.unconfirmed_email.present? %>
+    <p class="form-group">
+      <%= f.label :unconfirmed_email, "Pending email" %>
+      <%= f.text_field :unconfirmed_email, readonly: "readonly", disabled: "disabled", class: 'form-control' %>
+
+      <div class="help-block add-bottom-margin">
+        <%= link_to "Resend confirmation email", resend_email_change_user_path(f.object), :method => :put, :class => "btn btn-primary add-right-margin" %>
+        <%= link_to "Cancel change", cancel_email_change_user_path(f.object), :method => :delete, :class => "btn btn-danger" %>
+      </div>
+    </p>
+  <% end %>
+
+  <% if policy(User).assign_role? && f.object.reason_for_2sv_exemption.blank? %>
+    <p class="form-group">
+      <%= f.label :role %><br />
+      <%= f.select :role, options_for_select(assignable_user_roles.map(&:humanize).zip(assignable_user_roles), f.object.role), {}, class: "chosen-select form-control", 'data-module' => 'chosen' %>
+      <span class="help-block">
+        <strong>Superadmins</strong> can create and edit all user types and edit applications.<br />
+        <strong>Admins</strong> can create and edit normal users.<br />
+        <strong>Super Organisation Admins</strong> can unlock and unsuspend their organisation and related organisation accounts.<br />
+        <strong>Organisation Admins</strong> can unlock and unsuspend their organisation accounts.
+      </span>
+    </p>
+  <% elsif policy(User).assign_role? %>
+    <p>This user's role is set to <%= f.object.role %>. They are currently exempted from 2-step verification, meaning that their role cannot be changed as admins are required to have 2-step verification.</p>
+  <% end %>
+
+  <% if policy(f.object).mandate_2sv? && f.object.persisted? %>
+    <dl>
+      <dt>Account security</dt>
+      <dd>
+        <% if f.object.exempt_from_2sv? %>
+          <p>
+            The user has been made exempt from 2-step verification for the following reason: <%= f.object.reason_for_2sv_exemption %>
+          <% if policy(f.object).exempt_from_two_step_verification? %>
+            <br>
+            <%= link_to 'Edit reason or expiry date for 2-step verification exemption', edit_two_step_verification_exemption_path(f.object) %>
+          <% end %>
+          </p>
+        <% elsif f.object.has_2sv? %>
+          <p>2-step verification enabled</p>
+          <p>
+            <%= link_to 'Reset 2-step verification',
+              reset_two_step_verification_user_path(f.object),
+              data: { confirm: 'Are you sure?' },
+              method: :patch
+            %><br/>
+            Allows user to sign in without a verification code.<br/>
+            User will be prompted to set up 2-step verification again the next time they sign in.
+          </p>
+        <% elsif f.object.require_2sv? %>
+          <p>2-step verification required but not set up</p>
+        <% else %>
+          <p>2-step verification not set up</p>
+        <% end %>
+
+        <% unless f.object.require_2sv? %>
+          <p class="checkbox">
+            <%= f.label :require_2sv do %>
+              <%= f.check_box :require_2sv %> Mandate 2-step verification for this user <%= "(this will remove their exemption)" if f.object.exempt_from_2sv? %>
+            <% end %>
+          <br/>
+          User will be prompted to set up 2-step verification again the next time they sign in.</p>
+        <% end %>
+        <% if f.object.persisted? && policy(f.object).exempt_from_two_step_verification? && f.object.reason_for_2sv_exemption.nil? %>
+            <p>
+              <%= link_to 'Exempt user from 2-step verification', edit_two_step_verification_exemption_path(f.object) %>
+              <br/>
+              Exempt a user from 2-step verification (requires a reason to be supplied).
+            </p>
+        <%end %>
+      </dd>
+    </dl>
+  <% end %>
+
+  <% if policy(User).assign_organisations? %>
+    <p class="form-group">
+      <%= f.label :organisation_id, "Organisation" %><br />
+      <%= f.select :organisation_id, organisation_options(f), organisation_select_options, { class: "chosen-select form-control", 'data-module' => 'chosen' } %>
+    </p>
+  <% end %>
+
+  <h2 class="add-vertical-margins"> <%= "Editable " if (current_user.publishing_manager? ) %>Permissions</h2>
+  <%= render partial: "shared/user_permissions", locals: { user_object: f.object }%>
+
+  <% if current_user.publishing_manager? %>
+      <h2 class="add-vertical-margins">All Permissions for this user</h2>
+      <%= render partial: "app_permissions", locals: { user_object: f.object }%>
+  <% end %>
 
   <%= f.submit "Create user and send email", :class => 'btn btn-success' %>
 <% end %>

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -28,12 +28,10 @@
     </p>
   <% end %>
 
-  <% if policy(User).assign_organisations? %>
-    <p class="form-group">
-      <%= f.label :organisation_id, "Organisation" %><br />
-      <%= f.select :organisation_id, organisation_options(f), organisation_select_options, { class: "chosen-select form-control", 'data-module' => 'chosen' } %>
-    </p>
-  <% end %>
+  <p class="form-group">
+    <%= f.label :organisation_id, "Organisation" %><br />
+    <%= f.select :organisation_id, organisation_options(f), organisation_select_options, { class: "chosen-select form-control", 'data-module' => 'chosen' } %>
+  </p>
 
   <h2 class="add-vertical-margins">Permissions</h2>
   <%= render partial: "shared/user_permissions", locals: { user_object: f.object }%>

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -13,11 +13,6 @@
   <p class="form-group">
     <%= f.label :email %>
     <%= f.text_field :email, autocomplete: "off", class: 'form-control input-md-6 add-label-margin' %>
-    <% if f.object.persisted? %>
-      <% if f.object.invited_but_not_yet_accepted? %>
-        <span class="help-block">Changes will trigger a new signup email.</span>
-      <% end %>
-    <% end %>
   </p>
 
   <% if f.object.unconfirmed_email.present? %>
@@ -45,54 +40,6 @@
     </p>
   <% elsif policy(User).assign_role? %>
     <p>This user's role is set to <%= f.object.role %>. They are currently exempted from 2-step verification, meaning that their role cannot be changed as admins are required to have 2-step verification.</p>
-  <% end %>
-
-  <% if policy(f.object).mandate_2sv? && f.object.persisted? %>
-    <dl>
-      <dt>Account security</dt>
-      <dd>
-        <% if f.object.exempt_from_2sv? %>
-          <p>
-            The user has been made exempt from 2-step verification for the following reason: <%= f.object.reason_for_2sv_exemption %>
-          <% if policy(f.object).exempt_from_two_step_verification? %>
-            <br>
-            <%= link_to 'Edit reason or expiry date for 2-step verification exemption', edit_two_step_verification_exemption_path(f.object) %>
-          <% end %>
-          </p>
-        <% elsif f.object.has_2sv? %>
-          <p>2-step verification enabled</p>
-          <p>
-            <%= link_to 'Reset 2-step verification',
-              reset_two_step_verification_user_path(f.object),
-              data: { confirm: 'Are you sure?' },
-              method: :patch
-            %><br/>
-            Allows user to sign in without a verification code.<br/>
-            User will be prompted to set up 2-step verification again the next time they sign in.
-          </p>
-        <% elsif f.object.require_2sv? %>
-          <p>2-step verification required but not set up</p>
-        <% else %>
-          <p>2-step verification not set up</p>
-        <% end %>
-
-        <% unless f.object.require_2sv? %>
-          <p class="checkbox">
-            <%= f.label :require_2sv do %>
-              <%= f.check_box :require_2sv %> Mandate 2-step verification for this user <%= "(this will remove their exemption)" if f.object.exempt_from_2sv? %>
-            <% end %>
-          <br/>
-          User will be prompted to set up 2-step verification again the next time they sign in.</p>
-        <% end %>
-        <% if f.object.persisted? && policy(f.object).exempt_from_two_step_verification? && f.object.reason_for_2sv_exemption.nil? %>
-            <p>
-              <%= link_to 'Exempt user from 2-step verification', edit_two_step_verification_exemption_path(f.object) %>
-              <br/>
-              Exempt a user from 2-step verification (requires a reason to be supplied).
-            </p>
-        <%end %>
-      </dd>
-    </dl>
   <% end %>
 
   <% if policy(User).assign_organisations? %>

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -37,13 +37,8 @@
     </p>
   <% end %>
 
-  <h2 class="add-vertical-margins"> <%= "Editable " if (current_user.publishing_manager? ) %>Permissions</h2>
+  <h2 class="add-vertical-margins">Permissions</h2>
   <%= render partial: "shared/user_permissions", locals: { user_object: f.object }%>
-
-  <% if current_user.publishing_manager? %>
-      <h2 class="add-vertical-margins">All Permissions for this user</h2>
-      <%= render partial: "app_permissions", locals: { user_object: f.object }%>
-  <% end %>
 
   <%= f.submit "Create user and send email", :class => 'btn btn-success' %>
 <% end %>

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -16,20 +16,16 @@
   </p>
 
   <% if policy(User).assign_role? %>
-    <% if f.object.reason_for_2sv_exemption.blank? %>
-      <p class="form-group">
-        <%= f.label :role %><br />
-        <%= f.select :role, options_for_select(assignable_user_roles.map(&:humanize).zip(assignable_user_roles), f.object.role), {}, class: "chosen-select form-control", 'data-module' => 'chosen' %>
-        <span class="help-block">
-          <strong>Superadmins</strong> can create and edit all user types and edit applications.<br />
-          <strong>Admins</strong> can create and edit normal users.<br />
-          <strong>Super Organisation Admins</strong> can unlock and unsuspend their organisation and related organisation accounts.<br />
-          <strong>Organisation Admins</strong> can unlock and unsuspend their organisation accounts.
-        </span>
-      </p>
-    <% else %>
-      <p>This user's role is set to <%= f.object.role %>. They are currently exempted from 2-step verification, meaning that their role cannot be changed as admins are required to have 2-step verification.</p>
-    <% end %>
+    <p class="form-group">
+      <%= f.label :role %><br />
+      <%= f.select :role, options_for_select(assignable_user_roles.map(&:humanize).zip(assignable_user_roles), f.object.role), {}, class: "chosen-select form-control", 'data-module' => 'chosen' %>
+      <span class="help-block">
+        <strong>Superadmins</strong> can create and edit all user types and edit applications.<br />
+        <strong>Admins</strong> can create and edit normal users.<br />
+        <strong>Super Organisation Admins</strong> can unlock and unsuspend their organisation and related organisation accounts.<br />
+        <strong>Organisation Admins</strong> can unlock and unsuspend their organisation accounts.
+      </span>
+    </p>
   <% end %>
 
   <% if policy(User).assign_organisations? %>

--- a/app/views/users/_form_fields.html.erb
+++ b/app/views/users/_form_fields.html.erb
@@ -6,10 +6,8 @@
 <p class="form-group">
   <%= f.label :email %>
   <%= f.text_field :email, autocomplete: "off", class: 'form-control input-md-6 add-label-margin' %>
-  <% if f.object.persisted? %>
-    <% if f.object.invited_but_not_yet_accepted? %>
-      <span class="help-block">Changes will trigger a new signup email.</span>
-    <% end %>
+  <% if f.object.invited_but_not_yet_accepted? %>
+    <span class="help-block">Changes will trigger a new signup email.</span>
   <% end %>
 </p>
 
@@ -42,7 +40,7 @@
   <% end %>
 <% end %>
 
-<% if policy(@user).mandate_2sv? && @user.persisted? %>
+<% if policy(@user).mandate_2sv? %>
   <dl>
     <dt>Account security</dt>
     <dd>
@@ -79,7 +77,7 @@
         <br/>
         User will be prompted to set up 2-step verification again the next time they sign in.</p>
       <% end %>
-      <% if @user.persisted? && policy(@user).exempt_from_two_step_verification? && @user.reason_for_2sv_exemption.nil? %>
+      <% if policy(@user).exempt_from_two_step_verification? && @user.reason_for_2sv_exemption.nil? %>
           <p>
             <%= link_to 'Exempt user from 2-step verification', edit_two_step_verification_exemption_path(@user) %>
             <br/>

--- a/app/views/users/_form_fields.html.erb
+++ b/app/views/users/_form_fields.html.erb
@@ -25,19 +25,21 @@
   </p>
 <% end %>
 
-<% if policy(User).assign_role? && @user.reason_for_2sv_exemption.blank? %>
-  <p class="form-group">
-    <%= f.label :role %><br />
-    <%= f.select :role, options_for_select(assignable_user_roles.map(&:humanize).zip(assignable_user_roles), f.object.role), {}, class: "chosen-select form-control", 'data-module' => 'chosen' %>
-    <span class="help-block">
-      <strong>Superadmins</strong> can create and edit all user types and edit applications.<br />
-      <strong>Admins</strong> can create and edit normal users.<br />
-      <strong>Super Organisation Admins</strong> can unlock and unsuspend their organisation and related organisation accounts.<br />
-      <strong>Organisation Admins</strong> can unlock and unsuspend their organisation accounts.
-    </span>
-  </p>
-<% elsif policy(User).assign_role? %>
-  <p>This user's role is set to <%= @user.role %>. They are currently exempted from 2-step verification, meaning that their role cannot be changed as admins are required to have 2-step verification.</p>
+<% if policy(User).assign_role? %>
+  <% if @user.reason_for_2sv_exemption.blank? %>
+    <p class="form-group">
+      <%= f.label :role %><br />
+      <%= f.select :role, options_for_select(assignable_user_roles.map(&:humanize).zip(assignable_user_roles), f.object.role), {}, class: "chosen-select form-control", 'data-module' => 'chosen' %>
+      <span class="help-block">
+        <strong>Superadmins</strong> can create and edit all user types and edit applications.<br />
+        <strong>Admins</strong> can create and edit normal users.<br />
+        <strong>Super Organisation Admins</strong> can unlock and unsuspend their organisation and related organisation accounts.<br />
+        <strong>Organisation Admins</strong> can unlock and unsuspend their organisation accounts.
+      </span>
+    </p>
+  <% else %>
+    <p>This user's role is set to <%= @user.role %>. They are currently exempted from 2-step verification, meaning that their role cannot be changed as admins are required to have 2-step verification.</p>
+  <% end %>
 <% end %>
 
 <% if policy(@user).mandate_2sv? && @user.persisted? %>

--- a/lib/roles.rb
+++ b/lib/roles.rb
@@ -28,6 +28,10 @@ module Roles
       role_classes - [Roles::Normal, Roles::Base]
     end
 
+    def admin_roles
+      admin_role_classes.map(&:role_name)
+    end
+
     def roles
       role_classes.sort_by(&:level).map(&:role_name)
     end

--- a/test/controllers/invitations_controller_test.rb
+++ b/test/controllers/invitations_controller_test.rb
@@ -101,25 +101,25 @@ class InvitationsControllerTest < ActionController::TestCase
           assert_redirected_to require_2sv_user_path(User.last)
         end
 
-        should "not render 2SV form when invitee will be a superadmin" do
+        should "not render 2SV form for superadmin invitee, because superadmins must use 2SV" do
           post :create, params: { user: { name: "superadmin-invitee", email: "superadmin-invitee@gov.uk", organisation_id: @organisation, role: Roles::Superadmin.role_name } }
 
           assert_redirected_to users_path
         end
 
-        should "not render 2SV form when invitee will be an admin" do
+        should "not render 2SV for admin invitee, because admins must use 2SV" do
           post :create, params: { user: { name: "admin-invitee", email: "admin-invitee@gov.uk", organisation_id: @organisation, role: Roles::Admin.role_name } }
 
           assert_redirected_to users_path
         end
 
-        should "not render 2SV form when invitee will be an organisation admin" do
+        should "not render 2SV for organisation admin invitee, because organisation admins must use 2SV" do
           post :create, params: { user: { name: "org-admin-invitee", email: "org-admin-invitee@gov.uk", organisation_id: @organisation, role: Roles::OrganisationAdmin.role_name } }
 
           assert_redirected_to users_path
         end
 
-        should "not render 2SV form when invitee will be a super organisation admin" do
+        should "not render 2SV form for super organisation admin invitee, because super organisation admins must use 2SV" do
           post :create, params: { user: { name: "super-org-admin-invitee", email: "super-org-admin-invitee@gov.uk", organisation_id: @organisation, role: Roles::SuperOrganisationAdmin.role_name } }
 
           assert_redirected_to users_path

--- a/test/controllers/invitations_controller_test.rb
+++ b/test/controllers/invitations_controller_test.rb
@@ -90,37 +90,37 @@ class InvitationsControllerTest < ActionController::TestCase
         end
 
         should "save invitee" do
-          post :create, params: { user: { name: "invitee", email: "invitee@gov.uk", organisation_id: @organisation.id } }
+          post :create, params: { user: { name: "invitee", email: "invitee@gov.uk", organisation_id: @organisation } }
 
           assert_equal "invitee", User.last.name
         end
 
         should "render 2SV form allowing inviter to choose whether to require 2SV" do
-          post :create, params: { user: { name: "invitee", email: "invitee@gov.uk", organisation_id: @organisation.id } }
+          post :create, params: { user: { name: "invitee", email: "invitee@gov.uk", organisation_id: @organisation } }
 
           assert_redirected_to require_2sv_user_path(User.last)
         end
 
         should "not render 2SV form when invitee will be a superadmin" do
-          post :create, params: { user: { name: "superadmin-invitee", email: "superadmin-invitee@gov.uk", organisation_id: @organisation.id, role: Roles::Superadmin.role_name } }
+          post :create, params: { user: { name: "superadmin-invitee", email: "superadmin-invitee@gov.uk", organisation_id: @organisation, role: Roles::Superadmin.role_name } }
 
           assert_redirected_to users_path
         end
 
         should "not render 2SV form when invitee will be an admin" do
-          post :create, params: { user: { name: "admin-invitee", email: "admin-invitee@gov.uk", organisation_id: @organisation.id, role: Roles::Admin.role_name } }
+          post :create, params: { user: { name: "admin-invitee", email: "admin-invitee@gov.uk", organisation_id: @organisation, role: Roles::Admin.role_name } }
 
           assert_redirected_to users_path
         end
 
         should "not render 2SV form when invitee will be an organisation admin" do
-          post :create, params: { user: { name: "org-admin-invitee", email: "org-admin-invitee@gov.uk", organisation_id: @organisation.id, role: Roles::OrganisationAdmin.role_name } }
+          post :create, params: { user: { name: "org-admin-invitee", email: "org-admin-invitee@gov.uk", organisation_id: @organisation, role: Roles::OrganisationAdmin.role_name } }
 
           assert_redirected_to users_path
         end
 
         should "not render 2SV form when invitee will be a super organisation admin" do
-          post :create, params: { user: { name: "super-org-admin-invitee", email: "super-org-admin-invitee@gov.uk", organisation_id: @organisation.id, role: Roles::SuperOrganisationAdmin.role_name } }
+          post :create, params: { user: { name: "super-org-admin-invitee", email: "super-org-admin-invitee@gov.uk", organisation_id: @organisation, role: Roles::SuperOrganisationAdmin.role_name } }
 
           assert_redirected_to users_path
         end
@@ -132,13 +132,13 @@ class InvitationsControllerTest < ActionController::TestCase
         end
 
         should "save invitee" do
-          post :create, params: { user: { name: "invitee", email: "invitee@gov.uk", organisation_id: @organisation.id } }
+          post :create, params: { user: { name: "invitee", email: "invitee@gov.uk", organisation_id: @organisation } }
 
           assert_equal "invitee", User.last.name
         end
 
         should "not render 2SV form allowing inviter to choose whether to require 2SV" do
-          post :create, params: { user: { name: "invitee", email: "invitee@gov.uk", organisation_id: @organisation.id } }
+          post :create, params: { user: { name: "invitee", email: "invitee@gov.uk", organisation_id: @organisation } }
 
           assert_redirected_to users_path
           assert_equal "invitee", User.last.name
@@ -243,7 +243,7 @@ class InvitationsControllerTest < ActionController::TestCase
       should "resend account signup email to invitee" do
         User.any_instance.expects(:invite!).once
 
-        post :resend, params: { id: @user_to_resend_for.id }
+        post :resend, params: { id: @user_to_resend_for }
 
         assert_redirected_to users_path
       end
@@ -254,7 +254,7 @@ class InvitationsControllerTest < ActionController::TestCase
         end
 
         should "disallow access" do
-          post :resend, params: { id: @user_to_resend_for.id }
+          post :resend, params: { id: @user_to_resend_for }
 
           assert_redirected_to root_path
         end
@@ -266,7 +266,7 @@ class InvitationsControllerTest < ActionController::TestCase
         end
 
         should "disallow access" do
-          post :resend, params: { id: @user_to_resend_for.id }
+          post :resend, params: { id: @user_to_resend_for }
 
           assert_redirected_to root_path
         end
@@ -278,7 +278,7 @@ class InvitationsControllerTest < ActionController::TestCase
         end
 
         should "disallow access" do
-          post :resend, params: { id: @user_to_resend_for.id }
+          post :resend, params: { id: @user_to_resend_for }
 
           assert_redirected_to root_path
         end
@@ -288,7 +288,7 @@ class InvitationsControllerTest < ActionController::TestCase
     context "when inviter is not signed in" do
       should "require inviter to be signed in" do
         user_to_resend_for = create(:user)
-        post :resend, params: { id: user_to_resend_for.id }
+        post :resend, params: { id: user_to_resend_for }
 
         assert_redirected_to new_user_session_path
       end

--- a/test/controllers/invitations_controller_test.rb
+++ b/test/controllers/invitations_controller_test.rb
@@ -6,6 +6,14 @@ class InvitationsControllerTest < ActionController::TestCase
   end
 
   context "GET new" do
+    context "when not signed in" do
+      should "require user to be signed in" do
+        get :new
+
+        assert_redirected_to new_user_session_path
+      end
+    end
+
     context "when signed in" do
       setup do
         @user = create(:superadmin_user)
@@ -33,6 +41,14 @@ class InvitationsControllerTest < ActionController::TestCase
   end
 
   context "POST create" do
+    context "when not signed in" do
+      should "require user to be signed in" do
+        post :create
+
+        assert_redirected_to new_user_session_path
+      end
+    end
+
     context "when signed in" do
       setup do
         @user = create(:superadmin_user)
@@ -133,6 +149,15 @@ class InvitationsControllerTest < ActionController::TestCase
   end
 
   context "POST resend" do
+    context "when not signed in" do
+      should "require user to be signed in" do
+        user_to_resend_for = create(:user)
+        post :resend, params: { id: user_to_resend_for.id }
+
+        assert_redirected_to new_user_session_path
+      end
+    end
+
     context "when signed in" do
       setup do
         @user = create(:superadmin_user)

--- a/test/controllers/invitations_controller_test.rb
+++ b/test/controllers/invitations_controller_test.rb
@@ -242,6 +242,7 @@ class InvitationsControllerTest < ActionController::TestCase
 
     context "when inviter is signed in" do
       setup do
+        @user_to_resend_for = create(:user)
         sign_in create(:superadmin_user)
       end
 
@@ -251,9 +252,7 @@ class InvitationsControllerTest < ActionController::TestCase
         end
 
         should "disallow access" do
-          user_to_resend_for = create(:user)
-
-          post :resend, params: { id: user_to_resend_for.id }
+          post :resend, params: { id: @user_to_resend_for.id }
 
           assert_redirected_to root_path
         end
@@ -265,9 +264,7 @@ class InvitationsControllerTest < ActionController::TestCase
         end
 
         should "disallow access" do
-          user_to_resend_for = create(:user)
-
-          post :resend, params: { id: user_to_resend_for.id }
+          post :resend, params: { id: @user_to_resend_for.id }
 
           assert_redirected_to root_path
         end
@@ -279,19 +276,16 @@ class InvitationsControllerTest < ActionController::TestCase
         end
 
         should "disallow access" do
-          user_to_resend_for = create(:user)
-
-          post :resend, params: { id: user_to_resend_for.id }
+          post :resend, params: { id: @user_to_resend_for.id }
 
           assert_redirected_to root_path
         end
       end
 
       should "resend account signup email to invitee" do
-        user_to_resend_for = create(:user)
         User.any_instance.expects(:invite!).once
 
-        post :resend, params: { id: user_to_resend_for.id }
+        post :resend, params: { id: @user_to_resend_for.id }
 
         assert_redirected_to users_path
       end

--- a/test/controllers/invitations_controller_test.rb
+++ b/test/controllers/invitations_controller_test.rb
@@ -21,7 +21,7 @@ class InvitationsControllerTest < ActionController::TestCase
       end
 
       should "disallow access to non-admin inviter" do
-        @inviter.update_column(:role, "normal")
+        @inviter.update_column(:role, Roles::Normal.role_name)
         get :new
         assert_redirected_to root_path
       end
@@ -56,7 +56,7 @@ class InvitationsControllerTest < ActionController::TestCase
       end
 
       should "disallow access to non-admin inviter" do
-        @inviter.update_column(:role, "normal")
+        @inviter.update_column(:role, Roles::Normal.role_name)
         post :create, params: { user: { name: "invitee", email: "invitee@gov.uk" } }
         assert_redirected_to root_path
       end
@@ -192,7 +192,7 @@ class InvitationsControllerTest < ActionController::TestCase
       end
 
       should "disallow access to non-admin inviter" do
-        @inviter.update_column(:role, "normal")
+        @inviter.update_column(:role, Roles::Normal.role_name)
         user_to_resend_for = create(:user)
         post :resend, params: { id: user_to_resend_for.id }
         assert_redirected_to root_path

--- a/test/controllers/invitations_controller_test.rb
+++ b/test/controllers/invitations_controller_test.rb
@@ -152,6 +152,26 @@ class InvitationsControllerTest < ActionController::TestCase
         assert_template :new
         assert_not User.exists?(name: "User Name")
       end
+
+      should "record account invitation in event log when invitation sent" do
+        EventLog.expects(:record_account_invitation).with(instance_of(User), @user)
+
+        post :create, params: { user: { name: "User Name", email: "person@gov.uk" } }
+      end
+
+      should "not record account invitation in event log when invitation not sent because of validation errors" do
+        EventLog.expects(:record_account_invitation).never
+
+        post :create, params: { user: { name: "User Name", email: "" } }
+      end
+
+      should "not record account invitation in event log when invitation not sent because user already exists" do
+        user = create(:user)
+
+        EventLog.expects(:record_account_invitation).never
+
+        post :create, params: { user: { name: user.name, email: user.email } }
+      end
     end
   end
 

--- a/test/controllers/invitations_controller_test.rb
+++ b/test/controllers/invitations_controller_test.rb
@@ -6,34 +6,34 @@ class InvitationsControllerTest < ActionController::TestCase
   end
 
   context "GET new" do
-    context "when not signed in" do
-      should "require user to be signed in" do
+    context "when inviter is not signed in" do
+      should "require inviter to be signed in" do
         get :new
 
         assert_redirected_to new_user_session_path
       end
     end
 
-    context "when signed in" do
+    context "when inviter is signed in" do
       setup do
-        @user = create(:superadmin_user)
-        sign_in @user
+        @inviter = create(:superadmin_user)
+        sign_in @inviter
       end
 
-      should "disallow access to non-admins" do
-        @user.update_column(:role, "normal")
+      should "disallow access to non-admin inviter" do
+        @inviter.update_column(:role, "normal")
         get :new
         assert_redirected_to root_path
       end
 
-      should "disallow access to organisation admins" do
-        @user.update!(role: Roles::OrganisationAdmin.role_name, organisation_id: create(:organisation).id)
+      should "disallow access to organisation admin inviter" do
+        @inviter.update!(role: Roles::OrganisationAdmin.role_name, organisation_id: create(:organisation).id)
         get :new
         assert_redirected_to root_path
       end
 
-      should "disallow access to super organisation admins" do
-        @user.update!(role: Roles::SuperOrganisationAdmin.role_name, organisation_id: create(:organisation).id)
+      should "disallow access to super organisation admin inviter" do
+        @inviter.update!(role: Roles::SuperOrganisationAdmin.role_name, organisation_id: create(:organisation).id)
         get :new
         assert_redirected_to root_path
       end
@@ -41,22 +41,22 @@ class InvitationsControllerTest < ActionController::TestCase
   end
 
   context "POST create" do
-    context "when not signed in" do
-      should "require user to be signed in" do
+    context "when inviter is not signed in" do
+      should "require inviter to be signed in" do
         post :create
 
         assert_redirected_to new_user_session_path
       end
     end
 
-    context "when signed in" do
+    context "when inviter is signed in" do
       setup do
-        @user = create(:superadmin_user)
-        sign_in @user
+        @inviter = create(:superadmin_user)
+        sign_in @inviter
       end
 
-      should "disallow access to non-admins" do
-        @user.update_column(:role, "normal")
+      should "disallow access to non-admin inviter" do
+        @inviter.update_column(:role, "normal")
         post :create, params: { user: { name: "Testing Non-admins", email: "testing_non_admins@example.com" } }
         assert_redirected_to root_path
       end
@@ -76,14 +76,14 @@ class InvitationsControllerTest < ActionController::TestCase
         assert_equal "User already invited. If you want to, you can click 'Resend signup email'.", flash[:alert]
       end
 
-      should "disallow access to organisation admins" do
-        @user.update!(role: Roles::OrganisationAdmin.role_name, organisation_id: create(:organisation).id)
+      should "disallow access to organisation admin inviter" do
+        @inviter.update!(role: Roles::OrganisationAdmin.role_name, organisation_id: create(:organisation).id)
         post :create, params: { user: { name: "Testing Org Admins", email: "testing_org_admins@example.com" } }
         assert_redirected_to root_path
       end
 
-      should "disallow access to super organisation admins" do
-        @user.update!(role: Roles::SuperOrganisationAdmin.role_name, organisation_id: create(:organisation).id)
+      should "disallow access to super organisation admin inviter" do
+        @inviter.update!(role: Roles::SuperOrganisationAdmin.role_name, organisation_id: create(:organisation).id)
         post :create, params: { user: { name: "Testing Org Admins", email: "testing_org_admins@example.com" } }
         assert_redirected_to root_path
       end
@@ -154,7 +154,7 @@ class InvitationsControllerTest < ActionController::TestCase
       end
 
       should "record account invitation in event log when invitation sent" do
-        EventLog.expects(:record_account_invitation).with(instance_of(User), @user)
+        EventLog.expects(:record_account_invitation).with(instance_of(User), @inviter)
 
         post :create, params: { user: { name: "User Name", email: "person@gov.uk" } }
       end
@@ -176,8 +176,8 @@ class InvitationsControllerTest < ActionController::TestCase
   end
 
   context "POST resend" do
-    context "when not signed in" do
-      should "require user to be signed in" do
+    context "when inviter is not signed in" do
+      should "require inviter to be signed in" do
         user_to_resend_for = create(:user)
         post :resend, params: { id: user_to_resend_for.id }
 
@@ -185,38 +185,38 @@ class InvitationsControllerTest < ActionController::TestCase
       end
     end
 
-    context "when signed in" do
+    context "when inviter is signed in" do
       setup do
-        @user = create(:superadmin_user)
-        sign_in @user
+        @inviter = create(:superadmin_user)
+        sign_in @inviter
       end
 
-      should "disallow access to non-admins" do
-        @user.update_column(:role, "normal")
+      should "disallow access to non-admin inviter" do
+        @inviter.update_column(:role, "normal")
         user_to_resend_for = create(:user)
         post :resend, params: { id: user_to_resend_for.id }
         assert_redirected_to root_path
       end
 
-      should "disallow access to organisation admins" do
-        @user.update!(role: Roles::OrganisationAdmin.role_name, organisation_id: create(:organisation).id)
+      should "disallow access to organisation admin inviter" do
+        @inviter.update!(role: Roles::OrganisationAdmin.role_name, organisation_id: create(:organisation).id)
         user_to_resend_for = create(:user)
         post :resend, params: { id: user_to_resend_for.id }
         assert_redirected_to root_path
       end
 
-      should "disallow access to super organisation admins" do
-        @user.update!(role: Roles::SuperOrganisationAdmin.role_name, organisation_id: create(:organisation).id)
+      should "disallow access to super organisation admin inviter" do
+        @inviter.update!(role: Roles::SuperOrganisationAdmin.role_name, organisation_id: create(:organisation).id)
         user_to_resend_for = create(:user)
         post :resend, params: { id: user_to_resend_for.id }
         assert_redirected_to root_path
       end
 
       should "resend account signup email to user" do
-        admin = create(:admin_user)
+        admin_inviter = create(:admin_user)
         user_to_resend_for = create(:user)
         User.any_instance.expects(:invite!).once
-        sign_in admin
+        sign_in admin_inviter
 
         post :resend, params: { id: user_to_resend_for.id }
 

--- a/test/controllers/invitations_controller_test.rb
+++ b/test/controllers/invitations_controller_test.rb
@@ -145,6 +145,13 @@ class InvitationsControllerTest < ActionController::TestCase
         assert_equal "User Name", User.last.name
         assert User.last.require_2sv
       end
+
+      should "re-render form and not save user if there are validation errors" do
+        post :create, params: { user: { name: "User Name", email: "" } }
+
+        assert_template :new
+        assert_not User.exists?(name: "User Name")
+      end
     end
   end
 

--- a/test/controllers/invitations_controller_test.rb
+++ b/test/controllers/invitations_controller_test.rb
@@ -129,40 +129,101 @@ class InvitationsControllerTest < ActionController::TestCase
           @organisation = create(:organisation, require_2sv: false)
         end
 
+        should "set require_2sv on invitee to false" do
+          post :create, params: { user: { name: "invitee", email: "invitee@gov.uk", organisation_id: @organisation } }
+
+          assert_not User.last.require_2sv?
+        end
+
         should "render 2SV form allowing inviter to choose whether to require 2SV" do
           post :create, params: { user: { name: "invitee", email: "invitee@gov.uk", organisation_id: @organisation } }
 
           assert_redirected_to require_2sv_user_path(User.last)
         end
 
-        should "not render 2SV form for superadmin invitee, because superadmins must use 2SV" do
-          post :create, params: { user: { name: "superadmin-invitee", email: "superadmin-invitee@gov.uk", organisation_id: @organisation, role: Roles::Superadmin.role_name } }
+        context "when invitee role is set to superadmin" do
+          setup do
+            @role = Roles::Superadmin.role_name
+          end
 
-          assert_redirected_to users_path
+          should "set require_2sv on invitee to true" do
+            post :create, params: { user: { name: "superadmin-invitee", email: "superadmin-invitee@gov.uk", organisation_id: @organisation, role: @role } }
+
+            assert User.last.require_2sv?
+          end
+
+          should "not render 2SV form, because superadmins must use 2SV" do
+            post :create, params: { user: { name: "superadmin-invitee", email: "superadmin-invitee@gov.uk", organisation_id: @organisation, role: @role } }
+
+            assert_redirected_to users_path
+          end
         end
 
-        should "not render 2SV for admin invitee, because admins must use 2SV" do
-          post :create, params: { user: { name: "admin-invitee", email: "admin-invitee@gov.uk", organisation_id: @organisation, role: Roles::Admin.role_name } }
+        context "when invitee role is set to admin" do
+          setup do
+            @role = Roles::Admin.role_name
+          end
 
-          assert_redirected_to users_path
+          should "set require_2sv on invitee to true" do
+            post :create, params: { user: { name: "admin-invitee", email: "admin-invitee@gov.uk", organisation_id: @organisation, role: @role } }
+
+            assert User.last.require_2sv?
+          end
+
+          should "not render 2SV form, because admins must use 2SV" do
+            post :create, params: { user: { name: "admin-invitee", email: "admin-invitee@gov.uk", organisation_id: @organisation, role: @role } }
+
+            assert_redirected_to users_path
+          end
         end
 
-        should "not render 2SV for organisation admin invitee, because organisation admins must use 2SV" do
-          post :create, params: { user: { name: "org-admin-invitee", email: "org-admin-invitee@gov.uk", organisation_id: @organisation, role: Roles::OrganisationAdmin.role_name } }
+        context "when invitee role is set to organisation admin" do
+          setup do
+            @role = Roles::OrganisationAdmin.role_name
+          end
 
-          assert_redirected_to users_path
+          should "set require_2sv on invitee to true" do
+            post :create, params: { user: { name: "org-admin-invitee", email: "org-admin-invitee@gov.uk", organisation_id: @organisation, role: @role } }
+
+            assert User.last.require_2sv?
+          end
+
+          should "not render 2SV form, because organisation admins must use 2SV" do
+            post :create, params: { user: { name: "org-admin-invitee", email: "org-admin-invitee@gov.uk", organisation_id: @organisation, role: @role } }
+
+            assert_redirected_to users_path
+          end
         end
 
-        should "not render 2SV form for super organisation admin invitee, because super organisation admins must use 2SV" do
-          post :create, params: { user: { name: "super-org-admin-invitee", email: "super-org-admin-invitee@gov.uk", organisation_id: @organisation, role: Roles::SuperOrganisationAdmin.role_name } }
+        context "when invitee role is set to super organisation admin" do
+          setup do
+            @role = Roles::SuperOrganisationAdmin.role_name
+          end
 
-          assert_redirected_to users_path
+          should "set require_2sv on invitee to true" do
+            post :create, params: { user: { name: "super-org-admin-invitee", email: "super-org-admin-invitee@gov.uk", organisation_id: @organisation, role: @role } }
+
+            assert User.last.require_2sv?
+          end
+
+          should "not render 2SV form, because super organisation admins must use 2SV" do
+            post :create, params: { user: { name: "super-org-admin-invitee", email: "super-org-admin-invitee@gov.uk", organisation_id: @organisation, role: @role } }
+
+            assert_redirected_to users_path
+          end
         end
       end
 
       context "and invitee will be assigned to organisation requiring 2SV" do
         setup do
           @organisation = create(:organisation, require_2sv: true)
+        end
+
+        should "set require_2sv on invitee to true" do
+          post :create, params: { user: { name: "invitee", email: "invitee@gov.uk", organisation_id: @organisation } }
+
+          invitee = User.last
+          assert invitee.require_2sv?
         end
 
         should "not render 2SV form allowing inviter to choose whether to require 2SV" do

--- a/test/controllers/invitations_controller_test.rb
+++ b/test/controllers/invitations_controller_test.rb
@@ -6,65 +6,63 @@ class InvitationsControllerTest < ActionController::TestCase
   end
 
   context "GET new" do
-    context "when inviter is signed in" do
-      context "and inviter is an admin" do
-        setup do
-          sign_in create(:admin_user)
-        end
-
-        should "allow access" do
-          get :new
-
-          assert_template :new
-        end
+    context "when inviter is signed in as an admin" do
+      setup do
+        sign_in create(:admin_user)
       end
 
-      context "and inviter is a super admin" do
-        setup do
-          sign_in create(:superadmin_user)
-        end
+      should "allow access" do
+        get :new
 
-        should "allow access" do
-          get :new
+        assert_template :new
+      end
+    end
 
-          assert_template :new
-        end
+    context "when inviter is signed in as a superadmin" do
+      setup do
+        sign_in create(:superadmin_user)
       end
 
-      context "and inviter is not an admin" do
-        setup do
-          sign_in create(:user)
-        end
+      should "allow access" do
+        get :new
 
-        should "disallow access" do
-          get :new
+        assert_template :new
+      end
+    end
 
-          assert_redirected_to root_path
-        end
+    context "when inviter is signed in as a normal (non-admin) user" do
+      setup do
+        sign_in create(:user)
       end
 
-      context "and inviter is an organisation admin" do
-        setup do
-          sign_in create(:organisation_admin_user)
-        end
+      should "disallow access" do
+        get :new
 
-        should "disallow access" do
-          get :new
+        assert_redirected_to root_path
+      end
+    end
 
-          assert_redirected_to root_path
-        end
+    context "when inviter is signed in as an organisation admin" do
+      setup do
+        sign_in create(:organisation_admin_user)
       end
 
-      context "and inviter is a super organisation admin" do
-        setup do
-          sign_in create(:super_organisation_admin_user)
-        end
+      should "disallow access" do
+        get :new
 
-        should "disallow access" do
-          get :new
+        assert_redirected_to root_path
+      end
+    end
 
-          assert_redirected_to root_path
-        end
+    context "when inviter is signed in as a super organisation admin" do
+      setup do
+        sign_in create(:super_organisation_admin_user)
+      end
+
+      should "disallow access" do
+        get :new
+
+        assert_redirected_to root_path
       end
     end
 
@@ -78,7 +76,7 @@ class InvitationsControllerTest < ActionController::TestCase
   end
 
   context "POST create" do
-    context "when inviter is signed in" do
+    context "when inviter is signed in as a superadmin" do
       setup do
         @inviter = create(:superadmin_user)
         sign_in @inviter
@@ -186,41 +184,41 @@ class InvitationsControllerTest < ActionController::TestCase
         assert_redirected_to users_path
         assert_equal "User already invited. If you want to, you can click 'Resend signup email'.", flash[:alert]
       end
+    end
 
-      context "and inviter is not an admin" do
-        setup do
-          sign_in create(:user)
-        end
-
-        should "disallow access" do
-          post :create, params: { user: { name: "invitee", email: "invitee@gov.uk" } }
-
-          assert_redirected_to root_path
-        end
+    context "when inviter is signed in as a normal (non-admin) user" do
+      setup do
+        sign_in create(:user)
       end
 
-      context "and inviter is an organisation admin" do
-        setup do
-          sign_in create(:organisation_admin_user)
-        end
+      should "disallow access" do
+        post :create, params: { user: { name: "invitee", email: "invitee@gov.uk" } }
 
-        should "disallow access" do
-          post :create, params: { user: { name: "org-admin-invitee", email: "org-admin-invitee@gov.uk" } }
+        assert_redirected_to root_path
+      end
+    end
 
-          assert_redirected_to root_path
-        end
+    context "when inviter is signed in as an organisation admin" do
+      setup do
+        sign_in create(:organisation_admin_user)
       end
 
-      context "and inviter is a super organisation admin" do
-        setup do
-          sign_in create(:super_organisation_admin_user)
-        end
+      should "disallow access" do
+        post :create, params: { user: { name: "org-admin-invitee", email: "org-admin-invitee@gov.uk" } }
 
-        should "disallow access" do
-          post :create, params: { user: { name: "super-org-admin-invitee", email: "super-org-admin-invitee@gov.uk" } }
+        assert_redirected_to root_path
+      end
+    end
 
-          assert_redirected_to root_path
-        end
+    context "when inviter is signed in as a super organisation admin" do
+      setup do
+        sign_in create(:super_organisation_admin_user)
+      end
+
+      should "disallow access" do
+        post :create, params: { user: { name: "super-org-admin-invitee", email: "super-org-admin-invitee@gov.uk" } }
+
+        assert_redirected_to root_path
       end
     end
 
@@ -234,9 +232,12 @@ class InvitationsControllerTest < ActionController::TestCase
   end
 
   context "POST resend" do
-    context "when inviter is signed in" do
+    setup do
+      @user_to_resend_for = create(:user)
+    end
+
+    context "when inviter is signed in as a superadmin" do
       setup do
-        @user_to_resend_for = create(:user)
         sign_in create(:superadmin_user)
       end
 
@@ -247,41 +248,41 @@ class InvitationsControllerTest < ActionController::TestCase
 
         assert_redirected_to users_path
       end
+    end
 
-      context "and inviter is not an admin" do
-        setup do
-          sign_in create(:user)
-        end
-
-        should "disallow access" do
-          post :resend, params: { id: @user_to_resend_for }
-
-          assert_redirected_to root_path
-        end
+    context "when inviter is signed in as a normal (non-admin) user" do
+      setup do
+        sign_in create(:user)
       end
 
-      context "and inviter is an organisation admin" do
-        setup do
-          sign_in create(:organisation_admin_user)
-        end
+      should "disallow access" do
+        post :resend, params: { id: @user_to_resend_for }
 
-        should "disallow access" do
-          post :resend, params: { id: @user_to_resend_for }
+        assert_redirected_to root_path
+      end
+    end
 
-          assert_redirected_to root_path
-        end
+    context "when inviter is signed in as an organisation admin" do
+      setup do
+        sign_in create(:organisation_admin_user)
       end
 
-      context "and inviter is a super organisation admin" do
-        setup do
-          sign_in create(:super_organisation_admin_user)
-        end
+      should "disallow access" do
+        post :resend, params: { id: @user_to_resend_for }
 
-        should "disallow access" do
-          post :resend, params: { id: @user_to_resend_for }
+        assert_redirected_to root_path
+      end
+    end
 
-          assert_redirected_to root_path
-        end
+    context "when inviter is signed in as a super organisation admin" do
+      setup do
+        sign_in create(:super_organisation_admin_user)
+      end
+
+      should "disallow access" do
+        post :resend, params: { id: @user_to_resend_for }
+
+        assert_redirected_to root_path
       end
     end
 

--- a/test/controllers/invitations_controller_test.rb
+++ b/test/controllers/invitations_controller_test.rb
@@ -100,31 +100,6 @@ class InvitationsControllerTest < ActionController::TestCase
 
           assert_redirected_to require_2sv_user_path(User.last)
         end
-      end
-
-      context "and invitee will be assigned to organisation requiring 2SV" do
-        setup do
-          @organisation = create(:organisation, require_2sv: true)
-        end
-
-        should "save invitee" do
-          post :create, params: { user: { name: "invitee", email: "invitee@gov.uk", organisation_id: @organisation.id } }
-
-          assert_equal "invitee", User.last.name
-        end
-
-        should "not render 2SV form allowing inviter to choose whether to require 2SV" do
-          post :create, params: { user: { name: "invitee", email: "invitee@gov.uk", organisation_id: @organisation.id } }
-
-          assert_redirected_to users_path
-          assert_equal "invitee", User.last.name
-        end
-      end
-
-      context "and invitee will be assigned to organisation not requiring 2SV" do
-        setup do
-          @organisation = create(:organisation, require_2sv: false)
-        end
 
         should "not render 2SV form when invitee will be a superadmin" do
           post :create, params: { user: { name: "superadmin-invitee", email: "superadmin-invitee@gov.uk", organisation_id: @organisation.id, role: Roles::Superadmin.role_name } }
@@ -148,6 +123,25 @@ class InvitationsControllerTest < ActionController::TestCase
           post :create, params: { user: { name: "super-org-admin-invitee", email: "super-org-admin-invitee@gov.uk", organisation_id: @organisation.id, role: Roles::SuperOrganisationAdmin.role_name } }
 
           assert_redirected_to users_path
+        end
+      end
+
+      context "and invitee will be assigned to organisation requiring 2SV" do
+        setup do
+          @organisation = create(:organisation, require_2sv: true)
+        end
+
+        should "save invitee" do
+          post :create, params: { user: { name: "invitee", email: "invitee@gov.uk", organisation_id: @organisation.id } }
+
+          assert_equal "invitee", User.last.name
+        end
+
+        should "not render 2SV form allowing inviter to choose whether to require 2SV" do
+          post :create, params: { user: { name: "invitee", email: "invitee@gov.uk", organisation_id: @organisation.id } }
+
+          assert_redirected_to users_path
+          assert_equal "invitee", User.last.name
         end
       end
 

--- a/test/controllers/invitations_controller_test.rb
+++ b/test/controllers/invitations_controller_test.rb
@@ -68,9 +68,9 @@ class InvitationsControllerTest < ActionController::TestCase
       end
 
       should "redirect to users page and display flash alert when inviting an existing user" do
-        user = create(:user)
+        existing_user = create(:user)
 
-        post :create, params: { user: { name: user.name, email: user.email } }
+        post :create, params: { user: { name: existing_user.name, email: existing_user.email } }
 
         assert_redirected_to users_path
         assert_equal "User already invited. If you want to, you can click 'Resend signup email'.", flash[:alert]
@@ -88,7 +88,7 @@ class InvitationsControllerTest < ActionController::TestCase
         assert_redirected_to root_path
       end
 
-      should "save user and render 2SV form when user assigned to organisation that does not require 2SV" do
+      should "save invitee and render 2SV form when invitee will be assigned to organisation that does not require 2SV" do
         organisation = create(:organisation, require_2sv: false)
 
         post :create, params: { user: { name: "User Name", email: "person@gov.uk", organisation_id: organisation.id } }
@@ -97,7 +97,7 @@ class InvitationsControllerTest < ActionController::TestCase
         assert_equal "User Name", User.last.name
       end
 
-      should "save user and not render 2SV form when user assigned to organisation that requires 2SV" do
+      should "save invitee and not render 2SV form when invitee will be assigned to organisation that requires 2SV" do
         organisation = create(:organisation, require_2sv: true)
 
         post :create, params: { user: { name: "User Name", email: "person@gov.uk", organisation_id: organisation.id } }
@@ -106,7 +106,7 @@ class InvitationsControllerTest < ActionController::TestCase
         assert_equal "User Name", User.last.name
       end
 
-      should "not render 2SV form and saves user when user is a superadmin" do
+      should "not render 2SV form and saves invitee when invitee will be a superadmin" do
         organisation = create(:organisation, require_2sv: false)
 
         post :create, params: { user: { name: "User Name", email: "person@gov.uk", organisation_id: organisation.id, role: Roles::Superadmin.role_name } }
@@ -116,7 +116,7 @@ class InvitationsControllerTest < ActionController::TestCase
         assert User.last.require_2sv
       end
 
-      should "not render 2SV form and saves user when user is an admin" do
+      should "not render 2SV form and saves invitee when invitee will be an admin" do
         organisation = create(:organisation, require_2sv: false)
 
         post :create, params: { user: { name: "User Name", email: "person@gov.uk", organisation_id: organisation.id, role: Roles::Admin.role_name } }
@@ -126,7 +126,7 @@ class InvitationsControllerTest < ActionController::TestCase
         assert User.last.require_2sv
       end
 
-      should "not render 2SV form and saves user when user is an organisation admin" do
+      should "not render 2SV form and saves invitee when invitee will be an organisation admin" do
         organisation = create(:organisation, require_2sv: false)
 
         post :create, params: { user: { name: "User Name", email: "person@gov.uk", organisation_id: organisation.id, role: Roles::OrganisationAdmin.role_name } }
@@ -136,7 +136,7 @@ class InvitationsControllerTest < ActionController::TestCase
         assert User.last.require_2sv
       end
 
-      should "not render 2SV form and saves user when user is an super organisation admin" do
+      should "not render 2SV form and saves invitee when invitee will be a super organisation admin" do
         organisation = create(:organisation, require_2sv: false)
 
         post :create, params: { user: { name: "User Name", email: "person@gov.uk", organisation_id: organisation.id, role: Roles::SuperOrganisationAdmin.role_name } }
@@ -146,7 +146,7 @@ class InvitationsControllerTest < ActionController::TestCase
         assert User.last.require_2sv
       end
 
-      should "re-render form and not save user if there are validation errors" do
+      should "re-render form and not save invitee if there are validation errors" do
         post :create, params: { user: { name: "User Name", email: "" } }
 
         assert_template :new
@@ -166,11 +166,11 @@ class InvitationsControllerTest < ActionController::TestCase
       end
 
       should "not record account invitation in event log when invitation not sent because user already exists" do
-        user = create(:user)
+        existing_user = create(:user)
 
         EventLog.expects(:record_account_invitation).never
 
-        post :create, params: { user: { name: user.name, email: user.email } }
+        post :create, params: { user: { name: existing_user.name, email: existing_user.email } }
       end
     end
   end
@@ -212,7 +212,7 @@ class InvitationsControllerTest < ActionController::TestCase
         assert_redirected_to root_path
       end
 
-      should "resend account signup email to user" do
+      should "resend account signup email to invitee" do
         admin_inviter = create(:admin_user)
         user_to_resend_for = create(:user)
         User.any_instance.expects(:invite!).once

--- a/test/controllers/invitations_controller_test.rb
+++ b/test/controllers/invitations_controller_test.rb
@@ -50,6 +50,30 @@ class InvitationsControllerTest < ActionController::TestCase
           assert_redirected_to root_path
         end
       end
+
+      context "and inviter is an admin" do
+        setup do
+          sign_in create(:admin_user)
+        end
+
+        should "allow access" do
+          get :new
+
+          assert_template :new
+        end
+      end
+
+      context "and inviter is a super admin" do
+        setup do
+          sign_in create(:superadmin_user)
+        end
+
+        should "allow access" do
+          get :new
+
+          assert_template :new
+        end
+      end
     end
   end
 

--- a/test/controllers/invitations_controller_test.rb
+++ b/test/controllers/invitations_controller_test.rb
@@ -78,19 +78,20 @@ class InvitationsControllerTest < ActionController::TestCase
   context "POST create" do
     context "when inviter is signed in as a superadmin" do
       setup do
+        @organisation = create(:organisation)
         @inviter = create(:superadmin_user)
         sign_in @inviter
+      end
+
+      should "save invitee with permitted attributes" do
+        post :create, params: { user: { name: "invitee", email: "invitee@gov.uk", organisation_id: @organisation } }
+
+        assert_equal "invitee", User.last.name
       end
 
       context "and invitee will be assigned to organisation not requiring 2SV" do
         setup do
           @organisation = create(:organisation, require_2sv: false)
-        end
-
-        should "save invitee" do
-          post :create, params: { user: { name: "invitee", email: "invitee@gov.uk", organisation_id: @organisation } }
-
-          assert_equal "invitee", User.last.name
         end
 
         should "render 2SV form allowing inviter to choose whether to require 2SV" do
@@ -127,12 +128,6 @@ class InvitationsControllerTest < ActionController::TestCase
       context "and invitee will be assigned to organisation requiring 2SV" do
         setup do
           @organisation = create(:organisation, require_2sv: true)
-        end
-
-        should "save invitee" do
-          post :create, params: { user: { name: "invitee", email: "invitee@gov.uk", organisation_id: @organisation } }
-
-          assert_equal "invitee", User.last.name
         end
 
         should "not render 2SV form allowing inviter to choose whether to require 2SV" do

--- a/test/controllers/invitations_controller_test.rb
+++ b/test/controllers/invitations_controller_test.rb
@@ -57,12 +57,12 @@ class InvitationsControllerTest < ActionController::TestCase
 
       should "disallow access to non-admin inviter" do
         @inviter.update_column(:role, "normal")
-        post :create, params: { user: { name: "Testing Non-admins", email: "testing_non_admins@example.com" } }
+        post :create, params: { user: { name: "invitee", email: "invitee@gov.uk" } }
         assert_redirected_to root_path
       end
 
       should "not allow creation of api users" do
-        post :create, params: { user: { name: "Testing APIs", email: "api@example.com", api_user: true } }
+        post :create, params: { user: { name: "api-invitee", email: "api-invitee@gov.uk", api_user: true } }
 
         assert_empty User.where(api_user: true)
       end
@@ -78,91 +78,91 @@ class InvitationsControllerTest < ActionController::TestCase
 
       should "disallow access to organisation admin inviter" do
         @inviter.update!(role: Roles::OrganisationAdmin.role_name, organisation_id: create(:organisation).id)
-        post :create, params: { user: { name: "Testing Org Admins", email: "testing_org_admins@example.com" } }
+        post :create, params: { user: { name: "org-admin-invitee", email: "org-admin-invitee@gov.uk" } }
         assert_redirected_to root_path
       end
 
       should "disallow access to super organisation admin inviter" do
         @inviter.update!(role: Roles::SuperOrganisationAdmin.role_name, organisation_id: create(:organisation).id)
-        post :create, params: { user: { name: "Testing Org Admins", email: "testing_org_admins@example.com" } }
+        post :create, params: { user: { name: "super-org-admin-invitee", email: "super-org-admin-invitee@gov.uk" } }
         assert_redirected_to root_path
       end
 
       should "save invitee and render 2SV form when invitee will be assigned to organisation that does not require 2SV" do
         organisation = create(:organisation, require_2sv: false)
 
-        post :create, params: { user: { name: "User Name", email: "person@gov.uk", organisation_id: organisation.id } }
+        post :create, params: { user: { name: "invitee", email: "invitee@gov.uk", organisation_id: organisation.id } }
 
         assert_redirected_to require_2sv_user_path(User.last)
-        assert_equal "User Name", User.last.name
+        assert_equal "invitee", User.last.name
       end
 
       should "save invitee and not render 2SV form when invitee will be assigned to organisation that requires 2SV" do
         organisation = create(:organisation, require_2sv: true)
 
-        post :create, params: { user: { name: "User Name", email: "person@gov.uk", organisation_id: organisation.id } }
+        post :create, params: { user: { name: "invitee", email: "invitee@gov.uk", organisation_id: organisation.id } }
 
         assert_redirected_to users_path
-        assert_equal "User Name", User.last.name
+        assert_equal "invitee", User.last.name
       end
 
       should "not render 2SV form and saves invitee when invitee will be a superadmin" do
         organisation = create(:organisation, require_2sv: false)
 
-        post :create, params: { user: { name: "User Name", email: "person@gov.uk", organisation_id: organisation.id, role: Roles::Superadmin.role_name } }
+        post :create, params: { user: { name: "superadmin-invitee", email: "superadmin-invitee@gov.uk", organisation_id: organisation.id, role: Roles::Superadmin.role_name } }
 
         assert_redirected_to users_path
-        assert_equal "User Name", User.last.name
+        assert_equal "superadmin-invitee", User.last.name
         assert User.last.require_2sv
       end
 
       should "not render 2SV form and saves invitee when invitee will be an admin" do
         organisation = create(:organisation, require_2sv: false)
 
-        post :create, params: { user: { name: "User Name", email: "person@gov.uk", organisation_id: organisation.id, role: Roles::Admin.role_name } }
+        post :create, params: { user: { name: "admin-invitee", email: "admin-invitee@gov.uk", organisation_id: organisation.id, role: Roles::Admin.role_name } }
 
         assert_redirected_to users_path
-        assert_equal "User Name", User.last.name
+        assert_equal "admin-invitee", User.last.name
         assert User.last.require_2sv
       end
 
       should "not render 2SV form and saves invitee when invitee will be an organisation admin" do
         organisation = create(:organisation, require_2sv: false)
 
-        post :create, params: { user: { name: "User Name", email: "person@gov.uk", organisation_id: organisation.id, role: Roles::OrganisationAdmin.role_name } }
+        post :create, params: { user: { name: "org-admin-invitee", email: "org-admin-invitee@gov.uk", organisation_id: organisation.id, role: Roles::OrganisationAdmin.role_name } }
 
         assert_redirected_to users_path
-        assert_equal "User Name", User.last.name
+        assert_equal "org-admin-invitee", User.last.name
         assert User.last.require_2sv
       end
 
       should "not render 2SV form and saves invitee when invitee will be a super organisation admin" do
         organisation = create(:organisation, require_2sv: false)
 
-        post :create, params: { user: { name: "User Name", email: "person@gov.uk", organisation_id: organisation.id, role: Roles::SuperOrganisationAdmin.role_name } }
+        post :create, params: { user: { name: "super-org-admin-invitee", email: "super-org-admin-invitee@gov.uk", organisation_id: organisation.id, role: Roles::SuperOrganisationAdmin.role_name } }
 
         assert_redirected_to users_path
-        assert_equal "User Name", User.last.name
+        assert_equal "super-org-admin-invitee", User.last.name
         assert User.last.require_2sv
       end
 
       should "re-render form and not save invitee if there are validation errors" do
-        post :create, params: { user: { name: "User Name", email: "" } }
+        post :create, params: { user: { name: "invitee-without-email", email: "" } }
 
         assert_template :new
-        assert_not User.exists?(name: "User Name")
+        assert_not User.exists?(name: "invitee-without-email")
       end
 
       should "record account invitation in event log when invitation sent" do
         EventLog.expects(:record_account_invitation).with(instance_of(User), @inviter)
 
-        post :create, params: { user: { name: "User Name", email: "person@gov.uk" } }
+        post :create, params: { user: { name: "invitee", email: "invitee@gov.uk" } }
       end
 
       should "not record account invitation in event log when invitation not sent because of validation errors" do
         EventLog.expects(:record_account_invitation).never
 
-        post :create, params: { user: { name: "User Name", email: "" } }
+        post :create, params: { user: { name: "invitee-without-email", email: "" } }
       end
 
       should "not record account invitation in event log when invitation not sent because user already exists" do

--- a/test/controllers/invitations_controller_test.rb
+++ b/test/controllers/invitations_controller_test.rb
@@ -6,51 +6,7 @@ class InvitationsControllerTest < ActionController::TestCase
   end
 
   context "GET new" do
-    context "when inviter is not signed in" do
-      should "require inviter to be signed in" do
-        get :new
-
-        assert_redirected_to new_user_session_path
-      end
-    end
-
     context "when inviter is signed in" do
-      context "and inviter is not an admin" do
-        setup do
-          sign_in create(:user)
-        end
-
-        should "disallow access" do
-          get :new
-
-          assert_redirected_to root_path
-        end
-      end
-
-      context "and inviter is an organisation admin" do
-        setup do
-          sign_in create(:organisation_admin_user)
-        end
-
-        should "disallow access" do
-          get :new
-
-          assert_redirected_to root_path
-        end
-      end
-
-      context "and inviter is a super organisation admin" do
-        setup do
-          sign_in create(:super_organisation_admin_user)
-        end
-
-        should "disallow access" do
-          get :new
-
-          assert_redirected_to root_path
-        end
-      end
-
       context "and inviter is an admin" do
         setup do
           sign_in create(:admin_user)
@@ -74,23 +30,6 @@ class InvitationsControllerTest < ActionController::TestCase
           assert_template :new
         end
       end
-    end
-  end
-
-  context "POST create" do
-    context "when inviter is not signed in" do
-      should "require inviter to be signed in" do
-        post :create
-
-        assert_redirected_to new_user_session_path
-      end
-    end
-
-    context "when inviter is signed in" do
-      setup do
-        @inviter = create(:superadmin_user)
-        sign_in @inviter
-      end
 
       context "and inviter is not an admin" do
         setup do
@@ -98,25 +37,10 @@ class InvitationsControllerTest < ActionController::TestCase
         end
 
         should "disallow access" do
-          post :create, params: { user: { name: "invitee", email: "invitee@gov.uk" } }
+          get :new
 
           assert_redirected_to root_path
         end
-      end
-
-      should "not allow creation of api users" do
-        post :create, params: { user: { name: "api-invitee", email: "api-invitee@gov.uk", api_user: true } }
-
-        assert_empty User.where(api_user: true)
-      end
-
-      should "redirect to users page and display flash alert when inviting an existing user" do
-        existing_user = create(:user)
-
-        post :create, params: { user: { name: existing_user.name, email: existing_user.email } }
-
-        assert_redirected_to users_path
-        assert_equal "User already invited. If you want to, you can click 'Resend signup email'.", flash[:alert]
       end
 
       context "and inviter is an organisation admin" do
@@ -125,7 +49,7 @@ class InvitationsControllerTest < ActionController::TestCase
         end
 
         should "disallow access" do
-          post :create, params: { user: { name: "org-admin-invitee", email: "org-admin-invitee@gov.uk" } }
+          get :new
 
           assert_redirected_to root_path
         end
@@ -137,10 +61,27 @@ class InvitationsControllerTest < ActionController::TestCase
         end
 
         should "disallow access" do
-          post :create, params: { user: { name: "super-org-admin-invitee", email: "super-org-admin-invitee@gov.uk" } }
+          get :new
 
           assert_redirected_to root_path
         end
+      end
+    end
+
+    context "when inviter is not signed in" do
+      should "require inviter to be signed in" do
+        get :new
+
+        assert_redirected_to new_user_session_path
+      end
+    end
+  end
+
+  context "POST create" do
+    context "when inviter is signed in" do
+      setup do
+        @inviter = create(:superadmin_user)
+        sign_in @inviter
       end
 
       should "save invitee and render 2SV form when invitee will be assigned to organisation that does not require 2SV" do
@@ -227,23 +168,81 @@ class InvitationsControllerTest < ActionController::TestCase
 
         post :create, params: { user: { name: existing_user.name, email: existing_user.email } }
       end
-    end
-  end
 
-  context "POST resend" do
+      should "not allow creation of api users" do
+        post :create, params: { user: { name: "api-invitee", email: "api-invitee@gov.uk", api_user: true } }
+
+        assert_empty User.where(api_user: true)
+      end
+
+      should "redirect to users page and display flash alert when inviting an existing user" do
+        existing_user = create(:user)
+
+        post :create, params: { user: { name: existing_user.name, email: existing_user.email } }
+
+        assert_redirected_to users_path
+        assert_equal "User already invited. If you want to, you can click 'Resend signup email'.", flash[:alert]
+      end
+
+      context "and inviter is not an admin" do
+        setup do
+          sign_in create(:user)
+        end
+
+        should "disallow access" do
+          post :create, params: { user: { name: "invitee", email: "invitee@gov.uk" } }
+
+          assert_redirected_to root_path
+        end
+      end
+
+      context "and inviter is an organisation admin" do
+        setup do
+          sign_in create(:organisation_admin_user)
+        end
+
+        should "disallow access" do
+          post :create, params: { user: { name: "org-admin-invitee", email: "org-admin-invitee@gov.uk" } }
+
+          assert_redirected_to root_path
+        end
+      end
+
+      context "and inviter is a super organisation admin" do
+        setup do
+          sign_in create(:super_organisation_admin_user)
+        end
+
+        should "disallow access" do
+          post :create, params: { user: { name: "super-org-admin-invitee", email: "super-org-admin-invitee@gov.uk" } }
+
+          assert_redirected_to root_path
+        end
+      end
+    end
+
     context "when inviter is not signed in" do
       should "require inviter to be signed in" do
-        user_to_resend_for = create(:user)
-        post :resend, params: { id: user_to_resend_for.id }
+        post :create
 
         assert_redirected_to new_user_session_path
       end
     end
+  end
 
+  context "POST resend" do
     context "when inviter is signed in" do
       setup do
         @user_to_resend_for = create(:user)
         sign_in create(:superadmin_user)
+      end
+
+      should "resend account signup email to invitee" do
+        User.any_instance.expects(:invite!).once
+
+        post :resend, params: { id: @user_to_resend_for.id }
+
+        assert_redirected_to users_path
       end
 
       context "and inviter is not an admin" do
@@ -281,13 +280,14 @@ class InvitationsControllerTest < ActionController::TestCase
           assert_redirected_to root_path
         end
       end
+    end
 
-      should "resend account signup email to invitee" do
-        User.any_instance.expects(:invite!).once
+    context "when inviter is not signed in" do
+      should "require inviter to be signed in" do
+        user_to_resend_for = create(:user)
+        post :resend, params: { id: user_to_resend_for.id }
 
-        post :resend, params: { id: @user_to_resend_for.id }
-
-        assert_redirected_to users_path
+        assert_redirected_to new_user_session_path
       end
     end
   end

--- a/test/controllers/invitations_controller_test.rb
+++ b/test/controllers/invitations_controller_test.rb
@@ -67,7 +67,7 @@ class InvitationsControllerTest < ActionController::TestCase
         assert_empty User.where(api_user: true)
       end
 
-      should "not error while inviting an existing user" do
+      should "redirect to users page and display flash alert when inviting an existing user" do
         user = create(:user)
 
         post :create, params: { user: { name: user.name, email: user.email } }

--- a/test/lib/roles_test.rb
+++ b/test/lib/roles_test.rb
@@ -35,6 +35,19 @@ class RolesTest < ActiveSupport::TestCase
     end
   end
 
+  context ".admin_roles" do
+    should "only include admin role names" do
+      expected_role_names = [
+        Roles::Admin.role_name,
+        Roles::Superadmin.role_name,
+        Roles::OrganisationAdmin.role_name,
+        Roles::SuperOrganisationAdmin.role_name,
+      ]
+
+      assert_same_elements expected_role_names, Subject.admin_roles
+    end
+  end
+
   context ".roles" do
     should "order roles by their level" do
       expected_ordered_roles = %w[

--- a/test/policies/user_policy_test.rb
+++ b/test/policies/user_policy_test.rb
@@ -12,8 +12,8 @@ class UserPolicyTest < ActiveSupport::TestCase
     @gds = create(:organisation, name: "Government Digital Services", content_id: Organisation::GDS_ORG_CONTENT_ID)
   end
 
-  primary_management_actions = %i[new assign_organisations]
-  user_management_actions = %i[edit create update unlock suspension cancel_email_change resend_email_change event_logs reset_2sv mandate_2sv]
+  primary_management_actions = %i[new create assign_organisations]
+  user_management_actions = %i[edit update unlock suspension cancel_email_change resend_email_change event_logs reset_2sv mandate_2sv]
   superadmin_actions = %i[assign_role]
   two_step_verification_exemption_actions = %i[exempt_from_two_step_verification]
 
@@ -140,10 +140,6 @@ class UserPolicyTest < ActiveSupport::TestCase
       assert permit?(build(:super_organisation_admin_user), User, :index)
     end
 
-    should "not allow for create" do
-      assert forbid?(build(:super_organisation_admin_user), User, :create)
-    end
-
     primary_management_actions.each do |permission|
       should "not allow for #{permission}" do
         assert forbid?(build(:super_organisation_admin_user), User, permission)
@@ -199,10 +195,6 @@ class UserPolicyTest < ActiveSupport::TestCase
   context "organisation admins" do
     should "allow for index" do
       assert permit?(build(:organisation_admin_user), User, :index)
-    end
-
-    should "not allow for create" do
-      assert forbid?(build(:organisation_admin_user), User, :create)
     end
 
     primary_management_actions.each do |permission|

--- a/test/policies/user_policy_test.rb
+++ b/test/policies/user_policy_test.rb
@@ -42,8 +42,6 @@ class UserPolicyTest < ActiveSupport::TestCase
         assert permit?(user, build(:superadmin_user), permission)
       end
 
-      next if permission == :create
-
       should "not allow for #{permission} for the logged in user" do
         user = create(:superadmin_user)
 
@@ -101,8 +99,6 @@ class UserPolicyTest < ActiveSupport::TestCase
         assert permit?(user, build(:admin_user), permission)
         assert forbid?(user, build(:superadmin_user), permission)
       end
-
-      next if permission == :create
 
       should "not allow for #{permission} for the logged in user" do
         user = create(:admin_user)


### PR DESCRIPTION
Trello: https://trello.com/c/umBDQZUc

This is in preparation for splitting the page handled by the `InvitationsController#new` & `#create` actions into two pages with the second handling the setting of permissions. The `InvitationsController` is made more complicated than a typical controller for a few reasons, e.g.:

1.  The audience for the `#new`, `#create` & `#destroy` actions is admins & superadmins inviting new users; whereas the audience for the `#edit` & `#update` actions is new users accepting their invitations and setting their password.
2. It inherits from [`Devise::InvitationsController`][1] provided by `devise_invitable` but significantly customises its behaviour and its template(s) in `app/views/devise/invitations/`.

There's definitely a question in my mind about how much benefit we're getting from inheriting from `Devise::InvitationsController`, particularly given how much we are customising it and how easy it is for the code to get out-of-date with the gem as it gets updated with Dependabot. However, I decided that this is out-of-scope for this PR.

Currently there's an optional 2nd page for when an admin can choose whether or not the invited user must use 2SV which further complicates the controller. I'm hoping that I can combine this page into the 1st page in a subsequent PR.

While this PR has a lot of commits, most of them are relatively small and only make changes to two files:
* `app/controllers/invitations_controller.rb`
* `test/controllers/invitations_controller_test.rb`

The main changes in this PR are:
* Improve test coverage in `InvitationsControllerTest` and try to make `InvitationsControllerTest` easier to follow.
* Simplify `InvitationsController` and bring it more into line with the current version of `Devise::InvitationsController`
    * In particular, make use of [the built-in support for Strong Parameters][2] which I suspect may not have been available when some of the code was written.
    * As part of this, the controller no longer uses `UserParameterSanitiser`. I'm not convinced that the latter is a useful abstraction, because it makes it much harder to see which parameters are permitted for a given controller/action and (in combination with `Roles::***.permitted_user_params` methods it seems to contain logic that probably belongs in Pundit policies.
* Introduce a separate `app/views/devise/invitations/new.html.erb` template rather than re-using `app/views/users/_form_fields.html.erb` - the latter was unnecessarily complicated and made it hard to see the wood for the trees.  Admittedly this comes at the cost of a little duplication, but I think the benefits outweigh the costs.

[1]: https://github.com/scambra/devise_invitable/blob/v2.0.8/app/controllers/devise/invitations_controller.rb
[2]: https://github.com/scambra/devise_invitable/blob/v2.0.8/README.rdoc#label-Strong+Parameters