### PR TITLE
Email copy updates

### DIFF
--- a/app/views/user_mailer/invitation_instructions.text.erb
+++ b/app/views/user_mailer/invitation_instructions.text.erb
@@ -1,9 +1,7 @@
-Someone has invited you to <%= t('department.name') %> Signon, you can accept it through the link below.
+Your GOV.UK Signon account is ready.
 
-<%= accept_invitation_url(@user, invitation_token: @token) %>
+[Set your password to finish creating your account](<%= accept_invitation_url(@user, invitation_token: @token) %>) and get access to GOV.UK publishing apps.
 
-If you don't want to accept the invitation, please ignore this email.
+This link will expire in 2 weeks.
 
-Your account won't be created until you access the link above and set your password.
-
-If you do not access the link within two weeks, it will expire.
+Ignore this email if you no longer need a Signon account to publish or view data about GOV.UK content.

--- a/app/views/user_mailer/reset_password_instructions.text.erb
+++ b/app/views/user_mailer/reset_password_instructions.text.erb
@@ -1,9 +1,7 @@
-Someone has requested a link to change your password. You can do this through the link below.
+Someone has asked to reset your Signon password.
 
-<%= edit_password_url(@user, :reset_password_token => @token) %>
+[Reset your password.](<%= edit_password_url(@user, :reset_password_token => @token) %>)
 
-If you didn't request this, please ignore this email.
+This link will expire in 6 hours. You can only use it once.
 
-Your password won't change until you access the link above and create a new one.
-
-The link will be valid for 6 hours and will only work once.
+If you did not ask to reset your password, you can ignore this email.You can sign in using your current password.

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -55,7 +55,7 @@ en:
       confirmation_instructions:
         subject: 'Confirm your email change'
       reset_password_instructions:
-        subject: 'Reset password instructions'
+        subject: 'Reset password for GOV.UK publishing account'
       unlock_instructions:
         subject: 'Your %{app_name} account has been locked'
     links:

--- a/config/locales/devise_invitable.en.yml
+++ b/config/locales/devise_invitable.en.yml
@@ -7,4 +7,4 @@ en:
       no_invitations_remaining: "No invitations remaining"
     mailer:
       invitation_instructions:
-        subject: 'Please confirm your account'
+        subject: 'Set up your GOV.UK publishing account'

--- a/test/integration/batch_inviting_users_test.rb
+++ b/test/integration/batch_inviting_users_test.rb
@@ -147,7 +147,7 @@ class BatchInvitingUsersTest < ActionDispatch::IntegrationTest
     assert_equal "noreply-signon-development@digital.cabinet-office.gov.uk", invite_email.from[0]
     assert_nil invite_email.reply_to
 
-    assert_match "Please confirm your account", invite_email.subject
+    assert_match I18n.t("devise.mailer.invitation_instructions.subject"), invite_email.subject
   end
 
   def assert_user_not_created(email)

--- a/test/integration/email_change_test.rb
+++ b/test/integration/email_change_test.rb
@@ -54,13 +54,13 @@ class EmailChangeTest < ActionDispatch::IntegrationTest
           user = User.invite!(name: "Jim", email: "jim@web.com")
 
           open_email("jim@web.com")
-          assert_equal "Please confirm your account", current_email.subject
+          assert_equal I18n.t("devise.mailer.invitation_instructions.subject"), current_email.subject
 
           visit new_user_session_path
           signin_with(@admin)
           admin_changes_email_address(user:, new_email: "new@email.com")
 
-          email = emails_sent_to("new@email.com").detect { |mail| mail.subject == "Please confirm your account" }
+          email = emails_sent_to("new@email.com").detect { |mail| mail.subject == I18n.t("devise.mailer.invitation_instructions.subject") }
           assert email
           assert email.body.include?("/users/invitation/accept?invitation_token=")
           assert user.accept_invitation!

