### PR TITLE
Separate navigational and authorization concerns in UsersController

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -84,7 +84,7 @@ class UsersController < ApplicationController
 private
 
   def load_and_authorize_user
-    @user = current_user.normal? ? current_user : User.find(params[:id])
+    @user = User.find(params[:id])
     redirect_to(account_path) and return if current_user == @user && action_name == "edit"
 
     authorize @user

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,6 +7,7 @@ class UsersController < ApplicationController
 
   before_action :authenticate_user!
   before_action :load_user, except: %i[index]
+  before_action :redirect_to_account_page_if_acting_on_own_user, only: %i[edit]
   before_action :authorize_user, except: %i[index]
   before_action :allow_no_application_access, only: [:update]
   before_action :redirect_legacy_filters, only: [:index]
@@ -89,8 +90,6 @@ private
   end
 
   def authorize_user
-    redirect_to(account_path) and return if current_user == @user && action_name == "edit"
-
     authorize @user
   end
 
@@ -144,5 +143,9 @@ private
     if filter.redirect?
       redirect_to users_path(filter.options)
     end
+  end
+
+  def redirect_to_account_page_if_acting_on_own_user
+    redirect_to account_path if current_user == @user
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,7 +6,8 @@ class UsersController < ApplicationController
   layout "admin_layout", only: %w[index event_logs require_2sv]
 
   before_action :authenticate_user!
-  before_action :load_and_authorize_user, except: %i[index]
+  before_action :load_user, except: %i[index]
+  before_action :authorize_user, except: %i[index]
   before_action :allow_no_application_access, only: [:update]
   before_action :redirect_legacy_filters, only: [:index]
   helper_method :applications_and_permissions, :filter_params
@@ -83,8 +84,11 @@ class UsersController < ApplicationController
 
 private
 
-  def load_and_authorize_user
+  def load_user
     @user = User.find(params[:id])
+  end
+
+  def authorize_user
     redirect_to(account_path) and return if current_user == @user && action_name == "edit"
 
     authorize @user

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -13,8 +13,6 @@ class UserPolicy < BasePolicy
   alias_method :create?, :new?
 
   def edit?
-    return false if current_user == record
-
     case current_user.role
     when Roles::Superadmin.role_name
       true

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -24,8 +24,10 @@ class UserPolicy < BasePolicy
       can_manage? && (record_in_own_organisation? || record_in_child_organisation?)
     when Roles::OrganisationAdmin.role_name
       can_manage? && record_in_own_organisation?
-    else # 'normal'
+    when Roles::Normal.role_name
       false
+    else
+      raise "Unknown role: #{current_user.role}"
     end
   end
   alias_method :update?, :edit?

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -779,12 +779,13 @@ class UsersControllerTest < ActionController::TestCase
       end
 
       context "when current user tries to edit another user" do
-        should "redirect to the account page" do
+        should "redirect to the dashboard and explain user does not have permission" do
           another_user = create(:user)
 
           get :edit, params: { id: another_user }
 
-          assert_redirected_to account_path
+          assert_redirected_to root_path
+          assert_equal "You do not have permission to perform this action.", flash[:alert]
         end
       end
     end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -762,4 +762,31 @@ class UsersControllerTest < ActionController::TestCase
       end
     end
   end
+
+  context "as normal user" do
+    setup do
+      @user = create(:user, email: "normal@gov.uk")
+      sign_in @user
+    end
+
+    context "GET edit" do
+      context "when current user tries to edit their own user" do
+        should "redirect to the account page" do
+          get :edit, params: { id: @user }
+
+          assert_redirected_to account_path
+        end
+      end
+
+      context "when current user tries to edit another user" do
+        should "redirect to the account page" do
+          another_user = create(:user)
+
+          get :edit, params: { id: another_user }
+
+          assert_redirected_to account_path
+        end
+      end
+    end
+  end
 end

--- a/test/policies/user_policy_test.rb
+++ b/test/policies/user_policy_test.rb
@@ -41,12 +41,6 @@ class UserPolicyTest < ActiveSupport::TestCase
         assert permit?(user, build(:admin_user), permission)
         assert permit?(user, build(:superadmin_user), permission)
       end
