### PR TITLE
Button to clear permissions on new user pages

### DIFF
--- a/app/assets/javascripts/modules/clear-selected-permissions.js
+++ b/app/assets/javascripts/modules/clear-selected-permissions.js
@@ -1,0 +1,34 @@
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function (Modules) {
+  'use strict'
+
+  function ClearSelectedPermissions (module) {
+    this.module = module
+    this.clearButton = this.module.querySelector('button[data-action="clear"]')
+    this.checkboxes = this.module.querySelectorAll('.govuk-checkboxes__input')
+    this.checkboxLists = this.module.querySelectorAll('.gem-c-checkboxes__list')
+  }
+
+  ClearSelectedPermissions.prototype.init = function () {
+    this.clearButton.addEventListener('click', this.clear.bind(this))
+  }
+
+  ClearSelectedPermissions.prototype.clear = function (event) {
+    event.preventDefault()
+    this.uncheckBoxes()
+    this.updateSelectCounts()
+  }
+
+  ClearSelectedPermissions.prototype.uncheckBoxes = function () {
+    this.checkboxes.forEach(c => { c.checked = false })
+  }
+
+  ClearSelectedPermissions.prototype.updateSelectCounts = function () {
+    const event = new Event('change')
+    this.checkboxLists.forEach(c => { c.dispatchEvent(event) })
+  }
+
+  Modules.ClearSelectedPermissions = ClearSelectedPermissions
+})(window.GOVUK.Modules)

--- a/app/views/batch_invitation_permissions/new.html.erb
+++ b/app/views/batch_invitation_permissions/new.html.erb
@@ -18,18 +18,29 @@
    })
 %>
 
-<%= form_for @batch_invitation, url: :batch_invitation_permissions, method: :post do |f| %>
-  <% policy_scope(:user_permission_manageable_application).map do |application| %>
-    <% options = options_for_permission_option_select(application:, user: User.with_default_permissions) %>
-    <%= render("govuk_publishing_components/components/option_select", {
-      title: application.name,
-      key: "user[supported_permission_ids]",
-      options_container_id: "user_application_#{application.id}_supported_permissions",
-      show_filter: options.length > 4,
-      closed_on_load: options.map {|o| o[:checked] }.none?,
-      options:,
-    }) %>
-  <% end %>
+<div data-module="clear-selected-permissions">
+  <%= render "govuk_publishing_components/components/button", {
+    text: "Clear selected permissions",
+    secondary_solid: true,
+    margin_bottom: 4,
+    data_attributes: {
+      action: "clear"
+    }
+  } %>
 
-  <%= render "govuk_publishing_components/components/button", { text: "Create users and send emails" } %>
-<% end %>
+  <%= form_for @batch_invitation, url: :batch_invitation_permissions, method: :post do |f| %>
+    <% policy_scope(:user_permission_manageable_application).map do |application| %>
+      <% options = options_for_permission_option_select(application:, user: User.with_default_permissions) %>
+      <%= render("govuk_publishing_components/components/option_select", {
+        title: application.name,
+        key: "user[supported_permission_ids]",
+        options_container_id: "user_application_#{application.id}_supported_permissions",
+        show_filter: options.length > 4,
+        closed_on_load: options.map {|o| o[:checked] }.none?,
+        options:,
+      }) %>
+    <% end %>
+
+    <%= render "govuk_publishing_components/components/button", { text: "Create users and send emails" } %>
+  <% end %>
+<div>

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -81,24 +81,25 @@
         } %>
       <% end %>
 
-      <%= render "govuk_publishing_components/components/fieldset", {
-        legend_text: "Permissions",
-        heading_size: "l",
-      } do %>
+      <div>
+        <%= render "govuk_publishing_components/components/fieldset", {
+          legend_text: "Permissions",
+          heading_size: "l",
+        } do %>
 
