### PR TITLE
Split out edit user organisation page from user edit page

### DIFF
--- a/app/controllers/users/organisations_controller.rb
+++ b/app/controllers/users/organisations_controller.rb
@@ -1,0 +1,43 @@
+class Users::OrganisationsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :load_user
+  before_action :authorize_user
+  before_action :redirect_to_account_page_if_acting_on_own_user, only: %i[edit]
+
+  def edit; end
+
+  def update
+    updater = UserUpdate.new(@user, user_params, current_user, user_ip_address)
+    if updater.call
+      redirect_to edit_user_path(@user), notice: "Updated user #{@user.email} successfully"
+    else
+      render :edit
+    end
+  end
+
+private
+
+  def load_user
+    @user = User.find(params[:user_id])
+  end
+
+  def authorize_user
+    authorize(@user)
+    authorize(@user, :assign_organisations?)
+  end
+
+  def user_params
+    UserParameterSanitiser.new(
+      user_params: permitted_user_params,
+      current_user_role: current_user.role.to_sym,
+    ).sanitise
+  end
+
+  def permitted_user_params
+    @permitted_user_params ||= params.require(:user).permit(:organisation_id).to_h
+  end
+
+  def redirect_to_account_page_if_acting_on_own_user
+    redirect_to edit_account_organisation_path if current_user == @user
+  end
+end

--- a/app/controllers/users/organisations_controller.rb
+++ b/app/controllers/users/organisations_controller.rb
@@ -25,7 +25,7 @@ private
 
   def authorize_user
     authorize(@user)
-    authorize(@user, :assign_organisations?)
+    authorize(@user, :assign_organisation?)
   end
 
   def user_params

--- a/app/controllers/users/organisations_controller.rb
+++ b/app/controllers/users/organisations_controller.rb
@@ -29,14 +29,8 @@ private
   end
 
   def user_params
-    UserParameterSanitiser.new(
-      user_params: permitted_user_params,
-      current_user_role: current_user.role.to_sym,
-    ).sanitise
-  end
-
-  def permitted_user_params
-    @permitted_user_params ||= params.require(:user).permit(:organisation_id).to_h
+    permitted_user_params = current_user.role_class.permitted_user_params
+    params.require(:user).permit(*permitted_user_params.intersection([:organisation_id]))
   end
 
   def redirect_to_account_page_if_acting_on_own_user

--- a/app/controllers/users/organisations_controller.rb
+++ b/app/controllers/users/organisations_controller.rb
@@ -29,8 +29,7 @@ private
   end
 
   def user_params
-    permitted_user_params = current_user.role_class.permitted_user_params
-    params.require(:user).permit(*permitted_user_params.intersection([:organisation_id]))
+    params.require(:user).permit(*current_user.permitted_params.intersection([:organisation_id]))
   end
 
   def redirect_to_account_page_if_acting_on_own_user

--- a/app/controllers/users/organisations_controller.rb
+++ b/app/controllers/users/organisations_controller.rb
@@ -1,4 +1,6 @@
 class Users::OrganisationsController < ApplicationController
+  layout "admin_layout"
+
   before_action :authenticate_user!
   before_action :load_user
   before_action :authorize_user

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -36,8 +36,6 @@ class UsersController < ApplicationController
   end
 
   def update
-    raise Pundit::NotAuthorizedError if params[:user][:organisation_id].present? && !policy(@user).assign_organisations?
-
     updater = UserUpdate.new(@user, user_params, current_user, user_ip_address)
     if updater.call
       redirect_to users_path, notice: "Updated user #{@user.email} successfully"
@@ -112,7 +110,7 @@ private
   end
 
   def permitted_user_params
-    @permitted_user_params ||= params.require(:user).permit(:user, :organisation_id, :require_2sv, :skip_update_user_permissions, supported_permission_ids: []).to_h
+    @permitted_user_params ||= params.require(:user).permit(:user, :require_2sv, :skip_update_user_permissions, supported_permission_ids: []).to_h
   end
 
   def filter_params

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -110,7 +110,7 @@ private
   end
 
   def permitted_user_params
