### PR TITLE
Split manage permissions and manage tokens out of "edit API user" page

### DIFF
--- a/app/controllers/api_users_controller.rb
+++ b/app/controllers/api_users_controller.rb
@@ -4,7 +4,7 @@ class ApiUsersController < ApplicationController
   layout "admin_layout", only: %w[index new create]
 
   before_action :authenticate_user!
-  before_action :load_and_authorize_api_user, only: %i[edit update]
+  before_action :load_and_authorize_api_user, only: %i[edit manage_permissions update]
   helper_method :applications_and_permissions, :visible_applications
 
   respond_to :html
@@ -20,6 +20,8 @@ class ApiUsersController < ApplicationController
   end
 
   def edit; end
+
+  def manage_permissions; end
 
   def create
     authorize ApiUser

--- a/app/controllers/api_users_controller.rb
+++ b/app/controllers/api_users_controller.rb
@@ -4,7 +4,7 @@ class ApiUsersController < ApplicationController
   layout "admin_layout", only: %w[index new create]
 
   before_action :authenticate_user!
-  before_action :load_and_authorize_api_user, only: %i[edit manage_permissions update]
+  before_action :load_and_authorize_api_user, only: %i[edit manage_permissions manage_tokens update]
   helper_method :applications_and_permissions, :visible_applications
 
   respond_to :html
@@ -22,6 +22,8 @@ class ApiUsersController < ApplicationController
   def edit; end
 
   def manage_permissions; end
+
+  def manage_tokens; end
 
   def create
     authorize ApiUser

--- a/app/controllers/authorisations_controller.rb
+++ b/app/controllers/authorisations_controller.rb
@@ -23,7 +23,7 @@ class AuthorisationsController < ApplicationController
     else
       flash[:error] = "There was an error while creating the access token"
     end
-    redirect_to [:edit, @api_user]
+    redirect_to [:manage_tokens, @api_user]
   end
 
   def revoke
@@ -45,7 +45,7 @@ class AuthorisationsController < ApplicationController
     else
       flash[:error] = "There was an error while revoking access for #{authorisation.application.name}"
     end
-    redirect_to [:edit, @api_user]
+    redirect_to [:manage_tokens, @api_user]
   end
 
 private

--- a/app/policies/api_user_policy.rb
+++ b/app/policies/api_user_policy.rb
@@ -8,4 +8,5 @@ class ApiUserPolicy < BasePolicy
   alias_method :update?, :new?
   alias_method :revoke?, :new?
   alias_method :manage_permissions?, :new?
+  alias_method :manage_tokens?, :new?
 end

--- a/app/policies/api_user_policy.rb
+++ b/app/policies/api_user_policy.rb
@@ -7,4 +7,5 @@ class ApiUserPolicy < BasePolicy
   alias_method :edit?, :new?
   alias_method :update?, :new?
   alias_method :revoke?, :new?
+  alias_method :manage_permissions?, :new?
 end

--- a/app/views/api_users/edit.html.erb
+++ b/app/views/api_users/edit.html.erb
@@ -24,16 +24,12 @@
 <%= form_for @api_user, :html => {:class => 'well add-top-margin'} do |f| %>
   <%= render partial: "form_fields", locals: { f: f } %>
 
-  <% if applications_and_permissions(@api_user).any? %>
-    <hr />
-    <h2 class="add-vertical-margins">Permissions</h2>
-    <%= render partial: "shared/user_permissions", locals: { user_object: f.object }%>
-  <% end %>
-
-  <hr>
-
   <%= f.submit 'Update API user', :class => 'btn btn-primary' %>
 <% end %>
+
+<p>
+  <%= link_to "Manage permissions", manage_permissions_api_user_path(@api_user) %>
+</p>
 
 <h2 class="add-vertical-margins">Tokens</h2>
 

--- a/app/views/api_users/edit.html.erb
+++ b/app/views/api_users/edit.html.erb
@@ -1,6 +1,6 @@
-<% content_for :title, "Edit [#{@api_user.name}]" %>
+<% content_for :title, "Edit #{@api_user.name}" %>
 
