### PR TITLE
More improvements to UsersControllerTest

### DIFF
--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -624,18 +624,6 @@ class UsersControllerTest < ActionController::TestCase
         assert_equal "normal", not_an_admin.reload.role
       end
 
-      context "you are a superadmin" do
-        setup do
-          @user.update_column(:role, Roles::Superadmin.role_name)
-        end
-
-        should "let you set the role" do
-          not_an_admin = create(:user)
-          put :update, params: { id: not_an_admin.id, user: { role: Roles::Admin.role_name } }
-          assert_equal Roles::Admin.role_name, not_an_admin.reload.role
-        end
-      end
-
       context "changing an email" do
         should "not re-confirm email" do
           normal_user = create(:user, email: "old@email.com")
@@ -680,16 +668,6 @@ class UsersControllerTest < ActionController::TestCase
         end
       end
 
-      context "changing a role" do
-        should "log an event" do
-          @user.update_column(:role, Roles::Superadmin.role_name)
-          another_user = create(:admin_user)
-          put :update, params: { id: another_user.id, user: { role: "normal" } }
-
-          assert_equal 1, EventLog.where(event_id: EventLog::ROLE_CHANGED.id, uid: another_user.uid, initiator_id: @user.id).count
-        end
-      end
-
       should "push changes out to apps" do
         another_user = create(:user, name: "Old Name")
         PermissionUpdater.expects(:perform_on).with(another_user).once
@@ -726,6 +704,28 @@ class UsersControllerTest < ActionController::TestCase
           )
 
           assert_equal 1, @another_user.reload.application_permissions.count
+        end
+      end
+    end
+
+    context "signed in as a Superadmin user" do
+      setup do
+        @superadmin = create(:superadmin_user)
+        sign_in @superadmin
+      end
+
+      should "update the user's role" do
+        not_an_admin = create(:user)
+        put :update, params: { id: not_an_admin.id, user: { role: Roles::Admin.role_name } }
+        assert_equal Roles::Admin.role_name, not_an_admin.reload.role
+      end
+
+      context "changing a role" do
+        should "log an event" do
+          another_user = create(:admin_user)
+          put :update, params: { id: another_user.id, user: { role: "normal" } }
+
+          assert_equal 1, EventLog.where(event_id: EventLog::ROLE_CHANGED.id, uid: another_user.uid, initiator_id: @superadmin.id).count
         end
       end
     end


### PR DESCRIPTION
Move 2 UsersControllerTest tests into appropriate context - I missed these in #2494.

As before my motivation for making these changes is that I'm currently [working on the user edit page](https://trello.com/c/uZD2I9dj) which means I'll be making a lot of changes in this area. Making these changes first will make that easier. And getting the commits merged soon will reduce the chance of any merge conflicts.
