### PR TITLE
Hide API-only apps on most pages

### DIFF
--- a/app/controllers/account/applications_controller.rb
+++ b/app/controllers/account/applications_controller.rb
@@ -12,7 +12,7 @@ class Account::ApplicationsController < ApplicationController
   def index
     authorize [:account, Doorkeeper::Application]
 
-    @applications_with_signin = Doorkeeper::Application.can_signin(current_user)
-    @applications_without_signin = Doorkeeper::Application.without_signin_permission_for(current_user)
+    @applications_with_signin = Doorkeeper::Application.not_api_only.can_signin(current_user)
+    @applications_without_signin = Doorkeeper::Application.not_api_only.without_signin_permission_for(current_user)
   end
 end

--- a/app/controllers/account/permissions_controller.rb
+++ b/app/controllers/account/permissions_controller.rb
@@ -4,7 +4,7 @@ class Account::PermissionsController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @application = Doorkeeper::Application.find(params[:application_id])
+    @application = Doorkeeper::Application.not_api_only.find(params[:application_id])
 
     authorize [:account, @application], :view_permissions?
 

--- a/app/controllers/doorkeeper_applications_controller.rb
+++ b/app/controllers/doorkeeper_applications_controller.rb
@@ -45,7 +45,7 @@ private
       :retired,
       :home_uri,
       :supports_push_updates,
-      :show_on_dashboard,
+      :api_only,
     )
   end
 end

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -6,7 +6,7 @@ class RootController < ApplicationController
   skip_after_action :verify_authorized
 
   def index
-    applications = Doorkeeper::Application.where(show_on_dashboard: true).can_signin(current_user)
+    applications = Doorkeeper::Application.where(api_only: false).can_signin(current_user)
 
     @applications_and_permissions = zip_permissions(applications, current_user)
   end

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -6,7 +6,7 @@ class RootController < ApplicationController
   skip_after_action :verify_authorized
 
   def index
-    applications = Doorkeeper::Application.where(api_only: false).can_signin(current_user)
+    applications = Doorkeeper::Application.not_api_only.can_signin(current_user)
 
     @applications_and_permissions = zip_permissions(applications, current_user)
   end

--- a/app/models/doorkeeper/application.rb
+++ b/app/models/doorkeeper/application.rb
@@ -9,6 +9,7 @@ class Doorkeeper::Application < ActiveRecord::Base # rubocop:disable Rails/Appli
   scope :support_push_updates, -> { where(supports_push_updates: true) }
   scope :retired, -> { where(retired: true) }
   scope :not_retired, -> { where(retired: false) }
+  scope :not_api_only, -> { where(api_only: false) }
   scope :can_signin, ->(user) { with_signin_permission_for(user) }
   scope :with_signin_delegatable,
         lambda {

--- a/app/models/doorkeeper/application.rb
+++ b/app/models/doorkeeper/application.rb
@@ -9,6 +9,7 @@ class Doorkeeper::Application < ActiveRecord::Base # rubocop:disable Rails/Appli
   scope :support_push_updates, -> { where(supports_push_updates: true) }
   scope :retired, -> { where(retired: true) }
   scope :not_retired, -> { where(retired: false) }
+  scope :api_only, -> { where(api_only: true) }
   scope :not_api_only, -> { where(api_only: false) }
   scope :can_signin, ->(user) { with_signin_permission_for(user) }
   scope :with_signin_delegatable,

--- a/app/policies/user_permission_manageable_application_policy.rb
+++ b/app/policies/user_permission_manageable_application_policy.rb
@@ -31,7 +31,7 @@ class UserPermissionManageableApplicationPolicy
   private
 
     def applications
-      Doorkeeper::Application.includes(:supported_permissions)
+      Doorkeeper::Application.not_api_only.includes(:supported_permissions)
     end
   end
 end

--- a/app/views/doorkeeper_applications/edit.html.erb
+++ b/app/views/doorkeeper_applications/edit.html.erb
@@ -97,8 +97,13 @@
 
       <div class="govuk-body">
         <label>
-          <%= f.check_box :show_on_dashboard %> Show on dashboard
+          <%= f.check_box :api_only %> Is API-only
         </label>
+
+        <p>
+          An API-only application is one that doesn't have a user interface and is only used by API users.
+          It will not appear on the dashboard.
+        </p>
       </div>
 
       <div class="govuk-body">

--- a/app/views/doorkeeper_applications/edit.html.erb
+++ b/app/views/doorkeeper_applications/edit.html.erb
@@ -102,7 +102,7 @@
 
         <p>
           An API-only application is one that doesn't have a user interface and is only used by API users.
-          It will not appear on the dashboard.
+          API-only applications will not appear on most pages including the dashboard.
         </p>
       </div>
 

--- a/app/views/doorkeeper_applications/index.html.erb
+++ b/app/views/doorkeeper_applications/index.html.erb
@@ -5,7 +5,12 @@
     {
       id: "active",
       label: "Active applications",
-      content: render("application_list", applications: @applications)
+      content: render("application_list", applications: @applications.not_api_only)
+    },
+    {
+      id: "api-only",
+      label: "API-only applications",
+      content: render("application_list", applications: @applications.api_only)
     },
     {
       id: "retired",

--- a/app/views/doorkeeper_applications/index.html.erb
+++ b/app/views/doorkeeper_applications/index.html.erb
@@ -15,7 +15,7 @@
     {
       id: "retired",
       label: "Retired applications",
-      content: render("application_list", applications: @applications.unscoped.retired)
+      content: render("application_list", applications: @applications.unscoped.retired.ordered_by_name)
     }
   ]
 } %>