-<h1>Edit API User &ldquo;<%= @api_user.name %>&rdquo;</h1>
+<h1>Edit API User <%= @api_user.name %></h1>
 
 <p class="suspenders">
   User <strong><%= @api_user.status %></strong> &bull;

--- a/app/views/api_users/edit.html.erb
+++ b/app/views/api_users/edit.html.erb
@@ -1,5 +1,11 @@
 <% content_for :title, "Edit #{@api_user.name}" %>
 
+<ol class="breadcrumb">
+  <li><%= link_to "Dashboard", root_path %></li>
+  <li><%= link_to "API users", api_users_path %></li>
+  <li><%= "Edit #{@api_user.name}" %></li>
+</ol>
+
 <h1>Edit API User <%= @api_user.name %></h1>
 
 <p class="suspenders">

--- a/app/views/api_users/edit.html.erb
+++ b/app/views/api_users/edit.html.erb
@@ -31,67 +31,6 @@
   <%= link_to "Manage permissions", manage_permissions_api_user_path(@api_user) %>
 </p>
 
-<h2 class="add-vertical-margins">Tokens</h2>
-
-<% if authorisation = flash[:authorisation] %>
-  <div class="alert alert-danger">
-    Make sure to copy the access token for <%= authorisation["application_name"] %> now. You won't be able to see it again!
-  </div>
-  <div class="alert alert-info">
-    Access token for <%= authorisation["application_name"] %>: <span id='access-token'><%= authorisation["token"] %></span>
-    <%= link_to 'Copy to clipboard', '#', class: 'btn btn-info add-left-margin', data: { 'clipboard-target' => 'access-token' }, id: 'clip-button', title: 'Click to copy access token' %>
-  </div>
-<% end %>
-<table id="authorisations" class="table table-bordered table-on-white">
-  <thead>
-    <tr class="table-header">
-      <th>Application</th>
-      <th>Token (hidden)</th>
-      <th>Generated</th>
-      <th>Expires</th>
-      <th>State</th>
-      <th>Action</th>
-    </tr>
-  </thead>
-  <tbody>
-    <% @api_user.authorisations.not_revoked.ordered_by_application_name.ordered_by_expires_at.each do |authorisation| %>
-      <tr>
-        <td><%= authorisation.application.name %></td>
-        <td><code><%= truncate_access_token(authorisation.token) %></code></td>
-        <td>
-          <%= authorisation.created_at.to_date.to_fs(:govuk_date) %>
-        </td>
-        <td>
-          <%= authorisation.expires_at.to_date.to_fs(:govuk_date) %>
-        </td>
-        <td>
-          <% if authorisation.expired? %>
-            <span class="label label-danger">Expired</span>
-          <% else %>
-            <span class="label label-success">Valid</span>
-          <% end %>
-        </td>
-        <td>
-          <div class="btn-group">
-            <%= form_tag(revoke_api_user_authorisation_path(@api_user.id, authorisation.id, regenerate: true), method: "post") do %>
-            <%= submit_tag("Re-generate", class: "btn btn-default") %>
-            <% end %>
-            <%= form_tag(revoke_api_user_authorisation_path(@api_user.id, authorisation.id), method: "post") do %>
-            <%= submit_tag("Revoke", class: "btn btn-default") %>
-            <% end %>
-          </div>
-        </td>
-    <% end %>
-  </tbody>
-</table>
 <p>
-  <%= link_to [:new, @api_user, :authorisation], class: "btn btn-default" do %>
-    <span class="glyphicon glyphicon-plus glyphicon-smaller-than-text"></span> Add application token
-  <% end %>
+  <%= link_to "Manage tokens", manage_tokens_api_user_path(@api_user) %>
 </p>
-
-<script>
-  $(document).ready(function() {
-    new ZeroClipboard($("#clip-button"));
-  });
-</script>

