### PR TITLE
Add separate page for resetting another user's 2SV

### DIFF
--- a/app/controllers/users/two_step_verification_resets_controller.rb
+++ b/app/controllers/users/two_step_verification_resets_controller.rb
@@ -1,0 +1,31 @@
+class Users::TwoStepVerificationResetsController < ApplicationController
+  layout "admin_layout"
+
+  before_action :authenticate_user!
+  before_action :load_user
+  before_action :authorize_user
+  before_action :redirect_to_account_page_if_acting_on_own_user, only: %i[edit]
+
+  def edit; end
+
+  def update
+    @user.reset_2sv!(current_user)
+    UserMailer.two_step_reset(@user).deliver_later
+
+    redirect_to edit_user_path(@user), notice: "Reset 2-step verification for #{@user.email}"
+  end
+
+private
+
+  def load_user
+    @user = User.find(params[:user_id])
+  end
+
+  def authorize_user
+    authorize(@user, :reset_2sv?)
+  end
+
+  def redirect_to_account_page_if_acting_on_own_user
+    redirect_to two_step_verification_path if current_user == @user
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -57,13 +57,6 @@ class UsersController < ApplicationController
     @logs = @user.event_logs.page(params[:page]).per(100) if @user
   end
 
-  def reset_two_step_verification
-    @user.reset_2sv!(current_user)
-    UserMailer.two_step_reset(@user).deliver_later
-
-    redirect_to users_path, notice: "Reset 2-step verification for #{@user.email}"
-  end
-
   def require_2sv; end
 
 private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -393,7 +393,7 @@ class User < ApplicationRecord
     end
   end
 
-  def reset_2sv!(initiating_superadmin)
+  def reset_2sv!(initiator)
     transaction do
       self.otp_secret_key = nil
       self.require_2sv = true
@@ -402,7 +402,7 @@ class User < ApplicationRecord
       EventLog.record_event(
         self,
         EventLog::TWO_STEP_RESET,
-        initiator: initiating_superadmin,
+        initiator:,
       )
     end
   end

--- a/app/views/users/_form_fields.html.erb
+++ b/app/views/users/_form_fields.html.erb
@@ -67,7 +67,7 @@
         <br/>
         User will be prompted to set up 2-step verification again the next time they sign in.</p>
       <% end %>
-      <% if policy(@user).exempt_from_two_step_verification? && @user.reason_for_2sv_exemption.nil? %>
+      <% if policy(@user).exempt_from_two_step_verification? && !@user.exempt_from_2sv? %>
           <p>
             <%= link_to 'Exempt user from 2-step verification', edit_two_step_verification_exemption_path(@user) %>
             <br/>

--- a/app/views/users/_form_fields.html.erb
+++ b/app/views/users/_form_fields.html.erb
@@ -30,30 +30,30 @@
   <% end %>
 </p>
 
-<% if policy(@user).mandate_2sv? %>
-  <dl>
-    <dt>Account security</dt>
-    <dd>
-      <% if @user.exempt_from_2sv? %>
-        <p>
-          The user has been made exempt from 2-step verification for the following reason: <%= @user.reason_for_2sv_exemption %>
-        <% if policy(@user).exempt_from_two_step_verification? %>
-          <br>
-          <%= link_to 'Edit reason or expiry date for 2-step verification exemption', edit_two_step_verification_exemption_path(@user) %>
-        <% end %>
-        </p>
-      <% elsif @user.has_2sv? %>
-        <p>2-step verification enabled</p>
-        <p>
-          <%= link_to 'Reset 2-step verification', edit_user_two_step_verification_reset_path(@user) %>
-        </p>
-      <% elsif @user.require_2sv? %>
-        <p>2-step verification required but not set up</p>
-      <% else %>
-        <p>2-step verification not set up</p>
+<dl>
+  <dt>Account security</dt>
+  <dd>
+    <% if @user.exempt_from_2sv? %>
+      <p>
+        The user has been made exempt from 2-step verification for the following reason: <%= @user.reason_for_2sv_exemption %>
+      <% if policy(@user).exempt_from_two_step_verification? %>
+        <br>
+        <%= link_to 'Edit reason or expiry date for 2-step verification exemption', edit_two_step_verification_exemption_path(@user) %>
       <% end %>
