### PR TITLE
Remove vestiges of `permissions_attributes` param

### DIFF
--- a/app/controllers/api_users_controller.rb
+++ b/app/controllers/api_users_controller.rb
@@ -65,6 +65,6 @@ private
   end
 
   def permitted_user_params(params)
-    params.permit(:email, :name, permissions_attributes: {}, supported_permission_ids: [])
+    params.permit(:email, :name, supported_permission_ids: [])
   end
 end

--- a/test/controllers/api_users_controller_test.rb
+++ b/test/controllers/api_users_controller_test.rb
@@ -283,7 +283,6 @@ class ApiUsersControllerTest < ActionController::TestCase
       end
 
       should "push permission changes out to apps" do
-        application = create(:application)
         api_user = create(:api_user)
 
         PermissionUpdater.expects(:perform_on).with(api_user).once
@@ -292,8 +291,7 @@ class ApiUsersControllerTest < ActionController::TestCase
             params: {
               "id" => api_user.id,
               "api_user" => { "name" => api_user.name,
-                              "email" => api_user.email,
-                              "permissions_attributes" => { "0" => { "application_id" => application.id, "id" => "", "permissions" => %w[admin] } } },
+                              "email" => api_user.email },
             }
       end
     end


### PR DESCRIPTION
These relate to a time when the `User` model had `accepts_nested_attributes_for :permissions`. However, these were renamed to `:application_permissions` in [this commit][1] and removed entirely in [this commit][2] all as part of #311 which was merged 8 years ago!

The controller test about pushing permission changes out to apps wasn't relying on the `permissions_attributes` param being set. And none of the form fields under `app/views/api_users/*` use the name.

[1]: https://github.com/alphagov/signon/pull/311/commits/e2126f392b312a05263b5ca26c13e6c68ad002fc
[2]: https://github.com/alphagov/signon/pull/311/commits/d0df5b1b0569ffc08f04cace7e8665102188e138
