### PR TITLE
Consistently use PunditHelpers#stub_policy in controller tests

### DIFF
--- a/test/controllers/users/applications_controller_test.rb
+++ b/test/controllers/users/applications_controller_test.rb
@@ -254,10 +254,6 @@ class Users::ApplicationsControllerTest < ActionController::TestCase
 
 private
 
-  def stub_policy_for_navigation_links(current_user)
-    stub_policy(current_user, User, index?: true)
-  end
-
   def stub_user_application_permission(user, application)
     permission = UserApplicationPermission.new
     UserApplicationPermission.stubs(:for).with(user, application).returns(permission)

--- a/test/controllers/users/emails_controller_test.rb
+++ b/test/controllers/users/emails_controller_test.rb
@@ -73,8 +73,8 @@ class Users::EmailsControllerTest < ActionController::TestCase
       should "authorize access if UserPolicy#edit? returns true" do
         user = create(:user)
 
-        user_policy = stub_everything("user-policy", edit?: true)
-        UserPolicy.stubs(:new).returns(user_policy)
+        stub_policy(@superadmin, user, edit?: true)
+        stub_policy_for_navigation_links(@superadmin)
 
         get :edit, params: { user_id: user }
 
@@ -84,8 +84,8 @@ class Users::EmailsControllerTest < ActionController::TestCase
       should "not authorize access if UserPolicy#edit? returns false" do
         user = create(:user)
 
-        user_policy = stub_everything("user-policy", edit?: false)
-        UserPolicy.stubs(:new).returns(user_policy)
+        stub_policy(@superadmin, user, edit?: false)
+        stub_policy_for_navigation_links(@superadmin)
 
         get :edit, params: { user_id: user }
 
@@ -95,8 +95,8 @@ class Users::EmailsControllerTest < ActionController::TestCase
       should "authorize access if ApiUserPolicy#edit? returns true when user is an API user" do
         user = create(:api_user)
 
-        api_user_policy = stub_everything("api-user-policy", edit?: true)
-        ApiUserPolicy.stubs(:new).returns(api_user_policy)
+        stub_policy(@superadmin, user, edit?: true)
+        stub_policy_for_navigation_links(@superadmin)
 
         get :edit, params: { api_user_id: user }
 
@@ -106,8 +106,8 @@ class Users::EmailsControllerTest < ActionController::TestCase
       should "not authorize access if ApiUserPolicy#edit? returns false when user is an API user" do
         user = create(:api_user)
 
-        api_user_policy = stub_everything("api-user-policy", edit?: false)
-        ApiUserPolicy.stubs(:new).returns(api_user_policy)
+        stub_policy(@superadmin, user, edit?: false)
+        stub_policy_for_navigation_links(@superadmin)
 
         get :edit, params: { api_user_id: user }
 
@@ -269,8 +269,7 @@ class Users::EmailsControllerTest < ActionController::TestCase
       should "update user email if UserPolicy#update? returns true" do
         user = create(:user, email: "user@gov.uk")
 
-        user_policy = stub_everything("user-policy", update?: true)
-        UserPolicy.stubs(:new).returns(user_policy)
+        stub_policy(@superadmin, user, update?: true)
 
         put :update, params: { user_id: user, user: { email: "new-user@gov.uk" } }
 
@@ -280,8 +279,7 @@ class Users::EmailsControllerTest < ActionController::TestCase
       should "not update user email if UserPolicy#update? returns false" do
         user = create(:user, email: "user@gov.uk")
 
-        user_policy = stub_everything("user-policy", update?: false)
-        UserPolicy.stubs(:new).returns(user_policy)
+        stub_policy(@superadmin, user, update?: false)
 
         put :update, params: { user_id: user, user: { email: "new-user@gov.uk" } }
 
@@ -292,8 +290,7 @@ class Users::EmailsControllerTest < ActionController::TestCase
       should "update user email if ApiUserPolicy#update? returns true when user is an API user" do
         user = create(:api_user, email: "user@gov.uk")
 
