### PR TITLE
Update client apps when user's name changes

### DIFF
--- a/app/controllers/users/names_controller.rb
+++ b/app/controllers/users/names_controller.rb
@@ -9,8 +9,8 @@ class Users::NamesController < ApplicationController
   def edit; end
 
   def update
-    if @user.update(user_params)
-      EventLog.record_event(@user, EventLog::ACCOUNT_UPDATED, initiator: current_user, ip_address: user_ip_address)
+    updater = UserUpdate.new(@user, user_params, current_user, user_ip_address)
+    if updater.call
       redirect_to edit_user_path(@user), notice: "Updated user #{@user.email} successfully"
     else
       render :edit

--- a/test/controllers/users/emails_controller_test.rb
+++ b/test/controllers/users/emails_controller_test.rb
@@ -166,6 +166,13 @@ class Users::EmailsControllerTest < ActionController::TestCase
         put :update, params: { user_id: user, user: { email: "user@gov.uk" } }
       end
 
+      should "push changes out to apps" do
+        user = create(:user)
+        PermissionUpdater.expects(:perform_on).with(user).once
+
+        put :update, params: { user_id: user, user: { email: "new-user@gov.uk" } }
+      end
+
       should "redirect to edit user page and display success notice" do
         user = create(:user, email: "user@gov.uk")
 

--- a/test/controllers/users/names_controller_test.rb
+++ b/test/controllers/users/names_controller_test.rb
@@ -103,6 +103,13 @@ class Users::NamesControllerTest < ActionController::TestCase
         put :update, params: { user_id: user, user: { name: "new-user-name" } }
       end
 
+      should "push changes out to apps" do
+        user = create(:user)
+        PermissionUpdater.expects(:perform_on).with(user).once
+
+        put :update, params: { user_id: user, user: { name: "new-user-name" } }
+      end
+
       should "redirect to user page and display success notice" do
         user = create(:user, email: "user@gov.uk")
 


### PR DESCRIPTION
Trello - https://trello.com/c/2t9zx0Aq

Prior to https://github.com/alphagov/signon/pull/2497 changing a user's name in Signon would queue a job to push that update out to the applications the user has access to. This PR reinstates the previous behaviour by using `UserUpdate` in `Users::NamesController#update`, which in turn uses `PermissionUpdater` to push updates to the user's apps.

I can't find any documentation that describes the changes that result in push updates to a user's applications, but as far as I can see, changing a user's name has resulted in a push update since the relevant functionality was added to [Signon][1] and [gds-sso][2] in 2012 so it seems reasonable that we retain this behaviour.

I've also added a test to ensure we continue to push email updates out to a user's applications.

[1]: https://github.com/alphagov/signon/commit/f339848ac0c98188b0fc746935324f59215d26f2
[2]: https://github.com/alphagov/gds-sso/commit/8c0888cda78b2d0323da26ff4c8da362074168d7