--- a/db/migrate/20231019080657_replace_oauth_applications_show_on_dashboard_with_api_only.rb
+++ b/db/migrate/20231019080657_replace_oauth_applications_show_on_dashboard_with_api_only.rb
@@ -1,0 +1,17 @@
+class ReplaceOauthApplicationsShowOnDashboardWithApiOnly < ActiveRecord::Migration[7.0]
+  def up
+    add_column :oauth_applications, :api_only, :boolean, default: false, null: false
+
+    update "UPDATE oauth_applications SET api_only = !show_on_dashboard"
+
+    remove_column :oauth_applications, :show_on_dashboard
+  end
+
+  def down
+    add_column :oauth_applications, :show_on_dashboard, :boolean, default: true, null: false
+
+    update "UPDATE oauth_applications SET show_on_dashboard = !api_only"
+
+    remove_column :oauth_applications, :api_only
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_18_141956) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_19_080657) do
   create_table "batch_invitation_application_permissions", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "batch_invitation_id", null: false
     t.integer "supported_permission_id", null: false
@@ -95,8 +95,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_18_141956) do
     t.string "description"
     t.boolean "supports_push_updates", default: true
     t.boolean "retired", default: false, null: false
-    t.boolean "show_on_dashboard", default: true, null: false
     t.boolean "confidential", default: true, null: false
+    t.boolean "api_only", default: false, null: false
     t.index ["name"], name: "unique_application_name", unique: true
     t.index ["uid"], name: "index_oauth_applications_on_uid", unique: true
   end

--- a/lib/user_permissions_controller_methods.rb
+++ b/lib/user_permissions_controller_methods.rb
@@ -26,6 +26,10 @@ private
   end
 
   def all_applications_and_permissions_for(user)
-    user.supported_permissions.includes(:application).group_by(&:application)
+    user
+      .supported_permissions
+      .merge(Doorkeeper::Application.not_api_only)
+      .includes(:application)
+      .group_by(&:application)
   end
 end

--- a/test/controllers/account/applications_controller_test.rb
+++ b/test/controllers/account/applications_controller_test.rb
@@ -47,6 +47,15 @@ class Account::ApplicationsControllerTest < ActionController::TestCase
         assert_select "tr td", text: "app-name"
         assert_select "a[href='#{delete_account_application_signin_permission_path(application)}']"
       end
+
+      should "not display a retired application" do
+        create(:application, name: "retired-app-name", retired: true)
+        sign_in create(:admin_user)
+
+        get :index
+
+        assert_select "tr td", text: "retired-app-name", count: 0
+      end
     end
 
     context "logged in as a publishing manager" do

--- a/test/controllers/account/applications_controller_test.rb
+++ b/test/controllers/account/applications_controller_test.rb
@@ -24,6 +24,31 @@ class Account::ApplicationsControllerTest < ActionController::TestCase
   end
 
   context "#index" do
+    context "logged in as a GOV.UK admin" do
+      should "display the button to grant access to an application" do
+        application = create(:application, name: "app-name")
+        sign_in create(:admin_user)
+
+        get :index
+
+        assert_select "tr td", text: "app-name"
+        assert_select "form[action='#{account_application_signin_permission_path(application)}']"
+      end
+
+      should "display the button to remove access to an application" do
+        application = create(:application, name: "app-name")
+        application.signin_permission.update!(delegatable: false)
+        user = create(:admin_user, with_signin_permissions_for: [application])
+
+        sign_in user
+
+        get :index
+
+        assert_select "tr td", text: "app-name"
+        assert_select "a[href='#{delete_account_application_signin_permission_path(application)}']"
+      end
+    end
+
     context "logged in as a publishing manager" do
       should "not display the button to grant access to an application" do
         application = create(:application, name: "app-name")

