### PR TITLE
Fix Users and Account::PermissionsController#update

### DIFF
--- a/app/controllers/account/permissions_controller.rb
+++ b/app/controllers/account/permissions_controller.rb
@@ -3,6 +3,7 @@ class Account::PermissionsController < ApplicationController
 
   before_action :authenticate_user!
   before_action :set_application
+  before_action :set_permissions
 
   def show
     authorize [:account, @application], :view_permissions?
@@ -14,16 +15,12 @@ class Account::PermissionsController < ApplicationController
 
   def edit
     authorize [:account, @application], :edit_permissions?
-
-    @permissions = @application.sorted_supported_permissions_grantable_from_ui(include_signin: false)
   end
 
   def update
     authorize [:account, @application], :edit_permissions?
 
-    permission_ids_for_other_applications = current_user.supported_permissions.excluding_application(@application).pluck(:id)
-    user_update_params = { supported_permission_ids: permission_ids_for_other_applications + params[:application][:supported_permission_ids] }
-    UserUpdate.new(current_user, user_update_params, current_user, user_ip_address).call
+    UserUpdate.new(current_user, build_user_update_params, current_user, user_ip_address).call
 
     flash[:application_id] = @application.id
     redirect_to account_applications_path
@@ -31,7 +28,25 @@ class Account::PermissionsController < ApplicationController
 
 private
 
+  def update_params
+    params.require(:application).permit(supported_permission_ids: [])
+  end
+
   def set_application
     @application = Doorkeeper::Application.not_api_only.find(params[:application_id])
+  end
+
+  def set_permissions
+    @permissions = @application.sorted_supported_permissions_grantable_from_ui(include_signin: false)
+  end
+
+  def build_user_update_params
+    permissions_user_has = current_user.supported_permissions.pluck(:id)
+    updatable_permissions_for_this_app = @permissions.pluck(:id)
+    selected_permissions = update_params[:supported_permission_ids].map(&:to_i)
+    permissions_to_add = updatable_permissions_for_this_app.intersection(selected_permissions)
+    permissions_to_remove = updatable_permissions_for_this_app.difference(selected_permissions)
+
+    { supported_permission_ids: (permissions_user_has + permissions_to_add - permissions_to_remove).sort }
   end
 end

--- a/app/controllers/users/permissions_controller.rb
+++ b/app/controllers/users/permissions_controller.rb
@@ -21,14 +21,7 @@ class Users::PermissionsController < ApplicationController
   def update
     authorize UserApplicationPermission.for(@user, @application)
 
-    permissions_user_has = @user.supported_permissions.pluck(:id)
-    updatable_permissions_for_this_app = @permissions.pluck(:id)
-    selected_permissions = update_params[:supported_permission_ids].map(&:to_i)
-    permissions_to_add = updatable_permissions_for_this_app.intersection(selected_permissions)
-    permissions_to_remove = updatable_permissions_for_this_app.difference(selected_permissions)
-
-    user_update_params = { supported_permission_ids: (permissions_user_has + permissions_to_add - permissions_to_remove).sort }
-    UserUpdate.new(@user, user_update_params, current_user, user_ip_address).call
+    UserUpdate.new(@user, build_user_update_params, current_user, user_ip_address).call
 
     flash[:application_id] = @application.id
     redirect_to user_applications_path(@user)
@@ -50,5 +43,15 @@ private
 
   def set_permissions
     @permissions = @application.sorted_supported_permissions_grantable_from_ui(include_signin: false)
+  end
+
+  def build_user_update_params
+    permissions_user_has = @user.supported_permissions.pluck(:id)
+    updatable_permissions_for_this_app = @permissions.pluck(:id)
+    selected_permissions = update_params[:supported_permission_ids].map(&:to_i)
+    permissions_to_add = updatable_permissions_for_this_app.intersection(selected_permissions)
+    permissions_to_remove = updatable_permissions_for_this_app.difference(selected_permissions)
+
+    { supported_permission_ids: (permissions_user_has + permissions_to_add - permissions_to_remove).sort }
   end
 end

--- a/app/controllers/users/permissions_controller.rb
+++ b/app/controllers/users/permissions_controller.rb
@@ -23,7 +23,7 @@ class Users::PermissionsController < ApplicationController
     authorize UserApplicationPermission.for(@user, @application)
 
     permission_ids_for_other_applications = @user.supported_permissions.excluding_application(@application).pluck(:id)
-    user_update_params = { supported_permission_ids: permission_ids_for_other_applications + update_params[:supported_permission_ids].map(&:to_i) }
+    user_update_params = { supported_permission_ids: permission_ids_for_other_applications + update_params[:supported_permission_ids].map(&:to_i) + [@application.signin_permission.id] }
     UserUpdate.new(@user, user_update_params, current_user, user_ip_address).call
 
     flash[:application_id] = @application.id

--- a/app/controllers/users/permissions_controller.rb
+++ b/app/controllers/users/permissions_controller.rb
@@ -4,6 +4,7 @@ class Users::PermissionsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_user
   before_action :set_application
