### PR TITLE
Upgrade sidekiq to v6.5.10 to fix DoS vulnerability

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -645,7 +645,7 @@ GEM
       sentry-ruby (~> 5.12.0)
       sidekiq (>= 3.0)
     shoulda-context (2.0.0)
-    sidekiq (6.5.5)
+    sidekiq (6.5.10)
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
       redis (>= 4.5.0)


### PR DESCRIPTION
See https://github.com/alphagov/signon/security/dependabot/70

For some reason Dependabot couldn't do this upgrade, so I've done it manually.
