### PR TITLE
Add separate page for mandating 2SV for another user

### DIFF
--- a/app/controllers/users/two_step_verification_mandations_controller.rb
+++ b/app/controllers/users/two_step_verification_mandations_controller.rb
@@ -1,0 +1,29 @@
+class Users::TwoStepVerificationMandationsController < ApplicationController
+  layout "admin_layout"
+
+  before_action :authenticate_user!
+  before_action :load_user
+  before_action :authorize_user
+
+  def edit; end
+
+  def update
+    user_params = { require_2sv: true }
+    updater = UserUpdate.new(@user, user_params, current_user, user_ip_address)
+    if updater.call
+      redirect_to edit_user_path(@user), notice: "Updated user #{@user.email} successfully"
+    else
+      render :edit
+    end
+  end
+
+private
+
+  def load_user
+    @user = User.find(params[:user_id])
+  end
+
+  def authorize_user
+    authorize(@user, :mandate_2sv?)
+  end
+end

--- a/app/views/users/_form_fields.html.erb
+++ b/app/views/users/_form_fields.html.erb
@@ -54,12 +54,11 @@
 
     <% unless @user.require_2sv? %>
       <% if policy(@user).mandate_2sv? %>
-        <p class="checkbox">
-          <%= f.label :require_2sv do %>
-            <%= f.check_box :require_2sv %> Mandate 2-step verification for this user <%= "(this will remove their exemption)" if @user.exempt_from_2sv? %>
-          <% end %>
-          <br/>
-          User will be prompted to set up 2-step verification again the next time they sign in.
+        <p>
+          <%= link_to(
+            "Mandate 2-step verification for this user#{@user.exempt_from_2sv? ? ' (this will remove their exemption)' : nil}",
+            edit_user_two_step_verification_mandation_path(@user)
+          ) %>
         </p>
       <% end %>
     <% end %>

--- a/app/views/users/two_step_verification_mandations/edit.html.erb
+++ b/app/views/users/two_step_verification_mandations/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title_caption, "Manage other users" %>
-<% content_for :title, "Mandate 2-step verification for #{@user.name}" %>
+<% content_for :title, "Turn on 2-step verification for #{@user.name}" %>
 
 <% content_for :breadcrumbs,
    render("govuk_publishing_components/components/breadcrumbs", {
@@ -18,7 +18,7 @@
          url: edit_user_path(@user),
        },
        {
-         title: "Mandate 2-step verification",
+         title: "Turn on 2-step verification",
        }
      ]
    })
@@ -42,15 +42,14 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_for @user, url: user_two_step_verification_mandation_path(@user) do |f| %>
       <%= render "govuk_publishing_components/components/hint", {
-        text: [
-          "Mandate 2-step verification for this user#{@user.exempt_from_2sv? ? ' (this will remove their exemption)' : nil}.",
-          "They will be prompted to set up 2-step verification again the next time they sign in.",
-        ].join(" ")
+        text: @user.exempt_from_2sv? ?
+          "This will remove the user's exemption from 2-step verification. They will have to set up 2-step verification the next time they sign in." :
+          "This forces the user to set up 2-step verification the next time they sign in."
       } %>
 
       <div class="govuk-button-group">
         <%= render "govuk_publishing_components/components/button", {
-          text: "Mandate 2-step verification",
+          text: "Turn on 2-step verification",
           destructive: @user.exempt_from_2sv?,
         } %>
         <%= link_to "Cancel", edit_user_path(@user), class: "govuk-link govuk-link--no-visited-state" %>

