### PR TITLE
Move `UpdateUser` methods into `after_update` callbacks on `User`

### DIFF
--- a/app/controllers/account/organisations_controller.rb
+++ b/app/controllers/account/organisations_controller.rb
@@ -10,7 +10,7 @@ class Account::OrganisationsController < ApplicationController
     organisation_id = params[:user][:organisation_id]
     organisation = Organisation.find(organisation_id)
 
-    if UserUpdate.new(current_user, { organisation_id: }, current_user, user_ip_address).call
+    if UserUpdate.new(current_user, { organisation_id: }).call
       redirect_to account_path, notice: "Your organisation is now #{organisation.name}"
     else
       flash[:alert] = "There was a problem changing your organisation."

--- a/app/controllers/account/passwords_controller.rb
+++ b/app/controllers/account/passwords_controller.rb
@@ -8,12 +8,12 @@ class Account::PasswordsController < ApplicationController
 
   def update
     if current_user.update_with_password(password_params)
-      EventLog.record_event(current_user, EventLog::SUCCESSFUL_PASSWORD_CHANGE, ip_address: user_ip_address)
+      EventLog.record_event(current_user, EventLog::SUCCESSFUL_PASSWORD_CHANGE, ip_address: true)
       flash[:notice] = t(:updated, scope: "devise.passwords")
       bypass_sign_in(current_user)
       redirect_to account_path
     else
-      EventLog.record_event(current_user, EventLog::UNSUCCESSFUL_PASSWORD_CHANGE, ip_address: user_ip_address)
+      EventLog.record_event(current_user, EventLog::UNSUCCESSFUL_PASSWORD_CHANGE, ip_address: true)
       render :edit
     end
   end

--- a/app/controllers/account/permissions_controller.rb
+++ b/app/controllers/account/permissions_controller.rb
@@ -20,7 +20,7 @@ class Account::PermissionsController < ApplicationController
   def update
     authorize [:account, @application], :edit_permissions?
 
-    UserUpdate.new(current_user, build_user_update_params, current_user, user_ip_address).call
+    UserUpdate.new(current_user, build_user_update_params).call
 
     flash[:application_id] = @application.id
     redirect_to account_applications_path

--- a/app/controllers/account/roles_controller.rb
+++ b/app/controllers/account/roles_controller.rb
@@ -9,7 +9,7 @@ class Account::RolesController < ApplicationController
   def update
     role = params[:user][:role]
 
-    if UserUpdate.new(current_user, { role: }, current_user, user_ip_address).call
+    if UserUpdate.new(current_user, { role: }).call
       redirect_to account_path, notice: "Your role is now #{role.humanize}"
     else
       flash[:alert] = "There was a problem changing your role."

--- a/app/controllers/account/signin_permissions_controller.rb
+++ b/app/controllers/account/signin_permissions_controller.rb
@@ -7,7 +7,7 @@ class Account::SigninPermissionsController < ApplicationController
     authorize [:account, Doorkeeper::Application], :grant_signin_permission?
 
     params = { supported_permission_ids: current_user.supported_permissions.map(&:id) + [application.signin_permission.id] }
-    UserUpdate.new(current_user, params, current_user, user_ip_address).call
+    UserUpdate.new(current_user, params).call
 
     redirect_to account_applications_path
   end
@@ -20,7 +20,7 @@ class Account::SigninPermissionsController < ApplicationController
     authorize [:account, application], :remove_signin_permission?
 
     params = { supported_permission_ids: current_user.supported_permissions.map(&:id) - [application.signin_permission.id] }
-    UserUpdate.new(current_user, params, current_user, user_ip_address).call
+    UserUpdate.new(current_user, params).call
 
     redirect_to account_applications_path
   end

--- a/app/controllers/api_users_controller.rb
+++ b/app/controllers/api_users_controller.rb
@@ -41,7 +41,6 @@ class ApiUsersController < ApplicationController
   def update
     if @api_user.update(api_user_params_for_update)
       @api_user.application_permissions.reload
-      PermissionUpdater.perform_on(@api_user)
 
       redirect_to api_users_path, notice: "Updated API user #{@api_user.email} successfully"
     else

--- a/app/controllers/api_users_controller.rb
+++ b/app/controllers/api_users_controller.rb
@@ -31,7 +31,7 @@ class ApiUsersController < ApplicationController
     @api_user = ApiUser.build(api_user_params_for_create)
 
     if @api_user.save
-      EventLog.record_event(@api_user, EventLog::API_USER_CREATED, initiator: current_user, ip_address: user_ip_address)
+      EventLog.record_event(@api_user, EventLog::API_USER_CREATED, initiator: current_user, ip_address: true)
       redirect_to edit_api_user_path(@api_user), notice: "Successfully created API user"
     else
       render :new

--- a/app/controllers/api_users_controller.rb
+++ b/app/controllers/api_users_controller.rb
@@ -31,7 +31,7 @@ class ApiUsersController < ApplicationController
     @api_user = ApiUser.build(api_user_params_for_create)
 
     if @api_user.save
-      EventLog.record_event(@api_user, EventLog::API_USER_CREATED, initiator: current_user, ip_address: true)
+      EventLog.record_event(@api_user, EventLog::API_USER_CREATED, initiator: true, ip_address: true)
       redirect_to edit_api_user_path(@api_user), notice: "Successfully created API user"
     else
       render :new

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,7 @@ class ApplicationController < ActionController::Base
 
   include TwoStepVerificationHelper
 
+  before_action :set_current_user_and_ip
   before_action :handle_two_step_verification
   after_action :verify_authorized, unless: :devise_controller?
 
@@ -29,6 +30,11 @@ class ApplicationController < ActionController::Base
   end
 
 private
+
+  def set_current_user_and_ip
+    Current.user = current_user
+    Current.user_ip = user_ip_address
+  end
 
   def user_ip_address
     request.remote_ip

--- a/app/controllers/authorisations_controller.rb
+++ b/app/controllers/authorisations_controller.rb
@@ -18,7 +18,7 @@ class AuthorisationsController < ApplicationController
 
     if authorisation.save
       @api_user.grant_application_signin_permission(authorisation.application)
-      EventLog.record_event(@api_user, EventLog::ACCESS_TOKEN_GENERATED, initiator: current_user, application: authorisation.application, ip_address: true)
+      EventLog.record_event(@api_user, EventLog::ACCESS_TOKEN_GENERATED, initiator: true, application: authorisation.application, ip_address: true)
       flash[:authorisation] = { application_name: authorisation.application.name, token: authorisation.token }
     else
       flash[:error] = "There was an error while creating the access token"
@@ -29,7 +29,7 @@ class AuthorisationsController < ApplicationController
   def revoke
     authorisation = @api_user.authorisations.find(params[:id])
     if authorisation.revoke
-      EventLog.record_event(@api_user, EventLog::ACCESS_TOKEN_REVOKED, initiator: current_user, application: authorisation.application, ip_address: true)
+      EventLog.record_event(@api_user, EventLog::ACCESS_TOKEN_REVOKED, initiator: true, application: authorisation.application, ip_address: true)
       flash[:notice] = "Access for #{authorisation.application.name} was revoked"
     else
       flash[:error] = "There was an error while revoking access for #{authorisation.application.name}"

--- a/app/controllers/authorisations_controller.rb
+++ b/app/controllers/authorisations_controller.rb
@@ -18,7 +18,7 @@ class AuthorisationsController < ApplicationController
 
     if authorisation.save
       @api_user.grant_application_signin_permission(authorisation.application)
-      EventLog.record_event(@api_user, EventLog::ACCESS_TOKEN_GENERATED, initiator: current_user, application: authorisation.application, ip_address: user_ip_address)
+      EventLog.record_event(@api_user, EventLog::ACCESS_TOKEN_GENERATED, initiator: current_user, application: authorisation.application, ip_address: true)
       flash[:authorisation] = { application_name: authorisation.application.name, token: authorisation.token }
     else
       flash[:error] = "There was an error while creating the access token"
@@ -29,7 +29,7 @@ class AuthorisationsController < ApplicationController
   def revoke
     authorisation = @api_user.authorisations.find(params[:id])
     if authorisation.revoke
-      EventLog.record_event(@api_user, EventLog::ACCESS_TOKEN_REVOKED, initiator: current_user, application: authorisation.application, ip_address: user_ip_address)
+      EventLog.record_event(@api_user, EventLog::ACCESS_TOKEN_REVOKED, initiator: current_user, application: authorisation.application, ip_address: true)
       flash[:notice] = "Access for #{authorisation.application.name} was revoked"
     else
       flash[:error] = "There was an error while revoking access for #{authorisation.application.name}"

--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -19,7 +19,7 @@ class ConfirmationsController < Devise::ConfirmationsController
       else
         self.resource = resource_class.confirm_by_token(params[:confirmation_token])
         if resource.errors.empty?
-          EventLog.record_event(resource, EventLog::EMAIL_CHANGE_CONFIRMED, ip_address: user_ip_address)
+          EventLog.record_event(resource, EventLog::EMAIL_CHANGE_CONFIRMED, ip_address: true)
           set_flash_message(:notice, :confirmed) if is_navigational_format?
           sign_in(resource_name, resource)
           respond_with_navigational(resource) { redirect_to after_confirmation_path_for(resource_name, resource) }
@@ -41,7 +41,7 @@ class ConfirmationsController < Devise::ConfirmationsController
     if resource.valid_password?(params[:user][:password])
       self.resource = resource_class.confirm_by_token(params[:confirmation_token])
       if resource.errors.empty?