-        api_user_policy = stub_everything("api_user-policy", update?: true)
-        ApiUserPolicy.stubs(:new).returns(api_user_policy)
+        stub_policy(@superadmin, user, update?: true)
 
         put :update, params: { api_user_id: user, user: { email: "new-user@gov.uk" } }
 
@@ -303,8 +300,7 @@ class Users::EmailsControllerTest < ActionController::TestCase
       should "not update user email if ApiUserPolicy#update? returns false when user is an API user" do
         user = create(:api_user, email: "user@gov.uk")
 
-        api_user_policy = stub_everything("api_user-policy", update?: false)
-        ApiUserPolicy.stubs(:new).returns(api_user_policy)
+        stub_policy(@superadmin, user, update?: false)
 
         put :update, params: { api_user_id: user, user: { email: "new-user@gov.uk" } }
 
@@ -366,7 +362,8 @@ class Users::EmailsControllerTest < ActionController::TestCase
   context "PUT resend_email_change" do
     context "signed in as Superadmin user" do
       setup do
-        sign_in(create(:superadmin_user))
+        @superadmin = create(:superadmin_user)
+        sign_in(@superadmin)
       end
 
       should "send an email change confirmation email" do
@@ -412,8 +409,7 @@ class Users::EmailsControllerTest < ActionController::TestCase
       should "send an email change confirmation email if UserPolicy#resend_email_change? returns true" do
         user = create(:user_with_pending_email_change)
 
-        user_policy = stub_everything("user-policy", resend_email_change?: true)
-        UserPolicy.stubs(:new).returns(user_policy)
+        stub_policy(@superadmin, user, resend_email_change?: true)
 
         assert_enqueued_emails 1 do
           put :resend_email_change, params: { user_id: user }
@@ -424,8 +420,7 @@ class Users::EmailsControllerTest < ActionController::TestCase
       should "not send an email change confirmation email if UserPolicy#resend_email_change? returns false" do
         user = create(:user_with_pending_email_change)
 
-        user_policy = stub_everything("user-policy", resend_email_change?: false)
-        UserPolicy.stubs(:new).returns(user_policy)
+        stub_policy(@superadmin, user, resend_email_change?: false)
 
         assert_no_enqueued_emails do
           put :resend_email_change, params: { user_id: user }
@@ -462,7 +457,8 @@ class Users::EmailsControllerTest < ActionController::TestCase
   context "DELETE cancel_email_change" do
     context "signed in as Superadmin user" do
       setup do
-        sign_in(create(:superadmin_user))
+        @superadmin = create(:superadmin_user)
+        sign_in(@superadmin)
       end
 
       should "clear unconfirmed_email & confirmation_token" do
@@ -486,8 +482,7 @@ class Users::EmailsControllerTest < ActionController::TestCase
       should "clear email & token if UserPolicy#cancel_email_change? returns true" do
         user = create(:user_with_pending_email_change)
 
-        user_policy = stub_everything("user-policy", cancel_email_change?: true)
-        UserPolicy.stubs(:new).returns(user_policy)
+        stub_policy(@superadmin, user, cancel_email_change?: true)
 
         delete :cancel_email_change, params: { user_id: user }
 
@@ -497,8 +492,7 @@ class Users::EmailsControllerTest < ActionController::TestCase
       should "not clear email & token if UserPolicy#cancel_email_change? returns false" do
         user = create(:user_with_pending_email_change)
 
-        user_policy = stub_everything("user-policy", cancel_email_change?: false)
-        UserPolicy.stubs(:new).returns(user_policy)
+        stub_policy(@superadmin, user, cancel_email_change?: false)
 
         delete :cancel_email_change, params: { user_id: user }
 

--- a/test/controllers/users/invitation_resends_controller_test.rb
+++ b/test/controllers/users/invitation_resends_controller_test.rb
@@ -26,8 +26,8 @@ class Users::InvitationResendsControllerTest < ActionController::TestCase
       should "authorize access if UserPolicy#resend_invitation? returns true" do
         user = create(:invited_user)
 
-        user_policy = stub_everything("user-policy", resend_invitation?: true)
-        UserPolicy.stubs(:new).returns(user_policy)
+        stub_policy(@admin, user, resend_invitation?: true)
+        stub_policy_for_navigation_links(@admin)
 
         get :edit, params: { user_id: user }
 
