### PR TITLE
Add help text to explain "Send push updates to this app"

### DIFF
--- a/app/views/doorkeeper_applications/edit.html.erb
+++ b/app/views/doorkeeper_applications/edit.html.erb
@@ -93,6 +93,14 @@
         <label>
           <%= f.check_box :supports_push_updates %> Send push updates to this app
         </label>
+        <p>Should Signon notify this application when user details are updated, users are suspended/unsuspended, or when users sign out?</p>
+        <p>The application needs to implement the following routes in order to support push updates (these are normally provided by gds-sso):
+          <ul>
+            <ol><%= h "PUT /auth/gds/api/users/<id>" %></ol>
+            <ol><%= h "POST /auth/gds/api/users/<id>/reauth" %></ol>
+          </ul>
+        </p>
+        <p>See <%= link_to "Overlaying Permissions in this document", "https://docs.publishing.service.gov.uk/repos/signon/oauth.html#overlaying-permissions" %> for more information.</p>
       </div>
 
       <div class="govuk-body">


### PR DESCRIPTION
It took quite a bit of digging to understand what this setting does. Adding this will hopefully save someone else some time in future.

This application is owned by the Access & Permissions team.

## Before

![image](https://github.com/alphagov/signon/assets/6556/dff81592-434f-4124-a92c-8386b3c899c2)

## After

![image](https://github.com/alphagov/signon/assets/6556/e76e27f1-7b56-4fb0-9995-de5d80c0d760)
