### PR TITLE
Use github.event.release.tag_name in Deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,6 @@
 name: Deploy
 
-run-name: Deploy ${{ inputs.gitRef || github.ref_name  }} to ${{ inputs.environment || 'integration' }}
+run-name: Deploy ${{ inputs.gitRef || github.event.release.tag_name  }} to ${{ inputs.environment || 'integration' }}
 
 on:
   workflow_dispatch:
@@ -23,11 +23,11 @@ on:
 
 jobs:
   build-and-publish-image:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref_name, 'v')
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'v')
     name: Build and publish image
     uses: alphagov/govuk-infrastructure/.github/workflows/build-and-push-image.yml@main
     with:
-      gitRef: ${{ inputs.gitRef || github.ref_name }}
+      gitRef: ${{ inputs.gitRef || github.event.release.tag_name }}
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_GOVUK_ECR_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_GOVUK_ECR_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
We've been experiencing intermittent failures in this workflow that appear to be caused by `github.ref_name` being empty. Other teams in GDS have been [experiencing the same problem][1].

@theseanything has been in contact with GitHub support and received the following reply:

> We have an open internal issue where our engineers are investigating
> the intermittent unavailability of `github.ref_name` context when
> workflow runs are triggered on release events. I have added your report
> to the investigation.  We also have an open community discussion on
> this, You can add your voice to this. See below:
> https://github.com/actions/runner/issues/2788 As a workaround, could you
> try using `github.event.release.tag_name` instead, as this is the
> preferred method for referencing the tag name of a release.  See more
> details on this `github.event` context in the github context list below:
> https://docs.github.com/en/enterprise-cloud@latest/actions/learn-github-actions/contexts#github-context

Hopefully we'll see fewer of these intermittent deploy failures with this change in place.

[1]: https://gds.slack.com/archives/C013F737737/p1693313259502869