--- a/app/views/api_users/manage_permissions.html.erb
+++ b/app/views/api_users/manage_permissions.html.erb
@@ -1,0 +1,20 @@
+<% content_for :title, "Manage permissions for #{@api_user.name}" %>
+
+<ol class="breadcrumb">
+  <li><%= link_to "Dashboard", root_path %></li>
+  <li><%= link_to "API users", api_users_path %></li>
+  <li><%= link_to @api_user.name, edit_api_user_path(@api_user) %></li>
+  <li class="active">Manage permissions</li>
+</ol>
+
+<h1>Manage permissions for API User <%= @api_user.name %></h1>
+
+<%= form_for @api_user, :html => {:class => 'well add-top-margin'} do |f| %>
+  <% if applications_and_permissions(@api_user).any? %>
+    <hr />
+    <h2 class="add-vertical-margins">Permissions</h2>
+    <%= render partial: "shared/user_permissions", locals: { user_object: f.object }%>
+  <% end %>
+
+  <%= f.submit 'Update API user', :class => 'btn btn-primary' %>
+<% end %>

--- a/app/views/api_users/manage_tokens.html.erb
+++ b/app/views/api_users/manage_tokens.html.erb
@@ -1,0 +1,73 @@
+<% content_for :title, "Manage tokens for #{@api_user.name}" %>
+
+<ol class="breadcrumb">
+  <li><%= link_to "Dashboard", root_path %></li>
+  <li><%= link_to "API users", api_users_path %></li>
+  <li><%= link_to @api_user.name, edit_api_user_path(@api_user) %></li>
+  <li class="active">Manage tokens</li>
+</ol>
+
+<h1>Manage tokens for API User <%= @api_user.name %></h1>
+
+<% if authorisation = flash[:authorisation] %>
+  <div class="alert alert-danger">
+    Make sure to copy the access token for <%= authorisation["application_name"] %> now. You won't be able to see it again!
+  </div>
+  <div class="alert alert-info">
+    Access token for <%= authorisation["application_name"] %>: <span id='access-token'><%= authorisation["token"] %></span>
+    <%= link_to 'Copy to clipboard', '#', class: 'btn btn-info add-left-margin', data: { 'clipboard-target' => 'access-token' }, id: 'clip-button', title: 'Click to copy access token' %>
+  </div>
+<% end %>
+<table id="authorisations" class="table table-bordered table-on-white">
+  <thead>
+    <tr class="table-header">
+      <th>Application</th>
+      <th>Token (hidden)</th>
+      <th>Generated</th>
+      <th>Expires</th>
+      <th>State</th>
+      <th>Action</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @api_user.authorisations.not_revoked.ordered_by_application_name.ordered_by_expires_at.each do |authorisation| %>
+      <tr>
+        <td><%= authorisation.application.name %></td>
+        <td><code><%= truncate_access_token(authorisation.token) %></code></td>
+        <td>
+          <%= authorisation.created_at.to_date.to_fs(:govuk_date) %>
+        </td>
+        <td>
+          <%= authorisation.expires_at.to_date.to_fs(:govuk_date) %>
+        </td>
+        <td>
+          <% if authorisation.expired? %>
+            <span class="label label-danger">Expired</span>
+          <% else %>
+            <span class="label label-success">Valid</span>
+          <% end %>
+        </td>
+        <td>
+          <div class="btn-group">
+            <%= form_tag(revoke_api_user_authorisation_path(@api_user.id, authorisation.id, regenerate: true), method: "post") do %>
+            <%= submit_tag("Re-generate", class: "btn btn-default") %>
+            <% end %>
+            <%= form_tag(revoke_api_user_authorisation_path(@api_user.id, authorisation.id), method: "post") do %>
+            <%= submit_tag("Revoke", class: "btn btn-default") %>
+            <% end %>
+          </div>
+        </td>
+    <% end %>
+  </tbody>
+</table>
+<p>
+  <%= link_to [:new, @api_user, :authorisation], class: "btn btn-default" do %>
+    <span class="glyphicon glyphicon-plus glyphicon-smaller-than-text"></span> Add application token
+  <% end %>
+</p>
+
+<script>
+  $(document).ready(function() {
+    new ZeroClipboard($("#clip-button"));
+  });
+</script>

