### PR TITLE
Remove redundant EKS redirect for application URIs

### DIFF
--- a/app/models/doorkeeper/application.rb
+++ b/app/models/doorkeeper/application.rb
@@ -66,26 +66,7 @@ class Doorkeeper::Application < ActiveRecord::Base # rubocop:disable Rails/Appli
     ].include?(name)
   end
 
-  def redirect_uri
-    substituted_uri(self[:redirect_uri])
-  end
-
-  def home_uri
-    substituted_uri(self[:home_uri])
-  end
-
 private
-
-  def substituted_uri(uri)
-    uri_pattern = Rails.configuration.oauth_apps_uri_sub_pattern
-    uri_sub = Rails.configuration.oauth_apps_uri_sub_replacement
-
-    if uri_pattern.present? && uri_sub.present?
-      uri.sub(uri_pattern, uri_sub)
-    else
-      uri
-    end
-  end
 
   def create_signin_supported_permission
     supported_permissions.delegatable.signin.create!

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-Rails.configuration.oauth_apps_uri_sub_pattern = ENV["SIGNON_APPS_URI_SUB_PATTERN"]
-Rails.configuration.oauth_apps_uri_sub_replacement = ENV["SIGNON_APPS_URI_SUB_REPLACEMENT"]
-
 Doorkeeper.configure do
   # Change the ORM that doorkeeper will use (requires ORM extensions installed).
   # Check the list of supported ORMs here: https://github.com/doorkeeper-gem/doorkeeper#orms

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -21,13 +21,6 @@ Used to configure Mail::Notify for use by ActionMailer in sending emails.
 * `GOVUK_NOTIFY_API_KEY`
 * `GOVUK_NOTIFY_TEMPLATE_ID`
 
-## Rewrite URIs for OAuth Applications
-
-Used by `Doorkeeper::Application#substituted_uri`.
-
-* `SIGNON_APPS_URI_SUB_PATTERN`
-* `SIGNON_APPS_URI_SUB_REPLACEMENT`
-
 ## GOV.UK app domain
 
 Used to configure Google Analytics in the new `app/views/layouts/admin_layout.html.erb`.

--- a/test/models/doorkeeper/application_test.rb
+++ b/test/models/doorkeeper/application_test.rb
@@ -63,58 +63,6 @@ class Doorkeeper::ApplicationTest < ActiveSupport::TestCase
     end
   end
 
-  context "redirect_uri" do
-    should "return application redirect uri" do
-      application = create(:application)
-
-      assert_equal "https://app.com/callback", application.redirect_uri
-    end
-
-    should "return application substituted redirect uri if match" do
-      Rails.application.config.stubs(oauth_apps_uri_sub_pattern: "replace.me")
-      Rails.application.config.stubs(oauth_apps_uri_sub_replacement: "new.domain")
-
-      application = create(:application, redirect_uri: "https://app.replace.me/callback")
-
-      assert_equal "https://app.new.domain/callback", application.redirect_uri
-    end
-
-    should "return application original redirect uri if not matched" do
-      Rails.application.config.stubs(oauth_apps_uri_sub_pattern: "replace.me")
-      Rails.application.config.stubs(oauth_apps_uri_sub_replacement: "new.domain")
-
-      application = create(:application, redirect_uri: "https://app.keep.me/callback")
-
-      assert_equal "https://app.keep.me/callback", application.redirect_uri
-    end
-  end
-
-  context "home_uri" do
-    should "return application home uri" do
-      application = create(:application)
-
-      assert_equal "https://app.com/", application.home_uri
-    end
-
-    should "return application substituted home uri if match" do
-      Rails.application.config.stubs(oauth_apps_uri_sub_pattern: "replace.me")
-      Rails.application.config.stubs(oauth_apps_uri_sub_replacement: "new.domain")
-
-      application = create(:application, home_uri: "https://app.replace.me/")
-
-      assert_equal "https://app.new.domain/", application.home_uri
-    end
-
-    should "return application original home uri if not matched" do
-      Rails.application.config.stubs(oauth_apps_uri_sub_pattern: "replace.me")
-      Rails.application.config.stubs(oauth_apps_uri_sub_replacement: "new.domain")
-
-      application = create(:application, home_uri: "https://app.keep.me/")
-
-      assert_equal "https://app.keep.me/", application.home_uri
-    end
-  end
-
   context "sorted_supported_permissions_grantable_from_ui" do
     should "return all of the supported permissions that are grantable from the ui" do
       application = create(


### PR DESCRIPTION
This effectively reverts the changes in #1911 which seem to relate to the migration of applications to the EKS platform. This migration happened about a year ago and as far as I can see the relevant env vars are not currently set:

* https://github.com/search?q=repo%3Aalphagov%2Fgovuk-helm-charts%20SIGNON_APPS_URI_SUB_PATTERN&type=code
* https://github.com/search?q=repo%3Aalphagov%2Fgovuk-helm-charts+SIGNON_APPS_URI_SUB_REPLACEMENT&type=code

In fact, it's not obvious the two env vars have *ever* been set:

* https://github.com/search?q=org%3Aalphagov+SIGNON_APPS_URI_SUB_PATTERN&type=code
* https://github.com/search?q=org%3Aalphagov+SIGNON_APPS_URI_SUB_REPLACEMENT&type=code

Either way, since they're not currently set, this functionality is redudant and unnecessarily complicating the code.

I've also removed the two env vars from the docs which were added more recently.