-    @permitted_user_params ||= params.require(:user).permit(:user, :require_2sv, :skip_update_user_permissions, supported_permission_ids: []).to_h
+    @permitted_user_params ||= params.require(:user).permit(:require_2sv, :skip_update_user_permissions, supported_permission_ids: []).to_h
   end
 
   def filter_params

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -7,7 +7,7 @@ class UserPolicy < BasePolicy
   def new?
     %w[superadmin admin].include? current_user.role
   end
-  alias_method :assign_organisations?, :new?
+  alias_method :assign_organisation?, :new?
 
   # invitations#create
   alias_method :create?, :new?

--- a/app/views/users/_form_fields.html.erb
+++ b/app/views/users/_form_fields.html.erb
@@ -21,6 +21,15 @@
   <% end %>
 </p>
 
+<p>
+  <strong>Organisation:</strong> <%= @user.organisation.present? ? @user.organisation.name : Organisation::NONE %>
+  <% if policy(User).assign_organisations? %>
+    <%= link_to edit_user_organisation_path(@user) do %>
+      Change<span class="invisible"> organisation</span>
+    <% end %>
+  <% end %>
+</p>
+
 <% if policy(@user).mandate_2sv? %>
   <dl>
     <dt>Account security</dt>
@@ -67,13 +76,6 @@
       <%end %>
     </dd>
   </dl>
-<% end %>
-
-<% if policy(User).assign_organisations? %>
-  <p class="form-group">
-    <%= f.label :organisation_id, "Organisation" %><br />
-    <%= f.select :organisation_id, organisation_options(f), organisation_select_options, { class: "chosen-select form-control", 'data-module' => 'chosen' } %>
-  </p>
 <% end %>
 
 <h2 class="add-vertical-margins"> <%= "Editable " if (current_user.publishing_manager? ) %>Permissions</h2>

--- a/app/views/users/_form_fields.html.erb
+++ b/app/views/users/_form_fields.html.erb
@@ -23,7 +23,7 @@
 
 <p>
   <strong>Organisation:</strong> <%= @user.organisation.present? ? @user.organisation.name : Organisation::NONE %>
-  <% if policy(User).assign_organisations? %>
+  <% if policy(User).assign_organisation? %>
     <%= link_to edit_user_organisation_path(@user) do %>
       Change<span class="invisible"> organisation</span>
     <% end %>