@@ -37,8 +37,8 @@ class Users::InvitationResendsControllerTest < ActionController::TestCase
       should "not authorize access if UserPolicy#resend_invitation? returns false" do
         user = create(:invited_user)
 
-        user_policy = stub_everything("user-policy", resend_invitation?: false)
-        UserPolicy.stubs(:new).returns(user_policy)
+        stub_policy(@admin, user, resend_invitation?: false)
+        stub_policy_for_navigation_links(@admin)
 
         get :edit, params: { user_id: user }
 
@@ -137,8 +137,7 @@ class Users::InvitationResendsControllerTest < ActionController::TestCase
       should "resend signup email if UserPolicy#resend_invitation? returns true" do
         user = create(:invited_user)
 
-        user_policy = stub_everything("user-policy", resend_invitation?: true)
-        UserPolicy.stubs(:new).returns(user_policy)
+        stub_policy(@admin, user, resend_invitation?: true)
 
         assert_enqueued_emails(1) do
           put :update, params: { user_id: user }
@@ -148,8 +147,7 @@ class Users::InvitationResendsControllerTest < ActionController::TestCase
       should "not resend signup email if UserPolicy#resend_invitation? returns false" do
         user = create(:invited_user)
 
-        user_policy = stub_everything("user-policy", resend_invitation?: false)
-        UserPolicy.stubs(:new).returns(user_policy)
+        stub_policy(@admin, user, resend_invitation?: false)
 
         put :update, params: { user_id: user }
 

--- a/test/controllers/users/names_controller_test.rb
+++ b/test/controllers/users/names_controller_test.rb
@@ -59,8 +59,8 @@ class Users::NamesControllerTest < ActionController::TestCase
       should "authorize access if UserPolicy#edit? returns true" do
         user = create(:user)
 
-        user_policy = stub_everything("user-policy", edit?: true)
-        UserPolicy.stubs(:new).returns(user_policy)
+        stub_policy(@superadmin, user, edit?: true)
+        stub_policy_for_navigation_links(@superadmin)
 
         get :edit, params: { user_id: user }
 
@@ -70,8 +70,8 @@ class Users::NamesControllerTest < ActionController::TestCase
       should "not authorize access if UserPolicy#edit? returns false" do
         user = create(:user)
 
-        user_policy = stub_everything("user-policy", edit?: false)
-        UserPolicy.stubs(:new).returns(user_policy)
+        stub_policy(@superadmin, user, edit?: false)
+        stub_policy_for_navigation_links(@superadmin)
 
         get :edit, params: { user_id: user }
 
@@ -81,8 +81,8 @@ class Users::NamesControllerTest < ActionController::TestCase
       should "authorize access if ApiUserPolicy#edit? returns true when user is an API user" do
         user = create(:api_user)
 
-        api_user_policy = stub_everything("api-user-policy", edit?: true)
-        ApiUserPolicy.stubs(:new).returns(api_user_policy)
+        stub_policy(@superadmin, user, edit?: true)
+        stub_policy_for_navigation_links(@superadmin)
 
         get :edit, params: { api_user_id: user }
 
@@ -92,8 +92,8 @@ class Users::NamesControllerTest < ActionController::TestCase
       should "not authorize access if ApiUserPolicy#edit? returns false when user is an API user" do
         user = create(:api_user)
 
-        api_user_policy = stub_everything("api-user-policy", edit?: false)
-        ApiUserPolicy.stubs(:new).returns(api_user_policy)
+        stub_policy(@superadmin, user, edit?: false)
+        stub_policy_for_navigation_links(@superadmin)
 
         get :edit, params: { api_user_id: user }
 
@@ -190,8 +190,7 @@ class Users::NamesControllerTest < ActionController::TestCase
       should "update user name if UserPolicy#update? returns true" do
         user = create(:user, name: "user-name")
 
-        user_policy = stub_everything("user-policy", update?: true)
-        UserPolicy.stubs(:new).returns(user_policy)
+        stub_policy(@superadmin, user, update?: true)
 
         put :update, params: { user_id: user, user: { name: "new-user-name" } }
 