--- a/app/views/authorisations/new.html.erb
+++ b/app/views/authorisations/new.html.erb
@@ -16,6 +16,10 @@
          url: edit_api_user_path(@api_user),
        },
        {
+         title: "Manage tokens",
+         url: manage_tokens_api_user_path(@api_user),
+       },
+       {
          title: "Create new access token",
        }
      ]

--- a/app/views/users/manage_permissions.html.erb
+++ b/app/views/users/manage_permissions.html.erb
@@ -1,5 +1,12 @@
 <% content_for :title, "Manage permissions [#{@user.name}]" %>
 
+<ol class="breadcrumb">
+  <li><%= link_to "Dashboard", root_path %></li>
+  <li><%= link_to "Users", users_path %></li>
+  <li><%= link_to @user.name, edit_user_path(@user) %></li>
+  <li class="active">Manage permissions</li>
+</ol>
+
 <h1>Manage permissions for &ldquo;<%= @user.name %>&rdquo;</h1>
 
 <% if @user.errors.count > 0 %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -91,6 +91,9 @@ Rails.application.routes.draw do
   end
 
   resources :api_users, only: %i[new create index edit update] do
+    member do
+      get :manage_permissions
+    end
     resources :authorisations, only: %i[new create] do
       member do
         post :revoke

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -93,6 +93,7 @@ Rails.application.routes.draw do
   resources :api_users, only: %i[new create index edit update] do
     member do
       get :manage_permissions
+      get :manage_tokens
     end
     resources :authorisations, only: %i[new create] do
       member do

--- a/test/controllers/api_users_controller_test.rb
+++ b/test/controllers/api_users_controller_test.rb
@@ -114,54 +114,6 @@ class ApiUsersControllerTest < ActionController::TestCase
         end
       end
 
-      should "allow editing permissions for application which user has access to" do
-        application = create(:application, name: "app-name", with_supported_permissions: %w[edit])
-        api_user = create(:api_user, with_permissions: { application => [SupportedPermission::SIGNIN_NAME] })
-        create(:access_token, resource_owner_id: api_user.id, application:)
-
-        get :edit, params: { id: api_user.id }
-
-        assert_select "table#editable-permissions tr" do
-          assert_select "td", text: "app-name"
-          assert_select "td" do
-            assert_select "select[name='api_user[supported_permission_ids][]']" do
-              assert_select "option", text: "edit"
-            end
-          end
-        end
-      end
-
-      should "not allow editing permissions for application which user does not have access to" do
-        application = create(:application, name: "app-name", with_supported_permissions: %w[edit])
-        api_user = create(:api_user, with_permissions: { application => [SupportedPermission::SIGNIN_NAME] })
-
-        get :edit, params: { id: api_user.id }
-
-        assert_select "table#editable-permissions", count: 0
-      end
-
-      should "not allow editing permissions for retired application" do
-        application = create(:application, name: "retired-app-name", retired: true)
-        api_user = create(:api_user, with_permissions: { application => [SupportedPermission::SIGNIN_NAME] })
-        create(:access_token, resource_owner_id: api_user.id, application:)
-
-        get :edit, params: { id: api_user.id }
-
-        assert_select "table#editable-permissions", count: 0
-      end
-
-      should "allow editing permissions for API-only application" do
-        application = create(:application, name: "api-only-app-name", api_only: true)
-        api_user = create(:api_user, with_permissions: { application => [SupportedPermission::SIGNIN_NAME] })
-        create(:access_token, resource_owner_id: api_user.id, application:)
-
-        get :edit, params: { id: api_user.id }
-
-        assert_select "table#editable-permissions tr" do
-          assert_select "td", text: "api-only-app-name"
-        end
-      end
-
       should "show API user's access tokens" do
         application = create(:application)
         token = create(:access_token, resource_owner_id: @api_user.id, application:)