--- a/app/views/users/names/edit.html.erb
+++ b/app/views/users/names/edit.html.erb
@@ -40,7 +40,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_for @user, url: user_name_path(@user) do |f| %>
+    <%= form_for @user, url: user_name_path(@user) do %>
       <%= render "govuk_publishing_components/components/input", {
         label: {
           text: "Name"

--- a/app/views/users/organisations/edit.html.erb
+++ b/app/views/users/organisations/edit.html.erb
@@ -1,24 +1,59 @@
-<% content_for :title, "Edit [#{@user.name}]" %>
+<% content_for :title_caption, "Manage other users" %>
+<% content_for :title, "Change organisation for #{@user.name}" %>
 
-<h1>Edit &ldquo;<%= @user.name %>&rdquo;</h1>
+<% content_for :breadcrumbs,
+   render("govuk_publishing_components/components/breadcrumbs", {
+     collapse_on_mobile: true,
+     breadcrumbs: [
+       {
+         title: "Dashboard",
+         url: root_path,
+       },
+       {
+         title: "Users",
+         url: users_path,
+       },
+       {
+         title: @user.name,
+         url: edit_user_path(@user),
+       },
+       {
+         title: "Change organisation",
+       }
+     ]
+   })
+%>
 
-<%= form_for @user, :url => user_organisation_path(@user), :html => {:class => 'well add-top-margin'} do |f| %>
-  <% if @user.errors.count > 0 %>
-    <div class="govuk-error-summary alert alert-danger" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="error-summary">
-      <div class="govuk-error-summary__body">
-        <ul class="govuk-list govuk-error-summary__list">
-          <% @user.errors.full_messages.each do |message| %>
-            <%= content_tag :li, message %>
-          <% end %>
-        </ul>
-      </div>
-    </div>
+<% if @user.errors.count > 0 %>
+  <% content_for :error_summary do %>
+    <%= render "govuk_publishing_components/components/error_summary", {
+      title: "There is a problem",
+      items: @user.errors.map do |error|
+        {
+          text: error.full_message,
+          href: "#user_#{error.attribute}",
+        }
+      end,
+    } %>
   <% end %>
-
-  <p class="form-group">
-    <%= f.label :organisation_id, "Organisation" %><br />
-    <%= f.select :organisation_id, organisation_options(f), organisation_select_options, { class: "chosen-select form-control", 'data-module' => 'chosen' } %>
-  </p>
-
-  <%= f.submit :class => 'btn btn-primary' %>
 <% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @user, url: user_organisation_path(@user) do %>
+      <%= render "govuk_publishing_components/components/select", {
+        id: "user_organisation_id",
+        name: "user[organisation_id]",
+        label: "Organisation",
+        options: options_for_organisation_select(selected: @user.organisation_id),
+        error_message: @user.errors[:organisation_id].any? ? @user.errors.full_messages_for(:organisation_id).to_sentence : nil
+      } %>
+      <div class="govuk-button-group">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Change organisation",
+        } %>
+        <%= link_to "Cancel", edit_user_path(@user), class: "govuk-link govuk-link--no-visited-state" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/users/organisations/edit.html.erb
+++ b/app/views/users/organisations/edit.html.erb
@@ -1,0 +1,24 @@
+<% content_for :title, "Edit [#{@user.name}]" %>
+
+<h1>Edit &ldquo;<%= @user.name %>&rdquo;</h1>
+
+<%= form_for @user, :url => user_organisation_path(@user), :html => {:class => 'well add-top-margin'} do |f| %>
+  <% if @user.errors.count > 0 %>
+    <div class="govuk-error-summary alert alert-danger" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="error-summary">
+      <div class="govuk-error-summary__body">
+        <ul class="govuk-list govuk-error-summary__list">
+          <% @user.errors.full_messages.each do |message| %>
+            <%= content_tag :li, message %>
+          <% end %>
+        </ul>
+      </div>
+    </div>
+  <% end %>
+
+  <p class="form-group">
+    <%= f.label :organisation_id, "Organisation" %><br />
+    <%= f.select :organisation_id, organisation_options(f), organisation_select_options, { class: "chosen-select form-control", 'data-module' => 'chosen' } %>
+  </p>
+
+  <%= f.submit :class => 'btn btn-primary' %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,6 +49,7 @@ Rails.application.routes.draw do
       delete :cancel_email_change
     end
     resource :role, only: %i[edit update], controller: "users/roles"
+    resource :organisation, only: %i[edit update], controller: "users/organisations"
   end
   get "user", to: "oauth_users#show"
 

--- a/lib/roles/organisation_admin.rb
+++ b/lib/roles/organisation_admin.rb
@@ -7,7 +7,6 @@ module Roles
         :email,
         :password,
         :password_confirmation,
-        :organisation_id,
         :unconfirmed_email,
         :confirmation_token,
         :require_2sv,

--- a/lib/roles/super_organisation_admin.rb
+++ b/lib/roles/super_organisation_admin.rb
@@ -7,7 +7,6 @@ module Roles
         :email,
         :password,
         :password_confirmation,
-        :organisation_id,
         :unconfirmed_email,
         :confirmation_token,
         :require_2sv,

--- a/test/controllers/users/organisations_controller_test.rb
+++ b/test/controllers/users/organisations_controller_test.rb
@@ -1,0 +1,243 @@
+require "test_helper"
+
+class Users::OrganisationsControllerTest < ActionController::TestCase
+  attr_reader :organisation
+
+  setup do
+    @organisation = create(:organisation)
+  end
+
+  context "GET edit" do
+    context "signed in as Admin user" do
+      setup do
+        @admin = create(:admin_user)
+        sign_in(@admin)
+      end
+
+      should "display form with organisation_id field" do
+        user = create(:user, organisation:)
+
+        get :edit, params: { user_id: user }
+
+        assert_template :edit
+        assert_select "form[action='#{user_organisation_path(user)}']" do
+          assert_select "select[name='user[organisation_id]'] option", value: organisation.id
+          assert_select "input[type='submit']"
+        end
+      end
+
+      should "authorize access if UserPolicy#edit? and UserPolicy#assign_organisations? return true" do
+        user = create(:user)
+
+        user_policy = stub_everything("user-policy", edit?: true, assign_organisations?: true)
+        UserPolicy.stubs(:new).returns(user_policy)
+
+        get :edit, params: { user_id: user }
+
+        assert_response :success
+      end
+
+      should "not authorize access if UserPolicy#edit? returns false" do
+        user = create(:user)
+
+        user_policy = stub_everything("user-policy", edit?: false, assign_organisations?: true)
+        UserPolicy.stubs(:new).returns(user_policy)
+
+        get :edit, params: { user_id: user }
+
+        assert_not_authorised
+      end
+
+      should "not authorize access if UserPolicy#assign_organisations? returns false" do
+        user = create(:user)
+
+        user_policy = stub_everything("user-policy", edit?: true, assign_organisations?: false)
+        UserPolicy.stubs(:new).returns(user_policy)
+
+        get :edit, params: { user_id: user }
+
+        assert_not_authorised
+      end
+
+      should "redirect to account edit organisation page if admin is acting on their own user" do
+        get :edit, params: { user_id: @admin }
+
+        assert_redirected_to edit_account_organisation_path
+      end
+    end
+
+    context "signed in as Normal user" do
+      setup do
+        sign_in(create(:user))
+      end
+
+      should "not be authorized" do
+        user = create(:user)
+
+        get :edit, params: { user_id: user }
+
+        assert_not_authorised
+      end
+    end
+
+    context "not signed in" do
+      should "not be allowed access" do
+        user = create(:user)
+
+        get :edit, params: { user_id: user }
+
+        assert_not_authenticated
+      end
+    end
+  end
+
+  context "PUT update" do
+    attr_reader :another_organisation
+
+    setup do
+      @another_organisation = create(:organisation)
+    end
+
+    context "signed in as Admin user" do
+      setup do
+        @admin = create(:admin_user)
+        sign_in(@admin)
+      end
+
+      should "update user organisation" do
+        user = create(:user, organisation:)
+
+        put :update, params: { user_id: user, user: { organisation_id: another_organisation } }
+
+        assert_equal another_organisation, user.reload.organisation
+      end
+
+      should "record account updated & organisation change events" do
+        user = create(:user, organisation:)
+
+        @controller.stubs(:user_ip_address).returns("1.1.1.1")
+
+        EventLog.expects(:record_event).with(
+          user,
+          EventLog::ACCOUNT_UPDATED,
+          initiator: @admin,
+          ip_address: "1.1.1.1",
+        )
+
+        EventLog.expects(:record_organisation_change).with(
+          user,
+          organisation.name,
+          another_organisation.name,
+          @admin,
+        )
+
+        put :update, params: { user_id: user, user: { organisation_id: another_organisation } }
+      end
+
+      should "should not record organisation change event if organisation has not changed" do
+        user = create(:user, organisation:)
+
+        EventLog.expects(:record_organisation_change).never
+
+        put :update, params: { user_id: user, user: { organisation_id: organisation } }
+      end
+
+      should "push changes out to apps" do
+        user = create(:user, organisation:)
+
+        PermissionUpdater.expects(:perform_on).with(user).once
+
+        put :update, params: { user_id: user, user: { organisation_id: another_organisation } }
+      end
+
+      should "redirect to user page and display success notice" do
+        user = create(:user, organisation:, email: "user@gov.uk")
+
+        put :update, params: { user_id: user, user: { organisation_id: another_organisation } }
+
+        assert_redirected_to edit_user_path(user)
+        assert_equal "Updated user user@gov.uk successfully", flash[:notice]
+      end
+
+      should "update user organisation if UserPolicy#update? and UserPolicy#assign_organisations? return true" do
+        user = create(:user, organisation:)
+
+        user_policy = stub_everything("user-policy", update?: true, assign_organisations?: true)
+        UserPolicy.stubs(:new).returns(user_policy)
+
+        put :update, params: { user_id: user, user: { organisation_id: another_organisation } }
+
+        assert_equal another_organisation, user.reload.organisation
+      end
+
+      should "not update user organisation if UserPolicy#update? returns false" do
+        user = create(:user, organisation:)
+
+        user_policy = stub_everything("user-policy", update?: false, assign_organisations?: true)
+        UserPolicy.stubs(:new).returns(user_policy)
+
+        put :update, params: { user_id: user, user: { organisation_id: another_organisation } }
+
+        assert_equal organisation, user.reload.organisation
+        assert_not_authorised
+      end
+
+      should "not update user organisation if UserPolicy#assign_organisations? returns false" do
+        user = create(:user, organisation:)
+
+        user_policy = stub_everything("user-policy", update?: true, assign_role?: false)
+        UserPolicy.stubs(:new).returns(user_policy)
+
+        put :update, params: { user_id: user, user: { organisation_id: another_organisation } }
+
+        assert_equal organisation, user.reload.organisation
+        assert_not_authorised
+      end
+
+      should "redisplay form if organisation is not valid" do
+        user = create(:organisation_admin_user, organisation:)
+
+        put :update, params: { user_id: user, user: { organisation_id: nil } }
+
+        assert_template :edit
+        assert_select "form[action='#{user_organisation_path(user)}']" do
+          assert_select "select[name='user[organisation_id]'] option", value: organisation.id
+        end
+      end
+
+      should "display errors if organisation is not valid" do
+        user = create(:organisation_admin_user, organisation:)
+
+        put :update, params: { user_id: user, user: { organisation_id: nil } }
+
+        assert_select ".govuk-error-summary" do
+          assert_select "li", text: "Organisation can't be 'None' for Organisation Admin"
+        end
+      end
+    end
+
+    context "signed in as Normal user" do
+      setup do
+        sign_in(create(:user))
+      end
+
+      should "not be authorized" do
+        user = create(:user, organisation:)
+
+        put :update, params: { user_id: user, user: { organisation_id: another_organisation } }
+
+        assert_not_authorised
+      end
+    end
+
+    context "not signed in" do
+      should "not be allowed access" do
+        user = create(:user, organisation:)
+
+        put :update, params: { user_id: user, user: { organisation_id: another_organisation } }
+
+        assert_not_authenticated
+      end
+    end
+  end
+end

--- a/test/controllers/users/organisations_controller_test.rb
+++ b/test/controllers/users/organisations_controller_test.rb
@@ -27,10 +27,10 @@ class Users::OrganisationsControllerTest < ActionController::TestCase
         end
       end
 
-      should "authorize access if UserPolicy#edit? and UserPolicy#assign_organisations? return true" do
+      should "authorize access if UserPolicy#edit? and UserPolicy#assign_organisation? return true" do
         user = create(:user)
 
-        user_policy = stub_everything("user-policy", edit?: true, assign_organisations?: true)
+        user_policy = stub_everything("user-policy", edit?: true, assign_organisation?: true)
         UserPolicy.stubs(:new).returns(user_policy)
 
         get :edit, params: { user_id: user }
@@ -41,7 +41,7 @@ class Users::OrganisationsControllerTest < ActionController::TestCase
       should "not authorize access if UserPolicy#edit? returns false" do
         user = create(:user)
 
-        user_policy = stub_everything("user-policy", edit?: false, assign_organisations?: true)
+        user_policy = stub_everything("user-policy", edit?: false, assign_organisation?: true)
         UserPolicy.stubs(:new).returns(user_policy)
 
         get :edit, params: { user_id: user }
@@ -49,10 +49,10 @@ class Users::OrganisationsControllerTest < ActionController::TestCase
         assert_not_authorised
       end
 
-      should "not authorize access if UserPolicy#assign_organisations? returns false" do
+      should "not authorize access if UserPolicy#assign_organisation? returns false" do
         user = create(:user)
 
-        user_policy = stub_everything("user-policy", edit?: true, assign_organisations?: false)
+        user_policy = stub_everything("user-policy", edit?: true, assign_organisation?: false)
         UserPolicy.stubs(:new).returns(user_policy)
 
         get :edit, params: { user_id: user }
@@ -160,10 +160,10 @@ class Users::OrganisationsControllerTest < ActionController::TestCase
         assert_equal "Updated user user@gov.uk successfully", flash[:notice]
       end
 
-      should "update user organisation if UserPolicy#update? and UserPolicy#assign_organisations? return true" do
+      should "update user organisation if UserPolicy#update? and UserPolicy#assign_organisation? return true" do
         user = create(:user, organisation:)
 
-        user_policy = stub_everything("user-policy", update?: true, assign_organisations?: true)
+        user_policy = stub_everything("user-policy", update?: true, assign_organisation?: true)
         UserPolicy.stubs(:new).returns(user_policy)
 
         put :update, params: { user_id: user, user: { organisation_id: another_organisation } }
@@ -174,7 +174,7 @@ class Users::OrganisationsControllerTest < ActionController::TestCase
       should "not update user organisation if UserPolicy#update? returns false" do
         user = create(:user, organisation:)
 
-        user_policy = stub_everything("user-policy", update?: false, assign_organisations?: true)
+        user_policy = stub_everything("user-policy", update?: false, assign_organisation?: true)
         UserPolicy.stubs(:new).returns(user_policy)
 
         put :update, params: { user_id: user, user: { organisation_id: another_organisation } }
@@ -183,7 +183,7 @@ class Users::OrganisationsControllerTest < ActionController::TestCase
         assert_not_authorised
       end
 
-      should "not update user organisation if UserPolicy#assign_organisations? returns false" do
+      should "not update user organisation if UserPolicy#assign_organisation? returns false" do
         user = create(:user, organisation:)
 
         user_policy = stub_everything("user-policy", update?: true, assign_role?: false)

--- a/test/controllers/users/organisations_controller_test.rb
+++ b/test/controllers/users/organisations_controller_test.rb
@@ -22,7 +22,8 @@ class Users::OrganisationsControllerTest < ActionController::TestCase
         assert_template :edit
         assert_select "form[action='#{user_organisation_path(user)}']" do
           assert_select "select[name='user[organisation_id]'] option", value: organisation.id
-          assert_select "input[type='submit']"
+          assert_select "button[type='submit']", text: "Change organisation"
+          assert_select "a[href='#{edit_user_path(user)}']", text: "Cancel"
         end
       end
 
@@ -211,7 +212,11 @@ class Users::OrganisationsControllerTest < ActionController::TestCase
         put :update, params: { user_id: user, user: { organisation_id: nil } }
 
         assert_select ".govuk-error-summary" do
-          assert_select "li", text: "Organisation can't be 'None' for Organisation Admin"
+          assert_select "a", href: "#user_organisation_id", text: "Organisation can't be 'None' for Organisation Admin"
+        end
+        assert_select ".govuk-form-group" do
+          assert_select ".govuk-error-message", text: "Error: Organisation can't be 'None' for Organisation Admin"
+          assert_select "select[name='user[organisation_id]'].govuk-select--error"
         end
       end
     end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -602,10 +602,10 @@ class UsersControllerTest < ActionController::TestCase
       end
 
       should "push changes out to apps" do
-        another_user = create(:user, name: "Old Name")
+        another_user = create(:user)
         PermissionUpdater.expects(:perform_on).with(another_user).once
 
-        put :update, params: { id: another_user.id, user: { name: "New Name" } }
+        put :update, params: { id: another_user.id, user: {} }
       end
 
       context "update application access" do

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -276,6 +276,13 @@ class UsersControllerTest < ActionController::TestCase
         assert_select "a", href: edit_user_email_path(not_an_admin), text: "Change email"
       end
 
+      should "display the user's role but no link to change the role" do
+        user = create(:user, role: Roles::Normal.role_name)
+        get :edit, params: { id: user.id }
+        assert_select "*", text: /Role: Normal/
+        assert_select "a", href: edit_user_role_path(user), text: "Change role", count: 0
+      end
+
       should "show the organisation to which the user belongs" do
         user_in_org = create(:user_in_organisation)
         org_with_user = user_in_org.organisation
@@ -329,6 +336,14 @@ class UsersControllerTest < ActionController::TestCase
       setup do
         @organisation_admin = create(:organisation_admin_user)
         sign_in @organisation_admin
+      end
+
+      should "not display a link to change the user's role" do
+        user = create(:user, organisation: @organisation_admin.organisation)
+
+        get :edit, params: { id: user.id }
+
+        assert_select "a", href: edit_user_role_path(user), text: "Change role", count: 0
       end
 
       should "not be able to assign organisations" do
@@ -412,6 +427,14 @@ class UsersControllerTest < ActionController::TestCase
       setup do
         @super_organisation_admin = create(:super_organisation_admin_user)
         sign_in @super_organisation_admin
+      end
+
+      should "not display a link to change the user's role" do
+        user = create(:user, organisation: @super_organisation_admin.organisation)
+
+        get :edit, params: { id: user.id }
+
+        assert_select "a", href: edit_user_role_path(user), text: "Change role", count: 0
       end
 
       should "not be able to assign organisations" do
@@ -524,6 +547,12 @@ class UsersControllerTest < ActionController::TestCase
       setup do
         @superadmin = create(:superadmin_user)
         sign_in @superadmin
+      end
+
+      should "display a link to change the user's role" do
+        user = create(:user, role: Roles::Normal.role_name)
+        get :edit, params: { id: user.id }
+        assert_select "a", href: edit_user_role_path(user), text: "Change role"
       end
 
       should "not be able to see all permissions to applications for a user" do

--- a/test/policies/user_policy_test.rb
+++ b/test/policies/user_policy_test.rb
@@ -12,7 +12,7 @@ class UserPolicyTest < ActiveSupport::TestCase
     @gds = create(:organisation, name: "Government Digital Services", content_id: Organisation::GDS_ORG_CONTENT_ID)
   end
 
-  primary_management_actions = %i[new create assign_organisations]
+  primary_management_actions = %i[new create assign_organisation]
   user_management_actions = %i[edit update unlock suspension cancel_email_change resend_email_change event_logs reset_2sv mandate_2sv]
   superadmin_actions = %i[assign_role]
   two_step_verification_exemption_actions = %i[exempt_from_two_step_verification]


### PR DESCRIPTION
Trello: https://trello.com/c/uZD2I9dj & https://trello.com/c/fA6dRVSm

This splits out the editing of another user's organisation into a separate page. The latest design calls for the splitting out the editing of a bunch of user fields into separate pages like this. The new "edit user organisation page uses the GOV.UK Design System, but the "edit user" page still does not. c.f. #2497,  #2509 & #2537.

The new "Change (organisation)" link on the "edit user" page only shows up if the current user is an Admin or a Superadmin, i.e. they have permission to change another user's organisation.

In my use of the [`error_summary` component](https://components.publishing.service.gov.uk/component-guide/error_summary) I have also brought the display of validation errors more into line with [this Design System guidance](https://design-system.service.gov.uk/patterns/validation/#how-to-tell-the-user-about-validation-errors). The most obvious validation error that can occur is if you attempt to change an Organisation Admin or Super Organisation Admin's organisation to None. Although I do wonder if this would be better tackled by excluding the "None" option from the select box in that scenario. However, I suggest we tackle that separately.

### New "Change" link on "edit user" page
<img width="795" alt="Screenshot 2023-11-23 at 09 06 10" src="https://github.com/alphagov/signon/assets/3169/e2086901-667c-4f78-b5d6-6f8da54590a3">

### New "edit user organisation" page
<img width="795" alt="Screenshot 2023-11-23 at 09 06 28" src="https://github.com/alphagov/signon/assets/3169/2e7674cc-e19a-4df9-aabe-df97db3ed967">

### New "edit user organisation" page with validation error
<img width="813" alt="Screenshot 2023-11-23 at 09 06 58" src="https://github.com/alphagov/signon/assets/3169/93969966-ea8c-4655-808a-f0d2a57bcc7d">

### Planned design for the "edit user" page (not part of this PR)
<img width="542" alt="282090000-d8b41904-f74c-4896-8c35-3902beaebbbc" src="https://github.com/alphagov/signon/assets/3169/8d16a472-8a60-4054-b4ae-fa9199ac228a">