--- a/app/views/users/two_step_verification_mandations/edit.html.erb
+++ b/app/views/users/two_step_verification_mandations/edit.html.erb
@@ -1,0 +1,60 @@
+<% content_for :title_caption, "Manage other users" %>
+<% content_for :title, "Mandate 2-step verification for #{@user.name}" %>
+
+<% content_for :breadcrumbs,
+   render("govuk_publishing_components/components/breadcrumbs", {
+     collapse_on_mobile: true,
+     breadcrumbs: [
+       {
+         title: "Dashboard",
+         url: root_path,
+       },
+       {
+         title: "Users",
+         url: users_path,
+       },
+       {
+         title: @user.name,
+         url: edit_user_path(@user),
+       },
+       {
+         title: "Mandate 2-step verification",
+       }
+     ]
+   })
+%>
+
+<% if @user.errors.count > 0 %>
+  <% content_for :error_summary do %>
+    <%= render "govuk_publishing_components/components/error_summary", {
+      title: "There is a problem",
+      items: @user.errors.map do |error|
+        {
+          text: error.full_message,
+          href: "#user_#{error.attribute}",
+        }
+      end,
+    } %>
+  <% end %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @user, url: user_two_step_verification_mandation_path(@user) do |f| %>
+      <%= render "govuk_publishing_components/components/hint", {
+        text: [
+          "Mandate 2-step verification for this user#{@user.exempt_from_2sv? ? ' (this will remove their exemption)' : nil}.",
+          "They will be prompted to set up 2-step verification again the next time they sign in.",
+        ].join(" ")
+      } %>
+
+      <div class="govuk-button-group">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Mandate 2-step verification",
+          destructive: @user.exempt_from_2sv?,
+        } %>
+        <%= link_to "Cancel", edit_user_path(@user), class: "govuk-link govuk-link--no-visited-state" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,6 +50,7 @@ Rails.application.routes.draw do
     resource :role, only: %i[edit update], controller: "users/roles"
     resource :organisation, only: %i[edit update], controller: "users/organisations"
     resource :two_step_verification_reset, only: %i[edit update], controller: "users/two_step_verification_resets"
+    resource :two_step_verification_mandation, only: %i[edit update], controller: "users/two_step_verification_mandations"
   end
   get "user", to: "oauth_users#show"
 

--- a/test/controllers/users/two_step_verification_mandations_controller_test.rb
+++ b/test/controllers/users/two_step_verification_mandations_controller_test.rb
@@ -18,7 +18,7 @@ class Users::TwoStepVerificationMandationsControllerTest < ActionController::Tes
 
         assert_template :edit
         assert_select "form[action='#{user_two_step_verification_mandation_path(user)}']" do
-          assert_select "button[type='submit']", text: "Mandate 2-step verification"
+          assert_select "button[type='submit']", text: "Turn on 2-step verification"
           assert_select "a[href='#{edit_user_path(user)}']", text: "Cancel"
         end
       end

