### PR TITLE
Upgrade govuk_test to 4.0.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -197,7 +197,7 @@ GEM
       govuk_app_config (>= 1.1)
       redis-namespace (~> 1.6)
       sidekiq (~> 6)
-    govuk_test (3.0.1)
+    govuk_test (4.0.0)
       brakeman (>= 5.0.2)
       capybara (>= 3.36)
       puma


### PR DESCRIPTION
This will allow us to [upgrade selenium-webdriver][1].

[1]: https://github.com/alphagov/signon/pull/2406
