### PR TITLE
Fix style of action links on "edit user" page

### DIFF
--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -146,41 +146,41 @@ module UsersHelper
   end
 
   def link_to_access_log(user)
-    link_to "View account access log", event_logs_user_path(user)
+    link_to "View account access log", event_logs_user_path(user), class: "govuk-link"
   end
 
   def link_to_suspension(user)
     return unless policy(user).suspension?
 
-    link_to user.suspended? ? "Unsuspend user" : "Suspend user", edit_suspension_path(user)
+    link_to user.suspended? ? "Unsuspend user" : "Suspend user", edit_suspension_path(user), class: "govuk-link"
   end
 
   def link_to_resend_invitation(user)
     return unless policy(user).resend_invitation?
     return unless user.invited_but_not_yet_accepted?
 
-    link_to "Resend signup email", edit_user_invitation_resend_path(user)
+    link_to "Resend signup email", edit_user_invitation_resend_path(user), class: "govuk-link"
   end
 
   def link_to_unlock(user)
     return unless policy(user).unlock?
     return unless user.access_locked?
 
-    link_to "Unlock account", edit_user_unlocking_path(user)
+    link_to "Unlock account", edit_user_unlocking_path(user), class: "govuk-link"
   end
 
   def link_to_2sv_exemption(user)
     return unless policy(user).exempt_from_two_step_verification?
 
     text = user.exempt_from_2sv? ? "Edit 2-step verification exemption" : "Exempt user from 2-step verification"
-    link_to text, edit_two_step_verification_exemption_path(user)
+    link_to text, edit_two_step_verification_exemption_path(user), class: "govuk-link"
   end
 
   def link_to_reset_2sv(user)
     return unless policy(user).reset_2sv?
     return unless user.has_2sv?
 
-    link_to "Reset 2-step verification", edit_user_two_step_verification_reset_path(user)
+    link_to "Reset 2-step verification", edit_user_two_step_verification_reset_path(user), class: "govuk-link"
   end
 
   def link_to_mandate_2sv(user)
@@ -189,6 +189,6 @@ module UsersHelper
 
     text = "Turn on 2-step verification for this user"
     text += " (this will remove their exemption)" if user.exempt_from_2sv?
-    link_to text, edit_user_two_step_verification_mandation_path(user)
+    link_to text, edit_user_two_step_verification_mandation_path(user), class: "govuk-link"
   end
 end


### PR DESCRIPTION
Add `govuk-link` CSS class to action links on edit user page, so the links are styled more consistently with the rest of the app.