-
-      should "not allow for #{permission} for the logged in user" do
-        user = create(:superadmin_user)
-
-        assert forbid?(user, user, permission)
-      end
     end
 
     superadmin_actions.each do |permission|
@@ -99,12 +93,6 @@ class UserPolicyTest < ActiveSupport::TestCase
         assert permit?(user, build(:admin_user), permission)
         assert forbid?(user, build(:superadmin_user), permission)
       end
-
-      should "not allow for #{permission} for the logged in user" do
-        user = create(:admin_user)
-
-        assert forbid?(user, user, permission)
-      end
     end
 
     superadmin_actions.each do |permission|
@@ -143,10 +131,6 @@ class UserPolicyTest < ActiveSupport::TestCase
     end
 
     super_org_admin_actions.each do |permission|
-      should "not allow for #{permission} for the logged in user" do
-        assert forbid?(@super_org_admin, @super_org_admin, permission)
-      end
-
       should "allow for #{permission} and users of similar permissions or below from within their own organisation" do
         assert permit?(@super_org_admin, build(:user_in_organisation, organisation: @super_org_admin.organisation), permission)
         assert permit?(@super_org_admin, build(:organisation_admin_user, organisation: @super_org_admin.organisation), permission)
@@ -200,10 +184,6 @@ class UserPolicyTest < ActiveSupport::TestCase
     end
 
     org_admin_actions.each do |permission|
-      should "not allow for #{permission} for the logged in user" do
-        assert forbid?(@organisation_admin, @organisation_admin, permission)
-      end
-
       should "allow for #{permission} and users of similar permissions or below from within their own organisation" do
         assert permit?(@organisation_admin, build(:user_in_organisation, organisation: @organisation_admin.organisation), permission)
         assert permit?(@organisation_admin, build(:organisation_admin_user, organisation: @organisation_admin.organisation), permission)


### PR DESCRIPTION
The main thing I'm trying to achieve in here is to separate navigational concerns into the controller and authorization concerns into the policy class.

My motivation for doing this is that in [moving the "edit user" page to use the GOV.UK Design System](https://trello.com/c/uZD2I9dj), we're planning to have a separate page for changing just the email and I want to re-use the `Account::EmailsController` for users changing *another* user's email. I'm planning to move/rename `Account::EmailsController` -> `UserEmailsController` and share it between two sets of routes, one under the `account` namespace and one under the `users` resource, e.g. we will end up with paths like:

* `/account/emails/edit` (which already exists; to be used when a user edits their own email)
* `/users/:user_id/emails/edit` (which doesn't currently exist; to be used when a user edits another user's email)

In this newly named `UserEmailsController`, I'll need to authorize requests both in the context of a user changing their own email *and* in the context of a user changing another user's email. I'm planning to re-use the `UserPolicy` to achieve that and the changes in this PR will make that easier.

I'm slightly nervous that this is going against the thinking in [this PR](https://github.com/alphagov/signon/pull/2377), in particular these two commits (https://github.com/alphagov/signon/commit/acad605426e87bd6c8cdd4f18da7f3da425ce57f & https://github.com/alphagov/signon/commit/bcde44227c48a7a29cba0d925d6a740587adeb00), but it feels like it moves us in the direction of using Pundit policies in a more idiomatic way.

To elaborate on that, in my mind the `UserPolicy` should represent the *application-wide* rules for which actions a given user can carry out on another user irrespective of which controller is being used to perform that action, i.e. the `User` in `UserPolicy` refers to the `User` class and instances of that class rather than to `UsersController`.

I think we've diverged from this approach recently, particularly with the controllers and corresponding policies in the `Account` namespace. This has led to a proliferation of policy classes that are *only* concerned with scenarios where a user is editing their own user, but that condition is not built into the policy class; it's just *implied* by the choice of policy in the relevant controller. This seems a bit dangerous to me, because a developer might miss this implicit condition and incorrectly apply that policy in an inappropriate context. Also it means we don't have a single canonical place which defines all the rules about which actions a given user can carry out on another (or their own) user.