-        EventLog.record_event(resource, EventLog::EMAIL_CHANGE_CONFIRMED, ip_address: user_ip_address)
+        EventLog.record_event(resource, EventLog::EMAIL_CHANGE_CONFIRMED, ip_address: true)
         set_flash_message(:notice, :confirmed) if is_navigational_format?
         sign_in(resource_name, resource)
         respond_with_navigational(resource) { redirect_to after_confirmation_path_for(resource_name, resource) }

--- a/app/controllers/devise/two_step_verification_controller.rb
+++ b/app/controllers/devise/two_step_verification_controller.rb
@@ -14,11 +14,11 @@ class Devise::TwoStepVerificationController < DeviseController
   def update
     mode = current_user.has_2sv? ? :change : :setup
     if verify_code_and_update
-      EventLog.record_event(current_user, success_event_for(mode), ip_address: user_ip_address)
+      EventLog.record_event(current_user, success_event_for(mode), ip_address: true)
       send_notification(current_user, mode)
       redirect_to_prior_flow_or_to account_path, notice: I18n.t("devise.two_step_verification.messages.success.#{mode}")
     else
-      EventLog.record_event(current_user, failure_event_for(mode), ip_address: user_ip_address)
+      EventLog.record_event(current_user, failure_event_for(mode), ip_address: true)
       flash.now[:invalid_code] = "Sorry that code didn’t work. Please try again."
       render :show, status: :unprocessable_entity
     end

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -26,7 +26,7 @@ class InvitationsController < Devise::InvitationsController
 
     self.resource = resource_class.invite!(all_params, current_inviter)
     if resource.errors.empty?
-      EventLog.record_account_invitation(resource, current_user)
+      EventLog.record_account_invitation(resource)
       set_flash_message :notice, :send_instructions, email: resource.email
       respond_with resource, location: after_invite_path_for(resource)
     else

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -27,24 +27,24 @@ private
 
   def record_password_reset_request
     user = User.find_by(email: params[:user][:email]) if params[:user].present?
-    EventLog.record_event(user, EventLog::PASSWORD_RESET_REQUEST, ip_address: user_ip_address) if user
+    EventLog.record_event(user, EventLog::PASSWORD_RESET_REQUEST, ip_address: true) if user
   end
 
   def record_reset_page_loaded
-    EventLog.record_event(user_from_params, EventLog::PASSWORD_RESET_LOADED, ip_address: user_ip_address) if user_from_params
+    EventLog.record_event(user_from_params, EventLog::PASSWORD_RESET_LOADED, ip_address: true) if user_from_params
   end
 
   def record_password_reset_success(user)
-    EventLog.record_event(user, EventLog::SUCCESSFUL_PASSWORD_RESET, ip_address: user_ip_address)
+    EventLog.record_event(user, EventLog::SUCCESSFUL_PASSWORD_RESET, ip_address: true)
   end
 
   def record_reset_page_loaded_token_expired
-    EventLog.record_event(user_from_params, EventLog::PASSWORD_RESET_LOADED_BUT_TOKEN_EXPIRED, ip_address: user_ip_address) if user_from_params
+    EventLog.record_event(user_from_params, EventLog::PASSWORD_RESET_LOADED_BUT_TOKEN_EXPIRED, ip_address: true) if user_from_params
   end
 
   def record_password_reset_failure(user)
     message = "(errors: #{user.errors.full_messages.join(', ')})".truncate(255)
-    EventLog.record_event(user, EventLog::PASSWORD_RESET_FAILURE, trailing_message: message, ip_address: user_ip_address)
+    EventLog.record_event(user, EventLog::PASSWORD_RESET_FAILURE, trailing_message: message, ip_address: true)
   end
 
   def user_from_params

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -26,7 +26,7 @@ private
       EventLog.record_event(
         current_user,
         EventLog::SUCCESSFUL_LOGIN,
-        ip_address: user_ip_address,
+        ip_address: true,
         user_agent_id: user_agent_record_id,
       )
     else
@@ -37,14 +37,14 @@ private
         EventLog.record_event(
           user,
           EventLog::UNSUCCESSFUL_LOGIN,
-          ip_address: user_ip_address,
+          ip_address: true,
           user_agent_string: user_agent,
         )
       else
         EventLog.record_event(
           nil,
           EventLog::NO_SUCH_ACCOUNT_LOGIN,
-          ip_address: user_ip_address,
+          ip_address: true,
           user_agent_string: user_agent,
           user_email_string: email,
         )

--- a/app/controllers/suspensions_controller.rb
+++ b/app/controllers/suspensions_controller.rb
@@ -12,8 +12,7 @@ class SuspensionsController < ApplicationController
   def update
     @suspension = Suspension.new(suspend: params[:user][:suspended] == "1",
                                  reason_for_suspension: params[:user][:reason_for_suspension],
-                                 user: @user,
-                                 initiator: current_user)
+                                 user: @user)
 
     if @suspension.save
       flash[:notice] = "#{@user.email} is now #{@user.suspended? ? 'suspended' : 'active'}."

--- a/app/controllers/suspensions_controller.rb
+++ b/app/controllers/suspensions_controller.rb
@@ -13,8 +13,7 @@ class SuspensionsController < ApplicationController
     @suspension = Suspension.new(suspend: params[:user][:suspended] == "1",
                                  reason_for_suspension: params[:user][:reason_for_suspension],
                                  user: @user,
-                                 initiator: current_user,
-                                 ip_address: user_ip_address)
+                                 initiator: current_user)
 
     if @suspension.save
       flash[:notice] = "#{@user.email} is now #{@user.suspended? ? 'suspended' : 'active'}."

--- a/app/controllers/users/emails_controller.rb
+++ b/app/controllers/users/emails_controller.rb
@@ -12,7 +12,7 @@ class Users::EmailsController < ApplicationController
   def edit; end
 
   def update
-    updater = UserUpdate.new(@user, user_params, current_user, user_ip_address)
+    updater = UserUpdate.new(@user, user_params)
     if updater.call
       redirect_to return_path, notice: "Updated user #{@user.email} successfully"
     else

--- a/app/controllers/users/invitation_resends_controller.rb
+++ b/app/controllers/users/invitation_resends_controller.rb
@@ -10,7 +10,7 @@ class Users::InvitationResendsController < ApplicationController
 
   def update
     @user.invite!(current_user)
-    EventLog.record_account_invitation(@user, current_user)
+    EventLog.record_account_invitation(@user)
     flash[:notice] = "Resent account signup email to #{@user.email}"
     redirect_to edit_user_path(@user)
   end

--- a/app/controllers/users/names_controller.rb
+++ b/app/controllers/users/names_controller.rb
@@ -12,7 +12,7 @@ class Users::NamesController < ApplicationController
   def edit; end
 
   def update
-    updater = UserUpdate.new(@user, user_params, current_user, user_ip_address)
+    updater = UserUpdate.new(@user, user_params)
     if updater.call
       redirect_to return_path, notice: "Updated user #{@user.email} successfully"
     else

--- a/app/controllers/users/organisations_controller.rb
+++ b/app/controllers/users/organisations_controller.rb
@@ -9,7 +9,7 @@ class Users::OrganisationsController < ApplicationController
   def edit; end
 
   def update
-    updater = UserUpdate.new(@user, user_params, current_user, user_ip_address)
+    updater = UserUpdate.new(@user, user_params)
     if updater.call
       redirect_to edit_user_path(@user), notice: "Updated user #{@user.email} successfully"
     else

--- a/app/controllers/users/permissions_controller.rb
+++ b/app/controllers/users/permissions_controller.rb
@@ -21,7 +21,7 @@ class Users::PermissionsController < ApplicationController
   def update
     authorize UserApplicationPermission.for(@user, @application)
 
-    UserUpdate.new(@user, build_user_update_params, current_user, user_ip_address).call
+    UserUpdate.new(@user, build_user_update_params).call
 
     flash[:application_id] = @application.id
     redirect_to user_applications_path(@user)

--- a/app/controllers/users/roles_controller.rb
+++ b/app/controllers/users/roles_controller.rb
@@ -9,7 +9,7 @@ class Users::RolesController < ApplicationController
   def edit; end
 
   def update
-    updater = UserUpdate.new(@user, user_params, current_user, user_ip_address)
+    updater = UserUpdate.new(@user, user_params)
     if updater.call
       redirect_to edit_user_path(@user), notice: "Updated user #{@user.email} successfully"
     else

--- a/app/controllers/users/signin_permissions_controller.rb
+++ b/app/controllers/users/signin_permissions_controller.rb
@@ -10,7 +10,7 @@ class Users::SigninPermissionsController < ApplicationController
     authorize UserApplicationPermission.for(@user, application)
 
     params = { supported_permission_ids: @user.supported_permissions.map(&:id) + [application.signin_permission.id] }
-    UserUpdate.new(@user, params, current_user, user_ip_address).call
+    UserUpdate.new(@user, params).call
 
     redirect_to user_applications_path(@user)
   end
@@ -23,7 +23,7 @@ class Users::SigninPermissionsController < ApplicationController
     authorize UserApplicationPermission.for(@user, @application)
 
     params = { supported_permission_ids: @user.supported_permissions.map(&:id) - [@application.signin_permission.id] }
-    UserUpdate.new(@user, params, current_user, user_ip_address).call
+    UserUpdate.new(@user, params).call
 
     redirect_to user_applications_path(@user)
   end

--- a/app/controllers/users/two_step_verification_mandations_controller.rb
+++ b/app/controllers/users/two_step_verification_mandations_controller.rb
@@ -9,7 +9,7 @@ class Users::TwoStepVerificationMandationsController < ApplicationController
 
   def update
     user_params = { require_2sv: true }
