### PR TITLE
Prevent Admins from suspending/unsuspending API users

### DIFF
--- a/app/controllers/suspensions_controller.rb
+++ b/app/controllers/suspensions_controller.rb
@@ -28,7 +28,9 @@ class SuspensionsController < ApplicationController
 private
 
   def load_and_authorize_user
-    @user = User.find(params[:id])
+    @user = ApiUser.find_by(id: params[:id]) || User.find_by(id: params[:id])
+    raise ActiveRecord::RecordNotFound if @user.blank?
+
     authorize @user, :suspension?
   end
 end

--- a/app/policies/api_user_policy.rb
+++ b/app/policies/api_user_policy.rb
@@ -9,4 +9,5 @@ class ApiUserPolicy < BasePolicy
   alias_method :revoke?, :new?
   alias_method :manage_permissions?, :new?
   alias_method :manage_tokens?, :new?
+  alias_method :suspension?, :new?
 end

--- a/app/views/api_users/edit.html.erb
+++ b/app/views/api_users/edit.html.erb
@@ -12,7 +12,9 @@
   User <strong><%= @api_user.status %></strong> &bull;
   Created <%= time_ago_in_words(@api_user.created_at) %> ago &bull;
   <%= link_to "Account access log", event_logs_user_path(@api_user) %> &bull;
-  <%= link_to "#{@api_user.suspended? ? "Uns" : "S"}uspend user", edit_suspension_path(@api_user) %>
+  <% if policy(@api_user).suspension? %>
+    <%= link_to "#{@api_user.suspended? ? "Uns" : "S"}uspend user", edit_suspension_path(@api_user) %>
+  <% end %>
 </p>
 
 <% if @api_user.suspended? and @api_user.reason_for_suspension.present? %>

--- a/test/controllers/suspensions_controller_test.rb
+++ b/test/controllers/suspensions_controller_test.rb
@@ -74,6 +74,14 @@ class SuspensionsControllerTest < ActionController::TestCase
       assert_equal "Negligence", another_user.reason_for_suspension
     end
 
+    should "not be able to control suspension of an API user" do
+      api_user = create(:api_user)
+      put :update, params: { id: api_user.id, user: { suspended: "1", reason_for_suspension: "Negligence" } }
+
+      assert_not_authorised
+      assert_not api_user.reload.suspended?
+    end
+
     should "redisplay the form if the reason is blank" do
       another_user = create(:user)
       put :update, params: { id: another_user.id, user: { suspended: "1", reason_for_suspension: "" } }

--- a/test/policies/api_user_policy_test.rb
+++ b/test/policies/api_user_policy_test.rb
@@ -4,7 +4,7 @@ require "support/policy_helpers"
 class ApiUserPolicyTest < ActiveSupport::TestCase
   include PolicyHelpers
 
-  %i[new create index edit update revoke suspension].each do |permission_name|
+  %i[new create index edit update revoke manage_permissions manage_tokens suspension].each do |permission_name|
     context permission_name do
       should "allow only for superadmins" do
         assert permit?(create(:superadmin_user), User, permission_name)

--- a/test/policies/api_user_policy_test.rb
+++ b/test/policies/api_user_policy_test.rb
@@ -4,7 +4,7 @@ require "support/policy_helpers"
 class ApiUserPolicyTest < ActiveSupport::TestCase
   include PolicyHelpers
 
-  %i[new create index edit update revoke].each do |permission_name|
+  %i[new create index edit update revoke suspension].each do |permission_name|
     context permission_name do
       should "allow only for superadmins" do
         assert permit?(create(:superadmin_user), User, permission_name)


### PR DESCRIPTION
Trello: https://trello.com/c/s9Qdhk0Y

Previously, `SuspensionsController#load_and_authorize_user` was only ever checking `UserPolicy#suspension?` to determine whether the current user was authorized to suspend/unsuspend an API user. This meant that although it hasn't been possible for Admins to *navigate* to the suspend/unsuspend user page for an API user, it would have been easy enough to hack the URL to reach the page and then there was nothing preventing them from suspending/unsuspending the API user.

I think this was an oversight when the `UserPolicy#suspension?` was introduced almost 9 years ago in https://github.com/alphagov/signon/pull/298. Since it was calling `User.find` it would never have returned an instance of an `ApiUser` and thus it would never have tried to use `ApiUserPolicy#suspension?` instead of `UserPolicy#suspension?`. I've implemented the former by aliasing it to `ApiUserPolicy#new?` as per all the other `ApiUser`-related predicates which means that only Superadmins have permission.

I've also hidden the suspend/unsuspend API user link on the edit API user page if the current user doesn't have the relevant permission (even though this doesn't make any practical difference) and added some missing test coverage that I missed in #2587.