--- a/test/controllers/account/applications_controller_test.rb
+++ b/test/controllers/account/applications_controller_test.rb
@@ -56,6 +56,15 @@ class Account::ApplicationsControllerTest < ActionController::TestCase
 
         assert_select "tr td", text: "retired-app-name", count: 0
       end
+
+      should "not display an API-only application" do
+        create(:application, name: "api-only-app-name", api_only: true)
+        sign_in create(:admin_user)
+
+        get :index
+
+        assert_select "tr td", text: "api-only-app-name", count: 0
+      end
     end
 
     context "logged in as a publishing manager" do

--- a/test/controllers/account/manage_permissions_controller_test.rb
+++ b/test/controllers/account/manage_permissions_controller_test.rb
@@ -44,6 +44,20 @@ class Account::ManagePermissionsControllerTest < ActionController::TestCase
           assert_select "td", count: 0, text: retired_app.name
         end
       end
+
+      should "not list API-only applications" do
+        user = create(:admin_user, email: "admin@gov.uk")
+        sign_in user
+
+        api_only_app = create(:application, api_only: true)
+        user.grant_application_signin_permission(api_only_app)
+
+        get :show
+
+        assert_select ".container" do
+          assert_select "td", count: 0, text: api_only_app.name
+        end
+      end
     end
 
     context "organisation admin" do

--- a/test/controllers/account/manage_permissions_controller_test.rb
+++ b/test/controllers/account/manage_permissions_controller_test.rb
@@ -30,6 +30,20 @@ class Account::ManagePermissionsControllerTest < ActionController::TestCase
           assert_select "td", count: 1, text: non_delegatable_no_access_to_app.name
         end
       end
+
+      should "not list retired applications" do
+        user = create(:admin_user, email: "admin@gov.uk")
+        sign_in user
+
+        retired_app = create(:application, retired: true)
+        user.grant_application_signin_permission(retired_app)
+
+        get :show
+
+        assert_select ".container" do
+          assert_select "td", count: 0, text: retired_app.name
+        end
+      end
     end
 
     context "organisation admin" do

--- a/test/controllers/account/manage_permissions_controller_test.rb
+++ b/test/controllers/account/manage_permissions_controller_test.rb
@@ -106,6 +106,20 @@ class Account::ManagePermissionsControllerTest < ActionController::TestCase
           assert_select "td", count: 1, text: "GDS Admin"
         end
       end
+
+      should "not list API-only applications" do
+        user = create(:organisation_admin_user)
+        sign_in user
+
+        api_only_app = create(:application, api_only: true)
+        user.grant_application_signin_permission(api_only_app)
+
+        get :show
+
+        assert_select "#all-permissions" do
+          assert_select "td", count: 0, text: api_only_app.name
+        end
+      end
     end
 
     context "super organisation admin" do

--- a/test/controllers/account/permissions_controller_test.rb
+++ b/test/controllers/account/permissions_controller_test.rb
@@ -34,6 +34,16 @@ class Account::PermissionsControllerTest < ActionController::TestCase
       end
     end
 
+    should "exclude API-only applications" do
+      sign_in create(:admin_user)
+
+      application = create(:application, api_only: true)
+
+      assert_raises(ActiveRecord::RecordNotFound) do
+        get :index, params: { application_id: application.id }
+      end
+    end
+
     should "order permissions by whether the user has access and then alphabetically" do
       application = create(:application,
                            with_supported_permissions: %w[aaa bbb ttt uuu])

--- a/test/controllers/api_users_controller_test.rb
+++ b/test/controllers/api_users_controller_test.rb
@@ -125,6 +125,18 @@ class ApiUsersControllerTest < ActionController::TestCase
           assert_select "td", text: "retired-app-name", count: 0
         end
       end
+
+      should "allow editing permissions for API-only application" do
+        application = create(:application, name: "api-only-app-name", api_only: true)
+        api_user = create(:api_user, with_permissions: { application => [SupportedPermission::SIGNIN_NAME] })
+        create(:access_token, resource_owner_id: api_user.id, application:)
+
+        get :edit, params: { id: api_user.id }
+
+        assert_select "table#editable-permissions tr" do
+          assert_select "td", text: "api-only-app-name"
+        end
+      end
     end
 
     context "PUT update" do

--- a/test/controllers/api_users_controller_test.rb
+++ b/test/controllers/api_users_controller_test.rb
@@ -64,6 +64,19 @@ class ApiUsersControllerTest < ActionController::TestCase
           assert_select apps_span.parent, "ul>li", text: "app-name", count: 0
         end
       end