--- a/test/integration/inviting_users_test.rb
+++ b/test/integration/inviting_users_test.rb
@@ -68,7 +68,7 @@ class InvitingUsersTest < ActionDispatch::IntegrationTest
           click_button "Create user and send email"
 
           assert_equal "fred@example.com", last_email.to[0]
-          assert_match "Please confirm your account", last_email.subject
+          assert_match I18n.t("devise.mailer.invitation_instructions.subject"), last_email.subject
 
           assert has_field?("Mandate 2-step verification for this user")
           check "Mandate 2-step verification for this user"
@@ -94,7 +94,7 @@ class InvitingUsersTest < ActionDispatch::IntegrationTest
 
           assert_not_nil User.where(email: "fred@example.com", role: "normal").last
           assert_equal "fred@example.com", last_email.to[0]
-          assert_match "Please confirm your account", last_email.subject
+          assert_match I18n.t("devise.mailer.invitation_instructions.subject"), last_email.subject
           assert_equal false, User.where(email: "fred@example.com", role: "normal").last.require_2sv?
         end
       end
@@ -114,7 +114,7 @@ class InvitingUsersTest < ActionDispatch::IntegrationTest
 
             assert_not_nil User.where(email: "fred@example.com", role: "normal").last
             assert_equal "fred@example.com", last_email.to[0]
-            assert_match "Please confirm your account", last_email.subject
+            assert_match I18n.t("devise.mailer.invitation_instructions.subject"), last_email.subject
             assert User.where(email: "fred@example.com", role: "normal").last.require_2sv?
           end
         end
@@ -136,7 +136,7 @@ class InvitingUsersTest < ActionDispatch::IntegrationTest
         click_button "Resend signup email"
 
         assert page.has_content?("Resent account signup email")
-        emails_received = all_emails.count { |email| email.subject == "Please confirm your account" }
+        emails_received = all_emails.count { |email| email.subject == I18n.t("devise.mailer.invitation_instructions.subject") }
         assert_equal 2, emails_received
       end
     end
@@ -219,7 +219,7 @@ class InvitingUsersTest < ActionDispatch::IntegrationTest
           click_button "Create user and send email"
 
           assert_equal "fred_admin@example.com", last_email.to[0]
-          assert_match "Please confirm your account", last_email.subject
+          assert_match I18n.t("devise.mailer.invitation_instructions.subject"), last_email.subject
 
           assert has_field?("Mandate 2-step verification for this user")
           check "Mandate 2-step verification for this user"
@@ -252,7 +252,7 @@ class InvitingUsersTest < ActionDispatch::IntegrationTest
 
           assert_not_nil User.where(email: "fred@example.com", role: Roles::Superadmin.role_name).last
           assert_equal "fred@example.com", last_email.to[0]
-          assert_match "Please confirm your account", last_email.subject
+          assert_match I18n.t("devise.mailer.invitation_instructions.subject"), last_email.subject
           assert User.where(email: "fred@example.com", role: Roles::Superadmin.role_name).last.require_2sv?
         end
       end
@@ -268,7 +268,7 @@ class InvitingUsersTest < ActionDispatch::IntegrationTest
 
           assert_not_nil User.where(email: "fred@example.com", role: Roles::Admin.role_name).last
           assert_equal "fred@example.com", last_email.to[0]
-          assert_match "Please confirm your account", last_email.subject
+          assert_match I18n.t("devise.mailer.invitation_instructions.subject"), last_email.subject
           assert User.where(email: "fred@example.com", role: Roles::Admin.role_name).last.require_2sv?
         end
       end
@@ -290,7 +290,7 @@ class InvitingUsersTest < ActionDispatch::IntegrationTest
 
           assert_not_nil User.where(email: "fred@example.com", role: Roles::Superadmin.role_name).last
           assert_equal "fred@example.com", last_email.to[0]
-          assert_match "Please confirm your account", last_email.subject
+          assert_match I18n.t("devise.mailer.invitation_instructions.subject"), last_email.subject
           assert User.where(email: "fred@example.com", role: Roles::Superadmin.role_name).last.require_2sv?
         end
       end