+      </p>
+    <% elsif @user.has_2sv? %>
+      <p>2-step verification enabled</p>
+      <p>
+        <%= link_to 'Reset 2-step verification', edit_user_two_step_verification_reset_path(@user) %>
+      </p>
+    <% elsif @user.require_2sv? %>
+      <p>2-step verification required but not set up</p>
+    <% else %>
+      <p>2-step verification not set up</p>
+    <% end %>
 
-      <% unless @user.require_2sv? %>
+    <% unless @user.require_2sv? %>
+      <% if policy(@user).mandate_2sv? %>
         <p class="checkbox">
           <%= f.label :require_2sv do %>
             <%= f.check_box :require_2sv %> Mandate 2-step verification for this user <%= "(this will remove their exemption)" if @user.exempt_from_2sv? %>
@@ -61,16 +61,16 @@
         <br/>
         User will be prompted to set up 2-step verification again the next time they sign in.</p>
       <% end %>
-      <% if policy(@user).exempt_from_two_step_verification? && !@user.exempt_from_2sv? %>
-          <p>
-            <%= link_to 'Exempt user from 2-step verification', edit_two_step_verification_exemption_path(@user) %>
-            <br/>
-            Exempt a user from 2-step verification (requires a reason to be supplied).
-          </p>
-      <%end %>
-    </dd>
-  </dl>
-<% end %>
+    <% end %>
+    <% if policy(@user).exempt_from_two_step_verification? && !@user.exempt_from_2sv? %>
+        <p>
+          <%= link_to 'Exempt user from 2-step verification', edit_two_step_verification_exemption_path(@user) %>
+          <br/>
+          Exempt a user from 2-step verification (requires a reason to be supplied).
+        </p>
+    <%end %>
+  </dd>
+</dl>
 
 <h2 class="add-vertical-margins"> <%= "Editable " if (current_user.publishing_manager? ) %>Permissions</h2>
 <%= render partial: "shared/user_permissions", locals: { user_object: @user }%>

--- a/app/views/users/_form_fields.html.erb
+++ b/app/views/users/_form_fields.html.erb
@@ -45,13 +45,7 @@
       <% elsif @user.has_2sv? %>
         <p>2-step verification enabled</p>
         <p>
-          <%= link_to 'Reset 2-step verification',
-            reset_two_step_verification_user_path(@user),
-            data: { confirm: 'Are you sure?' },
-            method: :patch
-          %><br/>
-          Allows user to sign in without a verification code.<br/>
-          User will be prompted to set up 2-step verification again the next time they sign in.
+          <%= link_to 'Reset 2-step verification', edit_user_two_step_verification_reset_path(@user) %>
         </p>
       <% elsif @user.require_2sv? %>
         <p>2-step verification required but not set up</p>

--- a/app/views/users/_form_fields.html.erb
+++ b/app/views/users/_form_fields.html.erb
@@ -36,10 +36,10 @@
     <% if @user.exempt_from_2sv? %>
       <p>
         The user has been made exempt from 2-step verification for the following reason: <%= @user.reason_for_2sv_exemption %>
-      <% if policy(@user).exempt_from_two_step_verification? %>
-        <br>
-        <%= link_to 'Edit reason or expiry date for 2-step verification exemption', edit_two_step_verification_exemption_path(@user) %>
-      <% end %>
+        <% if policy(@user).exempt_from_two_step_verification? %>
+          <br>
+          <%= link_to 'Edit reason or expiry date for 2-step verification exemption', edit_two_step_verification_exemption_path(@user) %>
+        <% end %>
       </p>
     <% elsif @user.has_2sv? %>
       <p>2-step verification enabled</p>
@@ -58,17 +58,19 @@
           <%= f.label :require_2sv do %>
             <%= f.check_box :require_2sv %> Mandate 2-step verification for this user <%= "(this will remove their exemption)" if @user.exempt_from_2sv? %>
           <% end %>
-        <br/>
-        User will be prompted to set up 2-step verification again the next time they sign in.</p>
+          <br/>
+          User will be prompted to set up 2-step verification again the next time they sign in.
+        </p>
       <% end %>
     <% end %>