@@ -201,8 +200,7 @@ class Users::NamesControllerTest < ActionController::TestCase
       should "not update user name if UserPolicy#update? returns false" do
         user = create(:user, name: "user-name")
 
-        user_policy = stub_everything("user-policy", update?: false)
-        UserPolicy.stubs(:new).returns(user_policy)
+        stub_policy(@superadmin, user, update?: false)
 
         put :update, params: { user_id: user, user: { name: "new-user-name" } }
 
@@ -213,8 +211,7 @@ class Users::NamesControllerTest < ActionController::TestCase
       should "update user name if ApiUserPolicy#update? returns true when user is an API user" do
         user = create(:api_user, name: "user-name")
 
-        api_user_policy = stub_everything("api_user-policy", update?: true)
-        ApiUserPolicy.stubs(:new).returns(api_user_policy)
+        stub_policy(@superadmin, user, update?: true)
 
         put :update, params: { api_user_id: user, user: { name: "new-user-name" } }
 
@@ -224,8 +221,7 @@ class Users::NamesControllerTest < ActionController::TestCase
       should "not update user name if ApiUserPolicy#update? returns false when user is an API user" do
         user = create(:api_user, name: "user-name")
 
-        api_user_policy = stub_everything("api_user-policy", update?: false)
-        ApiUserPolicy.stubs(:new).returns(api_user_policy)
+        stub_policy(@superadmin, user, update?: false)
 
         put :update, params: { api_user_id: user, user: { name: "new-user-name" } }
 

--- a/test/controllers/users/organisations_controller_test.rb
+++ b/test/controllers/users/organisations_controller_test.rb
@@ -30,8 +30,8 @@ class Users::OrganisationsControllerTest < ActionController::TestCase
       should "authorize access if UserPolicy#assign_organisation? returns true" do
         user = create(:user)
 
-        user_policy = stub_everything("user-policy", assign_organisation?: true)
-        UserPolicy.stubs(:new).returns(user_policy)
+        stub_policy(@admin, user, assign_organisation?: true)
+        stub_policy_for_navigation_links(@admin)
 
         get :edit, params: { user_id: user }
 
@@ -41,8 +41,8 @@ class Users::OrganisationsControllerTest < ActionController::TestCase
       should "not authorize access if UserPolicy#assign_organisation? returns false" do
         user = create(:user)
 
-        user_policy = stub_everything("user-policy", assign_organisation?: false)
-        UserPolicy.stubs(:new).returns(user_policy)
+        stub_policy(@admin, user, assign_organisation?: false)
+        stub_policy_for_navigation_links(@admin)
 
         get :edit, params: { user_id: user }
 
@@ -152,8 +152,7 @@ class Users::OrganisationsControllerTest < ActionController::TestCase
       should "update user organisation if UserPolicy#assign_organisation? returns true" do
         user = create(:user, organisation:)
 
-        user_policy = stub_everything("user-policy", assign_organisation?: true)
-        UserPolicy.stubs(:new).returns(user_policy)
+        stub_policy(@admin, user, assign_organisation?: true)
 
         put :update, params: { user_id: user, user: { organisation_id: another_organisation } }
 
@@ -163,8 +162,7 @@ class Users::OrganisationsControllerTest < ActionController::TestCase
       should "not update user organisation if UserPolicy#assign_organisation? returns false" do
         user = create(:user, organisation:)
 
-        user_policy = stub_everything("user-policy", assign_organisation?: false)
-        UserPolicy.stubs(:new).returns(user_policy)
+        stub_policy(@admin, user, assign_organisation?: false)
 
         put :update, params: { user_id: user, user: { organisation_id: another_organisation } }
 

--- a/test/controllers/users/permissions_controller_test.rb
+++ b/test/controllers/users/permissions_controller_test.rb
@@ -434,10 +434,6 @@ class Users::PermissionsControllerTest < ActionController::TestCase
 
 private
 