-    updater = UserUpdate.new(@user, user_params, current_user, user_ip_address)
+    updater = UserUpdate.new(@user, user_params)
     if updater.call
       redirect_to edit_user_path(@user), notice: "Updated user #{@user.email} successfully"
     else

--- a/app/controllers/users/two_step_verification_resets_controller.rb
+++ b/app/controllers/users/two_step_verification_resets_controller.rb
@@ -9,7 +9,7 @@ class Users::TwoStepVerificationResetsController < ApplicationController
   def edit; end
 
   def update
-    @user.reset_2sv!(current_user)
+    @user.reset_2sv!
     UserMailer.two_step_reset(@user).deliver_later
 
     redirect_to edit_user_path(@user), notice: "Reset 2-step verification for #{@user.email}"

--- a/app/controllers/users/unlockings_controller.rb
+++ b/app/controllers/users/unlockings_controller.rb
@@ -10,7 +10,7 @@ class Users::UnlockingsController < ApplicationController
 
   def update
     @user.unlock_access!
-    EventLog.record_event(@user, EventLog::MANUAL_ACCOUNT_UNLOCK, initiator: current_user, ip_address: user_ip_address)
+    EventLog.record_event(@user, EventLog::MANUAL_ACCOUNT_UNLOCK, initiator: current_user, ip_address: true)
     flash[:notice] = "Unlocked #{@user.email}"
     redirect_to edit_user_path(@user)
   end

--- a/app/controllers/users/unlockings_controller.rb
+++ b/app/controllers/users/unlockings_controller.rb
@@ -10,7 +10,7 @@ class Users::UnlockingsController < ApplicationController
 
   def update
     @user.unlock_access!
-    EventLog.record_event(@user, EventLog::MANUAL_ACCOUNT_UNLOCK, initiator: current_user, ip_address: true)
+    EventLog.record_event(@user, EventLog::MANUAL_ACCOUNT_UNLOCK, initiator: true, ip_address: true)
     flash[:notice] = "Unlocked #{@user.email}"
     redirect_to edit_user_path(@user)
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -33,7 +33,7 @@ class UsersController < ApplicationController
   def edit; end
 
   def update
-    UserUpdate.new(@user, user_params, current_user, user_ip_address).call
+    UserUpdate.new(@user, user_params).call
     redirect_to users_path, notice: "Updated user #{@user.email} successfully"
   end
 

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,0 +1,4 @@
+class Current < ActiveSupport::CurrentAttributes
+  attribute :user
+  attribute :user_ip
+end

--- a/app/models/event_log.rb
+++ b/app/models/event_log.rb
@@ -96,7 +96,8 @@ class EventLog < ApplicationRecord
     EventLog.create!(attributes)
   end
 
-  def self.record_email_change(user, email_was, email_is, initiator = user)
+  def self.record_email_change(user, email_was, email_is)
+    initiator = Current.user || user
     event = user == initiator ? EMAIL_CHANGE_INITIATED : EMAIL_CHANGED
     record_event(user, event, initiator:, trailing_message: "from #{email_was} to #{email_is}")
   end

--- a/app/models/event_log.rb
+++ b/app/models/event_log.rb
@@ -85,6 +85,9 @@ class EventLog < ApplicationRecord
   end
 
   def self.record_event(user, event, options = {})
+    if options[:initiator]
+      options[:initiator] = Current.user
+    end
     if options[:ip_address] && Current.user_ip
       options[:ip_address] = convert_ip_address_to_integer(Current.user_ip)
     end
@@ -97,21 +100,20 @@ class EventLog < ApplicationRecord
   end
 
   def self.record_email_change(user, email_was, email_is)
-    initiator = Current.user
-    event = user == initiator ? EMAIL_CHANGE_INITIATED : EMAIL_CHANGED
-    record_event(user, event, initiator:, trailing_message: "from #{email_was} to #{email_is}")
+    event = user == Current.user ? EMAIL_CHANGE_INITIATED : EMAIL_CHANGED
+    record_event(user, event, initiator: true, trailing_message: "from #{email_was} to #{email_is}")
   end
 
   def self.record_role_change(user, previous_role, new_role)
-    record_event(user, ROLE_CHANGED, initiator: Current.user, trailing_message: "from #{previous_role} to #{new_role}")
+    record_event(user, ROLE_CHANGED, initiator: true, trailing_message: "from #{previous_role} to #{new_role}")
   end
 
   def self.record_organisation_change(user, previous_organisation_name, new_organisation_name)
-    record_event(user, ORGANISATION_CHANGED, initiator: Current.user, trailing_message: "from #{previous_organisation_name} to #{new_organisation_name}")
+    record_event(user, ORGANISATION_CHANGED, initiator: true, trailing_message: "from #{previous_organisation_name} to #{new_organisation_name}")
   end
 
   def self.record_account_invitation(user)
-    record_event(user, ACCOUNT_INVITED, initiator: Current.user)
+    record_event(user, ACCOUNT_INVITED, initiator: true)
   end
 
   def self.for(user)

--- a/app/models/event_log.rb
+++ b/app/models/event_log.rb
@@ -106,8 +106,8 @@ class EventLog < ApplicationRecord
     record_event(user, ROLE_CHANGED, initiator: Current.user, trailing_message: "from #{previous_role} to #{new_role}")
   end
 
-  def self.record_organisation_change(user, previous_organisation, new_organisation, initiator)
-    record_event(user, ORGANISATION_CHANGED, initiator:, trailing_message: "from #{previous_organisation} to #{new_organisation}")
+  def self.record_organisation_change(user, previous_organisation_name, new_organisation_name, initiator)
+    record_event(user, ORGANISATION_CHANGED, initiator:, trailing_message: "from #{previous_organisation_name} to #{new_organisation_name}")
   end
 
   def self.record_account_invitation(user, initiator)

--- a/app/models/event_log.rb
+++ b/app/models/event_log.rb
@@ -110,8 +110,8 @@ class EventLog < ApplicationRecord
     record_event(user, ORGANISATION_CHANGED, initiator: Current.user, trailing_message: "from #{previous_organisation_name} to #{new_organisation_name}")
   end
 
-  def self.record_account_invitation(user, initiator)
-    record_event(user, ACCOUNT_INVITED, initiator:)
+  def self.record_account_invitation(user)
+    record_event(user, ACCOUNT_INVITED, initiator: Current.user)
   end
 
   def self.for(user)

--- a/app/models/event_log.rb
+++ b/app/models/event_log.rb
@@ -97,7 +97,7 @@ class EventLog < ApplicationRecord
   end
 
   def self.record_email_change(user, email_was, email_is)
-    initiator = Current.user || user
+    initiator = Current.user
     event = user == initiator ? EMAIL_CHANGE_INITIATED : EMAIL_CHANGED
     record_event(user, event, initiator:, trailing_message: "from #{email_was} to #{email_is}")
   end

--- a/app/models/event_log.rb
+++ b/app/models/event_log.rb
@@ -106,8 +106,8 @@ class EventLog < ApplicationRecord
     record_event(user, ROLE_CHANGED, initiator: Current.user, trailing_message: "from #{previous_role} to #{new_role}")
   end
 
-  def self.record_organisation_change(user, previous_organisation_name, new_organisation_name, initiator)
-    record_event(user, ORGANISATION_CHANGED, initiator:, trailing_message: "from #{previous_organisation_name} to #{new_organisation_name}")
+  def self.record_organisation_change(user, previous_organisation_name, new_organisation_name)
+    record_event(user, ORGANISATION_CHANGED, initiator: Current.user, trailing_message: "from #{previous_organisation_name} to #{new_organisation_name}")
   end
 
   def self.record_account_invitation(user, initiator)

--- a/app/models/event_log.rb
+++ b/app/models/event_log.rb
@@ -102,8 +102,8 @@ class EventLog < ApplicationRecord
     record_event(user, event, initiator:, trailing_message: "from #{email_was} to #{email_is}")
   end
 
-  def self.record_role_change(user, previous_role, new_role, initiator)
-    record_event(user, ROLE_CHANGED, initiator:, trailing_message: "from #{previous_role} to #{new_role}")
+  def self.record_role_change(user, previous_role, new_role)
+    record_event(user, ROLE_CHANGED, initiator: Current.user, trailing_message: "from #{previous_role} to #{new_role}")
   end
 
   def self.record_organisation_change(user, previous_organisation, new_organisation, initiator)

--- a/app/models/event_log.rb
+++ b/app/models/event_log.rb
@@ -85,8 +85,8 @@ class EventLog < ApplicationRecord
   end
 
   def self.record_event(user, event, options = {})