+  before_action :set_permissions, only: %i[edit update]
 
   def show
     authorize @user, :edit?
@@ -15,15 +16,13 @@ class Users::PermissionsController < ApplicationController
 
   def edit
     authorize UserApplicationPermission.for(@user, @application)
-
-    @permissions = @application.sorted_supported_permissions_grantable_from_ui(include_signin: false)
   end
 
   def update
     authorize UserApplicationPermission.for(@user, @application)
 
     permissions_user_has = @user.supported_permissions.pluck(:id)
-    updatable_permissions_for_this_app = @application.sorted_supported_permissions_grantable_from_ui(include_signin: false).pluck(:id)
+    updatable_permissions_for_this_app = @permissions.pluck(:id)
     selected_permissions = update_params[:supported_permission_ids].map(&:to_i)
     permissions_to_add = updatable_permissions_for_this_app.intersection(selected_permissions)
     permissions_to_remove = updatable_permissions_for_this_app.difference(selected_permissions)
@@ -47,5 +46,9 @@ private
 
   def set_application
     @application = Doorkeeper::Application.with_signin_permission_for(@user).not_api_only.find(params[:application_id])
+  end
+
+  def set_permissions
+    @permissions = @application.sorted_supported_permissions_grantable_from_ui(include_signin: false)
   end
 end

--- a/test/controllers/users/permissions_controller_test.rb
+++ b/test/controllers/users/permissions_controller_test.rb
@@ -267,6 +267,31 @@ class Users::PermissionsControllerTest < ActionController::TestCase
       patch :update, params: { user_id: user, application_id: application.id, application: { supported_permission_ids: [new_permission.id] } }
     end
 
+    should "prevent permissions being added for apps that the current user does not have access to" do
+      organisation = create(:organisation)
+
+      application1 = create(:application)
+      application2 = create(:application, with_supported_permissions: %w[app2-permission])
+
+      user = create(:user, organisation:)
+      user.grant_application_signin_permission(application1)
+
+      current_user = create(:organisation_admin_user, organisation:)
+      current_user.grant_application_signin_permission(application1)
+      sign_in current_user
+
+      permission = stub_user_application_permission(user, application1)
+      stub_policy current_user, permission, update?: true
+
+      app2_permission = application2.supported_permissions.find_by!(name: "app2-permission")
+
+      patch :update, params: { user_id: user, application_id: application1, application: { supported_permission_ids: [app2_permission.id] } }
+
+      user.reload
+
+      assert_equal [], user.supported_permissions
+    end
+
     should "assign the application id to the application_id flash" do
       application = create(:application, with_supported_permissions: %w[new old])
       user = create(:user, with_permissions: { application => %w[old] })

--- a/test/controllers/users/permissions_controller_test.rb
+++ b/test/controllers/users/permissions_controller_test.rb
@@ -218,7 +218,7 @@ class Users::PermissionsControllerTest < ActionController::TestCase
 
       new_permission = application.supported_permissions.find_by(name: "new")
 
-      expected_params = { supported_permission_ids: [new_permission.id, application.signin_permission.id] }
+      expected_params = { supported_permission_ids: [new_permission.id, application.signin_permission.id].sort }
       user_update = stub("user-update").responds_like_instance_of(UserUpdate)
       user_update.expects(:call)
       UserUpdate.stubs(:new).with(user, expected_params, current_user, anything).returns(user_update)
@@ -259,7 +259,7 @@ class Users::PermissionsControllerTest < ActionController::TestCase
       new_permission = application.supported_permissions.find_by(name: "new")
       other_permission = other_application.supported_permissions.find_by(name: "other")
 
-      expected_params = { supported_permission_ids: [other_permission.id, new_permission.id, application.signin_permission.id] }
+      expected_params = { supported_permission_ids: [other_permission.id, new_permission.id, application.signin_permission.id].sort }
       user_update = stub("user-update").responds_like_instance_of(UserUpdate)
       user_update.expects(:call)
       UserUpdate.stubs(:new).with(user, expected_params, current_user, anything).returns(user_update)
@@ -309,6 +309,69 @@ class Users::PermissionsControllerTest < ActionController::TestCase
 
       user.reload
       assert_same_elements [application.signin_permission, other_permission], user.supported_permissions
