### PR TITLE
Parallelize Ruby tests in CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,9 +37,13 @@ jobs:
     with:
       useWithRails: true
 
-  test-ruby:
-    name: Test Ruby
+  test-ruby-matrix:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ci_node_total: [4]
+        ci_node_index: [0, 1, 2, 3]
     steps:
       - name: Setup MySQL
         id: setup-mysql
@@ -72,5 +76,13 @@ jobs:
         env:
           RAILS_ENV: test
           TEST_DATABASE_URL: ${{ steps.setup-mysql.outputs.db-url }}
-        run: bundle exec rake test
+          CI_NODE_TOTAL: ${{ matrix.ci_node_total }}
+          CI_NODE_INDEX: ${{ matrix.ci_node_index }}
+        run: ./script/minitest-ci
 
+  test-ruby:
+    name: Test Ruby
+    needs: test-ruby-matrix
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "All Minitest tests have passed 🚀"

--- a/script/minitest-ci
+++ b/script/minitest-ci
@@ -1,0 +1,16 @@
+#!/usr/bin/env ruby
+
+# This script is used during the GitHub Actions workflow
+# defined in .github/workflows/ci.yml.
+# It splits the MiniTest suite into randomly-allocated groups
+# which are executed across multiple GitHub Actions 'matrix' nodes.
+
+tests = Dir["test/**/*_test.rb"]
+  .sort
+  .shuffle(random: Random.new(ENV["GITHUB_SHA"].to_i(16)))
+  .select
+  .with_index do |_el, i|
+    i % ENV["CI_NODE_TOTAL"].to_i == ENV["CI_NODE_INDEX"].to_i
+  end
+
+exec "bundle exec rails test #{tests.join(' ')}"


### PR DESCRIPTION
Trello: https://trello.com/c/66qRtGlu

This is closely based on alphagov/whitehall#8364.

In summary, this adds a new `script/minitest-ci` script which is called from within [a GitHub Action matrix](https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs). The script orders the tests randomly (but deterministically based on the commit SHA), splits them into 4 batches, and runs each batch of tests as a separate job. Since each job has its own container with a separate database, etc, the batches of tests are completely isolated from each other. An extra job is added on the end which waits for all the matrix jobs to finish successfully. See commit note for more details.

Looking at [recent CI build times](https://github.com/alphagov/signon/actions/workflows/ci.yml), this seems to approximately half the build time from ~10 mins to ~5 mins. And I can't really see any significant downsides.

<img width="1182" alt="Screenshot 2023-10-25 at 09 17 44" src="https://github.com/alphagov/signon/assets/3169/75e4a4bb-338e-425b-8adc-67d9d57ad365">

One thing I noticed is that each container generates a new seed for Minitest. The combination of the random batching and the different seeds might make it slightly more awkward to reproduce an order-dependent test failure, but I don't think that's a big concern.