-    if options[:ip_address]
-      options[:ip_address] = convert_ip_address_to_integer(options[:ip_address])
+    if options[:ip_address] && Current.user_ip
+      options[:ip_address] = convert_ip_address_to_integer(Current.user_ip)
     end
     attributes = {
       uid: user&.uid,

--- a/app/models/suspension.rb
+++ b/app/models/suspension.rb
@@ -2,14 +2,13 @@ class Suspension
   include ActiveModel::Validations
   validates :reason_for_suspension, presence: true, if: :suspend
 
-  attr_reader :suspend, :reason_for_suspension, :user, :initiator, :ip_address
+  attr_reader :suspend, :reason_for_suspension, :user, :initiator
 
-  def initialize(suspend: nil, reason_for_suspension: nil, user: nil, initiator: nil, ip_address: nil)
+  def initialize(suspend: nil, reason_for_suspension: nil, user: nil, initiator: nil)
     @suspend = suspend
     @reason_for_suspension = reason_for_suspension
     @user = user
     @initiator = initiator
-    @ip_address = ip_address
   end
 
   def save
@@ -21,7 +20,7 @@ class Suspension
       user.unsuspend
     end
 
-    EventLog.record_event(user, action, initiator:, ip_address:)
+    EventLog.record_event(user, action, initiator:, ip_address: true)
     PermissionUpdater.perform_on(user)
     ReauthEnforcer.perform_on(user)
   end

--- a/app/models/suspension.rb
+++ b/app/models/suspension.rb
@@ -2,13 +2,12 @@ class Suspension
   include ActiveModel::Validations
   validates :reason_for_suspension, presence: true, if: :suspend
 
-  attr_reader :suspend, :reason_for_suspension, :user, :initiator
+  attr_reader :suspend, :reason_for_suspension, :user
 
-  def initialize(suspend: nil, reason_for_suspension: nil, user: nil, initiator: nil)
+  def initialize(suspend: nil, reason_for_suspension: nil, user: nil)
     @suspend = suspend
     @reason_for_suspension = reason_for_suspension
     @user = user
-    @initiator = initiator
   end
 
   def save
@@ -20,7 +19,7 @@ class Suspension
       user.unsuspend
     end
 
-    EventLog.record_event(user, action, initiator:, ip_address: true)
+    EventLog.record_event(user, action, initiator: true, ip_address: true)
     PermissionUpdater.perform_on(user)
     ReauthEnforcer.perform_on(user)
   end

--- a/app/models/suspension.rb
+++ b/app/models/suspension.rb
@@ -20,7 +20,6 @@ class Suspension
     end
 
     EventLog.record_event(user, action, initiator: true, ip_address: true)
-    PermissionUpdater.perform_on(user)
     ReauthEnforcer.perform_on(user)
   end
   alias_method :save!, :save

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -74,6 +74,7 @@ class User < ApplicationRecord
   after_update :record_organisation_change
   after_update :record_2sv_exemption_removed
   after_update :record_2sv_mandated
+  after_update :perform_permissions_update
 
   scope :web_users, -> { where(api_user: false) }
 
@@ -506,5 +507,11 @@ private
     return unless require_2sv && require_2sv_previously_changed?
 
     EventLog.record_event(self, EventLog::TWO_STEP_MANDATED, initiator: true, ip_address: true)
+  end
+
+  def perform_permissions_update
+    return if previous_changes.none?
+
+    PermissionUpdater.perform_on(self)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -398,7 +398,7 @@ class User < ApplicationRecord
       EventLog.record_event(
         self,
         EventLog::TWO_STEP_RESET,
-        initiator: Current.user,
+        initiator: true,
       )
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -70,6 +70,7 @@ class User < ApplicationRecord
   before_save :update_password_changed
   before_save :strip_whitespace_from_name
   after_update :record_update
+  after_update :record_role_change
 
   scope :web_users, -> { where(api_user: false) }
 
@@ -471,5 +472,12 @@ private
     return if previous_changes.none?
 
     EventLog.record_event(self, EventLog::ACCOUNT_UPDATED, initiator: true, ip_address: true)
+  end
+
+  def record_role_change
+    return if Current.user.blank?
+    return unless role_previously_changed?
+
+    EventLog.record_role_change(self, *role_previous_change)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -389,7 +389,7 @@ class User < ApplicationRecord
     end
   end
 
-  def reset_2sv!(initiator)
+  def reset_2sv!
     transaction do
       self.otp_secret_key = nil
       self.require_2sv = true
@@ -398,7 +398,7 @@ class User < ApplicationRecord
       EventLog.record_event(
         self,
         EventLog::TWO_STEP_RESET,
-        initiator:,
+        initiator: Current.user,
       )
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -72,6 +72,7 @@ class User < ApplicationRecord
   after_update :record_update
   after_update :record_role_change
   after_update :record_organisation_change
+  after_update :record_2sv_exemption_removed
 
   scope :web_users, -> { where(api_user: false) }
 
@@ -490,5 +491,12 @@ private
       Organisation.find_by(id: organisation_id)&.name || Organisation::NONE
     end
     EventLog.record_organisation_change(self, *organisations)
+  end
+
+  def record_2sv_exemption_removed
+    return if Current.user.blank?
+    return unless require_2sv && reason_for_2sv_exemption_previously_changed?
+
+    EventLog.record_event(self, EventLog::TWO_STEP_EXEMPTION_REMOVED, initiator: true, ip_address: true)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -73,6 +73,7 @@ class User < ApplicationRecord
   after_update :record_role_change
   after_update :record_organisation_change
   after_update :record_2sv_exemption_removed
+  after_update :record_2sv_mandated
 
   scope :web_users, -> { where(api_user: false) }
 
@@ -498,5 +499,12 @@ private
     return unless require_2sv && reason_for_2sv_exemption_previously_changed?
 
     EventLog.record_event(self, EventLog::TWO_STEP_EXEMPTION_REMOVED, initiator: true, ip_address: true)
+  end
+
+  def record_2sv_mandated
+    return if Current.user.blank?
+    return unless require_2sv && require_2sv_previously_changed?
+
+    EventLog.record_event(self, EventLog::TWO_STEP_MANDATED, initiator: true, ip_address: true)
   end
 end

--- a/app/services/user_update.rb
+++ b/app/services/user_update.rb
@@ -95,7 +95,6 @@ private
       user,
       Organisation.find_by(id: organisation_change.first)&.name || Organisation::NONE,
       Organisation.find_by(id: organisation_change.last)&.name || Organisation::NONE,
-      current_user,
     )
   end
 

--- a/app/services/user_update.rb
+++ b/app/services/user_update.rb
@@ -14,7 +14,6 @@ class UserUpdate
     user.application_permissions.reload
 
     record_permission_changes(old_permissions)
-    record_2sv_exemption_removed
     record_2sv_mandated
     send_two_step_mandated_notification
     perform_permissions_update
@@ -62,17 +61,6 @@ private
         ip_address: true,
       )
     end
-  end
-
-  def record_2sv_exemption_removed
-    return unless user.require_2sv && user.previous_changes[:reason_for_2sv_exemption]
-
-    EventLog.record_event(
-      user,
-      EventLog::TWO_STEP_EXEMPTION_REMOVED,
-      initiator: true,
-      ip_address: true,
-    )
   end
 
   def record_2sv_mandated

--- a/app/services/user_update.rb
+++ b/app/services/user_update.rb
@@ -1,11 +1,9 @@
 class UserUpdate
-  attr_reader :user, :user_params, :current_user, :user_ip
+  attr_reader :user, :user_params
 
-  def initialize(user, user_params, current_user, user_ip)
+  def initialize(user, user_params)
     @user = user
     @user_params = user_params
-    @current_user = current_user
-    @user_ip = user_ip
   end
 
   def call
@@ -156,4 +154,7 @@ private
       Permission.new(p.supported_permission.name, p.application_id)
     end
   end
+
+  def current_user = Current.user
+  def user_ip = Current.user_ip
 end

--- a/app/services/user_update.rb
+++ b/app/services/user_update.rb
@@ -51,7 +51,7 @@ private
         initiator: current_user,
         application_id:,
         trailing_message: "(#{permissions.map(&:name).join(', ')})",
-        ip_address: user_ip,
+        ip_address: true,
       )
     end
 
@@ -62,7 +62,7 @@ private
         initiator: current_user,
         application_id:,
         trailing_message: "(#{permissions.map(&:name).join(', ')})",
-        ip_address: user_ip,
+        ip_address: true,
       )
     end
   end
@@ -72,7 +72,7 @@ private
       user,
       EventLog::ACCOUNT_UPDATED,
       initiator: current_user,
-      ip_address: user_ip,
+      ip_address: true,
     )
   end
 
@@ -105,7 +105,7 @@ private
       user,
       EventLog::TWO_STEP_EXEMPTION_REMOVED,
       initiator: current_user,
-      ip_address: user_ip,
+      ip_address: true,
     )
   end
 
@@ -116,7 +116,7 @@ private
       user,
       EventLog::TWO_STEP_MANDATED,
       initiator: current_user,
-      ip_address: user_ip,
+      ip_address: true,
     )
   end
 
@@ -154,5 +154,4 @@ private
   end
 
   def current_user = Current.user
-  def user_ip = Current.user_ip
 end

--- a/app/services/user_update.rb
+++ b/app/services/user_update.rb
@@ -48,7 +48,7 @@ private
       EventLog.record_event(
         user,
         EventLog::PERMISSIONS_ADDED,
-        initiator: current_user,
+        initiator: true,
         application_id:,
         trailing_message: "(#{permissions.map(&:name).join(', ')})",
         ip_address: true,
@@ -59,7 +59,7 @@ private
       EventLog.record_event(
         user,
         EventLog::PERMISSIONS_REMOVED,
-        initiator: current_user,
+        initiator: true,
         application_id:,
         trailing_message: "(#{permissions.map(&:name).join(', ')})",
         ip_address: true,
@@ -71,7 +71,7 @@ private
     EventLog.record_event(
       user,
       EventLog::ACCOUNT_UPDATED,
-      initiator: current_user,
+      initiator: true,
       ip_address: true,
     )
   end
@@ -104,7 +104,7 @@ private
     EventLog.record_event(
       user,
       EventLog::TWO_STEP_EXEMPTION_REMOVED,
-      initiator: current_user,
+      initiator: true,
       ip_address: true,
     )
   end
@@ -115,7 +115,7 @@ private
     EventLog.record_event(
       user,
       EventLog::TWO_STEP_MANDATED,
-      initiator: current_user,
+      initiator: true,
       ip_address: true,
     )
   end

--- a/app/services/user_update.rb
+++ b/app/services/user_update.rb
@@ -14,7 +14,6 @@ class UserUpdate
     user.application_permissions.reload
 
     record_permission_changes(old_permissions)
-    record_2sv_mandated
     send_two_step_mandated_notification
     perform_permissions_update
     record_email_change_and_notify
@@ -61,17 +60,6 @@ private
         ip_address: true,
       )
     end
-  end
-
-  def record_2sv_mandated
-    return unless user.require_2sv && user.previous_changes[:require_2sv]
-
-    EventLog.record_event(
-      user,
-      EventLog::TWO_STEP_MANDATED,
-      initiator: true,
-      ip_address: true,
-    )
   end
 
   def perform_permissions_update

--- a/app/services/user_update.rb
+++ b/app/services/user_update.rb
@@ -14,7 +14,6 @@ class UserUpdate
     user.application_permissions.reload
 
     record_permission_changes(old_permissions)
-    record_role_change
     record_organisation_change
     record_2sv_exemption_removed
     record_2sv_mandated
@@ -64,17 +63,6 @@ private
         ip_address: true,
       )
     end
