### PR TITLE
Hide retired apps on most pages

### DIFF
--- a/app/controllers/account/applications_controller.rb
+++ b/app/controllers/account/applications_controller.rb
@@ -13,6 +13,6 @@ class Account::ApplicationsController < ApplicationController
     authorize [:account, Doorkeeper::Application]
 
     @applications_with_signin = Doorkeeper::Application.can_signin(current_user)
-    @applications_without_signin = Doorkeeper::Application.not_retired.without_signin_permission_for(current_user)
+    @applications_without_signin = Doorkeeper::Application.without_signin_permission_for(current_user)
   end
 end

--- a/app/controllers/account/permissions_controller.rb
+++ b/app/controllers/account/permissions_controller.rb
@@ -4,7 +4,7 @@ class Account::PermissionsController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @application = Doorkeeper::Application.not_retired.find(params[:application_id])
+    @application = Doorkeeper::Application.find(params[:application_id])
 
     authorize [:account, @application], :view_permissions?
 

--- a/app/controllers/account/signin_permissions_controller.rb
+++ b/app/controllers/account/signin_permissions_controller.rb
@@ -28,6 +28,6 @@ class Account::SigninPermissionsController < ApplicationController
 private
 
   def application
-    @application ||= Doorkeeper::Application.not_retired.find(params[:application_id])
+    @application ||= Doorkeeper::Application.find(params[:application_id])
   end
 end

--- a/app/controllers/account/signin_permissions_controller.rb
+++ b/app/controllers/account/signin_permissions_controller.rb
@@ -6,8 +6,6 @@ class Account::SigninPermissionsController < ApplicationController
   def create
     authorize [:account, Doorkeeper::Application], :grant_signin_permission?
 
-    application = Doorkeeper::Application.not_retired.find(params[:application_id])
-
     params = { supported_permission_ids: current_user.supported_permissions.map(&:id) + [application.signin_permission.id] }
     UserUpdate.new(current_user, params, current_user, user_ip_address).call
 
@@ -15,19 +13,21 @@ class Account::SigninPermissionsController < ApplicationController
   end
 
   def delete
-    @application = Doorkeeper::Application.not_retired.find(params[:application_id])
-
-    authorize [:account, @application], :remove_signin_permission?
+    authorize [:account, application], :remove_signin_permission?
   end
 
   def destroy
-    application = Doorkeeper::Application.not_retired.find(params[:application_id])
-
     authorize [:account, application], :remove_signin_permission?
 
     params = { supported_permission_ids: current_user.supported_permissions.map(&:id) - [application.signin_permission.id] }
     UserUpdate.new(current_user, params, current_user, user_ip_address).call
 
     redirect_to account_applications_path
+  end
+
+private
+
+  def application
+    @application ||= Doorkeeper::Application.not_retired.find(params[:application_id])
   end
 end

--- a/app/controllers/doorkeeper_applications_controller.rb
+++ b/app/controllers/doorkeeper_applications_controller.rb
@@ -11,6 +11,8 @@ class DoorkeeperApplicationsController < ApplicationController
     @applications = Doorkeeper::Application.all
   end
 
+  def edit; end
+
   def update
     if @application.update(doorkeeper_application_params)
       redirect_to doorkeeper_applications_path, notice: "Successfully updated #{@application.name}"

--- a/app/controllers/doorkeeper_applications_controller.rb
+++ b/app/controllers/doorkeeper_applications_controller.rb
@@ -29,7 +29,7 @@ class DoorkeeperApplicationsController < ApplicationController
 private
 
   def load_and_authorize_application
-    @application = Doorkeeper::Application.find(params[:id])
+    @application = Doorkeeper::Application.unscoped.find(params[:id])
     authorize @application
   end
 

--- a/app/models/api_user.rb
+++ b/app/models/api_user.rb
@@ -1,5 +1,6 @@
 class ApiUser < User
   default_scope { where(api_user: true).order(:name) }
+
   validate :reason_for_2sv_exemption_blank
   validate :require_2sv_is_false
 

--- a/app/models/doorkeeper/application.rb
+++ b/app/models/doorkeeper/application.rb
@@ -9,11 +9,7 @@ class Doorkeeper::Application < ActiveRecord::Base # rubocop:disable Rails/Appli
   scope :support_push_updates, -> { where(supports_push_updates: true) }
   scope :retired, -> { where(retired: true) }
   scope :not_retired, -> { where(retired: false) }
