### PR TITLE
Remove defunct `script/rails` file

### DIFF
--- a/script/rails
+++ b/script/rails
@@ -1,6 +1,0 @@
-#!/usr/bin/env ruby
-# This command will automatically be run when you run "rails" with Rails 3 gems installed from the root of your application.
-
-APP_PATH = File.expand_path("../config/application", __dir__)
-require File.expand_path("../config/boot", __dir__)
-require "rails/commands"


### PR DESCRIPTION
This was originally added in 2012 in [this original commit][1] with Rails v3.2.3.

However, `bin/rails` was added in 2015 in [this commit][2] as part of #352 which upgraded the app to Rails v4. And this is now [the canonical location][3] for the `rails` script in our current version of Rails (v7.0.8).

It's confusing and potentially problematic to have both scripts in the repo, so I've removed the older one.

[1]: https://github.com/alphagov/signon/commit/d82798abe10189930f89803e959fb3494b956f9b
[2]: https://github.com/alphagov/signon/commit/640ae2fdec2cf21363dcb06cff39e7427cf21790
[3]: https://github.com/rails/rails/tree/v7.0.8/railties/lib/rails/generators/rails/app/templates/bin