-  end
-
-  def record_role_change
-    role_change = user.previous_changes[:role]
-    return unless role_change
-
-    EventLog.record_role_change(
-      user,
-      role_change.first,
-      role_change.last,
-    )
   end
 
   def record_organisation_change

--- a/app/services/user_update.rb
+++ b/app/services/user_update.rb
@@ -13,7 +13,6 @@ class UserUpdate
 
     user.application_permissions.reload
 
-    record_update
     record_permission_changes(old_permissions)
     record_role_change
     record_organisation_change
@@ -65,15 +64,6 @@ private
         ip_address: true,
       )
     end
-  end
-
-  def record_update
-    EventLog.record_event(
-      user,
-      EventLog::ACCOUNT_UPDATED,
-      initiator: true,
-      ip_address: true,
-    )
   end
 
   def record_role_change

--- a/app/services/user_update.rb
+++ b/app/services/user_update.rb
@@ -14,7 +14,6 @@ class UserUpdate
     user.application_permissions.reload
 
     record_permission_changes(old_permissions)
-    record_organisation_change
     record_2sv_exemption_removed
     record_2sv_mandated
     send_two_step_mandated_notification
@@ -63,17 +62,6 @@ private
         ip_address: true,
       )
     end
-  end
-
-  def record_organisation_change
-    organisation_change = user.previous_changes[:organisation_id]
-    return unless organisation_change
-
-    EventLog.record_organisation_change(
-      user,
-      Organisation.find_by(id: organisation_change.first)&.name || Organisation::NONE,
-      Organisation.find_by(id: organisation_change.last)&.name || Organisation::NONE,
-    )
   end
 
   def record_2sv_exemption_removed

--- a/app/services/user_update.rb
+++ b/app/services/user_update.rb
@@ -136,7 +136,7 @@ private
     email_change = user.previous_changes[:email]
     return unless email_change
 
-    EventLog.record_email_change(user, email_change.first, email_change.last, current_user)
+    EventLog.record_email_change(user, email_change.first, email_change.last)
 
     return if user.api_user?
 

--- a/app/services/user_update.rb
+++ b/app/services/user_update.rb
@@ -15,7 +15,6 @@ class UserUpdate
 
     record_permission_changes(old_permissions)
     send_two_step_mandated_notification
-    perform_permissions_update
     record_email_change_and_notify
     true
   end
@@ -60,10 +59,6 @@ private
         ip_address: true,
       )
     end
-  end
-
-  def perform_permissions_update
-    PermissionUpdater.perform_on(user)
   end
 
   def send_two_step_mandated_notification

--- a/app/services/user_update.rb
+++ b/app/services/user_update.rb
@@ -84,7 +84,6 @@ private
       user,
       role_change.first,
       role_change.last,
-      current_user,
     )
   end
 

--- a/lib/inactive_users_suspender.rb
+++ b/lib/inactive_users_suspender.rb
@@ -7,7 +7,6 @@ class InactiveUsersSuspender
 
       user.revoke_all_authorisations
 
-      PermissionUpdater.perform_on(user)
       ReauthEnforcer.perform_on(user)
 
       EventLog.record_event(user, EventLog::ACCOUNT_AUTOSUSPENDED)

--- a/test/controllers/api_users_controller_test.rb
+++ b/test/controllers/api_users_controller_test.rb
@@ -88,7 +88,7 @@ class ApiUsersControllerTest < ActionController::TestCase
 
       should "log API user created event in the api users event log" do
         EventLog.stubs(:record_event) # to ignore logs being created, other than the one under test
-        EventLog.expects(:record_event).with(instance_of(ApiUser), EventLog::API_USER_CREATED, initiator: @superadmin, ip_address: request.remote_ip)
+        EventLog.expects(:record_event).with(instance_of(ApiUser), EventLog::API_USER_CREATED, initiator: @superadmin, ip_address: true)
         post :create, params: { api_user: { name: "Content Store Application", email: "content.store@gov.uk" } }
       end
 

--- a/test/controllers/api_users_controller_test.rb
+++ b/test/controllers/api_users_controller_test.rb
@@ -279,18 +279,6 @@ class ApiUsersControllerTest < ActionController::TestCase
         assert_template :manage_permissions
         assert_select "div.alert ul li", "Supported permission ids error"
       end
-
-      should "push permission changes out to apps" do
-        api_user = create(:api_user)
-
-        PermissionUpdater.expects(:perform_on).with(api_user).once
-
-        put :update,
-            params: {
-              "id" => api_user.id,
-              "api_user" => { "email" => api_user.email },
-            }
-      end
     end
   end
 end

--- a/test/controllers/api_users_controller_test.rb
+++ b/test/controllers/api_users_controller_test.rb
@@ -88,7 +88,7 @@ class ApiUsersControllerTest < ActionController::TestCase
 
       should "log API user created event in the api users event log" do
         EventLog.stubs(:record_event) # to ignore logs being created, other than the one under test
-        EventLog.expects(:record_event).with(instance_of(ApiUser), EventLog::API_USER_CREATED, initiator: @superadmin, ip_address: true)
+        EventLog.expects(:record_event).with(instance_of(ApiUser), EventLog::API_USER_CREATED, initiator: true, ip_address: true)
         post :create, params: { api_user: { name: "Content Store Application", email: "content.store@gov.uk" } }
       end
 

--- a/test/controllers/invitations_controller_test.rb
+++ b/test/controllers/invitations_controller_test.rb
@@ -386,7 +386,7 @@ class InvitationsControllerTest < ActionController::TestCase
       end
 
       should "record account invitation in event log when invitation sent" do
-        EventLog.expects(:record_account_invitation).with(instance_of(User), @inviter)
+        EventLog.expects(:record_account_invitation).with(instance_of(User))
 
         post :create, params: { user: { name: "invitee", email: "invitee@gov.uk" } }
       end

--- a/test/controllers/users/emails_controller_test.rb
+++ b/test/controllers/users/emails_controller_test.rb
@@ -228,7 +228,7 @@ class Users::EmailsControllerTest < ActionController::TestCase
       should "record email change" do
         user = create(:user, email: "user@gov.uk")
 
-        EventLog.expects(:record_email_change).with(user, "user@gov.uk", "new-user@gov.uk", @superadmin)
+        EventLog.expects(:record_email_change).with(user, "user@gov.uk", "new-user@gov.uk")
 
         put :update, params: { user_id: user, user: { email: "new-user@gov.uk" } }
       end

--- a/test/controllers/users/invitation_resends_controller_test.rb
+++ b/test/controllers/users/invitation_resends_controller_test.rb
@@ -120,7 +120,7 @@ class Users::InvitationResendsControllerTest < ActionController::TestCase
       should "record account invitation event" do
         user = create(:invited_user)
 
-        EventLog.expects(:record_account_invitation).with(user, @admin)
+        EventLog.expects(:record_account_invitation).with(user)
 
         put :update, params: { user_id: user }
       end

--- a/test/controllers/users/names_controller_test.rb
+++ b/test/controllers/users/names_controller_test.rb
@@ -153,7 +153,7 @@ class Users::NamesControllerTest < ActionController::TestCase
         EventLog.expects(:record_event).with(
           user,
           EventLog::ACCOUNT_UPDATED,
-          initiator: @superadmin,
+          initiator: true,
           ip_address: true,
         )
 

--- a/test/controllers/users/names_controller_test.rb
+++ b/test/controllers/users/names_controller_test.rb
@@ -150,13 +150,11 @@ class Users::NamesControllerTest < ActionController::TestCase
       should "record account updated event" do
         user = create(:user)
 
-        @controller.stubs(:user_ip_address).returns("1.1.1.1")
-
         EventLog.expects(:record_event).with(
           user,
           EventLog::ACCOUNT_UPDATED,
           initiator: @superadmin,
-          ip_address: "1.1.1.1",
+          ip_address: true,
         )
 
         put :update, params: { user_id: user, user: { name: "new-user-name" } }

--- a/test/controllers/users/organisations_controller_test.rb
+++ b/test/controllers/users/organisations_controller_test.rb
@@ -105,13 +105,11 @@ class Users::OrganisationsControllerTest < ActionController::TestCase
       should "record account updated & organisation change events" do
         user = create(:user, organisation:)
 
