### PR TITLE
Add database contraints for permission-related application_id columns

### DIFF
--- a/app/models/supported_permission.rb
+++ b/app/models/supported_permission.rb
@@ -5,6 +5,7 @@ class SupportedPermission < ApplicationRecord
   has_many :user_application_permissions, dependent: :destroy, inverse_of: :supported_permission
 
   validates :name, presence: true, uniqueness: { scope: :application_id }
+  validates :application, presence: true
   validate :signin_permission_name_not_changed
 
   default_scope { order(:name) }

--- a/db/migrate/20231017152747_add_foreign_key_constraint_for_user_application_permissions_application_id.rb
+++ b/db/migrate/20231017152747_add_foreign_key_constraint_for_user_application_permissions_application_id.rb
@@ -1,0 +1,5 @@
+class AddForeignKeyConstraintForUserApplicationPermissionsApplicationId < ActiveRecord::Migration[7.0]
+  def change
+    add_foreign_key :user_application_permissions, :oauth_applications, column: :application_id
+  end
+end

--- a/db/migrate/20231017153040_add_not_null_constraint_for_supported_permissions_application_id.rb
+++ b/db/migrate/20231017153040_add_not_null_constraint_for_supported_permissions_application_id.rb
@@ -1,0 +1,5 @@
+class AddNotNullConstraintForSupportedPermissionsApplicationId < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :supported_permissions, :application_id, false
+  end
+end

--- a/db/migrate/20231017153357_add_foreign_key_constraint_for_supported_permissions_application_id.rb
+++ b/db/migrate/20231017153357_add_foreign_key_constraint_for_supported_permissions_application_id.rb
@@ -1,0 +1,5 @@
+class AddForeignKeyConstraintForSupportedPermissionsApplicationId < ActiveRecord::Migration[7.0]
+  def change
+    add_foreign_key :supported_permissions, :oauth_applications, column: :application_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_17_152747) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_17_153040) do
   create_table "batch_invitation_application_permissions", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "batch_invitation_id", null: false
     t.integer "supported_permission_id", null: false
@@ -127,7 +127,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_17_152747) do
   end
 
   create_table "supported_permissions", id: :integer, charset: "utf8mb3", force: :cascade do |t|
-    t.integer "application_id"
+    t.integer "application_id", null: false
     t.string "name"
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_17_153040) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_17_153357) do
   create_table "batch_invitation_application_permissions", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "batch_invitation_id", null: false
     t.integer "supported_permission_id", null: false
@@ -207,5 +207,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_17_153040) do
 
   add_foreign_key "event_logs", "user_agents", name: "event_logs_user_agent_id_fk"
   add_foreign_key "oauth_access_tokens", "oauth_applications", column: "application_id"
+  add_foreign_key "supported_permissions", "oauth_applications", column: "application_id"
   add_foreign_key "user_application_permissions", "oauth_applications", column: "application_id"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_25_104849) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_17_152747) do
   create_table "batch_invitation_application_permissions", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "batch_invitation_id", null: false
     t.integer "supported_permission_id", null: false
@@ -150,6 +150,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_25_104849) do
     t.datetime "last_synced_at", precision: nil
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
+    t.index ["application_id"], name: "fk_rails_36355a4090"
     t.index ["user_id", "application_id", "supported_permission_id"], name: "index_app_permissions_on_user_and_app_and_supported_permission", unique: true
   end
 
@@ -206,4 +207,5 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_25_104849) do
 
   add_foreign_key "event_logs", "user_agents", name: "event_logs_user_agent_id_fk"
   add_foreign_key "oauth_access_tokens", "oauth_applications", column: "application_id"
+  add_foreign_key "user_application_permissions", "oauth_applications", column: "application_id"
 end

--- a/test/models/supported_permission_test.rb
+++ b/test/models/supported_permission_test.rb
@@ -26,6 +26,13 @@ class SupportedPermissionTest < ActiveSupport::TestCase
     assert_includes copy_cat_permission.errors[:name], "has already been taken"
   end
 
+  test "application of permission must be present" do
+    permission = build(:supported_permission, application: nil)
+
+    assert_not permission.valid?
+    assert_includes permission.errors[:application], "can't be blank"
+  end
+
   test "associated user application permissions are destroyed when supported permissions are destroyed" do
     user = create(:user)
     application = create(:application, with_supported_permissions: %w[managing_editor])


### PR DESCRIPTION
Some data integrity issues have come up in the context of [this Trello card](https://trello.com/c/kvmb5OHO), so I wanted to sort them out so I could make sensible assumptions when making the actual changes I want to make for that Trello card!

There are a bunch of orphan records in `user_application_permissions` & `supported_permissions` tables which although they have an `application_id` value set, that value doesn't correspond with the `id` of a record in the `oauth_applications` table. My assumption is that the relevant records in `oauth_applications` have previously been deleted without deleting the associated records.

Since the `has_many :supported_permissions` association on `Doorkeeper::Application` includes the `dependent: :destroy` option and the `has_many :user_application_permissions` association on `SupportedPermission` also includes the `dependent: :destroy` option, it looks as if the latter has only been in place since 2015 - see [this commit](https://github.com/alphagov/signon/commit/4c64128ddfe7252060e4067e8114b754c082b85a) which was part of [this PR](https://github.com/alphagov/signon/pull/311). So presumably either the relevant applications were deleted before that or the deletion bypassed the ActiveRecord callbacks.

We dealt with a similar issue in #2201 & #2203 and I've tried to learn the lessons of my mistakes in those. Since there aren't very many of them, I've chosen to fix the orphan records by creating placeholder applications manually in a Rails console for each environment rather than try to make that a part of the migrations themselves. The migrations just add the relevant database constraints. I plan to mark all these placeholder applications as retired as a separate manual step once these migrations have run.

I strongly suspect there are other database constraints we could add, but my current focus is around applications and permissions and so I'm going to stop at this point!

### Developer Note

If you have a copy of the integration database in your local development environment, you'll need to run the following in a Rails console *before* you can successfully run the migrations in this PR:

```ruby
class ::Doorkeeper::Application < ActiveRecord::Base
  def create_signin_supported_permission; end
end

application_ids = ApplicationRecord.connection.query(%(
  SELECT user_application_permissions.application_id
    FROM user_application_permissions
    LEFT OUTER JOIN oauth_applications ON user_application_permissions.application_id = oauth_applications.id
    WHERE oauth_applications.id IS NULL;
  )
).flatten.uniq

application_ids.each do |application_id|
  Doorkeeper::Application.create!(
    id: application_id,
    name: "Unknown #{application_id}",
    redirect_uri: "https://example.com/unknown-#{application_id}",
    description: "Added manually to give orphan user_application_permissions a parent application",
  )
end

application_ids = ApplicationRecord.connection.query(%(
  SELECT supported_permissions.application_id
    FROM supported_permissions
    LEFT OUTER JOIN oauth_applications ON supported_permissions.application_id = oauth_applications.id
    WHERE oauth_applications.id IS NULL;
)).flatten.uniq

application_ids.each do |application_id|
  Doorkeeper::Application.create!(
    id: application_id,
    name: "Unknown #{application_id}",
    redirect_uri: "https://example.com/unknown-#{application_id}",
    description: "Added manually to give orphan supported_permissions a parent application",
  )
end
```