--- a/test/controllers/users/two_step_verification_mandations_controller_test.rb
+++ b/test/controllers/users/two_step_verification_mandations_controller_test.rb
@@ -1,0 +1,201 @@
+require "test_helper"
+
+class Users::TwoStepVerificationMandationsControllerTest < ActionController::TestCase
+  include ActiveJob::TestHelper
+  include ActionMailer::TestHelper
+
+  context "GET edit" do
+    context "signed in as Admin user" do
+      setup do
+        @admin = create(:admin_user)
+        sign_in(@admin)
+      end
+
+      should "display form with submit button & cancel link" do
+        user = create(:user)
+
+        get :edit, params: { user_id: user }
+
+        assert_template :edit
+        assert_select "form[action='#{user_two_step_verification_mandation_path(user)}']" do
+          assert_select "button[type='submit']", text: "Mandate 2-step verification"
+          assert_select "a[href='#{edit_user_path(user)}']", text: "Cancel"
+        end
+      end
+
+      should "authorize access if UserPolicy#mandate_2sv? returns true" do
+        user = create(:user, require_2sv: false)
+
+        user_policy = stub_everything("user-policy", mandate_2sv?: true)
+        UserPolicy.stubs(:new).returns(user_policy)
+
+        get :edit, params: { user_id: user }
+
+        assert_template :edit
+      end
+
+      should "not authorize access if UserPolicy#mandate_2sv? returns false" do
+        user = create(:user, require_2sv: false)
+
+        user_policy = stub_everything("user-policy", mandate_2sv?: false)
+        UserPolicy.stubs(:new).returns(user_policy)
+
+        get :edit, params: { user_id: user }
+
+        assert_not_authorised
+      end
+    end
+
+    context "signed in as Normal user" do
+      setup do
+        sign_in(create(:user))
+      end
+
+      should "not be authorized" do
+        user = create(:user)
+
+        get :edit, params: { user_id: user }
+
+        assert_not_authorised
+      end
+    end
+
+    context "not signed in" do
+      should "not be allowed access" do
+        user = create(:user)
+
+        get :edit, params: { user_id: user }
+
+        assert_not_authenticated
+      end
+    end
+  end
+
+  context "PUT update" do
+    context "signed in as Admin user" do
+      setup do
+        @admin = create(:admin_user)
+        sign_in(@admin)
+      end
+
+      should "mandate 2SV for user" do
+        user = create(:user, require_2sv: false)
+
+        put :update, params: { user_id: user, user: { require_2sv: true } }
+
+        assert user.reload.require_2sv?
+      end
+
+      should "record account updated & 2SV mandated events" do
+        user = create(:user, require_2sv: false)
+
+        @controller.stubs(:user_ip_address).returns("1.1.1.1")
+
+        EventLog.expects(:record_event).with(
+          user,
+          EventLog::ACCOUNT_UPDATED,
+          initiator: @admin,
+          ip_address: "1.1.1.1",
+        )
+
+        EventLog.expects(:record_event).with(
+          user,
+          EventLog::TWO_STEP_MANDATED,
+          initiator: @admin,
+          ip_address: "1.1.1.1",
+        )
+
+        put :update, params: { user_id: user, user: { require_2sv: true } }
+      end
+
+      should "should send email notifying user that 2SV has been mandated" do
+        user = create(:user, require_2sv: false)
+
+        perform_enqueued_jobs do
+          put :update, params: { user_id: user, user: { require_2sv: true } }
+        end
+
+        email = ActionMailer::Base.deliveries.last
+        assert email.present?
+        assert_equal "Make your Signon account more secure", email.subject
+      end
+
+      should "push changes out to apps" do
+        user = create(:user, require_2sv: false)
+        PermissionUpdater.expects(:perform_on).with(user).once
+
+        put :update, params: { user_id: user, user: { require_2sv: true } }
+      end
+
+      should "redirect to user page and display success notice" do
+        user = create(:user, require_2sv: false, email: "user@gov.uk")
+
+        put :update, params: { user_id: user, user: { require_2sv: true } }
+
+        assert_redirected_to edit_user_path(user)
+        assert_equal "Updated user user@gov.uk successfully", flash[:notice]
+      end
+
+      should "mandate 2SV for user if UserPolicy#mandate_2sv? returns true" do
+        user = create(:user, require_2sv: false)
+
+        user_policy = stub_everything("user-policy", mandate_2sv?: true)
+        UserPolicy.stubs(:new).returns(user_policy)
+
+        put :update, params: { user_id: user, user: { require_2sv: true } }
+
+        assert user.reload.require_2sv?
+      end
+
+      should "not mandate 2SV for user if UserPolicy#mandate_2sv? returns false" do
+        user = create(:user, require_2sv: false)
+
+        user_policy = stub_everything("user-policy", mandate_2sv?: false)
+        UserPolicy.stubs(:new).returns(user_policy)
+
+        put :update, params: { user_id: user, user: { require_2sv: true } }
+
+        assert_not user.reload.require_2sv?
+        assert_not_authorised
+      end
+
+      should "display errors if user is not valid" do
+        user = User.new(id: 123)
+        user.errors.add(:require_2sv, "is not valid")
+
+        User.stubs(:find).returns(user)
+        UserUpdate.stubs(:new).returns(stub("user-update", call: false))
+
+        put :update, params: { user_id: user, user: { require_2sv: true } }
+
+        assert_select ".govuk-error-summary" do
+          assert_select "a", href: "#user_require_2sv", text: "Require 2sv is not valid"
+        end
+      end
+    end
+
+    context "signed in as Normal user" do
+      setup do
+        sign_in(create(:user))
+      end
+
+      should "not be authorized" do
+        user = create(:user)
+
+        put :update, params: { user_id: user }
+
+        assert_not_authorised
+      end
+    end
+
+    context "not signed in" do
+      should "not be allowed access" do
+        user = create(:user)
+
+        put :update, params: { user_id: user }
+
+        assert_not_authenticated
+      end
+    end
+  end
+end

--- a/test/integration/managing_two_step_verification_test.rb
+++ b/test/integration/managing_two_step_verification_test.rb
@@ -27,10 +27,6 @@ class ManagingTwoStepVerificationTest < ActionDispatch::IntegrationTest
         admin_can_send_2sv_email(@super_admin, @user)
       end
 