-        @controller.stubs(:user_ip_address).returns("1.1.1.1")
-
         EventLog.expects(:record_event).with(
           user,
           EventLog::ACCOUNT_UPDATED,
           initiator: @admin,
-          ip_address: "1.1.1.1",
+          ip_address: true,
         )
 
         EventLog.expects(:record_organisation_change).with(

--- a/test/controllers/users/organisations_controller_test.rb
+++ b/test/controllers/users/organisations_controller_test.rb
@@ -108,7 +108,7 @@ class Users::OrganisationsControllerTest < ActionController::TestCase
         EventLog.expects(:record_event).with(
           user,
           EventLog::ACCOUNT_UPDATED,
-          initiator: @admin,
+          initiator: true,
           ip_address: true,
         )
 

--- a/test/controllers/users/organisations_controller_test.rb
+++ b/test/controllers/users/organisations_controller_test.rb
@@ -118,7 +118,6 @@ class Users::OrganisationsControllerTest < ActionController::TestCase
           user,
           organisation.name,
           another_organisation.name,
-          @admin,
         )
 
         put :update, params: { user_id: user, user: { organisation_id: another_organisation } }

--- a/test/controllers/users/permissions_controller_test.rb
+++ b/test/controllers/users/permissions_controller_test.rb
@@ -221,7 +221,7 @@ class Users::PermissionsControllerTest < ActionController::TestCase
       expected_params = { supported_permission_ids: [new_permission.id, application.signin_permission.id].sort }
       user_update = stub("user-update").responds_like_instance_of(UserUpdate)
       user_update.expects(:call)
-      UserUpdate.stubs(:new).with(user, expected_params, current_user, anything).returns(user_update)
+      UserUpdate.stubs(:new).with(user, expected_params).returns(user_update)
 
       patch :update, params: { user_id: user, application_id: application.id, application: { supported_permission_ids: [new_permission.id] } }
     end
@@ -262,7 +262,7 @@ class Users::PermissionsControllerTest < ActionController::TestCase
       expected_params = { supported_permission_ids: [other_permission.id, new_permission.id, application.signin_permission.id].sort }
       user_update = stub("user-update").responds_like_instance_of(UserUpdate)
       user_update.expects(:call)
-      UserUpdate.stubs(:new).with(user, expected_params, current_user, anything).returns(user_update)
+      UserUpdate.stubs(:new).with(user, expected_params).returns(user_update)
 
       patch :update, params: { user_id: user, application_id: application.id, application: { supported_permission_ids: [new_permission.id] } }
     end

--- a/test/controllers/users/roles_controller_test.rb
+++ b/test/controllers/users/roles_controller_test.rb
@@ -107,7 +107,7 @@ class Users::RolesControllerTest < ActionController::TestCase
         EventLog.expects(:record_event).with(
           user,
           EventLog::ACCOUNT_UPDATED,
-          initiator: @superadmin,
+          initiator: true,
           ip_address: true,
         )
 

--- a/test/controllers/users/roles_controller_test.rb
+++ b/test/controllers/users/roles_controller_test.rb
@@ -104,13 +104,11 @@ class Users::RolesControllerTest < ActionController::TestCase
       should "record account updated & role change events" do
         user = create(:user_in_organisation, role: Roles::Normal.role_name)
 
-        @controller.stubs(:user_ip_address).returns("1.1.1.1")
-
         EventLog.expects(:record_event).with(
           user,
           EventLog::ACCOUNT_UPDATED,
           initiator: @superadmin,
-          ip_address: "1.1.1.1",
+          ip_address: true,
         )
 
         EventLog.expects(:record_role_change).with(

--- a/test/controllers/users/roles_controller_test.rb
+++ b/test/controllers/users/roles_controller_test.rb
@@ -117,7 +117,6 @@ class Users::RolesControllerTest < ActionController::TestCase
           user,
           Roles::Normal.role_name,
           Roles::OrganisationAdmin.role_name,
-          @superadmin,
         )
 
         put :update, params: { user_id: user, user: { role: Roles::OrganisationAdmin.role_name } }

--- a/test/controllers/users/signin_permissions_controller_test.rb
+++ b/test/controllers/users/signin_permissions_controller_test.rb
@@ -15,7 +15,7 @@ class Users::SigninPermissionsControllerTest < ActionController::TestCase
       expected_params = { supported_permission_ids: [application.signin_permission.id] }
       user_update = stub("user-update").responds_like_instance_of(UserUpdate)
       user_update.expects(:call)
-      UserUpdate.stubs(:new).with(user, expected_params, current_user, anything).returns(user_update)
+      UserUpdate.stubs(:new).with(user, expected_params).returns(user_update)
 
       post :create, params: { user_id: user, application_id: application.id }
     end
@@ -200,7 +200,7 @@ class Users::SigninPermissionsControllerTest < ActionController::TestCase
       expected_params = { supported_permission_ids: [] }
       user_update = stub("user-update").responds_like_instance_of(UserUpdate)
       user_update.expects(:call)
-      UserUpdate.stubs(:new).with(user, expected_params, current_user, anything).returns(user_update)
+      UserUpdate.stubs(:new).with(user, expected_params).returns(user_update)
 
       delete :destroy, params: { user_id: user, application_id: application.id }
     end

--- a/test/controllers/users/two_step_verification_mandations_controller_test.rb
+++ b/test/controllers/users/two_step_verification_mandations_controller_test.rb
@@ -89,20 +89,18 @@ class Users::TwoStepVerificationMandationsControllerTest < ActionController::Tes
       should "record account updated & 2SV mandated events" do
         user = create(:user, require_2sv: false)
 
-        @controller.stubs(:user_ip_address).returns("1.1.1.1")
-
         EventLog.expects(:record_event).with(
           user,
           EventLog::ACCOUNT_UPDATED,
           initiator: @admin,
-          ip_address: "1.1.1.1",
+          ip_address: true,
         )
 
         EventLog.expects(:record_event).with(
           user,
           EventLog::TWO_STEP_MANDATED,
           initiator: @admin,
-          ip_address: "1.1.1.1",
+          ip_address: true,
         )
 
         put :update, params: { user_id: user, user: { require_2sv: true } }

--- a/test/controllers/users/two_step_verification_mandations_controller_test.rb
+++ b/test/controllers/users/two_step_verification_mandations_controller_test.rb
@@ -92,14 +92,14 @@ class Users::TwoStepVerificationMandationsControllerTest < ActionController::Tes
         EventLog.expects(:record_event).with(
           user,
           EventLog::ACCOUNT_UPDATED,
-          initiator: @admin,
+          initiator: true,
           ip_address: true,
         )
 
         EventLog.expects(:record_event).with(
           user,
           EventLog::TWO_STEP_MANDATED,
-          initiator: @admin,
+          initiator: true,
           ip_address: true,
         )
 

--- a/test/controllers/users/two_step_verification_resets_controller_test.rb
+++ b/test/controllers/users/two_step_verification_resets_controller_test.rb
@@ -96,7 +96,7 @@ class Users::TwoStepVerificationResetsControllerTest < ActionController::TestCas
       should "record account updated event" do
         user = create(:two_step_enabled_user)
 
-        EventLog.expects(:record_event).with(user, EventLog::TWO_STEP_RESET, initiator: @admin)
+        EventLog.expects(:record_event).with(user, EventLog::TWO_STEP_RESET, initiator: true)
 
         put :update, params: { user_id: user }
       end

--- a/test/controllers/users/two_step_verification_resets_controller_test.rb
+++ b/test/controllers/users/two_step_verification_resets_controller_test.rb
@@ -96,6 +96,7 @@ class Users::TwoStepVerificationResetsControllerTest < ActionController::TestCas
       should "record account updated event" do
         user = create(:two_step_enabled_user)
 
+        EventLog.stubs(:record_event).with(user, EventLog::ACCOUNT_UPDATED, anything)
         EventLog.expects(:record_event).with(user, EventLog::TWO_STEP_RESET, initiator: true)
 
         put :update, params: { user_id: user }

--- a/test/controllers/users/unlockings_controller_test.rb
+++ b/test/controllers/users/unlockings_controller_test.rb
@@ -95,6 +95,7 @@ class Users::UnlockingsControllerTest < ActionController::TestCase
       should "record manual account unlock event" do
         user = create(:locked_user)
 
