### PR TITLE
SPIKE: How we might be able to simplify/improve UserUpdate

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,7 @@ class ApplicationController < ActionController::Base
 
   include TwoStepVerificationHelper
 
+  before_action :set_current_user_and_ip, if: :user_signed_in?
   before_action :handle_two_step_verification
   after_action :verify_authorized, unless: :devise_controller?
 
@@ -29,6 +30,11 @@ class ApplicationController < ActionController::Base
   end
 
 private
+
+  def set_current_user_and_ip
+    Current.user = current_user
+    Current.user_ip = user_ip_address
+  end
 
   def user_ip_address
     request.remote_ip

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,0 +1,4 @@
+class Current < ActiveSupport::CurrentAttributes
+  attribute :user
+  attribute :user_ip
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -69,6 +69,7 @@ class User < ApplicationRecord
   before_save :mark_two_step_mandated_changed
   before_save :update_password_changed
   before_save :strip_whitespace_from_name
+  after_update :record_update
 
   scope :web_users, -> { where(api_user: false) }
 
@@ -459,5 +460,14 @@ private
 
   def update_password_changed
     self.password_changed_at = Time.zone.now if (new_record? || encrypted_password_changed?) && !password_changed_at_changed?
+  end
+
+  def record_update
+    EventLog.record_event(
+      self,
+      EventLog::ACCOUNT_UPDATED,
+      initiator: Current.user,
+      ip_address: Current.user_ip,
+    )
   end
 end

--- a/app/services/user_update.rb
+++ b/app/services/user_update.rb
@@ -15,7 +15,6 @@ class UserUpdate
 
     user.application_permissions.reload
 
-    record_update
     record_permission_changes(old_permissions)
     record_role_change
     record_organisation_change
@@ -67,15 +66,6 @@ private
         ip_address: user_ip,
       )
     end
-  end
-
-  def record_update
-    EventLog.record_event(
-      user,
-      EventLog::ACCOUNT_UPDATED,
-      initiator: current_user,
-      ip_address: user_ip,
-    )
   end
 
   def record_role_change


### PR DESCRIPTION
Using `ActiveSupport::CurrentAttributes` means that we can have access to the current user in models; not just in controllers. This in turn means we ought to be able to move all of the logic in `UserUpdate` which is recording events in the activity log into model callbacks. These ought to be a lot more reliable in the sense that we don't need to keep remembering to use `UserUpdate` everywhere.

/cc @chrisroos