+
+      should "list API-only applications for api user" do
+        application = create(:application, name: "app-name", api_only: true)
+        api_user = create(:api_user, with_permissions: { application => [SupportedPermission::SIGNIN_NAME] })
+        create(:access_token, resource_owner_id: api_user.id, application:)
+
+        get :index
+
+        assert_select "td>span" do |spans|
+          apps_span = spans.find { |s| s.text.strip == "Apps" }
+          assert_select apps_span.parent, "ul>li", text: "app-name"
+        end
+      end
     end
 
     context "POST create" do

--- a/test/controllers/api_users_controller_test.rb
+++ b/test/controllers/api_users_controller_test.rb
@@ -96,6 +96,23 @@ class ApiUsersControllerTest < ActionController::TestCase
         assert_select "input[name='api_user[name]'][value='#{api_user.name}']"
         assert_select "input[name='api_user[email]'][value='#{api_user.email}']"
       end
+
+      should "allow editing permissions for application which user has access to" do
+        application = create(:application, name: "app-name", with_supported_permissions: %w[edit])
+        api_user = create(:api_user, with_permissions: { application => [SupportedPermission::SIGNIN_NAME] })
+        create(:access_token, resource_owner_id: api_user.id, application:)
+
+        get :edit, params: { id: api_user.id }
+
+        assert_select "table#editable-permissions tr" do
+          assert_select "td", text: "app-name"
+          assert_select "td" do
+            assert_select "select[name='api_user[supported_permission_ids][]']" do
+              assert_select "option", text: "edit"
+            end
+          end
+        end
+      end
     end
 
     context "PUT update" do

--- a/test/controllers/api_users_controller_test.rb
+++ b/test/controllers/api_users_controller_test.rb
@@ -164,6 +164,20 @@ class ApiUsersControllerTest < ActionController::TestCase
         assert_same_elements permissions, api_user.reload.supported_permissions
       end
 
+      should "update the user's permissions for API-only app" do
+        application = create(:application, name: "app-name", with_supported_permissions: %w[edit], api_only: true)
+        api_user = create(:api_user, with_permissions: { application => [SupportedPermission::SIGNIN_NAME] })
+        create(:access_token, resource_owner_id: api_user.id, application:)
+
+        signin_permission = application.supported_permissions.find_by(name: SupportedPermission::SIGNIN_NAME)
+        edit_permission = application.supported_permissions.find_by(name: "edit")
+        permissions = [signin_permission, edit_permission]
+
+        put :update, params: { id: api_user.id, api_user: { supported_permission_ids: permissions } }
+
+        assert_same_elements permissions, api_user.reload.supported_permissions
+      end
+
       should "redisplay the form with errors if save fails" do
         api_user = create(:api_user)
 

--- a/test/controllers/api_users_controller_test.rb
+++ b/test/controllers/api_users_controller_test.rb
@@ -113,6 +113,18 @@ class ApiUsersControllerTest < ActionController::TestCase
           end
         end
       end
+
+      should "not allow editing permissions for retired application" do
+        application = create(:application, name: "retired-app-name", retired: true)
+        api_user = create(:api_user, with_permissions: { application => [SupportedPermission::SIGNIN_NAME] })
+        create(:access_token, resource_owner_id: api_user.id, application:)
+
+        get :edit, params: { id: api_user.id }
+
+        assert_select "table#editable-permissions tr" do
+          assert_select "td", text: "retired-app-name", count: 0
+        end
+      end
     end
 
     context "PUT update" do

--- a/test/controllers/batch_invitation_permissions_controller_test.rb
+++ b/test/controllers/batch_invitation_permissions_controller_test.rb
@@ -78,6 +78,17 @@ class BatchInvitationPermissionsControllerTest < ActionController::TestCase
       end
     end
 
+    should "not include permissions for API-only apps" do
+      application = create(:application, api_only: true)
+      signin_permission = application.signin_permission
+
+      get :new, params: { batch_invitation_id: @batch_invitation.id }
+
+      assert_select "form" do
+        assert_select "input[type='checkbox'][name='user[supported_permission_ids][]'][value='#{signin_permission.to_param}']", count: 0
+      end
+    end
+
     should "not include permissions for retired apps" do
       application = create(:application, retired: true)
       signin_permission = application.signin_permission

--- a/test/controllers/doorkeeper_applications_controller_test.rb
+++ b/test/controllers/doorkeeper_applications_controller_test.rb
@@ -26,6 +26,16 @@ class DoorkeeperApplicationsControllerTest < ActionController::TestCase
       assert_select "#api-only td", text: /My retired app/, count: 0
       assert_select "#retired td", text: /My retired app/
     end
