### PR TITLE
Fix redirects in UsersController actions: unlock_access, resend_email_change & cancel_email_change

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -51,13 +51,13 @@ class UsersController < ApplicationController
     EventLog.record_event(@user, EventLog::MANUAL_ACCOUNT_UNLOCK, initiator: current_user, ip_address: user_ip_address)
     @user.unlock_access!
     flash[:notice] = "Unlocked #{@user.email}"
-    redirect_back_or_to(root_path)
+    redirect_to users_path
   end
 
   def resend_email_change
     @user.resend_confirmation_instructions
     if @user.errors.empty?
-      redirect_to root_path, notice: "Successfully resent email change email to #{@user.unconfirmed_email}"
+      redirect_to users_path, notice: "Successfully resent email change email to #{@user.unconfirmed_email}"
     else
       redirect_to edit_user_path(@user), alert: "Failed to send email change email"
     end
@@ -66,7 +66,7 @@ class UsersController < ApplicationController
   def cancel_email_change
     @user.cancel_email_change!
 
-    redirect_back_or_to(root_path)
+    redirect_to users_path
   end
 
   def event_logs
@@ -78,7 +78,7 @@ class UsersController < ApplicationController
     @user.reset_2sv!(current_user)
     UserMailer.two_step_reset(@user).deliver_later
 
-    redirect_to :root, notice: "Reset 2-step verification for #{@user.email}"
+    redirect_to users_path, notice: "Reset 2-step verification for #{@user.email}"
   end
 
   def require_2sv; end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -814,9 +814,9 @@ class UsersControllerTest < ActionController::TestCase
         assert_nil @another_user.confirmation_token
       end
 
-      should "redirect to the edit user admin page" do
+      should "redirect to the users page" do
         delete :cancel_email_change, params: { id: @another_user.id }
-        assert_redirected_to edit_user_path(@another_user)
+        assert_redirected_to users_path
       end
     end
   end


### PR DESCRIPTION
Trello: https://trello.com/c/PbX9UtR8

It's a bit hard to follow the git history of this controller, because it seems to have begun its life as a non-admin controller with actions allowing users to change their own user, but then in [this commit][1] a bunch of functionality from an admin controller was merged into it.

When we moved the users index page to use the Design System, we removed some actions from that page - see [this commit][2] & [this commit][3].

More recently we've split out a lot (all?) of the non-admin functionality into controllers under the `Account` namespace - see [this PR][4].

I'm pretty sure the redirects to `root_path` date back to a time when the action was called in the context of a user updating their own user. However, these three actions (`unlock_access`, `resend_email_change` & `cancel_email_change`) are now only every called in the context of the page rendered by `UsersController#edit`, so it doesn't make any sense to me to redirect to the `root_path`. Instead I've changed them to redirect to the `users_path` which seems consistent with the `update` action.

The redirects using `redirect_back_or_to` seem to relate to a time when the action was called in multiple contexts: either non-admin vs admin; or "user index" page vs "edit user" page. The idea was to redirect back to the page the user came from so the the user interaction makes sense in both contexts. Note that the path passed to this `redirect_back_or_to` method was only a fallback if the previous page could not be determined.

I've tried to standardize on using the "users index" page (i.e. `users_path`) as the success path and the "edit user" page (i.e. `edit_user_path`) as the failure path (i.e. the page where the form errors are typically displayed). This feels like it gives a better user experience and makes the code less suprising.

[1]: https://github.com/alphagov/signon/commit/b730700d82e5de79bc0b3004d74c7e547e7eb362
[2]: https://github.com/alphagov/signon/commit/62eb2f65c9655dcc2a5098f7e3ea277f65dece8d
[3]: https://github.com/alphagov/signon/commit/21970503e2294d5ee89b71d2c37f1a18b3cfae6b
[4]: https://github.com/alphagov/signon/pull/2377
