### PR TITLE
Remove incorrect type from edit user name input

### DIFF
--- a/app/views/users/names/edit.html.erb
+++ b/app/views/users/names/edit.html.erb
@@ -46,7 +46,6 @@
           text: "Name"
         },
         name: "user[name]",
-        type: "name",
         id: "user_name",
         value: @user.name,
         autocomplete: "off",


### PR DESCRIPTION
This was a mistake in #2497. There is no such input type as "name" - it was a copy & paste error. In this case there's no need to specifiy a type at all; we can just rely on the default "text" type for [the `input` component][1].

[1]: https://components.publishing.service.gov.uk/component-guide/input#specific_input_type