+
+    should "list retired apps in alphabetical order" do
+      create(:application, name: "My retired app B", retired: true)
+      create(:application, name: "My retired app A", retired: true)
+
+      get :index
+
+      assert_select "#retired tr:first-child td:first-child", text: /My retired app A/
+      assert_select "#retired tr:last-child td:first-child", text: /My retired app B/
+    end
   end
 
   context "GET edit" do

--- a/test/controllers/doorkeeper_applications_controller_test.rb
+++ b/test/controllers/doorkeeper_applications_controller_test.rb
@@ -7,14 +7,24 @@ class DoorkeeperApplicationsControllerTest < ActionController::TestCase
   end
 
   context "GET index" do
-    should "list applications" do
+    should "list applications in separate tabs for Active, API-only & Retired" do
       create(:application, name: "My first app")
+      create(:application, name: "My API-only app", api_only: true)
       create(:application, name: "My retired app", retired: true)
 
       get :index
 
-      assert_select "#active td", /My first app/
-      assert_select "#retired td", /My retired app/
+      assert_select "#active td", text: /My first app/
+      assert_select "#api-only td", text: /My first app/, count: 0
+      assert_select "#retired td", text: /My first app/, count: 0
+
+      assert_select "#active td", text: /My API-only app/, count: 0
+      assert_select "#api-only td", text: /My API-only app/
+      assert_select "#retired td", text: /My API-only app/, count: 0
+
+      assert_select "#active td", text: /My retired app/, count: 0
+      assert_select "#api-only td", text: /My retired app/, count: 0
+      assert_select "#retired td", text: /My retired app/
     end
   end
 

--- a/test/controllers/invitations_controller_test.rb
+++ b/test/controllers/invitations_controller_test.rb
@@ -84,6 +84,17 @@ class InvitationsControllerTest < ActionController::TestCase
         end
       end
 
+      should "not render form checkbox inputs for permissions for API-only applications" do
+        application = create(:application, api_only: true)
+        signin_permission = application.signin_permission
+
+        get :new
+
+        assert_select "form" do
+          assert_select "input[type='checkbox'][name='user[supported_permission_ids][]'][value='#{signin_permission.to_param}']", count: 0
+        end
+      end
+
       should "not render form checkbox inputs for permissions for retired applications" do
         application = create(:application, retired: true)
         signin_permission = application.signin_permission

--- a/test/controllers/root_controller_test.rb
+++ b/test/controllers/root_controller_test.rb
@@ -36,6 +36,16 @@ class RootControllerTest < ActionController::TestCase
     assert_select "h3", count: 1
   end
 
+  test "do not display retired application on dashboard even if you have signin permission" do
+    application = create(:application, name: "Retired app", retired: true)
+    user = create(:user, with_signin_permissions_for: [application])
+    sign_in user
+
+    get :index
+
+    assert_select "h3", text: "Retired app", count: 0
+  end
+
   test "GDS publishers should be told to ask their delivery manager when they don't have permission to use a publishing app" do
     gds = create(:organisation, content_id: "af07d5a5-df63-4ddc-9383-6a666845ebe9")
     gds_user = create(:user, organisation: gds)

--- a/test/controllers/root_controller_test.rb
+++ b/test/controllers/root_controller_test.rb
@@ -46,6 +46,16 @@ class RootControllerTest < ActionController::TestCase
     assert_select "h3", text: "Retired app", count: 0
   end
 
+  test "do not display API-only application on dashboard even if you have signin permission" do
+    application = create(:application, name: "API-only app", api_only: true)
+    user = create(:user, with_signin_permissions_for: [application])
+    sign_in user
+
+    get :index
+
+    assert_select "h3", text: "API-only app", count: 0
+  end
+
   test "GDS publishers should be told to ask their delivery manager when they don't have permission to use a publishing app" do
     gds = create(:organisation, content_id: "af07d5a5-df63-4ddc-9383-6a666845ebe9")
     gds_user = create(:user, organisation: gds)

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -557,6 +557,22 @@ class UsersControllerTest < ActionController::TestCase
             assert_select "td", text: retired_app.name, count: 0
           end
         end
+
+        should "not be able to see permissions to API-only applications for a user" do
+          api_only_app = create(:application, api_only: true)
+          super_org_admin = create(:super_organisation_admin_user)
+
+          sign_in super_org_admin
+          user = create(:user_in_organisation, organisation: super_org_admin.organisation)
+          create(:user_application_permission, application: api_only_app, user:)
+
+          get :edit, params: { id: user.id }
+
+          assert_select "h2", "All Permissions for this user"
+          assert_select "#all-permissions" do
+            assert_select "td", text: api_only_app.name, count: 0
+          end
+        end
       end
 
       context "superadmin" do

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -541,6 +541,22 @@ class UsersControllerTest < ActionController::TestCase
             assert_select "td", count: 1, text: "Import CSVs"
           end
         end