+
     <% if policy(@user).exempt_from_two_step_verification? && !@user.exempt_from_2sv? %>
         <p>
           <%= link_to 'Exempt user from 2-step verification', edit_two_step_verification_exemption_path(@user) %>
           <br/>
           Exempt a user from 2-step verification (requires a reason to be supplied).
         </p>
-    <%end %>
+    <% end %>
   </dd>
 </dl>
 

--- a/app/views/users/_form_fields.html.erb
+++ b/app/views/users/_form_fields.html.erb
@@ -42,7 +42,7 @@
           <%= link_to 'Edit reason or expiry date for 2-step verification exemption', edit_two_step_verification_exemption_path(@user) %>
         <% end %>
         </p>
-      <% elsif f.object.has_2sv? %>
+      <% elsif @user.has_2sv? %>
         <p>2-step verification enabled</p>
         <p>
           <%= link_to 'Reset 2-step verification',
@@ -53,7 +53,7 @@
           Allows user to sign in without a verification code.<br/>
           User will be prompted to set up 2-step verification again the next time they sign in.
         </p>
-      <% elsif f.object.require_2sv? %>
+      <% elsif @user.require_2sv? %>
         <p>2-step verification required but not set up</p>
       <% else %>
         <p>2-step verification not set up</p>
@@ -79,9 +79,9 @@
 <% end %>
 
 <h2 class="add-vertical-margins"> <%= "Editable " if (current_user.publishing_manager? ) %>Permissions</h2>
-<%= render partial: "shared/user_permissions", locals: { user_object: f.object }%>
+<%= render partial: "shared/user_permissions", locals: { user_object: @user }%>
 
 <% if current_user.publishing_manager? %>
     <h2 class="add-vertical-margins">All Permissions for this user</h2>
-    <%= render partial: "app_permissions", locals: { user_object: f.object }%>
+    <%= render partial: "app_permissions", locals: { user_object: @user }%>
 <% end %>

--- a/app/views/users/two_step_verification_resets/edit.html.erb
+++ b/app/views/users/two_step_verification_resets/edit.html.erb
@@ -1,0 +1,42 @@
+<% content_for :title_caption, "Manage other users" %>
+<% content_for :title, "Reset 2-step verification for #{@user.name}" %>
+
+<% content_for :breadcrumbs,
+   render("govuk_publishing_components/components/breadcrumbs", {
+     collapse_on_mobile: true,
+     breadcrumbs: [
+       {
+         title: "Dashboard",
+         url: root_path,
+       },
+       {
+         title: "Users",
+         url: users_path,
+       },
+       {
+         title: @user.name,
+         url: edit_user_path(@user),
+       },
+       {
+         title: "Reset 2-step verification",
+       }
+     ]
+   })
+%>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @user, url: user_two_step_verification_reset_path(@user) do %>
+      <%= render "govuk_publishing_components/components/hint", {
+        text: "Allows user to sign in without a verification code. User will be prompted to set up 2-step verification again the next time they sign in."
+      } %>
+      <div class="govuk-button-group">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Reset 2-step verification",
+          destructive: true,
+        } %>
+        <%= link_to "Cancel", edit_user_path(@user), class: "govuk-link govuk-link--no-visited-state" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,7 +40,6 @@ Rails.application.routes.draw do
     member do
       post :unlock
       get :event_logs
-      patch :reset_two_step_verification
       get :require_2sv
     end
     resource :name, only: %i[edit update], controller: "users/names"
@@ -50,6 +49,7 @@ Rails.application.routes.draw do
     end
     resource :role, only: %i[edit update], controller: "users/roles"
     resource :organisation, only: %i[edit update], controller: "users/organisations"
+    resource :two_step_verification_reset, only: %i[edit update], controller: "users/two_step_verification_resets"
   end
   get "user", to: "oauth_users#show"
 