@@ -219,6 +171,60 @@ class ApiUsersControllerTest < ActionController::TestCase
         get :edit, params: { id: @api_user }
 
         assert_select "table#authorisations tbody td", text: application.name, count: 0
+      end
+    end
+
+    context "GET manage_permissions" do
+      setup do
+        @api_user = create(:api_user)
+      end
+
+      should "allow editing permissions for application which user has access to" do
+        application = create(:application, name: "app-name", with_supported_permissions: %w[edit])
+        api_user = create(:api_user, with_permissions: { application => [SupportedPermission::SIGNIN_NAME] })
+        create(:access_token, resource_owner_id: api_user.id, application:)
+
+        get :manage_permissions, params: { id: api_user.id }
+
+        assert_select "table#editable-permissions tr" do
+          assert_select "td", text: "app-name"
+          assert_select "td" do
+            assert_select "select[name='api_user[supported_permission_ids][]']" do
+              assert_select "option", text: "edit"
+            end
+          end
+        end
+      end
+
+      should "not allow editing permissions for application which user does not have access to" do
+        application = create(:application, name: "app-name", with_supported_permissions: %w[edit])
+        api_user = create(:api_user, with_permissions: { application => [SupportedPermission::SIGNIN_NAME] })
+
+        get :manage_permissions, params: { id: api_user.id }
+
+        assert_select "table#editable-permissions", count: 0
+      end
+
+      should "not allow editing permissions for retired application" do
+        application = create(:application, name: "retired-app-name", retired: true)
+        api_user = create(:api_user, with_permissions: { application => [SupportedPermission::SIGNIN_NAME] })
+        create(:access_token, resource_owner_id: api_user.id, application:)
+
+        get :manage_permissions, params: { id: api_user.id }
+
+        assert_select "table#editable-permissions", count: 0
+      end
+
+      should "allow editing permissions for API-only application" do
+        application = create(:application, name: "api-only-app-name", api_only: true)
+        api_user = create(:api_user, with_permissions: { application => [SupportedPermission::SIGNIN_NAME] })
+        create(:access_token, resource_owner_id: api_user.id, application:)
+
+        get :manage_permissions, params: { id: api_user.id }
+
+        assert_select "table#editable-permissions tr" do
+          assert_select "td", text: "api-only-app-name"
+        end
       end
     end
 

--- a/test/controllers/api_users_controller_test.rb
+++ b/test/controllers/api_users_controller_test.rb
@@ -113,65 +113,6 @@ class ApiUsersControllerTest < ActionController::TestCase
           assert_select "input[name='api_user[email]'][value='#{@api_user.email}']"
         end
       end
-
-      should "show API user's access tokens" do
-        application = create(:application)
-        token = create(:access_token, resource_owner_id: @api_user.id, application:)
-
-        get :edit, params: { id: @api_user }
-
-        assert_select "table#authorisations tbody td", text: application.name do |td|
-          assert_select td.first.parent, "code", text: /^#{token[0..7]}/
-        end
-      end
-
-      should "show button for regenerating API user's access token for an application" do
-        application = create(:application)
-        token = create(:access_token, resource_owner_id: @api_user.id, application:)
-
-        get :edit, params: { id: @api_user }
-
-        regenerate_token_path = revoke_api_user_authorisation_path(@api_user, token, regenerate: true)
-
-        assert_select "table#authorisations tbody td", text: application.name do |td|
-          assert_select td.first.parent, "form[action='#{regenerate_token_path}']" do
-            assert_select "input[type='submit']", value: "Re-generate"
-          end
-        end
-      end
-
-      should "show button for revoking API user's access token for an application" do
-        application = create(:application)
-        token = create(:access_token, resource_owner_id: @api_user.id, application:)
-
-        get :edit, params: { id: @api_user }
-
-        revoke_token_path = revoke_api_user_authorisation_path(@api_user, token)
-
-        assert_select "table#authorisations tbody td", text: application.name do |td|
-          assert_select td.first.parent, "form[action='#{revoke_token_path}']" do
-            assert_select "input[type='submit']", value: "Revoke"
-          end
-        end
-      end
-
-      should "not show API user's revoked access tokens" do
-        application = create(:application)
-        create(:access_token, resource_owner_id: @api_user.id, application:, revoked_at: Time.current)
-
-        get :edit, params: { id: @api_user }
-
-        assert_select "table#authorisations tbody td", text: application.name, count: 0
-      end
-
-      should "not show API user's access tokens for retired applications" do
-        application = create(:application, retired: true)
-        create(:access_token, resource_owner_id: @api_user.id, application:)
-
-        get :edit, params: { id: @api_user }
-
-        assert_select "table#authorisations tbody td", text: application.name, count: 0
-      end
     end
 
     context "GET manage_permissions" do