@@ -306,7 +306,7 @@ class InvitingUsersTest < ActionDispatch::IntegrationTest
 
           assert_not_nil User.where(email: "fred@example.com", role: Roles::Admin.role_name).last
           assert_equal "fred@example.com", last_email.to[0]
-          assert_match "Please confirm your account", last_email.subject
+          assert_match I18n.t("devise.mailer.invitation_instructions.subject"), last_email.subject
           assert User.where(email: "fred@example.com", role: Roles::Admin.role_name).last.require_2sv?
         end
       end

--- a/test/integration/password_reset_test.rb
+++ b/test/integration/password_reset_test.rb
@@ -17,7 +17,7 @@ class PasswordResetTest < ActionDispatch::IntegrationTest
 
       open_email(user.email)
       assert current_email
-      assert_equal "Reset password instructions", current_email.subject
+      assert_equal I18n.t("devise.mailer.reset_password_instructions.subject"), current_email.subject
 
       complete_password_reset(current_email, new_password:)
       assert_response_contains("Your password was changed successfully")
@@ -67,7 +67,7 @@ class PasswordResetTest < ActionDispatch::IntegrationTest
 
       open_email(user.email)
       assert current_email
-      assert_equal "Reset password instructions", current_email.subject
+      assert_equal I18n.t("devise.mailer.reset_password_instructions.subject"), current_email.subject
 
       complete_password_reset(current_email, new_password:)
       assert_response_contains("Your password was changed successfully")
@@ -94,10 +94,10 @@ class PasswordResetTest < ActionDispatch::IntegrationTest
 
       open_email(user.email)
       assert current_email
-      assert_equal "Reset password instructions", current_email.subject
+      assert_equal I18n.t("devise.mailer.reset_password_instructions.subject"), current_email.subject
 
       # simulate something following the link in the email.
-      current_email.find_link(href: false).click
+      visit_password_reset_url_in(current_email)
 
       complete_password_reset(current_email, new_password:)
       assert_response_contains("Your password was changed successfully")
@@ -111,7 +111,7 @@ class PasswordResetTest < ActionDispatch::IntegrationTest
 
       open_email(user.email)
 
-      current_email.find_link(href: false).click
+      visit_password_reset_url_in(current_email)
       fill_in "New password", with: "A Password"
       fill_in "Confirm new password", with: "Not That Password"
       click_button "Save password"

--- a/test/models/batch_invitation_test.rb
+++ b/test/models/batch_invitation_test.rb
@@ -109,7 +109,7 @@ class BatchInvitationTest < ActiveSupport::TestCase
 
         email = ActionMailer::Base.deliveries.last
         assert_not_nil email
-        assert_equal "Please confirm your account", email.subject
+        assert_equal I18n.t("devise.mailer.invitation_instructions.subject"), email.subject
         assert_equal ["b@m.com"], email.to
       end
     end

--- a/test/support/password_helpers.rb
+++ b/test/support/password_helpers.rb
@@ -16,9 +16,14 @@ module PasswordHelpers
   end
 
   def complete_password_reset(email, options)
-    email.find_link(href: false).click
+    visit_password_reset_url_in(email)
     fill_in "New password", with: options[:new_password]
     fill_in "Confirm new password", with: options[:new_password]
     click_button "Save password"
+  end
+
+  def visit_password_reset_url_in(email)
+    reset_password_url = /\[Reset your password\.\]\((?<url>http.*)\)/.match(email.body).named_captures["url"]
+    visit reset_password_url
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/uENLLz5k

Copy and accessibility improvements to new account and password reset emails. 

# New "password reset" email 
<img width="1168" alt="Screenshot 2023-11-27 at 16 09 13" src="https://github.com/alphagov/signon/assets/16707/d9d6cc59-3f3b-4a71-9fed-14998744f263">

# New "Set up your account" email
<img width="1168" alt="Screenshot 2023-11-27 at 16 05 29" src="https://github.com/alphagov/signon/assets/16707/cb8807fa-6677-4000-a4f8-12a32077d6dc">
