### PR TITLE
Ignore expired & revoked tokens in SSOPushCredential.credentials

### DIFF
--- a/lib/sso_push_credential.rb
+++ b/lib/sso_push_credential.rb
@@ -9,6 +9,7 @@ class SSOPushCredential
       user.grant_application_permissions(application, PERMISSIONS)
 
       user.authorisations
+        .not_expired
         .create_with(expires_in: 10.years)
         .find_or_create_by!(application_id: application.id).token
     end

--- a/test/lib/sso_push_credential_test.rb
+++ b/test/lib/sso_push_credential_test.rb
@@ -8,13 +8,12 @@ class SSOPushCredentialTest < ActiveSupport::TestCase
 
   context "given an already authorised application" do
     setup do
-      authorisation = @user.authorisations.create!(application_id: @application.id)
-      authorisation.update!(token: "foo")
+      @authorisation = @user.authorisations.create!(application_id: @application.id)
     end
 
     should "return the bearer token for an already-authorized application" do
       bearer_token = SSOPushCredential.credentials(@application)
-      assert_equal "foo", bearer_token
+      assert_equal @authorisation.token, bearer_token
     end
 
     should "create required application permissions if they do not already exist" do


### PR DESCRIPTION
Trello: https://trello.com/c/piKwrxYP

Previously when a token reached its (10 year) expiry, the code in `SSOPushCredential.credentials` was still finding the expired token and trying to use it in the `SSOPushClient`, but triggering a `SSOPushError` exception due to an invalid bearer token, e.g. [this one](https://govuk.sentry.io/issues/4527419738/?project=202251).

While we were debugging this also realised that `SSOPushCredential.credentials` was also finding revoked tokens, thus making it impossible to resolve the situation from the Signon UI.

Now we ignore both expired & revoked tokens when deciding whether we already have a valid token or that we need to create one.

Note that [the `Doorkeeper::AccessToken.not_expired` scope][1] seems to helpfully exclude both expired *and* revoked tokens.

[1]: https://github.com/doorkeeper-gem/doorkeeper/blob/986115cc228ff30dc1ead0f4101195448994f5d4/lib/doorkeeper/orm/active_record/mixins/access_token.rb#L47-L66