@@ -225,6 +166,71 @@ class ApiUsersControllerTest < ActionController::TestCase
         assert_select "table#editable-permissions tr" do
           assert_select "td", text: "api-only-app-name"
         end
+      end
+    end
+
+    context "GET manage_tokens" do
+      setup do
+        @api_user = create(:api_user)
+      end
+
+      should "show API user's access tokens" do
+        application = create(:application)
+        token = create(:access_token, resource_owner_id: @api_user.id, application:)
+
+        get :manage_tokens, params: { id: @api_user }
+
+        assert_select "table#authorisations tbody td", text: application.name do |td|
+          assert_select td.first.parent, "code", text: /^#{token[0..7]}/
+        end
+      end
+
+      should "show button for regenerating API user's access token for an application" do
+        application = create(:application)
+        token = create(:access_token, resource_owner_id: @api_user.id, application:)
+
+        get :manage_tokens, params: { id: @api_user }
+
+        regenerate_token_path = revoke_api_user_authorisation_path(@api_user, token, regenerate: true)
+
+        assert_select "table#authorisations tbody td", text: application.name do |td|
+          assert_select td.first.parent, "form[action='#{regenerate_token_path}']" do
+            assert_select "input[type='submit']", value: "Re-generate"
+          end
+        end
+      end
+
+      should "show button for revoking API user's access token for an application" do
+        application = create(:application)
+        token = create(:access_token, resource_owner_id: @api_user.id, application:)
+
+        get :manage_tokens, params: { id: @api_user }
+
+        revoke_token_path = revoke_api_user_authorisation_path(@api_user, token)
+
+        assert_select "table#authorisations tbody td", text: application.name do |td|
+          assert_select td.first.parent, "form[action='#{revoke_token_path}']" do
+            assert_select "input[type='submit']", value: "Revoke"
+          end
+        end
+      end
+
+      should "not show API user's revoked access tokens" do
+        application = create(:application)
+        create(:access_token, resource_owner_id: @api_user.id, application:, revoked_at: Time.current)
+
+        get :manage_tokens, params: { id: @api_user }
+
+        assert_select "table#authorisations tbody td", text: application.name, count: 0
+      end
+
+      should "not show API user's access tokens for retired applications" do
+        application = create(:application, retired: true)
+        create(:access_token, resource_owner_id: @api_user.id, application:)
+
+        get :manage_tokens, params: { id: @api_user }
+
+        assert_select "table#authorisations tbody td", text: application.name, count: 0
       end
     end
 

--- a/test/integration/manage_api_users_test.rb
+++ b/test/integration/manage_api_users_test.rb
@@ -37,6 +37,7 @@ class ManageApiUsersTest < ActionDispatch::IntegrationTest
       create(:application, name: "Whitehall", with_supported_permissions: ["Managing Editor", SupportedPermission::SIGNIN_NAME])
 
       click_link @api_user.name
+      click_link "Manage tokens"
       click_link "Add application token"
 
       select "Whitehall", from: "Application"