+    end
+
+    should "not remove permissions the user already has that are not grantable from ui" do
+      application = create(:application, with_supported_permissions: %w[other], with_supported_permissions_not_grantable_from_ui: %w[not_from_ui])
+      user = create(:user)
+      user.grant_application_signin_permission(application)
+      user.grant_application_permission(application, "not_from_ui")
+
+      current_user = create(:admin_user)
+      sign_in current_user
+
+      permission = stub_user_application_permission(user, application)
+      stub_policy current_user, permission, update?: true
+
+      other_permission = application.supported_permissions.find_by(name: "other")
+      not_from_ui_permission = application.supported_permissions.find_by(name: "not_from_ui")
+
+      patch :update, params: { user_id: user, application_id: application.id, application: { supported_permission_ids: [other_permission.id] } }
+
+      user.reload
+
+      assert_same_elements [other_permission, application.signin_permission, not_from_ui_permission], user.supported_permissions
+    end
+
+    should "prevent permissions being added for other apps" do
+      other_application = create(:application, with_supported_permissions: %w[other])
+      application = create(:application)
+      user = create(:user)
+      user.grant_application_signin_permission(application)
+
+      current_user = create(:admin_user)
+      sign_in current_user
+
+      permission = stub_user_application_permission(user, application)
+      stub_policy current_user, permission, update?: true
+
+      other_permission = other_application.supported_permissions.find_by(name: "other")
+
+      patch :update, params: { user_id: user, application_id: application.id, application: { supported_permission_ids: [other_permission.id] } }
+
+      user.reload
+
+      assert_equal [application.signin_permission], user.supported_permissions
+    end
+
+    should "prevent permissions being added that are not grantable from the ui" do
+      application = create(:application, with_supported_permissions_not_grantable_from_ui: %w[not_from_ui])
+      user = create(:user)
+      user.grant_application_signin_permission(application)
+
+      current_user = create(:admin_user)
+      sign_in current_user
+
+      permission = stub_user_application_permission(user, application)
+      stub_policy current_user, permission, update?: true
+
+      not_from_ui_permission = application.supported_permissions.find_by(name: "not_from_ui")
+
+      patch :update, params: { user_id: user, application_id: application.id, application: { supported_permission_ids: [not_from_ui_permission.id] } }
+
+      user.reload
+
+      assert_equal [application.signin_permission], user.supported_permissions
     end
 
     should "assign the application id to the application_id flash" do

--- a/test/controllers/users/permissions_controller_test.rb
+++ b/test/controllers/users/permissions_controller_test.rb
@@ -218,7 +218,7 @@ class Users::PermissionsControllerTest < ActionController::TestCase
 
       new_permission = application.supported_permissions.find_by(name: "new")
 
-      expected_params = { supported_permission_ids: [new_permission.id] }
+      expected_params = { supported_permission_ids: [new_permission.id, application.signin_permission.id] }
       user_update = stub("user-update").responds_like_instance_of(UserUpdate)
       user_update.expects(:call)
       UserUpdate.stubs(:new).with(user, expected_params, current_user, anything).returns(user_update)
@@ -259,7 +259,7 @@ class Users::PermissionsControllerTest < ActionController::TestCase
       new_permission = application.supported_permissions.find_by(name: "new")
       other_permission = other_application.supported_permissions.find_by(name: "other")
 
-      expected_params = { supported_permission_ids: [other_permission.id, new_permission.id] }
+      expected_params = { supported_permission_ids: [other_permission.id, new_permission.id, application.signin_permission.id] }
       user_update = stub("user-update").responds_like_instance_of(UserUpdate)
       user_update.expects(:call)
       UserUpdate.stubs(:new).with(user, expected_params, current_user, anything).returns(user_update)
@@ -289,7 +289,26 @@ class Users::PermissionsControllerTest < ActionController::TestCase
 
       user.reload
 
-      assert_equal [], user.supported_permissions
+      assert_equal [application1.signin_permission], user.supported_permissions
+    end
+
+    should "not remove the signin permission from the app when updating other permissions" do
+      application = create(:application, with_supported_permissions: %w[other])
+      user = create(:user)
+      user.grant_application_signin_permission(application)
+
+      current_user = create(:admin_user)
+      sign_in current_user
+
+      permission = stub_user_application_permission(user, application)
+      stub_policy current_user, permission, update?: true
+
+      other_permission = application.supported_permissions.find_by(name: "other")
+
+      patch :update, params: { user_id: user, application_id: application.id, application: { supported_permission_ids: [other_permission.id] } }
+
+      user.reload
+      assert_same_elements [application.signin_permission, other_permission], user.supported_permissions
     end
 
     should "assign the application id to the application_id flash" do

--- a/test/support/pundit_helpers.rb
+++ b/test/support/pundit_helpers.rb
@@ -1,6 +1,7 @@
 module PunditHelpers
   def stub_policy(current_user, record, method_and_return_value)
     policy_class = Pundit::PolicyFinder.new(record).policy
+    record = record.last if record.is_a?(Array)
     policy = stub_everything("policy", method_and_return_value).responds_like_instance_of(policy_class)
     policy_class.stubs(:new).with(current_user, record).returns(policy)
   end


### PR DESCRIPTION
Trello: https://trello.com/c/09yMSdcU

We noticed some problems with the implementation of both `Users::PermissionsController#update` and `Account::PermissionsController#update`:

1. The signin permission would be removed unless explicitly added in the call to `update`
2. Permissions not grantable from the UI would be removed unless explicitly added in the call to `update`
3. Permissions not grantable from the UI could be added if explicitly added in the call to `update`
4. Permissions could be passed to `UserUpdate` for applications other than the application whose permissions were being viewed

See the individual commits for more detail.

We're fixing these problems before moving the API User edit page to use similar functionality.