--- a/test/controllers/users/two_step_verification_resets_controller_test.rb
+++ b/test/controllers/users/two_step_verification_resets_controller_test.rb
@@ -1,0 +1,173 @@
+require "test_helper"
+
+class Users::TwoStepVerificationResetsControllerTest < ActionController::TestCase
+  include ActiveJob::TestHelper
+
+  context "GET edit" do
+    context "signed in as Admin user" do
+      setup do
+        @admin = create(:admin_user)
+        sign_in(@admin)
+      end
+
+      should "display form with submit button & cancel link" do
+        user = create(:two_step_enabled_user)
+
+        get :edit, params: { user_id: user }
+
+        assert_template :edit
+        assert_select "form[action='#{user_two_step_verification_reset_path(user)}']" do
+          assert_select "button[type='submit']", text: "Reset 2-step verification"
+          assert_select "a[href='#{edit_user_path(user)}']", text: "Cancel"
+        end
+      end
+
+      should "authorize access if UserPolicy#reset_2sv? returns true" do
+        user = create(:two_step_enabled_user)
+
+        user_policy = stub_everything("user-policy", reset_2sv?: true)
+        UserPolicy.stubs(:new).returns(user_policy)
+
+        get :edit, params: { user_id: user }
+
+        assert_template :edit
+      end
+
+      should "not authorize access if UserPolicy#reset_2sv? returns false" do
+        user = create(:two_step_enabled_user)
+
+        user_policy = stub_everything("user-policy", reset_2sv?: false)
+        UserPolicy.stubs(:new).returns(user_policy)
+
+        get :edit, params: { user_id: user }
+
+        assert_not_authorised
+      end
+
+      should "redirect to account change 2-step verification phone page if admin is acting on their own user" do
+        get :edit, params: { user_id: @admin }
+
+        assert_redirected_to two_step_verification_path
+      end
+    end
+
+    context "signed in as Normal user" do
+      setup do
+        sign_in(create(:user))
+      end
+
+      should "not be authorized" do
+        user = create(:user)
+
+        get :edit, params: { user_id: user }
+
+        assert_not_authorised
+      end
+    end
+
+    context "not signed in" do
+      should "not be allowed access" do
+        user = create(:user)
+
+        get :edit, params: { user_id: user }
+
+        assert_not_authenticated
+      end
+    end
+  end
+
+  context "PUT update" do
+    context "signed in as Admin user" do
+      setup do
+        @admin = create(:admin_user)
+        sign_in(@admin)
+      end
+
+      should "reset 2SV for user" do
+        user = create(:two_step_enabled_user)
+
+        put :update, params: { user_id: user }
+
+        user.reload
+        assert user.otp_secret_key.blank?
+        assert user.require_2sv?
+      end
+
+      should "record account updated event" do
+        user = create(:two_step_enabled_user)
+
+        EventLog.expects(:record_event).with(user, EventLog::TWO_STEP_RESET, initiator: @admin)
+
+        put :update, params: { user_id: user }
+      end
+
+      should "should send email notifying user that their 2SV has been reset" do
+        user = create(:two_step_enabled_user)
+
+        perform_enqueued_jobs do
+          put :update, params: { user_id: user }
+        end
+
+        email = ActionMailer::Base.deliveries.last
+        assert email.present?
+        assert_equal "2-step verification has been reset", email.subject
+      end
+
+      should "redirect to user page and display success notice" do
+        user = create(:two_step_enabled_user, email: "user@gov.uk")
+
+        put :update, params: { user_id: user }
+
+        assert_redirected_to edit_user_path(user)
+        assert_equal "Reset 2-step verification for user@gov.uk", flash[:notice]
+      end
+
+      should "reset 2SV for user if UserPolicy#reset_2sv? returns true" do
+        user = create(:two_step_enabled_user)
+
+        user_policy = stub_everything("user-policy", reset_2sv?: true)
+        UserPolicy.stubs(:new).returns(user_policy)
+
+        put :update, params: { user_id: user }
+
+        assert user.reload.otp_secret_key.blank?
+      end
+
+      should "not reset 2SV for user if UserPolicy#reset_2sv? returns false" do
+        user = create(:two_step_enabled_user)
+
+        user_policy = stub_everything("user-policy", reset_2sv?: false)
+        UserPolicy.stubs(:new).returns(user_policy)
+
+        put :update, params: { user_id: user }
+
+        assert user.reload.otp_secret_key.present?
+        assert_not_authorised
+      end
+    end
+
+    context "signed in as Normal user" do
+      setup do
+        sign_in(create(:user))
+      end
+
+      should "not be authorized" do
+        user = create(:two_step_enabled_user)
+
+        put :update, params: { user_id: user }
+
+        assert_not_authorised
+      end
+    end
+
+    context "not signed in" do
+      should "not be allowed access" do
+        user = create(:two_step_enabled_user)
+
+        put :update, params: { user_id: user }
+
+        assert_not_authenticated
+      end
+    end
+  end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -202,12 +202,13 @@ class UserTest < ActiveSupport::TestCase
     end
 
     should "record the event" do
