### PR TITLE
Add missing breadcrumb links to account app/permissions pages

### DIFF
--- a/app/views/account/applications/index.html.erb
+++ b/app/views/account/applications/index.html.erb
@@ -9,6 +9,10 @@
          url: root_path,
        },
        {
+         title: "Settings",
+         url: account_path,
+       },
+       {
          title: "GOV.UK apps",
        }
      ]

--- a/app/views/account/permissions/edit.html.erb
+++ b/app/views/account/permissions/edit.html.erb
@@ -13,6 +13,10 @@
          url: account_applications_path,
        },
        {
+         title: "Settings",
+         url: account_path,
+       },
+       {
          title: "Update permissions for #{@application.name}",
        },
      ]

--- a/app/views/account/permissions/show.html.erb
+++ b/app/views/account/permissions/show.html.erb
@@ -13,6 +13,10 @@
          url: account_applications_path,
        },
        {
+         title: "Settings",
+         url: account_path,
+       },
+       {
          title: "My permissions for #{@application.name}",
        },
      ]


### PR DESCRIPTION
Trello: https://trello.com/c/w3rzFU0k

We noticed that the "applications" and "view/update permissions" pages under a user account had inconsistent breadcrumb navigation when compared to, for example, "change your organisation" (`app/views/account/organisations/edit.html.erb`).