-  def stub_policy_for_navigation_links(current_user)
-    stub_policy(current_user, User, index?: true)
-  end
-
   def stub_user_application_permission(user, application)
     permission = UserApplicationPermission.new
     UserApplicationPermission.stubs(:for).with(user, application).returns(permission)

--- a/test/controllers/users/roles_controller_test.rb
+++ b/test/controllers/users/roles_controller_test.rb
@@ -35,8 +35,8 @@ class Users::RolesControllerTest < ActionController::TestCase
       should "authorize access if UserPolicy#assign_role? returns true" do
         user = create(:user)
 
-        user_policy = stub_everything("user-policy", assign_role?: true)
-        UserPolicy.stubs(:new).returns(user_policy)
+        stub_policy(@superadmin, user, assign_role?: true)
+        stub_policy_for_navigation_links(@superadmin)
 
         get :edit, params: { user_id: user }
 
@@ -46,8 +46,8 @@ class Users::RolesControllerTest < ActionController::TestCase
       should "not authorize access if UserPolicy#assign_role? returns false" do
         user = create(:user)
 
-        user_policy = stub_everything("user-policy", assign_role?: false)
-        UserPolicy.stubs(:new).returns(user_policy)
+        stub_policy(@superadmin, user, assign_role?: false)
+        stub_policy_for_navigation_links(@superadmin)
 
         get :edit, params: { user_id: user }
 
@@ -150,8 +150,7 @@ class Users::RolesControllerTest < ActionController::TestCase
       should "update user role if UserPolicy#assign_role? returns true" do
         user = create(:user_in_organisation, role: Roles::Normal.role_name)
 
-        user_policy = stub_everything("user-policy", assign_role?: true)
-        UserPolicy.stubs(:new).returns(user_policy)
+        stub_policy(@superadmin, user, assign_role?: true)
 
         put :update, params: { user_id: user, user: { role: Roles::OrganisationAdmin.role_name } }
 
@@ -161,8 +160,7 @@ class Users::RolesControllerTest < ActionController::TestCase
       should "not update user role if UserPolicy#assign_role? returns false" do
         user = create(:user_in_organisation, role: Roles::Normal.role_name)
 
-        user_policy = stub_everything("user-policy", assign_role?: false)
-        UserPolicy.stubs(:new).returns(user_policy)
+        stub_policy(@superadmin, user, assign_role?: false)
 
         put :update, params: { user_id: user, user: { role: Roles::OrganisationAdmin.role_name } }
 

--- a/test/controllers/users/two_step_verification_mandations_controller_test.rb
+++ b/test/controllers/users/two_step_verification_mandations_controller_test.rb
@@ -26,8 +26,8 @@ class Users::TwoStepVerificationMandationsControllerTest < ActionController::Tes
       should "authorize access if UserPolicy#mandate_2sv? returns true" do
         user = create(:user, require_2sv: false)
 
-        user_policy = stub_everything("user-policy", mandate_2sv?: true)
-        UserPolicy.stubs(:new).returns(user_policy)
+        stub_policy(@admin, user, mandate_2sv?: true)
+        stub_policy_for_navigation_links(@admin)
 
         get :edit, params: { user_id: user }
 
@@ -37,8 +37,8 @@ class Users::TwoStepVerificationMandationsControllerTest < ActionController::Tes
       should "not authorize access if UserPolicy#mandate_2sv? returns false" do
         user = create(:user, require_2sv: false)
 
-        user_policy = stub_everything("user-policy", mandate_2sv?: false)
-        UserPolicy.stubs(:new).returns(user_policy)
+        stub_policy(@admin, user, mandate_2sv?: false)
+        stub_policy_for_navigation_links(@admin)
 
         get :edit, params: { user_id: user }
 
@@ -139,8 +139,7 @@ class Users::TwoStepVerificationMandationsControllerTest < ActionController::Tes
       should "mandate 2SV for user if UserPolicy#mandate_2sv? returns true" do
         user = create(:user, require_2sv: false)
 
-        user_policy = stub_everything("user-policy", mandate_2sv?: true)
-        UserPolicy.stubs(:new).returns(user_policy)
+        stub_policy(@admin, user, mandate_2sv?: true)
 
         put :update, params: { user_id: user, user: { require_2sv: true } }
 