+
+        should "not be able to see permissions to retired applications for a user" do
+          retired_app = create(:application, retired: true)
+          super_org_admin = create(:super_organisation_admin_user)
+
+          sign_in super_org_admin
+          user = create(:user_in_organisation, organisation: super_org_admin.organisation)
+          create(:user_application_permission, application: retired_app, user:)
+
+          get :edit, params: { id: user.id }
+
+          assert_select "h2", "All Permissions for this user"
+          assert_select "#all-permissions" do
+            assert_select "td", text: retired_app.name, count: 0
+          end
+        end
       end
 
       context "superadmin" do

--- a/test/integration/account_applications_test.rb
+++ b/test/integration/account_applications_test.rb
@@ -5,6 +5,7 @@ class AccountApplicationsTest < ActionDispatch::IntegrationTest
     setup do
       @application = create(:application, name: "app-name", description: "app-description")
       @retired_application = create(:application, retired: true, name: "retired-app-name")
+      @api_only_application = create(:application, api_only: true, name: "api-only-app-name")
       @user = FactoryBot.create(:admin_user)
     end
 
@@ -38,6 +39,17 @@ class AccountApplicationsTest < ActionDispatch::IntegrationTest
       assert_not page.has_content?("retired-app-name")
     end
 
+    should "not list API-only applications the user has access to" do
+      @user.grant_application_signin_permission(@api_only_application)
+
+      visit new_user_session_path
+      signin_with @user
+
+      visit account_applications_path
+
+      assert_not page.has_content?("api-only-app-name")
+    end
+
     should "list the applications the user does not have access to" do
       visit new_user_session_path
       signin_with @user
@@ -58,6 +70,15 @@ class AccountApplicationsTest < ActionDispatch::IntegrationTest
       visit account_applications_path
 
       assert_not page.has_content?("retired-app-name")
+    end
+
+    should "not list API-only applications the user does not have access to" do
+      visit new_user_session_path
+      signin_with @user
+
+      visit account_applications_path
+
+      assert_not page.has_content?("api-only-app-name")
     end
   end
 

--- a/test/integration/dashboard_test.rb
+++ b/test/integration/dashboard_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class DashboardTest < ActionDispatch::IntegrationTest
   should "notify the user if they've not been assigned any applications" do
-    app = create(:application, name: "MyApp", show_on_dashboard: false)
+    app = create(:application, name: "MyApp", api_only: true)
     user = create(:user, with_signin_permissions_for: [app])
 
     visit root_path

--- a/test/models/doorkeeper/application_test.rb
+++ b/test/models/doorkeeper/application_test.rb
@@ -192,6 +192,22 @@ class Doorkeeper::ApplicationTest < ActiveSupport::TestCase
     end
   end
 
+  context ".api_only" do
+    setup do
+      @app = create(:application)
+    end
+
+    should "include apps that are api only" do
+      @app.update!(api_only: true)
+      assert_equal [@app], Doorkeeper::Application.api_only
+    end
+
+    should "exclude apps that are not api only" do
+      @app.update!(api_only: false)
+      assert_equal [], Doorkeeper::Application.api_only
+    end
+  end
+
   context ".not_api_only" do
     setup do
       @app = create(:application)

--- a/test/models/doorkeeper/application_test.rb
+++ b/test/models/doorkeeper/application_test.rb
@@ -192,6 +192,22 @@ class Doorkeeper::ApplicationTest < ActiveSupport::TestCase
     end
   end
 
+  context ".not_api_only" do
+    setup do
+      @app = create(:application)
+    end
+
+    should "include apps that are not api only" do
+      @app.update!(api_only: false)
+      assert_equal [@app], Doorkeeper::Application.not_api_only
+    end
+
+    should "exclude apps that are api only" do
+      @app.update!(api_only: true)
+      assert_equal [], Doorkeeper::Application.not_api_only
+    end
+  end
+
   context ".can_signin" do
     should "return applications that the user can signin into" do
       user = create(:user)

--- a/test/policies/user_permission_manageable_application_policy_scope_test.rb
+++ b/test/policies/user_permission_manageable_application_policy_scope_test.rb
@@ -7,16 +7,18 @@ class UserPermissionManageableApplicationPolicyScopeTest < ActiveSupport::TestCa
     @app_three = create(:application, name: "App three")
     @app_four = create(:application, name: "App four")
     @retired_app = create(:application, name: "Retired app", retired: true)