+        EventLog.stubs(:record_event).with(user, EventLog::ACCOUNT_UPDATED, anything)
         EventLog.expects(:record_event).with(
           user,
           EventLog::MANUAL_ACCOUNT_UNLOCK,

--- a/test/controllers/users/unlockings_controller_test.rb
+++ b/test/controllers/users/unlockings_controller_test.rb
@@ -95,13 +95,11 @@ class Users::UnlockingsControllerTest < ActionController::TestCase
       should "record manual account unlock event" do
         user = create(:locked_user)
 
-        @controller.stubs(:user_ip_address).returns("1.1.1.1")
-
         EventLog.expects(:record_event).with(
           user,
           EventLog::MANUAL_ACCOUNT_UNLOCK,
           initiator: @admin,
-          ip_address: "1.1.1.1",
+          ip_address: true,
         )
 
         put :update, params: { user_id: user }

--- a/test/controllers/users/unlockings_controller_test.rb
+++ b/test/controllers/users/unlockings_controller_test.rb
@@ -98,7 +98,7 @@ class Users::UnlockingsControllerTest < ActionController::TestCase
         EventLog.expects(:record_event).with(
           user,
           EventLog::MANUAL_ACCOUNT_UNLOCK,
-          initiator: @admin,
+          initiator: true,
           ip_address: true,
         )
 

--- a/test/integration/set_current_attributes_test.rb
+++ b/test/integration/set_current_attributes_test.rb
@@ -1,0 +1,66 @@
+require "test_helper"
+
+class SetCurrentAttributesTest < ActionDispatch::IntegrationTest
+  class TestsController < ApplicationController
+    cattr_accessor :current_user
+    skip_after_action :verify_authorized
+
+    def show
+      render json: { user_id: Current.user&.id, user_ip: Current.user_ip }
+    end
+
+  private
+
+    def current_user
+      self.class.current_user
+    end
+  end
+
+  should "set Current.user if user is signed in" do
+    with_test_route do
+      user = create(:user)
+      with_current_user(user) do
+        visit "/test"
+
+        assert_equal user.id, JSON.parse(page.body)["user_id"]
+      end
+    end
+  end
+
+  should "not set Current.user if user is not signed in" do
+    with_test_route do
+      with_current_user(nil) do
+        visit "/test"
+
+        assert_nil JSON.parse(page.body)["user_id"]
+      end
+    end
+  end
+
+  should "set Current.user_ip" do
+    with_test_route do
+      page.driver.options[:headers] = { "REMOTE_ADDR" => "4.5.6.7" }
+      visit "/test"
+
+      assert_equal "4.5.6.7", JSON.parse(page.body)["user_ip"]
+    end
+  end
+
+private
+
+  def with_test_route
+    Rails.application.routes.draw do
+      get "/test" => "set_current_attributes_test/tests#show"
+    end
+    yield
+  ensure
+    Rails.application.reload_routes!
+  end
+
+  def with_current_user(user)
+    TestsController.current_user = user
+    yield
+  ensure
+    TestsController.current_user = nil
+  end
+end

--- a/test/lib/data_hygiene/bulk_organisation_updater_test.rb
+++ b/test/lib/data_hygiene/bulk_organisation_updater_test.rb
@@ -7,7 +7,9 @@ class DataHygiene::BulkOrganisationUpdaterTest < ActiveSupport::TestCase
     file.close
 
     begin
-      DataHygiene::BulkOrganisationUpdater.call(file.path, logger: Rails.logger)
+      with_current(user: create(:admin_user)) do
+        DataHygiene::BulkOrganisationUpdater.call(file.path, logger: Rails.logger)
+      end
     ensure
       file.unlink
     end

--- a/test/models/event_log_test.rb
+++ b/test/models/event_log_test.rb
@@ -46,14 +46,18 @@ class EventLogTest < ActiveSupport::TestCase
 
     should "record event EMAIL_CHANGE_INITIATED when a user is changing their own email" do
       user = create(:user, email: "new@example.com")
-      EventLog.record_email_change(user, "old@example.com", user.email)
+      with_current(user:) do
+        EventLog.record_email_change(user, "old@example.com", user.email)
+      end
 
       assert_equal EventLog::EMAIL_CHANGE_INITIATED, EventLog.last.entry
     end
 
     should "record email change events with a trailing message" do
       user = create(:user, email: "new@example.com")
-      EventLog.record_email_change(user, "old@example.com", user.email)
+      with_current(user:) do
+        EventLog.record_email_change(user, "old@example.com", user.email)
+      end
 
       event_log = EventLog.last
       assert_equal user.uid, event_log.uid

--- a/test/models/event_log_test.rb
+++ b/test/models/event_log_test.rb
@@ -104,7 +104,9 @@ class EventLogTest < ActiveSupport::TestCase
   test "records the IPv6 address of the user passed as an option" do
     raw_ip_address = "2001:0db8:0000:0000:0008:0800:200c:417a"
     parsed_ip_address = IPAddr.new(raw_ip_address, Socket::AF_INET6).to_s
-    EventLog.record_event(create(:user), EventLog::SUCCESSFUL_LOGIN, ip_address: raw_ip_address)
+    with_current(user_ip: raw_ip_address) do
+      EventLog.record_event(create(:user), EventLog::SUCCESSFUL_LOGIN, ip_address: true)
+    end
 
     assert_equal parsed_ip_address, EventLog.last.ip_address_string
   end
@@ -112,7 +114,9 @@ class EventLogTest < ActiveSupport::TestCase
   test "records the IP address of the user passed as an option" do
     raw_ip_address = "1.2.3.4"
     parsed_ip_address = IPAddr.new(raw_ip_address, Socket::AF_INET).to_s
-    EventLog.record_event(create(:user), EventLog::SUCCESSFUL_LOGIN, ip_address: raw_ip_address)
+    with_current(user_ip: raw_ip_address) do
+      EventLog.record_event(create(:user), EventLog::SUCCESSFUL_LOGIN, ip_address: true)
+    end
 
     assert_equal parsed_ip_address, EventLog.last.ip_address_string
   end

--- a/test/models/event_log_test.rb
+++ b/test/models/event_log_test.rb
@@ -37,22 +37,23 @@ class EventLogTest < ActiveSupport::TestCase
   context ".record_email_change" do
     should "record event EMAIL_CHANGED when initiator is an admin" do
       user = create(:user, email: "new@example.com")
-      event_log = EventLog.record_email_change(user, "old@example.com", user.email, create(:admin_user))
+      EventLog.record_email_change(user, "old@example.com", user.email, create(:admin_user))
 
-      assert_equal EventLog::EMAIL_CHANGED, event_log.entry
+      assert_equal EventLog::EMAIL_CHANGED, EventLog.last.entry
     end
 
     should "record event EMAIL_CHANGE_INITIATED when a user is changing their own email" do
       user = create(:user, email: "new@example.com")
-      event_log = EventLog.record_email_change(user, "old@example.com", user.email)
+      EventLog.record_email_change(user, "old@example.com", user.email)
 
-      assert_equal EventLog::EMAIL_CHANGE_INITIATED, event_log.entry
+      assert_equal EventLog::EMAIL_CHANGE_INITIATED, EventLog.last.entry
     end
 
     should "record email change events with a trailing message" do
       user = create(:user, email: "new@example.com")
-      event_log = EventLog.record_email_change(user, "old@example.com", user.email)
+      EventLog.record_email_change(user, "old@example.com", user.email)
 
+      event_log = EventLog.last
       assert_equal user.uid, event_log.uid
       assert_equal user.id, event_log.initiator_id
       assert_equal "from old@example.com to new@example.com", event_log.trailing_message
@@ -61,9 +62,9 @@ class EventLogTest < ActiveSupport::TestCase
     should "record the initiator when initiator is other than the user" do
       user = create(:user, email: "new@example.com")
       admin = create(:admin_user)
-      event_log = EventLog.record_email_change(user, "old@example.com", user.email, admin)
+      EventLog.record_email_change(user, "old@example.com", user.email, admin)
 
-      assert_equal admin.id, event_log.initiator_id
+      assert_equal admin.id, EventLog.last.initiator_id
     end
   end
 

--- a/test/models/event_log_test.rb
+++ b/test/models/event_log_test.rb
@@ -145,7 +145,11 @@ class EventLogTest < ActiveSupport::TestCase
     user = create(:user)
     admin = create(:admin_user)
 
-    event_log = EventLog.record_account_invitation(user, admin)
+    with_current(user: admin) do
+      EventLog.record_account_invitation(user)
+    end
+
+    event_log = EventLog.last
     assert_equal admin, event_log.initiator
     assert_equal EventLog::ACCOUNT_INVITED, event_log.entry
   end

--- a/test/models/event_log_test.rb
+++ b/test/models/event_log_test.rb
@@ -37,7 +37,9 @@ class EventLogTest < ActiveSupport::TestCase
   context ".record_email_change" do
     should "record event EMAIL_CHANGED when initiator is an admin" do
       user = create(:user, email: "new@example.com")
-      EventLog.record_email_change(user, "old@example.com", user.email, create(:admin_user))
+      with_current(user: create(:admin_user)) do
+        EventLog.record_email_change(user, "old@example.com", user.email)
+      end
 
       assert_equal EventLog::EMAIL_CHANGED, EventLog.last.entry
     end
@@ -62,7 +64,9 @@ class EventLogTest < ActiveSupport::TestCase
     should "record the initiator when initiator is other than the user" do
       user = create(:user, email: "new@example.com")
       admin = create(:admin_user)
-      EventLog.record_email_change(user, "old@example.com", user.email, admin)
+      with_current(user: admin) do
+        EventLog.record_email_change(user, "old@example.com", user.email)
+      end
 
       assert_equal admin.id, EventLog.last.initiator_id
     end

--- a/test/models/event_log_test.rb
+++ b/test/models/event_log_test.rb
@@ -78,10 +78,11 @@ class EventLogTest < ActiveSupport::TestCase
 
   test "records role changes with the details of the roles" do
     user = create(:user, email: "new@example.com")
-    admin = create(:admin_user)
-    event_log = EventLog.record_role_change(user, Roles::Admin.role_name, Roles::Superadmin.role_name, admin)
+    with_current(user: create(:admin_user)) do
+      EventLog.record_role_change(user, Roles::Admin.role_name, Roles::Superadmin.role_name)
+    end
 
-    assert_equal "from admin to superadmin", event_log.trailing_message
+    assert_equal "from admin to superadmin", EventLog.last.trailing_message
   end
 
   test "records the initiator of the event passed as an option" do

--- a/test/models/event_log_test.rb
+++ b/test/models/event_log_test.rb
@@ -87,7 +87,9 @@ class EventLogTest < ActiveSupport::TestCase
 
   test "records organisation changes with the details of the organisations" do
     user = create(:user)
-    EventLog.record_organisation_change(user, "org-name-1", "org-name-2", create(:admin_user))
+    with_current(user: create(:admin_user)) do
+      EventLog.record_organisation_change(user, "org-name-1", "org-name-2")
+    end
 
     assert_equal "from org-name-1 to org-name-2", EventLog.last.trailing_message
   end

--- a/test/models/event_log_test.rb
+++ b/test/models/event_log_test.rb
@@ -96,7 +96,9 @@ class EventLogTest < ActiveSupport::TestCase
 
   test "records the initiator of the event passed as an option" do
     initiator = create(:admin_user)
-    EventLog.record_event(create(:user), EventLog::EMAIL_CHANGED, initiator:)
+    with_current(user: initiator) do
+      EventLog.record_event(create(:user), EventLog::EMAIL_CHANGED, initiator: true)
+    end
 
     assert_equal initiator, EventLog.last.initiator
   end

--- a/test/models/event_log_test.rb
+++ b/test/models/event_log_test.rb
@@ -85,6 +85,13 @@ class EventLogTest < ActiveSupport::TestCase
     assert_equal "from admin to superadmin", EventLog.last.trailing_message
   end
 
+  test "records organisation changes with the details of the organisations" do
+    user = create(:user)
+    EventLog.record_organisation_change(user, "org-name-1", "org-name-2", create(:admin_user))
+
+    assert_equal "from org-name-1 to org-name-2", EventLog.last.trailing_message
+  end
+
   test "records the initiator of the event passed as an option" do
     initiator = create(:admin_user)
     EventLog.record_event(create(:user), EventLog::EMAIL_CHANGED, initiator:)

--- a/test/models/suspension_test.rb
+++ b/test/models/suspension_test.rb
@@ -69,7 +69,7 @@ class SuspensionTest < ActiveSupport::TestCase
   end
 
   should "call the PermissionUpdater when saving" do
-    user = stub(unsuspend: true)
+    user = create(:suspended_user)
 
     PermissionUpdater.expects(:perform_on).with(user)
     suspension = Suspension.new(suspend: false, user:)

--- a/test/models/suspension_test.rb
+++ b/test/models/suspension_test.rb
@@ -53,10 +53,9 @@ class SuspensionTest < ActiveSupport::TestCase
   should "log unsuspend events" do
     user = stub(unsuspend: true)
     initiator = mock
-    ip_address = "127.0.0.1"
 
-    EventLog.expects(:record_event).with(user, EventLog::ACCOUNT_UNSUSPENDED, initiator:, ip_address:)
-    suspension = Suspension.new(suspend: false, user:, initiator:, ip_address:)
+    EventLog.expects(:record_event).with(user, EventLog::ACCOUNT_UNSUSPENDED, initiator:, ip_address: true)
+    suspension = Suspension.new(suspend: false, user:, initiator:)
 
     suspension.save!
   end
@@ -64,10 +63,9 @@ class SuspensionTest < ActiveSupport::TestCase
   should "log suspend events" do
     user = stub(suspend: true)
     initiator = mock
-    ip_address = "127.0.0.1"
 
-    EventLog.expects(:record_event).with(user, EventLog::ACCOUNT_SUSPENDED, initiator:, ip_address:)
-    suspension = Suspension.new(suspend: true, reason_for_suspension: "A reason", user:, initiator:, ip_address:)
+    EventLog.expects(:record_event).with(user, EventLog::ACCOUNT_SUSPENDED, initiator:, ip_address: true)
+    suspension = Suspension.new(suspend: true, reason_for_suspension: "A reason", user:, initiator:)
 
     suspension.save!
   end

--- a/test/models/suspension_test.rb
+++ b/test/models/suspension_test.rb
@@ -52,20 +52,18 @@ class SuspensionTest < ActiveSupport::TestCase
 
   should "log unsuspend events" do
     user = stub(unsuspend: true)
-    initiator = mock
 
-    EventLog.expects(:record_event).with(user, EventLog::ACCOUNT_UNSUSPENDED, initiator:, ip_address: true)
-    suspension = Suspension.new(suspend: false, user:, initiator:)
+    EventLog.expects(:record_event).with(user, EventLog::ACCOUNT_UNSUSPENDED, initiator: true, ip_address: true)
+    suspension = Suspension.new(suspend: false, user:)
 
     suspension.save!
   end
 
   should "log suspend events" do
     user = stub(suspend: true)
-    initiator = mock
 
-    EventLog.expects(:record_event).with(user, EventLog::ACCOUNT_SUSPENDED, initiator:, ip_address: true)
-    suspension = Suspension.new(suspend: true, reason_for_suspension: "A reason", user:, initiator:)
+    EventLog.expects(:record_event).with(user, EventLog::ACCOUNT_SUSPENDED, initiator: true, ip_address: true)
+    suspension = Suspension.new(suspend: true, reason_for_suspension: "A reason", user:)
 
     suspension.save!
   end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -512,7 +512,7 @@ class UserTest < ActiveSupport::TestCase
 
     @user.suspend("Nothing personal, just needed to suspend a user for testing")
 
-    assert @user.authorisations.all?(&:revoked?)
+    assert @user.authorisations.reload.all?(&:revoked?)
   end
 
   context "#revoke_all_authorisations" do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -395,7 +395,9 @@ class UserTest < ActiveSupport::TestCase
         @user = create(:two_step_enabled_user)
         @initiator = create(:superadmin_user)
         @expiry_date = Time.zone.today + 10
-        @user.exempt_from_2sv("accessibility reasons", @initiator, @expiry_date)
+        with_current(user: @initiator) do
+          @user.exempt_from_2sv("accessibility reasons", @initiator, @expiry_date)
+        end
       end
 
       should "set require 2sv to false and store the reason and expiry date" do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -191,7 +191,9 @@ class UserTest < ActiveSupport::TestCase
     setup do
       @super_admin   = create(:superadmin_user)
       @two_step_user = create(:two_step_enabled_user)
-      @two_step_user.reset_2sv!(@super_admin)
+      with_current(user: @super_admin) do
+        @two_step_user.reset_2sv!
+      end
     end
 
     should "persist the required attributes" do

--- a/test/services/user_update_test.rb
+++ b/test/services/user_update_test.rb
@@ -7,6 +7,7 @@ class UserUpdateTest < ActionView::TestCase
   setup do
     @current_user = create(:superadmin_user)
     @affected_user = create(:user)
+    @affected_user.name = "different-name"
     @ip_address = "1.2.3.4"
   end
 

--- a/test/services/user_update_test.rb
+++ b/test/services/user_update_test.rb
@@ -132,7 +132,7 @@ class UserUpdateTest < ActionView::TestCase
 
   should "record email change if value of email attribute has changed" do
     params = { email: "new@gov.uk" }
-    EventLog.expects(:record_email_change).with(affected_user, affected_user.email, "new@gov.uk", current_user)
+    EventLog.expects(:record_email_change).with(affected_user, affected_user.email, "new@gov.uk")
 
     with_current(user: current_user, user_ip: ip_address) do
       UserUpdate.new(affected_user, params).call
@@ -214,21 +214,6 @@ class UserUpdateTest < ActionView::TestCase
 
     with_current(user: current_user, user_ip: ip_address) do
       UserUpdate.new(affected_user, params).call
-    end
-  end
-
-private
-
-  def with_current(user: nil, user_ip: nil)
-    original_user = Current.user
-    original_user_ip = Current.user_ip
-    begin
-      Current.user = user
-      Current.user_ip = user_ip
-      yield
-    ensure
-      Current.user = original_user
-      Current.user_ip = original_user_ip
     end
   end
 end

--- a/test/support/current_helpers.rb
+++ b/test/support/current_helpers.rb
@@ -1,0 +1,14 @@
+module CurrentHelpers
+  def with_current(user: nil, ip_address: nil)
+    original_user = Current.user
+    original_ip_address = Current.user_ip
+    begin
+      Current.user = user
+      Current.user_ip = ip_address
+      yield
+    ensure
+      Current.user = original_user
+      Current.user_ip = original_ip_address
+    end
+  end
+end

--- a/test/support/current_helpers.rb
+++ b/test/support/current_helpers.rb
@@ -1,14 +1,14 @@
 module CurrentHelpers
-  def with_current(user: nil, ip_address: nil)
+  def with_current(user: nil, user_ip: nil)
     original_user = Current.user
-    original_ip_address = Current.user_ip
+    original_user_ip = Current.user_ip
     begin
       Current.user = user
-      Current.user_ip = ip_address
+      Current.user_ip = user_ip
       yield
     ensure
       Current.user = original_user
-      Current.user_ip = original_ip_address
+      Current.user_ip = original_user_ip
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,8 +14,11 @@ require "mocha/minitest"
 
 GovukTest.configure
 
+require "support/current_helpers"
+
 class ActiveSupport::TestCase
   include FactoryBot::Syntax::Methods
+  include CurrentHelpers
 
   teardown do
     Timecop.return


### PR DESCRIPTION
## Questions
1. Does this approach broadly make sense?
2. I'm fairly confident that moving the creation of `EventLog` records makes sense to do in callbacks on `User`, but I'm slightly less sure about sending email notifications. I think it still makes sense, but I'll probably need to be very careful that the logic is implemented correctly so that e.g. we don't end up sending out emails multiple times.
3. I think the user's permissions are going to be slightly more awkward to deal with, because everything else relates to attributes directly on the `User` record. However, I think we can either use callbacks on the `UserApplicationPermission` join model or implement some custom `ActiveModel::Dirty`-esque methods to detect changes to a user's permissions. The former would be conceptually simpler, but it would mean that we'd lose the ability to group permission changes together, so we'd end up e.g. creating multiple `EventLog` records (one for each user permission that's changed) and sending multiple SSO Push Updates out to each app. The latter might not be a problem though.