-      assert_equal 1,
-                   EventLog.where(
-                     event_id: EventLog::TWO_STEP_RESET.id,
-                     uid: @two_step_user.uid,
-                     initiator: @super_admin,
-                   ).count
+      number_of_2sv_reset_events = EventLog.where(
+        event_id: EventLog::TWO_STEP_RESET.id,
+        uid: @two_step_user.uid,
+        initiator: @super_admin,
+      ).count
+
+      assert_equal 1, number_of_2sv_reset_events
     end
   end
 

--- a/test/support/managing_two_sv_helpers.rb
+++ b/test/support/managing_two_sv_helpers.rb
@@ -61,9 +61,8 @@ module ManagingTwoSvHelpers
     perform_enqueued_jobs do
       assert_response_contains "2-step verification enabled"
 
-      accept_alert do
-        click_link "Reset 2-step verification"
-      end
+      click_link "Reset 2-step verification"
+      click_button "Reset 2-step verification"
 
       assert_response_contains "Reset 2-step verification for #{user_to_be_reset.email}"
 


### PR DESCRIPTION
Trello: https://trello.com/c/uZD2I9dj & https://trello.com/c/caETStGa

This splits out the resetting of another user's 2SV into a separate page. The latest design calls for the splitting out of a bunch of user operations into separate pages like this. The new "reset user 2SV" page uses the GOV.UK Design System, but the "edit user" page still does not. c.f. https://github.com/alphagov/signon/pull/2497, https://github.com/alphagov/signon/pull/2509 & https://github.com/alphagov/signon/pull/2537.

Previously the "Reset 2-step verification" link on the "edit user" page was enhanced by UJS to prompt the user with a confirmation dialog and then submit a PATCH HTTP request to the controller. Since you now have to click the "Reset 2-step verification" link on the "edit user" page AND then click the "Reset 2-step verification" button on the new page, I don't think we need the confirmation dialog any more. However, I've used the `destructive` option on the button component to indicate that some information is lost when you click it.

All this means we no longer need to use UJS for this operation which is a plus for two reasons: (a) UJS is deprecated in Rails v7.0 and we're about to upgrade to Rails v7.1; and (b) this functionality did not work without JS enabled which was an accessibility issue.

Previously there wasn't anything stopping a hand-crafted request to `UsersController#reset_two_step_verification` from calling `User#reset_2sv!` & `UserMailer.two_step_reset` for a user that didn't have 2SV setup. And I haven't added any such check into the new controller. Since the "Reset 2-step verification" link on the "edit user" page still only shows up if the user has 2SV setup, it's not possible to _navigate_ to the new "Reset 2SV" page if the user doesn't have 2SV setup. However, I suppose it's now slightly easier to hack the URL to get to the new "Reset 2SV" page and submit the form. So it _might_ be worth protecting against this somehow, although I don't think it will do any harm if `User#reset_2sv!` & `UserMailer.two_step_reset` are called for a user that doesn't have 2SV setup - it might just be a bit confusing. What do you think?

### Unchanged "Reset 2-step verification" link on "edit user" page
<img width="759" alt="Screenshot 2023-11-23 at 16 25 50" src="https://github.com/alphagov/signon/assets/3169/094b0081-3322-41ab-bc5d-067e72e41f8a">

### New "reset 2SV" page
<img width="759" alt="Screenshot 2023-11-23 at 16 26 05" src="https://github.com/alphagov/signon/assets/3169/5ea53540-dc8b-4a97-8204-b454d0e7820b">
