### PR TITLE
Preselect some permissions on users invitation new

### DIFF
--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -13,7 +13,9 @@ class InvitationsController < Devise::InvitationsController
 
   def new
     authorize User
-    super
+
+    self.resource = User.with_preselected_permissions
+    render :new
   end
 
   def create

--- a/app/models/preselected_permission.rb
+++ b/app/models/preselected_permission.rb
@@ -1,0 +1,21 @@
+class PreselectedPermission
+  PRESELECTED_PERMISSIONS = [
+    { application_name: "Asset Manager", permission: SupportedPermission::SIGNIN_NAME },
+    { application_name: "Content Data", permission: SupportedPermission::SIGNIN_NAME },
+    { application_name: "Content Preview", permission: SupportedPermission::SIGNIN_NAME },
+    { application_name: "GovSearch", permission: SupportedPermission::SIGNIN_NAME },
+    { application_name: "Maslow", permission: SupportedPermission::SIGNIN_NAME },
+    { application_name: "Support", permission: "feedex" },
+  ].freeze
+
+  def self.permissions
+    permissions = PRESELECTED_PERMISSIONS.map do |preselected_permission|
+      application = Doorkeeper::Application.where(name: preselected_permission[:application_name]).first
+      next unless application
+
+      SupportedPermission.find_by(application_id: application.id, name: preselected_permission[:permission])
+    end
+
+    permissions.reject(&:nil?)
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -211,7 +211,11 @@ class User < ApplicationRecord
   end
 
   def grant_permission(supported_permission)
-    application_permissions.where(supported_permission_id: supported_permission.id).first_or_create!
+    if persisted?
+      application_permissions.where(supported_permission_id: supported_permission.id).first_or_create!
+    else
+      supported_permissions << supported_permission
+    end
   end
 
   # This overrides `Devise::Recoverable` behavior.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -122,6 +122,16 @@ class User < ApplicationRecord
     relation
   end
 
+  def self.with_preselected_permissions
+    user = new
+
+    PreselectedPermission.permissions.each do |permission|
+      user.grant_permission(permission)
+    end
+
+    user
+  end
+
   def require_2sv?
     return require_2sv unless organisation
 

--- a/test/controllers/invitations_controller_test.rb
+++ b/test/controllers/invitations_controller_test.rb
@@ -61,6 +61,19 @@ class InvitationsControllerTest < ActionController::TestCase
         end
       end
 
+      should "render form checkbox inputs with some permissions preselected" do
+        preselected_application_name = PreselectedPermission::PRESELECTED_PERMISSIONS.first[:application_name]
+        preselected_permission_name = PreselectedPermission::PRESELECTED_PERMISSIONS.first[:permission]
+        application = create(:application, name: preselected_application_name, with_supported_permissions: [preselected_permission_name])
+        expected_permission = application.supported_permissions.first
+
+        get :new
+
+        assert_select "form" do
+          assert_select "input[type='checkbox'][checked='checked'][name='user[supported_permission_ids][]'][value='#{expected_permission.to_param}']"
+        end
+      end
+
       should "render filter for option-select component when app has more than 4 permissions" do
         application = create(:application)
         4.times { create(:supported_permission, application:) }

--- a/test/models/preselected_permission_test.rb
+++ b/test/models/preselected_permission_test.rb
@@ -1,0 +1,15 @@
+require "test_helper"
+
+class BatchInvitationTest < ActiveSupport::TestCase
+  context ".permissions" do
+    should "return the preselected permissions" do
+      application = create(:application, name: "Asset Manager")
+
+      assert_includes PreselectedPermission.permissions, application.signin_permission
+    end
+
+    should "not return the preselected permissions for applications that don't exist" do
+      assert_empty PreselectedPermission.permissions
+    end
+  end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1140,6 +1140,18 @@ class UserTest < ActiveSupport::TestCase
     end
   end
 
+  context ".with_preselected_permissions" do
+    should "return a new user with some permissions added" do
+      preselected_application_name = PreselectedPermission::PRESELECTED_PERMISSIONS.first[:application_name]
+      preselected_permission_name = PreselectedPermission::PRESELECTED_PERMISSIONS.first[:permission]
+      create(:application, name: preselected_application_name, with_supported_permissions: [preselected_permission_name])
+
+      user = User.with_preselected_permissions
+
+      assert 1, user.supported_permissions.size
+    end
+  end
+
   def authenticate_access(user, app)
     Doorkeeper::AccessToken.create!(resource_owner_id: user.id, application_id: app.id)
   end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -512,14 +512,35 @@ class UserTest < ActiveSupport::TestCase
     assert_equal old_encrypted_password, u.encrypted_password, "Changed password"
   end
 
-  test "#grant_permission" do
-    user = create(:user)
-    application = create(:application)
-    supported_permission = create(:supported_permission, application:)
+  context "#grant_permission" do
+    setup do
+      application = create(:application)
+      @supported_permission = create(:supported_permission, application:)
+    end
 
-    user.grant_permission(supported_permission)
+    context "for a persisted user" do
+      setup do
+        @user = create(:user)
+      end
 
-    assert user.has_permission?(supported_permission)
+      should "grant the permission" do
+        @user.grant_permission(@supported_permission)
+
+        assert @user.has_permission?(@supported_permission)
+      end
+    end
+
+    context "for an unpersisted user" do
+      setup do
+        @user = build(:user)
+      end
+
+      should "grant the permission" do
+        @user.grant_permission(@supported_permission)
+
+        assert @user.has_permission?(@supported_permission)
+      end
+    end
   end
 
   test "can grant signin permission to allow user to access the app" do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -512,6 +512,16 @@ class UserTest < ActiveSupport::TestCase
     assert_equal old_encrypted_password, u.encrypted_password, "Changed password"
   end
 
+  test "#grant_permission" do
+    user = create(:user)
+    application = create(:application)
+    supported_permission = create(:supported_permission, application:)
+
+    user.grant_permission(supported_permission)
+
+    assert user.has_permission?(supported_permission)
+  end
+
   test "can grant signin permission to allow user to access the app" do
     app = create(:application)
     user = create(:user)


### PR DESCRIPTION
Trello: https://trello.com/c/5tHKKbWq

This PR preselects some permissions when inviting a new user. These permissions are commonly added to new users but we want the inviting user to be able to decide whether they are required - so it didn't make sense to just grant them on user creation. By having them preselected we save the inviting user some time as they don't have to find the individual permissions themselves in the list of dropdown select boxes. 

## Before

![before](https://github.com/alphagov/signon/assets/16707/d85793d3-7a7f-4c69-8e74-edfd12629cec)

## After

![after](https://github.com/alphagov/signon/assets/16707/4a6cad6b-59f2-4309-bff8-1dd0a9592141)