-  scope :can_signin,
-        lambda { |user|
-          with_signin_permission_for(user)
-            .not_retired
-        }
+  scope :can_signin, ->(user) { with_signin_permission_for(user) }
   scope :with_signin_delegatable,
         lambda {
           joins(:supported_permissions)

--- a/app/models/doorkeeper/application.rb
+++ b/app/models/doorkeeper/application.rb
@@ -1,8 +1,6 @@
 require "doorkeeper/orm/active_record/application"
 
-# rubocop:disable Rails/ApplicationRecord
-class Doorkeeper::Application < ActiveRecord::Base
-  # rubocop:enable Rails/ApplicationRecord
+class Doorkeeper::Application < ActiveRecord::Base # rubocop:disable Rails/ApplicationRecord
   has_many :supported_permissions, dependent: :destroy
 
   default_scope { ordered_by_name }

--- a/app/models/doorkeeper/application.rb
+++ b/app/models/doorkeeper/application.rb
@@ -3,7 +3,7 @@ require "doorkeeper/orm/active_record/application"
 class Doorkeeper::Application < ActiveRecord::Base # rubocop:disable Rails/ApplicationRecord
   has_many :supported_permissions, dependent: :destroy
 
-  default_scope { ordered_by_name }
+  default_scope { not_retired.ordered_by_name }
 
   scope :ordered_by_name, -> { order("oauth_applications.name") }
   scope :support_push_updates, -> { where(supports_push_updates: true) }

--- a/app/models/doorkeeper/application.rb
+++ b/app/models/doorkeeper/application.rb
@@ -8,6 +8,7 @@ class Doorkeeper::Application < ActiveRecord::Base
   default_scope { ordered_by_name }
   scope :ordered_by_name, -> { order("oauth_applications.name") }
   scope :support_push_updates, -> { where(supports_push_updates: true) }
+  scope :retired, -> { where(retired: true) }
   scope :not_retired, -> { where(retired: false) }
   scope :can_signin,
         lambda { |user|

--- a/app/models/doorkeeper/application.rb
+++ b/app/models/doorkeeper/application.rb
@@ -4,6 +4,7 @@ class Doorkeeper::Application < ActiveRecord::Base # rubocop:disable Rails/Appli
   has_many :supported_permissions, dependent: :destroy
 
   default_scope { ordered_by_name }
+
   scope :ordered_by_name, -> { order("oauth_applications.name") }
   scope :support_push_updates, -> { where(supports_push_updates: true) }
   scope :retired, -> { where(retired: true) }

--- a/app/models/supported_permission.rb
+++ b/app/models/supported_permission.rb
@@ -9,6 +9,7 @@ class SupportedPermission < ApplicationRecord
   validate :signin_permission_name_not_changed
 
   default_scope { order(:name) }
+
   scope :delegatable, -> { where(delegatable: true) }
   scope :grantable_from_ui, -> { where(grantable_from_ui: true) }
   scope :default, -> { where(default: true) }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -161,8 +161,8 @@ class User < ApplicationRecord
     application_permissions
       .joins(:supported_permission)
       .where(application_id: application.id)
-      .order("supported_permissions.name")
-      .pluck(:name)
+      .order(SupportedPermission.arel_table[:name])
+      .pluck(SupportedPermission.arel_table[:name])
   end
 
   # Avoid N+1 queries by using the relations eager loaded with `includes()`.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -208,6 +208,8 @@ class User < ApplicationRecord
   end
 
   def grant_application_permissions(application, supported_permission_names)
+    return [] if application.retired?
+
     supported_permission_names.map do |supported_permission_name|
       supported_permission = SupportedPermission.find_by(application_id: application.id, name: supported_permission_name)
       grant_permission(supported_permission)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -58,7 +58,7 @@ class User < ApplicationRecord
 
   has_many :authorisations, class_name: "Doorkeeper::AccessToken", foreign_key: :resource_owner_id
   has_many :application_permissions, -> { joins(:application) }, class_name: "UserApplicationPermission", inverse_of: :user, dependent: :destroy
-  has_many :supported_permissions, through: :application_permissions
+  has_many :supported_permissions, -> { joins(:application) }, through: :application_permissions
   has_many :batch_invitations
   belongs_to :organisation
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -57,7 +57,7 @@ class User < ApplicationRecord
   validate :organisation_has_mandatory_2sv, on: :create
 
   has_many :authorisations, class_name: "Doorkeeper::AccessToken", foreign_key: :resource_owner_id
-  has_many :application_permissions, class_name: "UserApplicationPermission", inverse_of: :user, dependent: :destroy
+  has_many :application_permissions, -> { joins(:application) }, class_name: "UserApplicationPermission", inverse_of: :user, dependent: :destroy
   has_many :supported_permissions, through: :application_permissions
   has_many :batch_invitations
   belongs_to :organisation

--- a/app/views/batch_invitation_permissions/new.html.erb
+++ b/app/views/batch_invitation_permissions/new.html.erb
@@ -19,7 +19,7 @@
 %>
 
 <%= form_for @batch_invitation, url: :batch_invitation_permissions, method: :post do |f| %>
-  <% policy_scope(:user_permission_manageable_application).not_retired.map do |application| %>
+  <% policy_scope(:user_permission_manageable_application).map do |application| %>
     <% options = options_for_permission_option_select(application:, user: User.with_default_permissions) %>
     <%= render("govuk_publishing_components/components/option_select", {
       title: application.name,

--- a/app/views/batch_invitation_permissions/new.html.erb
+++ b/app/views/batch_invitation_permissions/new.html.erb
@@ -19,7 +19,7 @@
 %>
 
 <%= form_for @batch_invitation, url: :batch_invitation_permissions, method: :post do |f| %>
-  <% policy_scope(:user_permission_manageable_application).reject(&:retired?).map do |application| %>
+  <% policy_scope(:user_permission_manageable_application).not_retired.map do |application| %>
     <% options = options_for_permission_option_select(application:, user: User.with_default_permissions) %>
     <%= render("govuk_publishing_components/components/option_select", {
       title: application.name,

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -86,7 +86,7 @@
         heading_size: "l",
       } do %>
 
-        <% policy_scope(:user_permission_manageable_application).not_retired.map do |application| %>
+        <% policy_scope(:user_permission_manageable_application).map do |application| %>
           <% options = options_for_permission_option_select(application:, user: f.object) %>
           <%= render("govuk_publishing_components/components/option_select", {
             title: application.name,

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -86,7 +86,7 @@
         heading_size: "l",
       } do %>
 
-        <% policy_scope(:user_permission_manageable_application).reject(&:retired?).map do |application| %>
+        <% policy_scope(:user_permission_manageable_application).not_retired.map do |application| %>
           <% options = options_for_permission_option_select(application:, user: f.object) %>
           <%= render("govuk_publishing_components/components/option_select", {
             title: application.name,

--- a/app/views/doorkeeper_applications/edit.html.erb
+++ b/app/views/doorkeeper_applications/edit.html.erb
@@ -107,8 +107,10 @@
         </label>
 
         <p>
-          Retiring an application will hide the application from the dashboard. It will
-          not delete data. If you're retiring an app you should also disable push updates.
+          Retiring an application indicates that it is no longer in use.
+          Retired applications will not appear on most pages including the dashboard.
+          Data associated with retired applications is not deleted.
+          If you're retiring an application you should also disable push updates.
         </p>
       </div>
 

--- a/app/views/doorkeeper_applications/index.html.erb
+++ b/app/views/doorkeeper_applications/index.html.erb
@@ -5,12 +5,12 @@
     {
       id: "active",
       label: "Active applications",
-      content: render("application_list", applications: @applications.reject(&:retired?))
+      content: render("application_list", applications: @applications.not_retired)
     },
     {
       id: "retired",
       label: "Retired applications",
-      content: render("application_list", applications: @applications.select(&:retired?))
+      content: render("application_list", applications: @applications.retired)
     }
   ]
 } %>

--- a/app/views/doorkeeper_applications/index.html.erb
+++ b/app/views/doorkeeper_applications/index.html.erb
@@ -10,7 +10,7 @@
     {
       id: "retired",
       label: "Retired applications",
-      content: render("application_list", applications: @applications.retired)
+      content: render("application_list", applications: @applications.unscoped.retired)
     }
   ]
 } %>

--- a/app/views/doorkeeper_applications/index.html.erb
+++ b/app/views/doorkeeper_applications/index.html.erb
@@ -5,7 +5,7 @@
     {
       id: "active",
       label: "Active applications",
-      content: render("application_list", applications: @applications.not_retired)
+      content: render("application_list", applications: @applications)
     },
     {
       id: "retired",

--- a/db/migrate/20231018141956_add_not_null_constraint_to_oauth_applications_retired.rb
+++ b/db/migrate/20231018141956_add_not_null_constraint_to_oauth_applications_retired.rb
@@ -1,0 +1,5 @@
+class AddNotNullConstraintToOauthApplicationsRetired < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :oauth_applications, :retired, false, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_17_153357) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_18_141956) do
   create_table "batch_invitation_application_permissions", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "batch_invitation_id", null: false
     t.integer "supported_permission_id", null: false
@@ -94,7 +94,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_17_153357) do
     t.string "home_uri"
     t.string "description"
     t.boolean "supports_push_updates", default: true
-    t.boolean "retired", default: false
+    t.boolean "retired", default: false, null: false
     t.boolean "show_on_dashboard", default: true, null: false
     t.boolean "confidential", default: true, null: false
     t.index ["name"], name: "unique_application_name", unique: true

--- a/test/controllers/batch_invitation_permissions_controller_test.rb
+++ b/test/controllers/batch_invitation_permissions_controller_test.rb
@@ -77,6 +77,17 @@ class BatchInvitationPermissionsControllerTest < ActionController::TestCase
         assert_select "input[type='checkbox'][checked='checked'][name='user[supported_permission_ids][]'][value='#{permission.to_param}']"
       end
     end
+
+    should "not include permissions for retired apps" do
+      application = create(:application, retired: true)
+      signin_permission = application.signin_permission
+
+      get :new, params: { batch_invitation_id: @batch_invitation.id }
+
+      assert_select "form" do
+        assert_select "input[type='checkbox'][name='user[supported_permission_ids][]'][value='#{signin_permission.to_param}']", count: 0
+      end
+    end
   end
 
   context "POST create" do

--- a/test/controllers/doorkeeper_applications_controller_test.rb
+++ b/test/controllers/doorkeeper_applications_controller_test.rb
@@ -24,6 +24,12 @@ class DoorkeeperApplicationsControllerTest < ActionController::TestCase
       get :edit, params: { id: app.id }
       assert_select "input[name='doorkeeper_application[name]'][value='My first app']"
     end
+
+    should "render the form for retired app" do
+      app = create(:application, name: "My first app", retired: true)
+      get :edit, params: { id: app.id }
+      assert_select "input[name='doorkeeper_application[name]'][value='My first app']"
+    end
   end
 
   context "PUT update" do
@@ -34,6 +40,13 @@ class DoorkeeperApplicationsControllerTest < ActionController::TestCase
       assert_equal "A better name", app.reload.name
       assert_redirected_to doorkeeper_applications_path
       assert_match(/updated/, flash[:notice])
+    end
+
+    should "update a retired application" do
+      app = create(:application, name: "My first app", retired: true)
+      put :update, params: { id: app.id, doorkeeper_application: { name: "A better name" } }
+
+      assert_equal "A better name", app.reload.name
     end
 
     should "redisplay the form if save fails" do

--- a/test/controllers/doorkeeper_applications_controller_test.rb
+++ b/test/controllers/doorkeeper_applications_controller_test.rb
@@ -9,8 +9,12 @@ class DoorkeeperApplicationsControllerTest < ActionController::TestCase
   context "GET index" do
     should "list applications" do
       create(:application, name: "My first app")
+      create(:application, name: "My retired app", retired: true)
+
       get :index
-      assert_select "td", /My first app/
+
+      assert_select "#active td", /My first app/
+      assert_select "#retired td", /My retired app/
     end
   end
 

--- a/test/controllers/invitations_controller_test.rb
+++ b/test/controllers/invitations_controller_test.rb
@@ -83,6 +83,17 @@ class InvitationsControllerTest < ActionController::TestCase
           assert_select ".gem-c-option-select[data-filter-element]"
         end
       end
+
+      should "not render form checkbox inputs for permissions for retired applications" do
+        application = create(:application, retired: true)
+        signin_permission = application.signin_permission
+
+        get :new
+
+        assert_select "form" do
+          assert_select "input[type='checkbox'][name='user[supported_permission_ids][]'][value='#{signin_permission.to_param}']", count: 0
+        end
+      end
     end
 
     context "when inviter is signed in as a superadmin" do

--- a/test/factories/oauth_applications.rb
+++ b/test/factories/oauth_applications.rb
@@ -18,19 +18,19 @@ FactoryBot.define do
         # this line takes care of tests creating signin in order to look complete or modify delegatable on it.
         app.signin_permission.update(delegatable: false) && next if permission_name == SupportedPermission::SIGNIN_NAME
 
-        create(:supported_permission, application_id: app.id, name: permission_name)
+        create(:supported_permission, application: app, name: permission_name)
       end
 
       evaluator.with_supported_permissions_not_grantable_from_ui.each do |permission_name|
         next if permission_name == SupportedPermission::SIGNIN_NAME
 
-        create(:supported_permission, application_id: app.id, name: permission_name, grantable_from_ui: false)
+        create(:supported_permission, application: app, name: permission_name, grantable_from_ui: false)
       end
 
       evaluator.with_delegatable_supported_permissions.each do |permission_name|
         next if permission_name == SupportedPermission::SIGNIN_NAME
 
-        create(:delegatable_supported_permission, application_id: app.id, name: permission_name)
+        create(:delegatable_supported_permission, application: app, name: permission_name)
       end
     end
   end

--- a/test/models/doorkeeper/application_test.rb
+++ b/test/models/doorkeeper/application_test.rb
@@ -144,6 +144,38 @@ class Doorkeeper::ApplicationTest < ActiveSupport::TestCase
     end
   end
 
+  context ".retired" do
+    setup do
+      @app = create(:application)
+    end
+
+    should "include apps that have been retired" do
+      @app.update!(retired: true)
+      assert_equal [@app], Doorkeeper::Application.retired
+    end
+
+    should "exclude apps that have not been retired" do
+      @app.update!(retired: false)
+      assert_equal [], Doorkeeper::Application.retired
+    end
+  end
+
+  context ".not_retired" do
+    setup do
+      @app = create(:application)
+    end
+
+    should "include apps that have not been retired" do
+      @app.update!(retired: false)
+      assert_equal [@app], Doorkeeper::Application.not_retired
+    end
+
+    should "exclude apps that have been retired" do
+      @app.update!(retired: true)
+      assert_equal [], Doorkeeper::Application.not_retired
+    end
+  end
+
   context ".can_signin" do
     should "return applications that the user can signin into" do
       user = create(:user)
@@ -180,38 +212,6 @@ class Doorkeeper::ApplicationTest < ActiveSupport::TestCase
       create(:application, with_supported_permissions: [SupportedPermission::SIGNIN_NAME])
 
       assert_empty Doorkeeper::Application.with_signin_delegatable
-    end
-  end
-
-  context ".retired" do
-    setup do
-      @app = create(:application)
-    end
-
-    should "include apps that have been retired" do
-      @app.update!(retired: true)
-      assert_equal [@app], Doorkeeper::Application.retired
-    end
-
-    should "exclude apps that have not been retired" do
-      @app.update!(retired: false)
-      assert_equal [], Doorkeeper::Application.retired
-    end
-  end
-
-  context ".not_retired" do
-    setup do
-      @app = create(:application)
-    end
-
-    should "include apps that have not been retired" do
-      @app.update!(retired: false)
-      assert_equal [@app], Doorkeeper::Application.not_retired
-    end
-
-    should "exclude apps that have been retired" do
-      @app.update!(retired: true)
-      assert_equal [], Doorkeeper::Application.not_retired
     end
   end
 

--- a/test/models/doorkeeper/application_test.rb
+++ b/test/models/doorkeeper/application_test.rb
@@ -144,6 +144,22 @@ class Doorkeeper::ApplicationTest < ActiveSupport::TestCase
     end
   end
 
+  context ".all (default scope)" do
+    setup do
+      @app = create(:application)
+    end
+
+    should "include apps that have not been retired" do
+      @app.update!(retired: false)
+      assert_equal [@app], Doorkeeper::Application.all
+    end
+
+    should "exclude apps that have been retired" do
+      @app.update!(retired: true)
+      assert_equal [], Doorkeeper::Application.all
+    end
+  end
+
   context ".retired" do
     setup do
       @app = create(:application)
@@ -151,12 +167,12 @@ class Doorkeeper::ApplicationTest < ActiveSupport::TestCase
 
     should "include apps that have been retired" do
       @app.update!(retired: true)
-      assert_equal [@app], Doorkeeper::Application.retired
+      assert_equal [@app], Doorkeeper::Application.unscoped.retired
     end
 
     should "exclude apps that have not been retired" do
       @app.update!(retired: false)
-      assert_equal [], Doorkeeper::Application.retired
+      assert_equal [], Doorkeeper::Application.unscoped.retired
     end
   end
 

--- a/test/models/doorkeeper/application_test.rb
+++ b/test/models/doorkeeper/application_test.rb
@@ -180,6 +180,22 @@ class Doorkeeper::ApplicationTest < ActiveSupport::TestCase
       assert_empty Doorkeeper::Application.with_signin_delegatable
     end
 
+    context ".retired" do
+      setup do
+        @app = create(:application)
+      end
+
+      should "include apps that have been retired" do
+        @app.update!(retired: true)
+        assert_equal [@app], Doorkeeper::Application.retired
+      end
+
+      should "exclude apps that have not been retired" do
+        @app.update!(retired: false)
+        assert_equal [], Doorkeeper::Application.retired
+      end
+    end
+
     context ".not_retired" do
       setup do
         @app = create(:application)

--- a/test/models/doorkeeper/application_test.rb
+++ b/test/models/doorkeeper/application_test.rb
@@ -144,7 +144,7 @@ class Doorkeeper::ApplicationTest < ActiveSupport::TestCase
     end
   end
 
-  context "scopes" do
+  context ".can_signin" do
     should "return applications that the user can signin into" do
       user = create(:user)
       application = create(:application)
@@ -167,7 +167,9 @@ class Doorkeeper::ApplicationTest < ActiveSupport::TestCase
 
       assert_empty Doorkeeper::Application.can_signin(user)
     end
+  end
 
+  context ".with_signin_delegatable" do
     should "return applications that support delegation of signin permission" do
       application = create(:application, with_delegatable_supported_permissions: [SupportedPermission::SIGNIN_NAME])
 
@@ -179,83 +181,83 @@ class Doorkeeper::ApplicationTest < ActiveSupport::TestCase
 
       assert_empty Doorkeeper::Application.with_signin_delegatable
     end
+  end
 
-    context ".retired" do
-      setup do
-        @app = create(:application)
-      end
-
-      should "include apps that have been retired" do
-        @app.update!(retired: true)
-        assert_equal [@app], Doorkeeper::Application.retired
-      end
-
-      should "exclude apps that have not been retired" do
-        @app.update!(retired: false)
-        assert_equal [], Doorkeeper::Application.retired
-      end
+  context ".retired" do
+    setup do
+      @app = create(:application)
     end
 
-    context ".not_retired" do
-      setup do
-        @app = create(:application)
-      end
-
-      should "include apps that have not been retired" do
-        @app.update!(retired: false)
-        assert_equal [@app], Doorkeeper::Application.not_retired
-      end
-
-      should "exclude apps that have been retired" do
-        @app.update!(retired: true)
-        assert_equal [], Doorkeeper::Application.not_retired
-      end
+    should "include apps that have been retired" do
+      @app.update!(retired: true)
+      assert_equal [@app], Doorkeeper::Application.retired
     end
 
-    context ".with_signin_permission_for" do
-      setup do
-        @user = create(:user)
-        @app = create(:application)
-      end
+    should "exclude apps that have not been retired" do
+      @app.update!(retired: false)
+      assert_equal [], Doorkeeper::Application.retired
+    end
+  end
 
-      should "include applications the user has the signin permission for" do
-        @user.grant_application_signin_permission(@app)
-
-        assert_equal [@app], Doorkeeper::Application.with_signin_permission_for(@user)
-      end
-
-      should "exclude applications the user does not have the signin permission for" do
-        create(:supported_permission, application: @app, name: "not-signin")
-
-        @user.grant_application_permission(@app, %w[not-signin])
-
-        assert_equal [], Doorkeeper::Application.with_signin_permission_for(@user)
-      end
+  context ".not_retired" do
+    setup do
+      @app = create(:application)
     end
 
-    context ".without_signin_permission_for" do
-      setup do
-        @user = create(:user)
-        @app = create(:application)
-      end
+    should "include apps that have not been retired" do
+      @app.update!(retired: false)
+      assert_equal [@app], Doorkeeper::Application.not_retired
+    end
 
-      should "exclude applications the user has the signin permission for" do
-        @user.grant_application_signin_permission(@app)
+    should "exclude apps that have been retired" do
+      @app.update!(retired: true)
+      assert_equal [], Doorkeeper::Application.not_retired
+    end
+  end
 
-        assert_equal [], Doorkeeper::Application.without_signin_permission_for(@user)
-      end
+  context ".with_signin_permission_for" do
+    setup do
+      @user = create(:user)
+      @app = create(:application)
+    end
 
-      should "include applications the user does not have the signin permission for" do
-        create(:supported_permission, application: @app, name: "not-signin")
+    should "include applications the user has the signin permission for" do
+      @user.grant_application_signin_permission(@app)
 
-        @user.grant_application_permission(@app, %w[not-signin])
+      assert_equal [@app], Doorkeeper::Application.with_signin_permission_for(@user)
+    end
 
-        assert_equal [@app], Doorkeeper::Application.without_signin_permission_for(@user)
-      end
+    should "exclude applications the user does not have the signin permission for" do
+      create(:supported_permission, application: @app, name: "not-signin")
 
-      should "include applications the user doesn't have any permissions for" do
-        assert_equal [@app], Doorkeeper::Application.without_signin_permission_for(@user)
-      end
+      @user.grant_application_permission(@app, %w[not-signin])
+
+      assert_equal [], Doorkeeper::Application.with_signin_permission_for(@user)
+    end
+  end
+
+  context ".without_signin_permission_for" do
+    setup do
+      @user = create(:user)
+      @app = create(:application)
+    end
+
+    should "exclude applications the user has the signin permission for" do
+      @user.grant_application_signin_permission(@app)
+
+      assert_equal [], Doorkeeper::Application.without_signin_permission_for(@user)
+    end
+
+    should "include applications the user does not have the signin permission for" do
+      create(:supported_permission, application: @app, name: "not-signin")
+
+      @user.grant_application_permission(@app, %w[not-signin])
+
+      assert_equal [@app], Doorkeeper::Application.without_signin_permission_for(@user)
+    end
+
+    should "include applications the user doesn't have any permissions for" do
+      assert_equal [@app], Doorkeeper::Application.without_signin_permission_for(@user)
     end
   end
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -17,6 +17,13 @@ class UserTest < ActiveSupport::TestCase
 
       assert_includes @user.application_permissions, user_application_permission
     end
+
+    should "not include user application permissions for retired applications" do
+      application = create(:application, retired: true)
+      user_application_permission = create(:user_application_permission, user: @user, application:)
+
+      assert_not_includes @user.application_permissions, user_application_permission
+    end
   end
 
   context "#require_2sv" do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -596,6 +596,18 @@ class UserTest < ActiveSupport::TestCase
       assert_user_has_permissions ["Create publications"], app, user
     end
 
+    should "grant permission to user for a retired application" do
+      app = create(:application, retired: true, with_supported_permissions: %w[edit])
+      user = create(:user)
+
+      signin_permission = user.grant_application_signin_permission(app)
+      edit_permission = user.grant_application_permission(app, "edit")
+
+      assert_includes user.application_permissions, signin_permission
+      assert_includes user.application_permissions, edit_permission
+      assert_user_has_permissions ["edit", SupportedPermission::SIGNIN_NAME], app, user
+    end
+
     should "return multiple permissions in name order" do
       app = create(:application, with_supported_permissions: %w[edit])
       user = create(:user)

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -34,6 +34,14 @@ class UserTest < ActiveSupport::TestCase
 
       assert_includes @user.supported_permissions, supported_permission
     end
+
+    should "not include supported permissions for retired applications" do
+      application = create(:application, retired: true)
+      supported_permission = create(:supported_permission, application:)
+      create(:user_application_permission, user: @user, application:, supported_permission:)
+
+      assert_not_includes @user.supported_permissions, supported_permission
+    end
   end
 
   context "#require_2sv" do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -26,6 +26,16 @@ class UserTest < ActiveSupport::TestCase
     end
   end
 
+  context "#supported_permissions" do
+    should "return supported permissions for user" do
+      application = create(:application)
+      supported_permission = create(:supported_permission, application:)
+      create(:user_application_permission, user: @user, application:, supported_permission:)
+
+      assert_includes @user.supported_permissions, supported_permission
+    end
+  end
+
   context "#require_2sv" do
     should "default to false for normal users" do
       assert_not create(:user).require_2sv?

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -10,6 +10,15 @@ class UserTest < ActiveSupport::TestCase
     @user = create(:user)
   end
 
+  context "#application_permissions" do
+    should "return user application permissions for user" do
+      application = create(:application)
+      user_application_permission = create(:user_application_permission, user: @user, application:)
+
+      assert_includes @user.application_permissions, user_application_permission
+    end
+  end
+
   context "#require_2sv" do
     should "default to false for normal users" do
       assert_not create(:user).require_2sv?

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -596,16 +596,16 @@ class UserTest < ActiveSupport::TestCase
       assert_user_has_permissions ["Create publications"], app, user
     end
 
-    should "grant permission to user for a retired application" do
+    should "not grant permission to user for a retired application" do
       app = create(:application, retired: true, with_supported_permissions: %w[edit])
       user = create(:user)
 
       signin_permission = user.grant_application_signin_permission(app)
       edit_permission = user.grant_application_permission(app, "edit")
 
-      assert_includes user.application_permissions, signin_permission
-      assert_includes user.application_permissions, edit_permission
-      assert_user_has_permissions ["edit", SupportedPermission::SIGNIN_NAME], app, user
+      assert_nil signin_permission
+      assert_nil edit_permission
+      assert_user_has_permissions [], app, user
     end
 
     should "return multiple permissions in name order" do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -577,7 +577,7 @@ class UserTest < ActiveSupport::TestCase
     end
 
     should "not create duplication permission when granting an already granted permission" do
-      app = create(:application, name: "my_app")
+      app = create(:application)
       user = create(:user)
 
       user.grant_application_signin_permission(app)
@@ -587,7 +587,7 @@ class UserTest < ActiveSupport::TestCase
     end
 
     should "grant permissions to user and return the created permission" do
-      app = create(:application, name: "my_app", with_supported_permissions: ["Create publications", "Delete publications"])
+      app = create(:application, with_supported_permissions: ["Create publications", "Delete publications"])
       user = create(:user)
 
       permission = user.grant_application_permission(app, "Create publications")
@@ -597,7 +597,7 @@ class UserTest < ActiveSupport::TestCase
     end
 
     should "return multiple permissions in name order" do
-      app = create(:application, name: "my_app", with_supported_permissions: %w[edit])
+      app = create(:application, with_supported_permissions: %w[edit])
       user = create(:user)
 
       user.grant_application_signin_permission(app)


### PR DESCRIPTION
Trello: https://trello.com/c/kvmb5OHO

While the Trello card is about hiding API-only apps, the overall motivation is to reduce the number of apps on various permissions pages and so I thought a good first step would be to exclude permissions relating to retired apps.

This adds a condition to the default scope on the `Doorkeeper::Application` model to only include `not_retired` applications in any query by default. It also incorporates this default scope into the `has_many :application_permissions` & `has_many :supported_permissions` associations on the `User` model. While using a default scope is perhaps a bit controversial, I think the notion of retiring an application is effectively a "soft delete" and this seems like a good use case for a default scope, not least because it should make it less likely a retired app or its permissions show up on any pages added in the future.

All this should mean that retired apps will only be listed in the following places:

1. On the "Retired" tab on the apps index page. It should still be possible to view all the permissions supported by a retired application via this page.
2. On the API user edit page in the "Tokens" section. This is because I haven't (yet) incorporated the default scope on the `Doorkeeper::Application` model to the `has_many :authorisations` association on the `User` model. I've decided to hold off on that for now (a) to reduce the scope of this PR; and (b) because 2nd line might still get alerts for expired tokens associated with retired apps and I want them to be able to still be able to access the UI to revoke/regenerate the token.

Retired apps should no longer appear on any pages where a user's permissions are being added/removed/changed.

The most significant commits are:
* [Add `not_retired` to `Doorkeeper::Application` default scope ](https://github.com/alphagov/signon/pull/2446/commits/7367d2e95bcfd84212395265276cdbcdfae3c102)
* [Exclude retired apps from `User#application_permissions`](https://github.com/alphagov/signon/pull/2446/commits/044a4aabaed3e993a4078a57d70205ffac9405a8)
* [Exclude retired apps from `User#supported_permissions`](https://github.com/alphagov/signon/pull/2446/commits/5bae5c412b66353b3c5437beeb5cb7c4ecc70502)

The other commits are mostly adding test coverage, removing redundant code, or just generally tidying up.

I haven't yet removed the logic to wrap application names in `<del>` tags to strike-through the name, because I want to double-check no retired apps end up appearing anywhere in the integration or production environments before I make that change.

Joseph has recommended that we publicise this change in the `#govuk-publishing` Slack channel before we deploy it.
 