-      should "be able to unset the requirement for 2SV" do
-        admin_can_remove_2sv_requirement_without_notifying_user(@super_admin, @user)
-      end
-
       should "remove the user's exemption reason when 2SV is mandated" do
         user = create(:two_step_exempted_user)
 
@@ -63,10 +59,6 @@ class ManagingTwoStepVerificationTest < ActionDispatch::IntegrationTest
         admin_can_send_2sv_email(@admin, @user)
       end
 
-      should "be able to unset the requirement for 2SV" do
-        admin_can_remove_2sv_requirement_without_notifying_user(@admin, @user)
-      end
-
       should "reset 2-step verification and notify the chosen user by email for users in any organisation" do
         admin_can_reset_2sv_on_user(@admin, @user_requring_2sv)
       end
@@ -81,16 +73,8 @@ class ManagingTwoStepVerificationTest < ActionDispatch::IntegrationTest
         admin_can_send_2sv_email(@super_org_admin, @user)
       end
 
-      should "be able to unset the requirement for 2SV" do
-        admin_can_remove_2sv_requirement_without_notifying_user(@super_org_admin, @user)
-      end
-
       should "be able to send a notification to a user in a child organisation to set up 2SV" do
         admin_can_send_2sv_email(@super_org_admin, @user_in_child_organisation)
-      end
-
-      should "be able to unset the requirement for 2SV for a user in a child organisation" do
-        admin_can_remove_2sv_requirement_without_notifying_user(@super_org_admin, @user_in_child_organisation)
       end
 
       should "be able to reset 2-step verification and notify the chosen user by email if they belong to the same org as the user" do
@@ -113,10 +97,6 @@ class ManagingTwoStepVerificationTest < ActionDispatch::IntegrationTest
 
       should "be able to send a notification to a user to set up 2SV" do
         admin_can_send_2sv_email(@org_admin, @user)
-      end
-
-      should "be able to unset the requirement for 2SV" do
-        admin_can_remove_2sv_requirement_without_notifying_user(@org_admin, @user)
       end
 
       should "be able to reset 2-step verification and notify the chosen user by email if they belong to the same org as the user" do

--- a/test/integration/managing_two_step_verification_test.rb
+++ b/test/integration/managing_two_step_verification_test.rb
@@ -132,7 +132,7 @@ class ManagingTwoStepVerificationTest < ActionDispatch::IntegrationTest
         sign_in_as_and_edit_user(@org_admin, user)
 
         assert page.has_text? "2-step verification enabled"
-        assert page.has_no_text? "Mandate 2-step verification for this user"
+        assert page.has_no_text? "Change 2-step verification requirement for this user"
       end
 
       should "be able to see an appropriate message reflecting the user's 2sv status when 2sv set up" do

--- a/test/support/managing_two_sv_helpers.rb
+++ b/test/support/managing_two_sv_helpers.rb
@@ -53,8 +53,6 @@ module ManagingTwoSvHelpers
   end
 
   def admin_can_reset_2sv_on_user(logged_in_as, user_to_be_reset)
-    use_javascript_driver
-
     visit edit_user_path(user_to_be_reset)
     signin_with(logged_in_as)
 
@@ -72,8 +70,6 @@ module ManagingTwoSvHelpers
   end
 
   def user_cannot_reset_2sv(logged_in_as, user_to_be_reset)
-    use_javascript_driver
-
     visit edit_user_path(user_to_be_reset)
     signin_with(logged_in_as)
 

--- a/test/support/managing_two_sv_helpers.rb
+++ b/test/support/managing_two_sv_helpers.rb
@@ -19,8 +19,8 @@ module ManagingTwoSvHelpers
   end
 
   def mandate_2sv_for_exempted_user
-    check "Mandate 2-step verification for this user (this will remove their exemption)"
-    click_button "Update User"
+    click_link "Mandate 2-step verification for this user (this will remove their exemption)"
+    click_button "Mandate 2-step verification"
   end
 
   def admin_can_send_2sv_email(admin, user)
@@ -29,8 +29,8 @@ module ManagingTwoSvHelpers
     assert page.has_text? "2-step verification not set up"
 
     perform_enqueued_jobs do
-      check "Mandate 2-step verification for this user"
-      click_button "Update User"
+      click_link "Mandate 2-step verification for this user"
+      click_button "Mandate 2-step verification"
 
       assert last_email
       assert_equal "Make your Signon account more secure", last_email.subject

