### PR TITLE
Change default name in User factory to be less confusing

### DIFF
--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
     sequence(:email) { |n| "user#{n}@example.com" }
     password { "this 1s 4 v3333ry s3cur3 p4ssw0rd.!Z" }
     confirmed_at { 1.day.ago }
-    name { "A name is now required" }
+    sequence(:name) { |n| "user-name-#{n}" }
     role { "normal" }
 
     after(:create) do |user, evaluator|


### PR DESCRIPTION
I've seen the string "A name is now required" on a number of occasions when trying to debug a failing test and incorrectly assumed that it related to some kind of unexpected validation error which has wasted a chunk of time.

This changes the name to use a sequence a bit like the email attribute which should be a lot less confusing in similar circumstances. 🤞