### PR TITLE
Add explanatory comments for Devise-related methods in Devise::Models::Suspendable

### DIFF
--- a/lib/devise/models/suspendable.rb
+++ b/lib/devise/models/suspendable.rb
@@ -14,6 +14,8 @@ module Devise
         scope(:current, proc { |current| current == "t" ? active : suspended })
       end
 
+      # Overrides Devise::Models::Authenticatable#active_for_authentication?
+      # See https://www.rubydoc.info/github/plataformatec/devise/Devise/Models/Authenticatable
       def active_for_authentication?
         if super
           return true unless suspended?
@@ -23,6 +25,8 @@ module Devise
         false
       end
 
+      # Overrides Devise::Models::Authenticatable#inactive_message
+      # See https://www.rubydoc.info/github/plataformatec/devise/Devise/Models/Authenticatable
       def inactive_message
         suspended? ? :suspended : super
       end


### PR DESCRIPTION
Although the `Suspendable` csutom module is in the `Devise::Models` namespace, it wasn't very clear that `Suspendable#active_for_authentication?` and `Suspendable#inactive_message` override methods in `Devise::Models::Authenticatable`. Hopefully these comments will make things less confusing.

There are a bunch of other things in this module which aren't ideal, but I haven't addressed in this PR because I need to move on to something else:
* I wasn't even aware of its existence until just now - I think I had assumed it was an offical Devise module. I wonder it it would be better to inline the methods in this module into `User`, especially as it has some significant coupling to that class, e.g. the call to `User#revoke_all_authorisations`.
* The `active` & `suspended` scopes look like they clash with ones defined in `User`. I can only assume the ones in `User` "win" the battle, because `Suspendable.active` doesn't exclude invited or locked users like `User.active` does. Although in theory it would be nice to define suspension-related scopes in this module, I'm not sure how well that works for scopes that might be affected by other modules.
* The "TODO" comment doesn't make much sense to me - I think it might be out-of-date or perhaps was never relevant.
* I'm pretty sure the `current` scope is not used. Either way it strike me as being very odd - why would you expect calling `User.current("t")` would give you active users but `User.current` would give you suspended users?

@chrislo Do you think I should do anything about the above now? I'm not specifically working on this bit of code, but came across it while doing something else.