+    @api_only_app = create(:application, name: "API-only app", api_only: true)
 
     @app_one_signin_permission = @app_one.signin_permission.tap { |s| s.update(delegatable: true) }
     @app_two_signin_permission = @app_two.signin_permission.tap { |s| s.update(delegatable: false) }
     @app_three_signin_permission = @app_three.signin_permission.tap { |s| s.update(delegatable: true) }
     @app_four_signin_permission = @app_four.signin_permission.tap { |s| s.update(delegatable: false) }
     @retired_app_signin_permission = @retired_app.signin_permission.tap { |s| s.update(delegatable: true) }
+    @api_only_app_signin_permission = @api_only_app.signin_permission.tap { |s| s.update(delegatable: true) }
   end
 
   context "resolve" do
-    should "include all application for superadmins except retired apps" do
+    should "include all application for superadmins except retired & API-only apps" do
       user = create(:superadmin_user)
       resolved_scope = UserPermissionManageableApplicationPolicy::Scope.new(user).resolve
       assert_includes resolved_scope, @app_one
@@ -24,9 +26,10 @@ class UserPermissionManageableApplicationPolicyScopeTest < ActiveSupport::TestCa
       assert_includes resolved_scope, @app_three
       assert_includes resolved_scope, @app_four
       assert_not_includes resolved_scope, @retired_app
+      assert_not_includes resolved_scope, @api_only_app
     end
 
-    should "include all application for admins except retired apps" do
+    should "include all application for admins except retired & API-only apps" do
       user = create(:admin_user)
       resolved_scope = UserPermissionManageableApplicationPolicy::Scope.new(user).resolve
       assert_includes resolved_scope, @app_one
@@ -34,6 +37,7 @@ class UserPermissionManageableApplicationPolicyScopeTest < ActiveSupport::TestCa
       assert_includes resolved_scope, @app_three
       assert_includes resolved_scope, @app_four
       assert_not_includes resolved_scope, @retired_app
+      assert_not_includes resolved_scope, @api_only_app
     end
 
     context "super organisation admins" do
@@ -46,9 +50,10 @@ class UserPermissionManageableApplicationPolicyScopeTest < ActiveSupport::TestCa
         @resolved_scope = UserPermissionManageableApplicationPolicy::Scope.new(user).resolve
       end
 
-      should "include non-retired applications with delegatable signin that the super organisation admin has access to" do
+      should "include non-retired, non-API-only applications with delegatable signin that the super organisation admin has access to" do
         assert_includes @resolved_scope, @app_one
         assert_not_includes @resolved_scope, @retired_app
+        assert_not_includes @resolved_scope, @api_only_app
       end
 
       should "not include applications without delegatable signin that the super organisation admin does has access to" do
@@ -71,9 +76,10 @@ class UserPermissionManageableApplicationPolicyScopeTest < ActiveSupport::TestCa
         @resolved_scope = UserPermissionManageableApplicationPolicy::Scope.new(user).resolve
       end
 
-      should "include non-retired applications with delegatable signin that the organisation admin has access to" do
+      should "include non-retired, non-API-only applications with delegatable signin that the organisation admin has access to" do
         assert_includes @resolved_scope, @app_one
         assert_not_includes @resolved_scope, @retired_app
+        assert_not_includes @resolved_scope, @api_only_app
       end
 
       should "not include applications without delegatable signin that the organisation admin does has access to" do

--- a/test/policies/user_permission_manageable_application_policy_scope_test.rb
+++ b/test/policies/user_permission_manageable_application_policy_scope_test.rb
@@ -6,30 +6,34 @@ class UserPermissionManageableApplicationPolicyScopeTest < ActiveSupport::TestCa
     @app_two = create(:application, name: "App two")
     @app_three = create(:application, name: "App three")
     @app_four = create(:application, name: "App four")
+    @retired_app = create(:application, name: "Retired app", retired: true)
 
     @app_one_signin_permission = @app_one.signin_permission.tap { |s| s.update(delegatable: true) }
     @app_two_signin_permission = @app_two.signin_permission.tap { |s| s.update(delegatable: false) }
     @app_three_signin_permission = @app_three.signin_permission.tap { |s| s.update(delegatable: true) }
     @app_four_signin_permission = @app_four.signin_permission.tap { |s| s.update(delegatable: false) }
+    @retired_app_signin_permission = @retired_app.signin_permission.tap { |s| s.update(delegatable: true) }
   end
 
   context "resolve" do
