### PR TITLE
Fix redirect after admin updates another user's name

### DIFF
--- a/app/controllers/users/names_controller.rb
+++ b/app/controllers/users/names_controller.rb
@@ -10,7 +10,7 @@ class Users::NamesController < ApplicationController
   def update
     if @user.update(user_params)
       EventLog.record_event(@user, EventLog::ACCOUNT_UPDATED, initiator: current_user, ip_address: user_ip_address)
-      redirect_to user_path(@user), notice: "Updated user #{@user.email} successfully"
+      redirect_to edit_user_path(@user), notice: "Updated user #{@user.email} successfully"
     else
       render :edit
     end

--- a/test/controllers/users/names_controller_test.rb
+++ b/test/controllers/users/names_controller_test.rb
@@ -101,7 +101,7 @@ class Users::NamesControllerTest < ActionController::TestCase
 
         put :update, params: { user_id: user, user: { name: "new-user-name" } }
 
-        assert_redirected_to user_path(user), notice: "Updated name of user@gov.uk successfully"
+        assert_redirected_to edit_user_path(user), notice: "Updated name of user@gov.uk successfully"
       end
 
       should "update user name if UserPolicy#update? returns true" do


### PR DESCRIPTION
Trello: https://trello.com/c/DjdHEqxG

This was a mistake in #2497.

When the update completes successfully, the admin should be taken back to the "edit user" page for the user in question.

Previously they were redirected to the *non-existent* path for a non-existent `UsersController#show` action which was somehow (🤷) being handled by `UsersController#edit` as I intended!