@@ -150,8 +149,7 @@ class Users::TwoStepVerificationMandationsControllerTest < ActionController::Tes
       should "not mandate 2SV for user if UserPolicy#mandate_2sv? returns false" do
         user = create(:user, require_2sv: false)
 
-        user_policy = stub_everything("user-policy", mandate_2sv?: false)
-        UserPolicy.stubs(:new).returns(user_policy)
+        stub_policy(@admin, user, mandate_2sv?: false)
 
         put :update, params: { user_id: user, user: { require_2sv: true } }
 

--- a/test/controllers/users/two_step_verification_resets_controller_test.rb
+++ b/test/controllers/users/two_step_verification_resets_controller_test.rb
@@ -25,8 +25,8 @@ class Users::TwoStepVerificationResetsControllerTest < ActionController::TestCas
       should "authorize access if UserPolicy#reset_2sv? returns true" do
         user = create(:two_step_enabled_user)
 
-        user_policy = stub_everything("user-policy", reset_2sv?: true)
-        UserPolicy.stubs(:new).returns(user_policy)
+        stub_policy(@admin, user, reset_2sv?: true)
+        stub_policy_for_navigation_links(@admin)
 
         get :edit, params: { user_id: user }
 
@@ -36,8 +36,8 @@ class Users::TwoStepVerificationResetsControllerTest < ActionController::TestCas
       should "not authorize access if UserPolicy#reset_2sv? returns false" do
         user = create(:two_step_enabled_user)
 
-        user_policy = stub_everything("user-policy", reset_2sv?: false)
-        UserPolicy.stubs(:new).returns(user_policy)
+        stub_policy(@admin, user, reset_2sv?: false)
+        stub_policy_for_navigation_links(@admin)
 
         get :edit, params: { user_id: user }
 
@@ -125,8 +125,7 @@ class Users::TwoStepVerificationResetsControllerTest < ActionController::TestCas
       should "reset 2SV for user if UserPolicy#reset_2sv? returns true" do
         user = create(:two_step_enabled_user)
 
-        user_policy = stub_everything("user-policy", reset_2sv?: true)
-        UserPolicy.stubs(:new).returns(user_policy)
+        stub_policy(@admin, user, reset_2sv?: true)
 
         put :update, params: { user_id: user }
 
@@ -136,8 +135,7 @@ class Users::TwoStepVerificationResetsControllerTest < ActionController::TestCas
       should "not reset 2SV for user if UserPolicy#reset_2sv? returns false" do
         user = create(:two_step_enabled_user)
 
-        user_policy = stub_everything("user-policy", reset_2sv?: false)
-        UserPolicy.stubs(:new).returns(user_policy)
+        stub_policy(@admin, user, reset_2sv?: false)
 
         put :update, params: { user_id: user }
 

--- a/test/controllers/users/unlockings_controller_test.rb
+++ b/test/controllers/users/unlockings_controller_test.rb
@@ -23,8 +23,8 @@ class Users::UnlockingsControllerTest < ActionController::TestCase
       should "authorize access if UserPolicy#unlock? returns true" do
         user = create(:locked_user)
 
-        user_policy = stub_everything("user-policy", unlock?: true)
-        UserPolicy.stubs(:new).returns(user_policy)
+        stub_policy(@admin, user, unlock?: true)
+        stub_policy_for_navigation_links(@admin)
 
         get :edit, params: { user_id: user }
 
@@ -34,8 +34,8 @@ class Users::UnlockingsControllerTest < ActionController::TestCase
       should "not authorize access if UserPolicy#unlock? returns false" do
         user = create(:locked_user)
 
-        user_policy = stub_everything("user-policy", unlock?: false)
-        UserPolicy.stubs(:new).returns(user_policy)
+        stub_policy(@admin, user, unlock?: false)
+        stub_policy_for_navigation_links(@admin)
 
         get :edit, params: { user_id: user }
 
@@ -129,8 +129,7 @@ class Users::UnlockingsControllerTest < ActionController::TestCase
       should "unlock user if UserPolicy#unlock? returns true" do
         user = create(:locked_user)
 
