### PR TITLE
Hide permissions for API-only apps on users index page

### DIFF
--- a/app/models/users_filter.rb
+++ b/app/models/users_filter.rb
@@ -60,7 +60,7 @@ class UsersFilter
   end
 
   def permission_option_select_options(aria_controls_id: nil)
-    Doorkeeper::Application.includes(:supported_permissions).flat_map do |application|
+    Doorkeeper::Application.not_api_only.includes(:supported_permissions).flat_map do |application|
       application.supported_permissions.map do |permission|
         {
           label: "#{application.name} #{permission.name}",

--- a/test/models/users_filter_test.rb
+++ b/test/models/users_filter_test.rb
@@ -242,6 +242,20 @@ class UsersFilterTest < ActiveSupport::TestCase
         assert_equal expected_options, options
       end
     end
+
+    context "when App 2 is retired" do
+      setup do
+        @app2.update!(retired: true)
+      end
+
+      should "return not include options for retired application permissions" do
+        filter = UsersFilter.new(User.all, @current_user, {})
+        options = filter.permission_option_select_options
+
+        app2_option = options.detect { |o| o[:value] == @app2.signin_permission.to_param }
+        assert_not app2_option
+      end
+    end
   end
 
   context "when filtering by organisation" do

--- a/test/models/users_filter_test.rb
+++ b/test/models/users_filter_test.rb
@@ -256,6 +256,20 @@ class UsersFilterTest < ActiveSupport::TestCase
         assert_not app2_option
       end
     end
+
+    context "when App 2 is API-only" do
+      setup do
+        @app2.update!(api_only: true)
+      end
+
+      should "return not include options for API-only application permissions" do
+        filter = UsersFilter.new(User.all, @current_user, {})
+        options = filter.permission_option_select_options
+
+        app2_option = options.detect { |o| o[:value] == @app2.signin_permission.to_param }
+        assert_not app2_option
+      end
+    end
   end
 
   context "when filtering by organisation" do


### PR DESCRIPTION
Trello: https://trello.com/c/kvmb5OHO

Previously, despite #2452, we were still showing permissions for API-only apps in the permissions filter on the users index page. Joseph spotted that I had missed it. This PR should fix it!

### Before
<img width="374" alt="Screenshot 2023-10-24 at 18 07 43" src="https://github.com/alphagov/signon/assets/3169/adb09704-9e92-4a89-b04b-60ef2a6a897b">

### After
<img width="374" alt="Screenshot 2023-10-24 at 18 07 56" src="https://github.com/alphagov/signon/assets/3169/8b0a3134-e9f5-429f-aa1b-bf98a373b98f">

