### PR TITLE
Handle retired apps when deleting expired grants/tokens

### DIFF
--- a/lib/expired_oauth_access_records_deleter.rb
+++ b/lib/expired_oauth_access_records_deleter.rb
@@ -18,7 +18,7 @@ class ExpiredOauthAccessRecordsDeleter
 
   def delete_expired
     @record_class.expired.in_batches do |relation|
-      records_by_user_id = relation.includes(:application).group_by(&:resource_owner_id)
+      records_by_user_id = Doorkeeper::Application.unscoped { relation.includes(:application).group_by(&:resource_owner_id) }
       all_users = User.where(id: records_by_user_id.keys)
 
       all_users.each do |user|


### PR DESCRIPTION
Trello: https://trello.com/c/GGWWve9b

We saw the following exception in production over the weekend:

> NoMethodError oauth_access_grants:delete_expired
>
> undefined method `name' for nil:NilClass application_names =
> records_by_user_id[user.id].map { |record| record.application.name }

The problem is that some of the expired `Doorkeeper::AccessToken`s belong to retired applications. Commit
9a9cd02d8574529b19f572a8352f031c3f07455e updated the default scope of `Doorkeeper::Application` so that it excludes retired apps by default.

The fix is to execute the query that finds the batch of expired grants/tokens within `Doorkeeper::Application.unscoped` so that we include retired apps.

As well as the tests added in this commit, I also used the Rails console in development, and its SQL query output, to give me confidence that this really is doing what we want. Given that we have an application and an API user that has an access token for that application:

    > Doorkeeper::AccessToken.includes(:application).group_by(&:resource_owner_id)
    # Note that the query for the applications ignores retired apps
      Doorkeeper::AccessToken Load (0.8ms)  SELECT `oauth_access_tokens`.*
        FROM `oauth_access_tokens`
      Doorkeeper::Application Load (0.7ms)  SELECT `oauth_applications`.*
        FROM `oauth_applications` WHERE `oauth_applications`.`retired` = FALSE
        AND `oauth_applications`.`id` = 1 ORDER BY oauth_applications.name

    * Doorkeeper::Application.unscoped {
    *   Doorkeeper::AccessToken.includes(:application).group_by(&:resource_owner_id)
    > }
    # Note that the query for the applications is not ignoring retired apps
      Doorkeeper::AccessToken Load (0.6ms)  SELECT `oauth_access_tokens`.*
        FROM `oauth_access_tokens`
      Doorkeeper::Application Load (0.6ms)  SELECT `oauth_applications`.*
        FROM `oauth_applications` WHERE `oauth_applications`.`id` = 1