@@ -51,6 +52,7 @@ class ManageApiUsersTest < ActionDispatch::IntegrationTest
       assert_not page.has_selector?("code", text: (token[9..-9]).to_s)
       assert page.has_selector?("code", text: (token[-8..]).to_s)
 
+      click_link @api_user.name
       click_link "Manage permissions"
       select "Managing Editor", from: "Permissions for Whitehall"
       click_button "Update API user"
@@ -76,6 +78,7 @@ class ManageApiUsersTest < ActionDispatch::IntegrationTest
 
     should "be able to revoke application access for an API user which should get recorded in event log" do
       click_link @api_user.name
+      click_link "Manage tokens"
 
       assert page.has_selector?("td:first-child", text: @application.name)
       click_button "Revoke"
@@ -83,12 +86,14 @@ class ManageApiUsersTest < ActionDispatch::IntegrationTest
       assert page.has_text?("Access for #{@application.name} was revoked")
       assert_not page.has_selector?("td:first-child", text: @application.name)
 
+      click_link @api_user.name
       click_link "Account access log"
       assert page.has_text?("Access token revoked for #{@application.name} by #{@superadmin.name}")
     end
 
     should "be able to regenerate application access token for an API user which should get recorded in event log" do
       click_link @api_user.name
+      click_link "Manage tokens"
 
       assert page.has_selector?("td:first-child", text: @application.name)
       click_button "Re-generate"
@@ -96,6 +101,7 @@ class ManageApiUsersTest < ActionDispatch::IntegrationTest
       assert page.has_selector?("div.alert-danger", text: "Make sure to copy the access token for #{@application.name} now. You won't be able to see it again!")
       assert page.has_selector?("div.alert-info", text: "Access token for #{@application.name}: #{@api_user.authorisations.last.token}")
 
+      click_link @api_user.name
       click_link "Account access log"
       assert page.has_text?("Access token re-generated for #{@application.name} by #{@superadmin.name}")
     end

--- a/test/integration/manage_api_users_test.rb
+++ b/test/integration/manage_api_users_test.rb
@@ -51,10 +51,12 @@ class ManageApiUsersTest < ActionDispatch::IntegrationTest
       assert_not page.has_selector?("code", text: (token[9..-9]).to_s)
       assert page.has_selector?("code", text: (token[-8..]).to_s)
 
+      click_link "Manage permissions"
       select "Managing Editor", from: "Permissions for Whitehall"
       click_button "Update API user"
 
       click_link @api_user.name
+      click_link "Manage permissions"
 
       assert_has_signin_permission_for("Whitehall")
       assert_has_other_permissions("Whitehall", ["Managing Editor"])
@@ -63,9 +65,11 @@ class ManageApiUsersTest < ActionDispatch::IntegrationTest
       click_button "Update API user"
 
       click_link @api_user.name
+      click_link "Manage permissions"
 
       assert_has_signin_permission_for("Whitehall")
 
+      click_link @api_user.name
       click_link "Account access log"
       assert page.has_text?("Access token generated for Whitehall by #{@superadmin.name}")
     end


### PR DESCRIPTION
Trello: https://trello.com/c/wSKG73MP

This is a small step towards moving this page to use the GOV.UK Design System. Splitting the page up like this should mean we can work on different bits of the page in parallel.

Note that I've added breadcrumbs for the page as part of this.

### "edit API user" page split into 3 parts

<img width="827" alt="Screenshot 2023-12-11 at 12 06 36" src="https://github.com/alphagov/signon/assets/3169/1eddbc7d-0515-448c-8365-a5dd56b68eaa">

### New "manage permissions" page
<img width="982" alt="Screenshot 2023-12-11 at 12 19 32" src="https://github.com/alphagov/signon/assets/3169/fb003501-8709-48d6-b4b7-0e3ffa64a442">

### New "manage tokens" page
<img width="1218" alt="Screenshot 2023-12-11 at 12 20 53" src="https://github.com/alphagov/signon/assets/3169/2236a596-2e41-4e57-ad79-cc4e6ad35f55">