-    should "include all application for superadmins" do
+    should "include all application for superadmins except retired apps" do
       user = create(:superadmin_user)
       resolved_scope = UserPermissionManageableApplicationPolicy::Scope.new(user).resolve
       assert_includes resolved_scope, @app_one
       assert_includes resolved_scope, @app_two
       assert_includes resolved_scope, @app_three
       assert_includes resolved_scope, @app_four
+      assert_not_includes resolved_scope, @retired_app
     end
 
-    should "include all application for admins" do
+    should "include all application for admins except retired apps" do
       user = create(:admin_user)
       resolved_scope = UserPermissionManageableApplicationPolicy::Scope.new(user).resolve
       assert_includes resolved_scope, @app_one
       assert_includes resolved_scope, @app_two
       assert_includes resolved_scope, @app_three
       assert_includes resolved_scope, @app_four
+      assert_not_includes resolved_scope, @retired_app
     end
 
     context "super organisation admins" do
@@ -42,8 +46,9 @@ class UserPermissionManageableApplicationPolicyScopeTest < ActiveSupport::TestCa
         @resolved_scope = UserPermissionManageableApplicationPolicy::Scope.new(user).resolve
       end
 
-      should "include applications with delegatable signin that the super organisation admin has access to" do
+      should "include non-retired applications with delegatable signin that the super organisation admin has access to" do
         assert_includes @resolved_scope, @app_one
+        assert_not_includes @resolved_scope, @retired_app
       end
 
       should "not include applications without delegatable signin that the super organisation admin does has access to" do
@@ -66,8 +71,9 @@ class UserPermissionManageableApplicationPolicyScopeTest < ActiveSupport::TestCa
         @resolved_scope = UserPermissionManageableApplicationPolicy::Scope.new(user).resolve
       end
 
-      should "include applications with delegatable signin that the organisation admin has access to" do
+      should "include non-retired applications with delegatable signin that the organisation admin has access to" do
         assert_includes @resolved_scope, @app_one
+        assert_not_includes @resolved_scope, @retired_app
       end
 
       should "not include applications without delegatable signin that the organisation admin does has access to" do


### PR DESCRIPTION
Trello: https://trello.com/c/kvmb5OHO

This follows on from #2446 in which we hid retired apps from most pages.

The idea in this PR is to hide API-only apps from most (but not all) pages in order to reduce the clutter on a bunch of pages - mainly (only?) pages which involve viewing/managing permissions for a user. It should no longer be possible to view or edit permissions for API-only apps on any pages except for the API user edit page and the "Edit supported permissions" page accessible via the application link in the "API-only" tab on the applications index page. We think this makes sense, because a non-API user should never need permissions for an API-only application.

<img width="800" alt="Screenshot 2023-10-19 at 17 49 02" src="https://github.com/alphagov/signon/assets/3169/7eb08a54-4c91-4621-8933-efde8fd7a0ec">

Note that I've replaced `Doorkeeper::Application#show_on_dashboard` with `Doorkeeper::Application#api_only` and inverted the values. I think this better reflects what the boolean flag means.

The commits which make significant changes are:
* [Replace `Application#show_on_dashboard` -> `#api_only`](https://github.com/alphagov/signon/pull/2452/commits/b2bff6a9172378f2cf23070804a7808fb942ed0c)
* [Add new tab for API-only applications on applications index page](https://github.com/alphagov/signon/pull/2452/commits/680bce76ec3f49234781dfb83edad97aec25772d)
* [Do not display API-only apps on account applications page](https://github.com/alphagov/signon/pull/2452/commits/d36723a7e14a7ca95b99b3c5e15161df3b49fb3b)
* [Do not display API-only apps on account permissions page](https://github.com/alphagov/signon/pull/2452/commits/8c6a56bf0a4513085b4ad32d2ff4c2bf0f345ef3)
* [Do not display API-only apps on a bunch of pages](https://github.com/alphagov/signon/pull/2452/commits/858309d4f8a09bd3bf877b271d042814dfc92475)
    * `/users/invitation/new`
    * `/batch_invitations/:batch_invitation_id/permissions/new`
    * `/account/manage_permissions`
* [Do not display API-only apps on two more pages](https://github.com/alphagov/signon/pull/2452/commits/92cf7eb232f4d53239b9422121993010cb8bdc15)

Most of the rest of the commits are adding test coverage to (hopefully) catch any regressions.

I would dearly like to have done some more refactoring of the code, particularly that involving `UserPermissionsControllerMethods` and `UserPermissionManageableApplicationPolicy`, but the scope of these changes was already large. Hopefully the test coverage I've put in place would make any such refactoring a bit easier the future.
