### PR TITLE
Add Mysql2::Error to exceptions not reported during db sync

### DIFF
--- a/config/initializers/govuk_error.rb
+++ b/config/initializers/govuk_error.rb
@@ -1,0 +1,3 @@
+GovukError.configure do |config|
+  config.data_sync_excluded_exceptions << "Mysql2::Error"
+end


### PR DESCRIPTION
Trello: https://trello.com/c/MD4UabpW

Reently we've started seeing [a load of `ActiveRecord::StatementInvalid` exceptions][1] every night at about 01:00. These all wrap `Mysql2::Error` exceptions with a message along the following lines:

    Table 'signon_production.<table-name>' doesn't exist

These exceptions seem to have started occuring around the time the db sync was moved to EKS. Presumably the sync is happening in a different way - perhaps table are being dropped & recreated when previously the data in the table was just being updated.

Anyway, [these docs][2] explain that we can configure Sentry to ignore specific exceptions that occur during the db sync and it looks like this is what other apps are relying on.

The [default `GovukError` configuration][3] excludes `PG:Error` & `GdsApi::ContentStore::ItemNotFound`. However, Signon uses MySQL rather than PostgreSQL, which is why the `Mysql2::Error` exceptions are still being reported.

I contemplated adding `ActiveRecord::StatementInvalid` to the exclusion list, but that seemed slightly at odds with `PG::Error` currently being on the list.

According to the docs:

> When determining whether or not to ignore an exception, the exception chain is inspected. This means if an exception isn’t on the ignore list, but its underlying cause is an exception on the ignore list, then it will be ignored. This applies to `excluded_exceptions` and to `data_sync_excluded_exceptions`.

So this commit adds `Mysql2::Error` to the exclusion list on the assumption that it will be recognised as the underlying cause of the `ActiveRecord::StatementInvalid`.

I contemplated adding this to the [default `GovukError` configuration][3], but I can't remember off-hand whether there are any other apps using MySQL and in any case I think it's worth trying it out in Signon first to see if it does the trick.

[1]: https://govuk.sentry.io/issues/4607637619/
[2]: https://docs.publishing.service.gov.uk/manual/sentry.html#ignoring-exception-types
[3]: https://github.com/alphagov/govuk_app_config/blob/8598b901e73a9a023d27018f30a06ab5dac66ad8/lib/govuk_app_config/govuk_error/configuration.rb#L55-L63
