### PR TITLE
Copy tweaks for account application permissions

### DIFF
--- a/app/helpers/account_applications_helper.rb
+++ b/app/helpers/account_applications_helper.rb
@@ -10,7 +10,7 @@ module AccountApplicationsHelper
       list = tag.ul(class: "govuk-list govuk-list--bullet")
       additional_permissions.map { |permission| list << tag.li(permission) }
     else
-      paragraph = tag.p("You can access but have no additional permissions for #{application.name}.", class: "govuk-body")
+      paragraph = tag.p("You can access #{application.name} but you do not have any additional permissions.", class: "govuk-body")
       list = nil
     end
 

--- a/app/views/account/applications/index.html.erb
+++ b/app/views/account/applications/index.html.erb
@@ -39,8 +39,10 @@
         <td class="govuk-table__cell"><%= application.description %></td>
         <td class="govuk-table__cell govuk-!-text-align-right">
           <% if policy([:account, application]).edit_permissions? %>
-            <%= link_to edit_account_application_permissions_path(application), class: "govuk-link" do %>
+            <% unless application.sorted_supported_permissions_grantable_from_ui(include_signin: false).empty? %>
+              <%= link_to edit_account_application_permissions_path(application), class: "govuk-link" do %>
                 Update permissions<span class="govuk-visually-hidden"> for <%= application.name %></span>
+              <% end %>
             <% end %>
           <% elsif policy([:account, application]).view_permissions? %>
             <%= link_to account_application_permissions_path(application), class: "govuk-link" do %>

--- a/test/controllers/account/applications_controller_test.rb
+++ b/test/controllers/account/applications_controller_test.rb
@@ -50,8 +50,8 @@ class Account::ApplicationsControllerTest < ActionController::TestCase
         assert_select "a[href='#{delete_account_application_signin_permission_path(application)}']"
       end
 
-      should "display a link to update permissions" do
-        application = create(:application, name: "app-name")
+      should "display a link to update permissions when the application has more than just a signin permission" do
+        application = create(:application, name: "app-name", with_supported_permissions: %w[permission])
         @user.grant_application_signin_permission(application)
         sign_in @user
 
@@ -59,6 +59,17 @@ class Account::ApplicationsControllerTest < ActionController::TestCase
 
         assert_select "tr td", text: "app-name"
         assert_select "a[href='#{edit_account_application_permissions_path(application)}']"
+      end
+
+      should "not display a link to update permissions when the application has just a signin permission" do
+        application = create(:application, name: "app-name")
+        @user.grant_application_signin_permission(application)
+        sign_in @user
+
+        get :index
+
+        assert_select "tr td", text: "app-name"
+        assert_select "a[href='#{edit_account_application_permissions_path(application)}']", count: 0
       end
 
       should "not display a retired application" do
@@ -109,13 +120,24 @@ class Account::ApplicationsControllerTest < ActionController::TestCase
           assert_select "a[href='#{delete_account_application_signin_permission_path(@application)}']"
         end
 
-        should "display a link to update permissions" do
+        should "display a link to update permissions when the application has more than just a signin permission" do
+          create(:supported_permission, application: @application, name: "permission")
+
           sign_in @user
 
           get :index
 
           assert_select "tr td", text: "app-name"
           assert_select "a[href='#{edit_account_application_permissions_path(@application)}']"
+        end
+
+        should "not display a link to update permissions when the application has just a signin permission" do
+          sign_in @user
+
+          get :index
+
+          assert_select "tr td", text: "app-name"
+          assert_select "a[href='#{edit_account_application_permissions_path(@application)}']", count: 0
         end
 
         context "when the application does not have a delegatable signin permission" do

--- a/test/helpers/account_applications_helper_test.rb
+++ b/test/helpers/account_applications_helper_test.rb
@@ -33,7 +33,7 @@ class AccountApplicationsHelperTest < ActionView::TestCase
       end
 
       should "indicate that the user has no additional permissions" do
-        assert_includes message_for_success(@application.id), "You can access but have no additional permissions for Whitehall."
+        assert_includes message_for_success(@application.id), "You can access Whitehall but you do not have any additional permissions."
       end
     end
   end


### PR DESCRIPTION
Trello: https://trello.com/c/vInbSoSc

After reviewing the new account permissions pages we spotted a couple of small tweaks: 
- Change the wording of the "success" flash message
- Don't link to "update permissions" when there are no permissions to update. 