-        user_policy = stub_everything("user-policy", unlock?: true)
-        UserPolicy.stubs(:new).returns(user_policy)
+        stub_policy(@admin, user, unlock?: true)
 
         put :update, params: { user_id: user }
 
@@ -140,8 +139,7 @@ class Users::UnlockingsControllerTest < ActionController::TestCase
       should "not unock user if UserPolicy#unlock? returns false" do
         user = create(:locked_user)
 
-        user_policy = stub_everything("user-policy", unlock?: false)
-        UserPolicy.stubs(:new).returns(user_policy)
+        stub_policy(@admin, user, unlock?: false)
 
         put :update, params: { user_id: user }
 

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -435,10 +435,4 @@ class UsersControllerTest < ActionController::TestCase
       end
     end
   end
-
-private
-
-  def stub_policy_for_navigation_links(current_user)
-    stub_policy(current_user, User, index?: true)
-  end
 end

--- a/test/support/pundit_helpers.rb
+++ b/test/support/pundit_helpers.rb
@@ -8,5 +8,8 @@ module PunditHelpers
 
   def stub_policy_for_navigation_links(current_user)
     stub_policy(current_user, User, index?: true)
+    stub_policy(current_user, ApiUser, index?: true)
+    stub_policy(current_user, Doorkeeper::Application, index?: true)
+    stub_policy(current_user, Organisation, index?: true)
   end
 end

--- a/test/support/pundit_helpers.rb
+++ b/test/support/pundit_helpers.rb
@@ -5,4 +5,8 @@ module PunditHelpers
     policy = stub_everything("policy", method_and_return_value).responds_like_instance_of(policy_class)
     policy_class.stubs(:new).with(current_user, record).returns(policy)
   end
+
+  def stub_policy_for_navigation_links(current_user)
+    stub_policy(current_user, User, index?: true)
+  end
 end


### PR DESCRIPTION
This tidies up a bunch of controller tests as follows:
* [Extract `PunditHelpers#stub_policy_for_navigation_links`](https://github.com/alphagov/signon/pull/2597/commits/ab2f9261c53d09cf5e85518b056c7ddd24b8474b).
* [Stub all the policies used in the navigation items](https://github.com/alphagov/signon/pull/2597/commits/71929fd102f4373740a3fdb65bbd18906095db3c).
* A bunch of commits changing controller tests to use `PunditHelpers#stub_policy` instead  of stubbing `UserPolicy.new` directly.

### Original description
> I ran into a problem with this, because when using the `PunditHelpers#stub_policy` helper method, the stubbing of `UserPolicy.new` specifies the arguments it should be called with, i.e. the `with(current_user, record)` bit of `policy_class.stubs(:new).with(current_user, record).returns(policy)`. This means that if `UserPolicy.new` is called with any *other* arguments, we'll see an "Unexpected invocation" error. And it's moderately like that this will happen, because of e.g. `NavigationItemsHelper#navigation_items` which is called as part of the layout and makes calls to things like `policy(User).index?` & `policy(ApiUser).index?`. These calls result in `UserPolicy.new` being called with `User` or `ApiUser` as the second (`record`) argument which will not match the *instance* of `User` or `ApiUser` required by the stubbed method.
>
> This PR demonstrates how we _could_ change `PunditHelpers#stub_policy` to make this work OK. However, having complex stubbing like this (especially when it's effectively mimicing internal behaviour of a 3rd party library) sets off alarm bells for me and I think it might be worth rethinking this approach.
>
> An alternative would be to relax the constraint on the arguments of `UserPolicy.new` much like how `Users::EmailsControllerTest` was working before the change in this PR.
>
> Another alternative would be to stub the `authorize` method on the controller. I haven't actually tried this, but it ought to be simpler and more robust and I think it should give us almost as much confidence as the current tests.
>
> Note that I was only focussed on getting `Users::EmailsControllerTest` to pass using the stub helper method - it looks like the changes I've made to `PunditHelpers` might have broken other stuff!
>
> @chrisroos @chrislo What do you think...?