--- a/test/support/managing_two_sv_helpers.rb
+++ b/test/support/managing_two_sv_helpers.rb
@@ -39,19 +39,6 @@ module ManagingTwoSvHelpers
     assert user.reload.require_2sv
   end
 
-  def admin_can_remove_2sv_requirement_without_notifying_user(admin, user)
-    sign_in_as_and_edit_user(admin, user)
-
-    perform_enqueued_jobs do
-      uncheck "Mandate 2-step verification for this user"
-      click_button "Update User"
-
-      assert_not last_email
-    end
-
-    assert_not user.reload.require_2sv
-  end
-
   def admin_can_reset_2sv_on_user(logged_in_as, user_to_be_reset)
     visit edit_user_path(user_to_be_reset)
     signin_with(logged_in_as)

--- a/test/support/managing_two_sv_helpers.rb
+++ b/test/support/managing_two_sv_helpers.rb
@@ -20,7 +20,7 @@ module ManagingTwoSvHelpers
 
   def mandate_2sv_for_exempted_user
     click_link "Mandate 2-step verification for this user (this will remove their exemption)"
-    click_button "Mandate 2-step verification"
+    click_button "Turn on 2-step verification"
   end
 
   def admin_can_send_2sv_email(admin, user)
@@ -30,7 +30,7 @@ module ManagingTwoSvHelpers
 
     perform_enqueued_jobs do
       click_link "Mandate 2-step verification for this user"
-      click_button "Mandate 2-step verification"
+      click_button "Turn on 2-step verification"
 
       assert last_email
       assert_equal "Make your Signon account more secure", last_email.subject


### PR DESCRIPTION
Trello: https://trello.com/c/uZD2I9dj & https://trello.com/c/caETStGa

This splits out mandating 2SV for another user into a separate page. The latest design calls for the splitting out of a bunch of user operations into separate pages like this. The new "mandate 2SV" page uses the GOV.UK Design System, but the "edit user" page still does not. c.f. https://github.com/alphagov/signon/pull/2497, https://github.com/alphagov/signon/pull/2509, https://github.com/alphagov/signon/pull/2537 & https://github.com/alphagov/signon/pull/2545.

Previously this functionality was implemented via a checkbox on the "edit user" page. This checkbox was only displayed when 2SV was not already mandated for the user either via an organisation mandate or an individual mandate, i.e. when `User#require_2sv?` was `false`. I've implemented the new page as just a button (no checkbox), because we only ever need to set `User#require_2sv` to `true`. If the user has a 2SV exemption, then some additional text is displayed in both the link and the form to explain that the exemption will be removed. Also in this case the `destructive` option on the button is set to `true` to highlight that the exemption data will be lost.

### Notes
* `User#require_2sv` can be set to `false` by adding a 2SV exemption for the user.
* For similar reasons as in this PR, we can probably get rid of the checkbox on the `UsersController#require_2sv` page which is part of the inviting a new user workflow.
* We can probably remove some duplication by combining `UsersController#require_2sv` page with the page in this PR (i.e. `Users::TwoStepVerificationMandations#edit`), but there were enough differences that I decided it was out-of-scope in this PR.

### New "Mandate 2SV" link on "edit user" page
<img width="744" alt="Screenshot 2023-11-26 at 18 37 55" src="https://github.com/alphagov/signon/assets/3169/ee594a7e-daa4-4807-be2b-f7d6b1d3cad6">

### New "mandate 2SV" page
<img width="795" alt="Screenshot 2023-11-26 at 18 38 11" src="https://github.com/alphagov/signon/assets/3169/1856670f-8c21-47fb-bd9a-593e7b03ba65">

### New "Mandate 2SV" link on "edit user" page (when user has 2SV exemption)
<img width="734" alt="Screenshot 2023-11-26 at 18 34 48" src="https://github.com/alphagov/signon/assets/3169/4803dd6b-0ffd-45c9-93c7-d1290555f7bf">

### New "mandate 2SV" page (when user has 2SV exemption)
<img width="738" alt="Screenshot 2023-11-26 at 18 35 01" src="https://github.com/alphagov/signon/assets/3169/491c6b71-9f93-4cf6-9f95-c084d2cabc40">

