### PR TITLE
Only show apps on dashboard if they have a home page

### DIFF
--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -6,7 +6,7 @@ class RootController < ApplicationController
   skip_after_action :verify_authorized
 
   def index
-    applications = Doorkeeper::Application.not_api_only.can_signin(current_user)
+    applications = Doorkeeper::Application.not_api_only.with_home_uri.can_signin(current_user)
 
     @applications_and_permissions = zip_permissions(applications, current_user)
   end

--- a/app/models/doorkeeper/application.rb
+++ b/app/models/doorkeeper/application.rb
@@ -11,6 +11,7 @@ class Doorkeeper::Application < ActiveRecord::Base # rubocop:disable Rails/Appli
   scope :not_retired, -> { where(retired: false) }
   scope :api_only, -> { where(api_only: true) }
   scope :not_api_only, -> { where(api_only: false) }
+  scope :with_home_uri, -> { where.not(home_uri: nil).where.not(home_uri: "") }
   scope :can_signin, ->(user) { with_signin_permission_for(user) }
   scope :with_signin_delegatable,
         lambda {
@@ -77,6 +78,8 @@ class Doorkeeper::Application < ActiveRecord::Base # rubocop:disable Rails/Appli
 private
 
   def substituted_uri(uri)
+    return if uri.blank?
+
     uri_pattern = Rails.configuration.oauth_apps_uri_sub_pattern
     uri_sub = Rails.configuration.oauth_apps_uri_sub_replacement
 

--- a/app/views/doorkeeper_applications/edit.html.erb
+++ b/app/views/doorkeeper_applications/edit.html.erb
@@ -49,7 +49,7 @@
         },
         name: "doorkeeper_application[home_uri]",
         type: "text",
-        hint: "Used to link to the app on the dashboard",
+        hint: "Used to link to the app on the dashboard. Leave blank if app has no user-facing home page.",
         value: @application.home_uri,
         autocomplete: "off"
       } %>

--- a/test/controllers/root_controller_test.rb
+++ b/test/controllers/root_controller_test.rb
@@ -36,6 +36,16 @@ class RootControllerTest < ActionController::TestCase
     assert_select "h3", count: 1
   end
 
+  test "do not display application with no home URI on dashboard even if you have signin permission" do
+    application = create(:application, name: "App without home page", home_uri: nil)
+    user = create(:user, with_signin_permissions_for: [application])
+    sign_in user
+
+    get :index
+
+    assert_select "h3", text: "App without home page", count: 0
+  end
+
   test "do not display retired application on dashboard even if you have signin permission" do
     application = create(:application, name: "Retired app", retired: true)
     user = create(:user, with_signin_permissions_for: [application])


### PR DESCRIPTION
Trello: https://trello.com/c/VLXpwPJ8

Previously the Asset Manager & Content Preview apps were (sensibly) not displayed on the dashboard, because `Doorkeeper::Application#show_on_dashboard?` was set to `false`. When we converted that attribute into `Doorkeeper::Application#api_only?` in [this commit][1] as part of [this PR][2], those two apps has `#api_only?` set to `true` which prevented them from being displayed on the dashboard.

However, other changes in [that PR][2] meant that permission checkboxes for those apps were not displayed on any permission-related forms, because they were marked as API-only. Since the Rails controllers make use of the `supported_permission_ids` array param, this meant that when a user's permissions were updated, the permissions for Asset Manager & Content Preview were inadvertently removed.

Also for similar reasons, since the changes in [this PR][3], signin permissions for Asset Manager & Content Preview apps (which are included in the list of default permissions) were not being added to new users.

It turns out that signin permission for Asset Manager & Content Preview are needed for users to access draft content & draft assets, i.e. while they don't have a home page, these apps do serve content to non-API users and hence while they do have an API, they are not API-only apps. This was a real problem for new users never getting access to draft content/assets and for updated users having access to draft content/assets removed.

To fix this problem, we marked Asset Manager & Content Preview as not API-only, so that their permissions do now show up on permission-related forms. However, this in turn meant the two apps were displayed on the dashboard, even though they don't have a home page.

I contemplated re-introducing `Doorkeeper::Application#show_on_dashboard?`, but in the end I decided to make use of the existing `Doorkeeper::Application#home_uri` attribute which does not have to be set and only seems to be used for displaying the link to the app on the dashboard (not for any OAuth-related malarky). So now any application which does not have `#home_uri` set is not displayed on the dashboard. I've expanded the "hint" text for `Doorkeeper::Application#home_uri` to explain this. I plan to remove the `#home_uri` values for Asset Manager & Content Preview in integration & production via the UI once these changes have been merged.

Note that I've had to make the `Doorkeeper::Application#substituted_uri` method more complicated by adding a guard condition which isn't very nice. However, I believe that functionality relates to the migration to the EKS platform and can be removed, so I'm not overly concerned about complicating that method.

[1]: https://github.com/alphagov/signon/commit/b21bee195e8a1663dae0014d80f74c49d121a188
[2]: https://github.com/alphagov/signon/pull/2452
[3]: https://github.com/alphagov/signon/pull/2451
