### PR TITLE
Remove redundant HTTP_REFERER header from UsersControllerTest

### DIFF
--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -803,7 +803,6 @@ class UsersControllerTest < ActionController::TestCase
         sign_in @user
 
         @another_user = create(:user_with_pending_email_change)
-        request.env["HTTP_REFERER"] = edit_user_path(@another_user)
       end
 
       should "clear the unconfirmed_email and the confirmation_token" do


### PR DESCRIPTION
I should have removed this in #2503 when we stopped using `redirect_back_or_to` in the `UsersController#cancel_email_change` action.