-        <% policy_scope(:user_permission_manageable_application).map do |application| %>
-          <% options = options_for_permission_option_select(application:, user: f.object) %>
-          <%= render("govuk_publishing_components/components/option_select", {
-            title: application.name,
-            key: "user[supported_permission_ids]",
-            options_container_id: "user_application_#{application.id}_supported_permissions",
-            show_filter: options.length > 4,
-            closed_on_load: options.none? { |o| o[:checked] },
-            options: with_checked_options_at_top(options),
-          }) %>
+          <% policy_scope(:user_permission_manageable_application).map do |application| %>
+            <% options = options_for_permission_option_select(application:, user: f.object) %>
+            <%= render("govuk_publishing_components/components/option_select", {
+              title: application.name,
+              key: "user[supported_permission_ids]",
+              options_container_id: "user_application_#{application.id}_supported_permissions",
+              show_filter: options.length > 4,
+              closed_on_load: options.none? { |o| o[:checked] },
+              options: with_checked_options_at_top(options),
+            }) %>
+          <% end %>
         <% end %>
-
-      <% end %>
+      </div>
 
       <div class="govuk-button-group">
         <%= render "govuk_publishing_components/components/button", {

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -81,11 +81,20 @@
         } %>
       <% end %>
 
-      <div>
+      <div data-module="clear-selected-permissions">
         <%= render "govuk_publishing_components/components/fieldset", {
           legend_text: "Permissions",
           heading_size: "l",
         } do %>
+
+          <%= render "govuk_publishing_components/components/button", {
+            text: "Clear selected permissions",
+            secondary_solid: true,
+            margin_bottom: 4,
+            data_attributes: {
+              action: "clear"
+            }
+          } %>
 
           <% policy_scope(:user_permission_manageable_application).map do |application| %>
             <% options = options_for_permission_option_select(application:, user: f.object) %>

--- a/spec/javascripts/modules/clear-selected-permissions-spec.js
+++ b/spec/javascripts/modules/clear-selected-permissions-spec.js
@@ -1,0 +1,36 @@
+describe('GOVUK.Modules.ClearSelectedPermissions', function () {
+  let component, module
+
+  beforeEach(function () {
+    component = document.createElement('div')
+    component.innerHTML = `
+      <button type="submit" data-action="clear">Clear selected permissions</button>
+
+      <ul class="gem-c-checkboxes__list">
+        <li class="govuk-checkboxes__item">
+          <input type="checkbox" class="govuk-checkboxes__input" checked="checked" />
+        </li>
+      </ul>
+    `
+    module = new GOVUK.Modules.ClearSelectedPermissions(component)
+    module.init()
+  })
+
+  it('clears the checked status of the checkboxes when the button is clicked', function () {
+    const input = component.querySelector('input')
+    expect(input.checked).toBe(true)
+
+    component.querySelector('button').click()
+
+    expect(input.checked).toBe(false)
+  })
+
+  it('sends a change event to the checkbox list when the button is clicked', function () {
+    const list = component.querySelector('ul')
+    spyOn(list, 'dispatchEvent')
+
+    component.querySelector('button').click()
+
+    expect(list.dispatchEvent).toHaveBeenCalledWith(jasmine.objectContaining({ type: 'change' }))
+  })
+})

--- a/spec/support/jasmine-browser.json
+++ b/spec/support/jasmine-browser.json
@@ -1,6 +1,7 @@
 {
   "srcDir": "public/assets/signon",
   "srcFiles": [
+    "application-*.js",
     "govuk-admin-template-*.js",
     "legacy_layout-*.js"
   ],


### PR DESCRIPTION
Trello: https://trello.com/c/c6TxIASX

In #2436 we ensured that the default permissions for new users were checked in the permissions checkboxes on when inviting new users (singly or in a batch). This is a big time-saver for some inviting users who frequently add these
permissions. However there's a subset of inviting users who set up new user accounts who don't need these default permissions (e.g. when setting up users who use the Licensing app).

This PR adds a "Clear selected permissions" button to the `/users/invitations/new` and `/batch_invitations/:id/permissions/new` pages to make it easier for those inviting users to complete their task. 

Clicking the button clears the checked boxes and resets the "selected" counter for each app

https://github.com/alphagov/signon/assets/16707/570af1c2-a658-4003-8735-511ca5ef5bde

