### PR TITLE
Fix breadcrumbs for pages shared with API users

### DIFF
--- a/app/views/suspensions/edit.html.erb
+++ b/app/views/suspensions/edit.html.erb
@@ -8,8 +8,8 @@
          url: root_path,
        },
        {
-         title: "Users",
-         url: users_path,
+         title: @user.api_user? ? "API users" : "Users",
+         url: @user.api_user? ? api_users_path : users_path,
        },
        {
          title: @user.name,

--- a/app/views/users/event_logs.html.erb
+++ b/app/views/users/event_logs.html.erb
@@ -8,8 +8,8 @@
          url: root_path,
        },
        {
-         title: "Users",
-         url: users_path,
+         title: @user.api_user? ? "API users" : "Users",
+         url: @user.api_user? ? api_users_path : users_path,
        },
        {
          title: @user.name,


### PR DESCRIPTION
The "access log" and "suspend/unsuspend user" pages are linked to from both the "edit user" page *AND* the "edit API user" page and so we should take that into account in the breadcrumb links to avoid confusing the user.

### New "access log" page
<img width="746" alt="Screenshot 2023-12-04 at 17 03 27" src="https://github.com/alphagov/signon/assets/3169/7cf2ad62-9276-4b43-966a-efb479fd7864">

### New "suspend/unsuspend user" page
<img width="618" alt="Screenshot 2023-12-04 at 17 03 53" src="https://github.com/alphagov/signon/assets/3169/8fbdc0e2-8761-4a66-bb7c-9462e8465ece">
