### PR TITLE
Log application access

### DIFF
--- a/app/models/doorkeeper/after_successful_authorization_processor.rb
+++ b/app/models/doorkeeper/after_successful_authorization_processor.rb
@@ -1,0 +1,29 @@
+module Doorkeeper
+  class AfterSuccessfulAuthorizationProcessor
+    def initialize(controller, context)
+      @controller = controller
+      @context = context
+    end
+
+    def process
+      return unless @controller.instance_of?(Doorkeeper::TokensController)
+      return unless application && user
+
+      EventLog.record_event(user, EventLog::SUCCESSFUL_USER_APPLICATION_AUTHORIZATION, application:)
+    end
+
+  private
+
+    def token
+      @context.auth.token
+    end
+
+    def application
+      Doorkeeper::Application.find_by(id: token.application_id)
+    end
+
+    def user
+      User.find_by(id: token.resource_owner_id)
+    end
+  end
+end

--- a/app/models/event_log.rb
+++ b/app/models/event_log.rb
@@ -49,6 +49,7 @@ class EventLog < ApplicationRecord
     ACCESS_TOKENS_DELETED = LogEntry.new(id: 44, description: "Access tokens deleted", require_uid: true),
     ACCOUNT_DELETED = LogEntry.new(id: 45, description: "Account deleted", require_uid: true),
     ORGANISATION_CHANGED = LogEntry.new(id: 46, description: "Organisation changed", require_uid: true, require_initiator: true),
+    SUCCESSFUL_USER_APPLICATION_AUTHORIZATION = LogEntry.new(id: 47, description: "Successful user application authorization", require_uid: true, require_application: true),
   ].freeze
 
   EVENTS_REQUIRING_UID = EVENTS.select(&:require_uid?)

--- a/app/models/event_log.rb
+++ b/app/models/event_log.rb
@@ -49,9 +49,6 @@ class EventLog < ApplicationRecord
     ACCESS_TOKENS_DELETED = LogEntry.new(id: 44, description: "Access tokens deleted", require_uid: true),
     ACCOUNT_DELETED = LogEntry.new(id: 45, description: "Account deleted", require_uid: true),
     ORGANISATION_CHANGED = LogEntry.new(id: 46, description: "Organisation changed", require_uid: true, require_initiator: true),
-
-    # We no longer expire passwords, but we keep this event for history purposes
-    PASSWORD_EXPIRED = LogEntry.new(id: 6, description: "Password expired"),
   ].freeze
 
   EVENTS_REQUIRING_UID = EVENTS.select(&:require_uid?)

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -344,6 +344,10 @@ Doorkeeper.configure do
   #       .logout_uri
   # end
 
+  after_successful_authorization do |controller, context|
+    Doorkeeper::AfterSuccessfulAuthorizationProcessor.new(controller, context).process
+  end
+
   # Under some circumstances you might want to have applications auto-approved,
   # so that the user skips the authorization step.
   # For example if dealing with a trusted application.

--- a/test/models/doorkeeper/after_successful_authorization_processor_test.rb
+++ b/test/models/doorkeeper/after_successful_authorization_processor_test.rb
@@ -1,0 +1,56 @@
+require "test_helper"
+
+class Doorkeeper::AfterSuccessfulAuthorizationProcessorTest < ActiveSupport::TestCase
+  context "#process" do
+    setup do
+      @controller = Doorkeeper::TokensController.new
+      @user = create(:user)
+      @application = create(:application)
+      token = create(:access_token, application: @application, resource_owner_id: @user.id)
+      token_response = Doorkeeper::OAuth::TokenResponse.new(token)
+      @context = Doorkeeper::OAuth::Hooks::Context.new(auth: token_response)
+    end
+
+    should "log a SUCCESSFUL_USER_APPLICATION_AUTHORIZATION event" do
+      EventLog.expects(:record_event).with(@user, EventLog::SUCCESSFUL_USER_APPLICATION_AUTHORIZATION, application: @application)
+
+      Doorkeeper::AfterSuccessfulAuthorizationProcessor.new(@controller, @context).process
+    end
+
+    context "when the controller is not an instance of Doorkeeper::TokensController" do
+      setup do
+        @controller = Object.new
+      end
+
+      should "not log a SUCCESSFUL_USER_APPLICATION_AUTHORIZATION event" do
+        EventLog.expects(:record_event).never
+
+        Doorkeeper::AfterSuccessfulAuthorizationProcessor.new(@controller, @context).process
+      end
+    end
+
+    context "when the application does not exist" do
+      setup do
+        @application.destroy
+      end
+
+      should "not log a SUCCESSFUL_USER_APPLICATION_AUTHORIZATION event" do
+        EventLog.expects(:record_event).never
+
+        Doorkeeper::AfterSuccessfulAuthorizationProcessor.new(@controller, @context).process
+      end
+    end
+
+    context "when the user does not exist" do
+      setup do
+        @user.destroy
+      end
+
+      should "not log a SUCCESSFUL_USER_APPLICATION_AUTHORIZATION event" do
+        EventLog.expects(:record_event).never
+
+        Doorkeeper::AfterSuccessfulAuthorizationProcessor.new(@controller, @context).process
+      end
+    end
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/2SRZa6cA

We've had some requests from other teams who want to know how often users log in to the applications they maintain.

We've decided to create an EventLog record each time a user is successfully authorized and an access token is created. This should be sufficient to answer the question "how many unique users have accessed a specific application in a given time period?".

I'll address the displaying of this data to users in a follow up PR once we've started collecting the data. At the moment the user-visible change as a consequence of this PR is the additional of a new event log item in the user's "access log":

<img width="1181" alt="Screenshot 2023-10-31 at 15 09 39" src="https://github.com/alphagov/signon/assets/16707/dffd0cdd-c33e-45c1-8492-bf63e2d19aca">
