### PR TITLE
Update brakeman.ignore file against latest code

### DIFF
--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,26 +1,7 @@
 {
   "ignored_warnings": [
-    {
-      "warning_type": "Remote Code Execution",
-      "warning_code": 24,
-      "fingerprint": "4cd2ed8b5c42364bd8833951a3362765136652a03c91a4c12115eb6563446c9c",
-      "check_name": "UnsafeReflection",
-      "message": "Unsafe reflection method `const_get` called with model attribute",
-      "file": "app/policies/user_policy.rb",
-      "line": 71,
-      "link": "https://brakemanscanner.org/docs/warning_types/remote_code_execution/",
-      "code": "Roles.const_get(current_user.role.classify)",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "UserPolicy",
-        "method": "can_manage?"
-      },
-      "user_input": "current_user.role.classify",
-      "confidence": "Medium",
-      "note": "This is safe because the User model has a validation that the role is in a known set."
-    }
+
   ],
-  "updated": "2021-06-10 09:26:12 +0000",
-  "brakeman_version": "5.0.4"
+  "updated": "2023-10-10 13:35:33 +0000",
+  "brakeman_version": "6.0.1"
 }


### PR DESCRIPTION
I ran the following command which is based on [the version used in the CI pipeline][1]:

    bundle exec brakeman . --except CheckRenderInline --interactive-ignore

And followed the instructions. It highlighted the one ignored warning as being "unused" and asked me whether I wanted to remove it, so I did.

[1]: https://github.com/alphagov/govuk-infrastructure/blob/b8b29b87e4c45c6ea010f29f17bc18fb78243712/.github/workflows/brakeman.yml#L20
