### PR TITLE
Fix test name in Users::NamesControllerTest

### DIFF
--- a/test/controllers/users/names_controller_test.rb
+++ b/test/controllers/users/names_controller_test.rb
@@ -168,7 +168,7 @@ class Users::NamesControllerTest < ActionController::TestCase
         sign_in(create(:user))
       end
 
-      should "update user name" do
+      should "not be authorized" do
         user = create(:user, name: "user-name")
 
         put :update, params: { user_id: user, user: { name: "new-user-name" } }


### PR DESCRIPTION
This was a copy & paste error in #2497. I thought it was worth fixing it, because it's pretty much saying the opposite of what the assertion is testing.