### PR TITLE
Move managing tokens for API users to use GOV.UK Design System

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,6 @@ gem "sprockets-rails"
 gem "uglifier"
 gem "uuid"
 gem "whenever"
-gem "zeroclipboard-rails"
 
 # GDS Gems
 gem "gds-api-adapters"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -689,8 +689,6 @@ GEM
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.6.12)
-    zeroclipboard-rails (0.1.2)
-      railties (>= 3.1)
     zxcvbn-ruby (1.2.0)
 
 PLATFORMS
@@ -754,7 +752,6 @@ DEPENDENCIES
   uuid
   webmock
   whenever
-  zeroclipboard-rails
 
 BUNDLED WITH
    2.4.10

--- a/app/assets/javascripts/legacy_layout.js
+++ b/app/assets/javascripts/legacy_layout.js
@@ -1,3 +1,2 @@
 //= require chosen.jquery
 //= require_directory ./legacy/modules
-//= require zeroclipboard

--- a/app/controllers/api_users_controller.rb
+++ b/app/controllers/api_users_controller.rb
@@ -1,7 +1,7 @@
 class ApiUsersController < ApplicationController
   include UserPermissionsControllerMethods
 
-  layout "admin_layout", only: %w[index new create edit]
+  layout "admin_layout", only: %w[index new create edit manage_tokens]
 
   before_action :authenticate_user!
   before_action :load_and_authorize_api_user, only: %i[edit manage_permissions manage_tokens update]

--- a/app/controllers/authorisations_controller.rb
+++ b/app/controllers/authorisations_controller.rb
@@ -12,7 +12,7 @@ class AuthorisationsController < ApplicationController
   def new; end
 
   def create
-    @authorisation.application_id = params[:doorkeeper_access_token][:application_id]
+    @authorisation.application_id = params[:authorisation][:application_id]
 
     if @authorisation.save
       @api_user.grant_application_signin_permission(@authorisation.application)

--- a/app/controllers/authorisations_controller.rb
+++ b/app/controllers/authorisations_controller.rb
@@ -4,22 +4,22 @@ class AuthorisationsController < ApplicationController
   layout "admin_layout", only: %w[new]
 
   before_action :authenticate_user!
-  before_action :load_and_authorize_api_user
+  before_action :load_api_user
+  before_action :build_authorisation, only: %i[new create]
+  before_action :load_authorisation, only: %i[revoke]
+  before_action :authorize_authorisation
 
   respond_to :html
 
-  def new
-    @authorisation = @api_user.authorisations.build
-  end
+  def new; end
 
   def create
-    authorisation = @api_user.authorisations.build(expires_in: ApiUser::DEFAULT_TOKEN_LIFE)
-    authorisation.application_id = params[:doorkeeper_access_token][:application_id]
+    @authorisation.application_id = params[:doorkeeper_access_token][:application_id]
 
-    if authorisation.save
-      @api_user.grant_application_signin_permission(authorisation.application)
-      EventLog.record_event(@api_user, EventLog::ACCESS_TOKEN_GENERATED, initiator: current_user, application: authorisation.application, ip_address: user_ip_address)
-      flash[:authorisation] = { application_name: authorisation.application.name, token: authorisation.token }
+    if @authorisation.save
+      @api_user.grant_application_signin_permission(@authorisation.application)
+      EventLog.record_event(@api_user, EventLog::ACCESS_TOKEN_GENERATED, initiator: current_user, application: @authorisation.application, ip_address: user_ip_address)
+      flash[:authorisation] = { application_name: @authorisation.application.name, token: @authorisation.token }
     else
       flash[:error] = "There was an error while creating the access token"
     end
@@ -27,20 +27,30 @@ class AuthorisationsController < ApplicationController
   end
 
   def revoke
-    authorisation = @api_user.authorisations.find(params[:id])
-    if authorisation.revoke
-      EventLog.record_event(@api_user, EventLog::ACCESS_TOKEN_REVOKED, initiator: current_user, application: authorisation.application, ip_address: user_ip_address)
-      flash[:notice] = "Access for #{authorisation.application.name} was revoked"
+    if @authorisation.revoke
+      EventLog.record_event(@api_user, EventLog::ACCESS_TOKEN_REVOKED, initiator: current_user, application: @authorisation.application, ip_address: user_ip_address)
+      flash[:notice] = "Access for #{@authorisation.application.name} was revoked"
     else
-      flash[:error] = "There was an error while revoking access for #{authorisation.application.name}"
+      flash[:error] = "There was an error while revoking access for #{@authorisation.application.name}"
     end
     redirect_to manage_tokens_api_user_path(@api_user)
   end
 
 private
 
-  def load_and_authorize_api_user
+  def load_api_user
     @api_user = ApiUser.find(params[:api_user_id])
-    authorize @api_user
+  end
+
+  def build_authorisation
+    @authorisation = @api_user.authorisations.build(expires_in: ApiUser::DEFAULT_TOKEN_LIFE)
+  end
+
+  def load_authorisation
+    @authorisation = @api_user.authorisations.find(params[:id])
+  end
+
+  def authorize_authorisation
+    authorize @authorisation, policy_class: AuthorisationPolicy
   end
 end

--- a/app/controllers/authorisations_controller.rb
+++ b/app/controllers/authorisations_controller.rb
@@ -1,10 +1,10 @@
 class AuthorisationsController < ApplicationController
-  layout "admin_layout", only: %w[new]
+  layout "admin_layout"
 
   before_action :authenticate_user!
   before_action :load_api_user
   before_action :build_authorisation, only: %i[new create]
-  before_action :load_authorisation, only: %i[revoke]
+  before_action :load_authorisation, only: %i[edit revoke]
   before_action :authorize_authorisation
 
   respond_to :html
@@ -23,6 +23,8 @@ class AuthorisationsController < ApplicationController
     end
     redirect_to manage_tokens_api_user_path(@api_user)
   end
+
+  def edit; end
 
   def revoke
     if @authorisation.revoke

--- a/app/controllers/authorisations_controller.rb
+++ b/app/controllers/authorisations_controller.rb
@@ -1,6 +1,4 @@
 class AuthorisationsController < ApplicationController
-  include UserPermissionsControllerMethods
-
   layout "admin_layout", only: %w[new]
 
   before_action :authenticate_user!

--- a/app/controllers/authorisations_controller.rb
+++ b/app/controllers/authorisations_controller.rb
@@ -23,7 +23,7 @@ class AuthorisationsController < ApplicationController
     else
       flash[:error] = "There was an error while creating the access token"
     end
-    redirect_to [:manage_tokens, @api_user]
+    redirect_to manage_tokens_api_user_path(@api_user)
   end
 
   def revoke
@@ -34,7 +34,7 @@ class AuthorisationsController < ApplicationController
     else
       flash[:error] = "There was an error while revoking access for #{authorisation.application.name}"
     end
-    redirect_to [:manage_tokens, @api_user]
+    redirect_to manage_tokens_api_user_path(@api_user)
   end
 
 private

--- a/app/policies/authorisation_policy.rb
+++ b/app/policies/authorisation_policy.rb
@@ -1,0 +1,7 @@
+class AuthorisationPolicy < BasePolicy
+  def new?
+    current_user.superadmin?
+  end
+  alias_method :create?, :new?
+  alias_method :revoke?, :new?
+end

--- a/app/policies/authorisation_policy.rb
+++ b/app/policies/authorisation_policy.rb
@@ -3,5 +3,6 @@ class AuthorisationPolicy < BasePolicy
     current_user.superadmin?
   end
   alias_method :create?, :new?
+  alias_method :edit?, :new?
   alias_method :revoke?, :new?
 end

--- a/app/views/api_users/manage_tokens.html.erb
+++ b/app/views/api_users/manage_tokens.html.erb
@@ -58,7 +58,7 @@
   </tbody>
 </table>
 <p>
-  <%= link_to [:new, @api_user, :authorisation], class: "btn btn-default" do %>
+  <%= link_to new_api_user_authorisation_path(@api_user), class: "btn btn-default" do %>
     <span class="glyphicon glyphicon-plus glyphicon-smaller-than-text"></span> Add application token
   <% end %>
 </p>

--- a/app/views/api_users/manage_tokens.html.erb
+++ b/app/views/api_users/manage_tokens.html.erb
@@ -48,7 +48,9 @@
           <% end %>
         </td>
         <td>
-          <%= link_to "Revoke", edit_api_user_authorisation_path(@api_user, authorisation) %>
+          <%= link_to edit_api_user_authorisation_path(@api_user, authorisation) do %>
+            Revoke<span class="invisible"> token giving <%= @api_user.name %> access to <%= authorisation.application.name %></span>
+          <% end %>
         </td>
     <% end %>
   </tbody>

--- a/app/views/api_users/manage_tokens.html.erb
+++ b/app/views/api_users/manage_tokens.html.erb
@@ -48,11 +48,7 @@
           <% end %>
         </td>
         <td>
-          <div class="btn-group">
-            <%= form_tag(revoke_api_user_authorisation_path(@api_user.id, authorisation.id), method: "post") do %>
-            <%= submit_tag("Revoke", class: "btn btn-default") %>
-            <% end %>
-          </div>
+          <%= link_to "Revoke", edit_api_user_authorisation_path(@api_user, authorisation) %>
         </td>
     <% end %>
   </tbody>

--- a/app/views/api_users/manage_tokens.html.erb
+++ b/app/views/api_users/manage_tokens.html.erb
@@ -1,68 +1,94 @@
+<% content_for :title_caption, "Manage API users" %>
 <% content_for :title, "Manage tokens for #{@api_user.name}" %>
 
-<ol class="breadcrumb">
-  <li><%= link_to "Dashboard", root_path %></li>
-  <li><%= link_to "API users", api_users_path %></li>
-  <li><%= link_to @api_user.name, edit_api_user_path(@api_user) %></li>
-  <li class="active">Manage tokens</li>
-</ol>
-
-<h1>Manage tokens for API User <%= @api_user.name %></h1>
+<% content_for :breadcrumbs,
+   render("govuk_publishing_components/components/breadcrumbs", {
+     collapse_on_mobile: true,
+     breadcrumbs: [
+       {
+         title: "Dashboard",
+         url: root_path,
+       },
+       {
+         title: "API users",
+         url: api_users_path,
+       },
+       {
+         title: @api_user.name,
+         url: edit_api_user_path(@api_user),
+       },
+       {
+         title: "Manage tokens",
+       }
+     ]
+   })
+%>
 
 <% if authorisation = flash[:authorisation] %>
-  <div class="alert alert-danger">
-    Make sure to copy the access token for <%= authorisation["application_name"] %> now. You won't be able to see it again!
-  </div>
-  <div class="alert alert-info">
-    Access token for <%= authorisation["application_name"] %>: <span id='access-token'><%= authorisation["token"] %></span>
-    <%= link_to 'Copy to clipboard', '#', class: 'btn btn-info add-left-margin', data: { 'clipboard-target' => 'access-token' }, id: 'clip-button', title: 'Click to copy access token' %>
-  </div>
-<% end %>
-<table id="authorisations" class="table table-bordered table-on-white">
-  <thead>
-    <tr class="table-header">
-      <th>Application</th>
-      <th>Token (hidden)</th>
-      <th>Generated</th>
-      <th>Expires</th>
-      <th>State</th>
-      <th>Action</th>
-    </tr>
-  </thead>
-  <tbody>
-    <% @api_user.authorisations.not_revoked.ordered_by_application_name.ordered_by_expires_at.each do |authorisation| %>
-      <tr>
-        <td><%= authorisation.application.name %></td>
-        <td><code><%= truncate_access_token(authorisation.token) %></code></td>
-        <td>
-          <%= authorisation.created_at.to_date.to_fs(:govuk_date) %>
-        </td>
-        <td>
-          <%= authorisation.expires_at.to_date.to_fs(:govuk_date) %>
-        </td>
-        <td>
-          <% if authorisation.expired? %>
-            <span class="label label-danger">Expired</span>
-          <% else %>
-            <span class="label label-success">Valid</span>
-          <% end %>
-        </td>
-        <td>
-          <%= link_to edit_api_user_authorisation_path(@api_user, authorisation) do %>
-            Revoke<span class="invisible"> token giving <%= @api_user.name %> access to <%= authorisation.application.name %></span>
-          <% end %>
-        </td>
-    <% end %>
-  </tbody>
-</table>
-<p>
-  <%= link_to new_api_user_authorisation_path(@api_user), class: "btn btn-default" do %>
-    <span class="glyphicon glyphicon-plus glyphicon-smaller-than-text"></span> Add application token
+  <% content_for :custom_alerts do %>
+    <%= render "govuk_publishing_components/components/success_alert", {
+      message: "Make sure to copy the access token for #{authorisation["application_name"]} now. You won't be able to see it again!",
+      description: render("govuk_publishing_components/components/copy_to_clipboard", {
+        label: "Access token for #{authorisation["application_name"]}",
+        copyable_content: authorisation["token"],
+        button_text: "Copy access token",
+      })
+    } %>
   <% end %>
-</p>
+<% end %>
 
-<script>
-  $(document).ready(function() {
-    new ZeroClipboard($("#clip-button"));
-  });
-</script>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-form-group">
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Add application token",
+        href: new_api_user_authorisation_path(@api_user),
+      } %>
+    </div>
+
+    <% @api_user.authorisations.not_revoked.ordered_by_application_name.ordered_by_expires_at.each do |authorisation| %>
+      <div class="govuk-summary-card">
+        <div class="govuk-summary-card__title-wrapper">
+          <h2 class="govuk-summary-card__title"><%= authorisation.application.name %></h2>
+          <ul class="govuk-summary-card__actions">
+            <li class="govuk-summary-card__action">
+              <a class="govuk-link" href="<%= edit_api_user_authorisation_path(@api_user, authorisation) %>">
+                Revoke<span class="govuk-visually-hidden"> token giving <%= @api_user.name %> access to <%= authorisation.application.name %></span>
+              </a>
+            </li>
+          </ul>
+        </div>
+        <div class="govuk-summary-card__content">
+          <dl class="govuk-summary-list">
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Token (hidden)
+              </dt>
+              <dd class="govuk-summary-list__value">
+                <code>
+                  <%= truncate_access_token(authorisation.token) %>
+                </code>
+              </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Generated
+              </dt>
+              <dd class="govuk-summary-list__value">
+                <%= authorisation.created_at.to_date.to_fs(:govuk_date) %>
+              </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Expires
+              </dt>
+              <dd class="govuk-summary-list__value">
+                <%= authorisation.expires_at.to_date.to_fs(:govuk_date) %>
+              </dd>
+            </div>
+          </dl>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/api_users/new.html.erb
+++ b/app/views/api_users/new.html.erb
@@ -8,40 +8,33 @@
           id: "error-summary",
           title: "There was a problem with your new API user",
           items: @api_user.errors.map do |error|
-          {
-            text: error.full_message,
-            href: "#api_user_#{error.attribute}",
-          }
+            { text: error.full_message, href: "#api_user_#{error.attribute}" }
           end
-          } %>
+        } %>
       <% end %>
 
       <%= render "govuk_publishing_components/components/input", {
-        label: {
-          text: "Name"
-        },
+        label: { text: "Name" },
         name: "api_user[name]",
         id: "api_user_name",
-        error_items: @api_user.errors.full_messages_for(:name).map {|message| { text: message } },
+        error_items: @api_user.errors.full_messages_for(:name).map { |message| { text: message } },
         value: @api_user.name,
         autocomplete: "off",
-        } %>
+      } %>
 
       <%= render "govuk_publishing_components/components/input", {
-        label: {
-          text: "Email"
-        },
+        label: { text: "Email" },
         name: "api_user[email]",
         id: "api_user_email",
         type: "email",
-        error_items: @api_user.errors.full_messages_for(:email).map {|message| { text: message } },
+        error_items: @api_user.errors.full_messages_for(:email).map { |message| { text: message } },
         value: @api_user.email,
         autocomplete: "off",
-        } %>
+      } %>
 
       <%= render "govuk_publishing_components/components/button", {
         text: "Create API user"
-        } %>
+      } %>
     <% end %>
   </div>
 </div>

--- a/app/views/api_users/new.html.erb
+++ b/app/views/api_users/new.html.erb
@@ -1,3 +1,4 @@
+<% content_for :title_caption, "Manage API users" %>
 <% content_for :title, "Create new API user" %>
 
 <div class="govuk-grid-row">

--- a/app/views/api_users/new.html.erb
+++ b/app/views/api_users/new.html.erb
@@ -1,6 +1,25 @@
 <% content_for :title_caption, "Manage API users" %>
 <% content_for :title, "Create new API user" %>
 
+<% content_for :breadcrumbs,
+   render("govuk_publishing_components/components/breadcrumbs", {
+     collapse_on_mobile: true,
+     breadcrumbs: [
+       {
+         title: "Dashboard",
+         url: root_path,
+       },
+       {
+         title: "API users",
+         url: api_users_path,
+       },
+       {
+         title: "New API user",
+       }
+     ]
+   })
+%>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for @api_user do |f| %>

--- a/app/views/authorisations/edit.html.erb
+++ b/app/views/authorisations/edit.html.erb
@@ -1,0 +1,56 @@
+<% content_for :title, "Revoke token giving #{@api_user.name} access to #{@authorisation.application.name}" %>
+<% content_for :breadcrumbs,
+   render("govuk_publishing_components/components/breadcrumbs", {
+     collapse_on_mobile: true,
+     breadcrumbs: [
+       {
+         title: "Home",
+         url: root_path,
+       },
+       {
+         title: "API users",
+         url: api_users_path,
+       },
+       {
+         title: @api_user.name,
+         url: edit_api_user_path(@api_user),
+       },
+       {
+         title: "Manage tokens",
+         url: manage_tokens_api_user_path(@api_user),
+       },
+       {
+         title: "Revoke access token",
+       }
+     ]
+   })
+%>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <section>
+      <%= render "govuk_publishing_components/components/summary_list", {
+        title: "Access token details",
+        items: [
+          { field: "Application", value: @authorisation.application.name },
+          { field: "Token (hidden)", value: content_tag(:code) { truncate_access_token(@authorisation.token) } },
+          { field: "Generated", value: @authorisation.created_at.to_date.to_fs(:govuk_date) },
+          { field: "Expires", value: @authorisation.expires_at.to_date.to_fs(:govuk_date) },
+        ]
+      } %>
+    </section>
+    <section>
+      <div class="govuk-button-group">
+        <%= form_tag(revoke_api_user_authorisation_path(@api_user, @authorisation), method: :post) do %>
+          <div class="govuk-button-group">
+            <%= render "govuk_publishing_components/components/button", {
+              text: "Revoke token",
+              destructive: true,
+            } %>
+            <%= link_to "Cancel", manage_tokens_api_user_path(@api_user), class: "govuk-link govuk-link--no-visited-state" %>
+          </div>
+        <% end %>
+      </div>
+    </section>
+  </div>
+</div>

--- a/app/views/authorisations/new.html.erb
+++ b/app/views/authorisations/new.html.erb
@@ -1,4 +1,6 @@
+<% content_for :title_caption, "Manage API users" %>
 <% content_for :title, "Create new access token for #{@api_user.name}" %>
+
 <% content_for :breadcrumbs,
    render("govuk_publishing_components/components/breadcrumbs", {
      collapse_on_mobile: true,

--- a/app/views/authorisations/new.html.erb
+++ b/app/views/authorisations/new.html.erb
@@ -36,7 +36,10 @@
     options: Doorkeeper::Application.all.map { |application| { text: application.name, value: application.id } }
   } %>
 
-  <%= render "govuk_publishing_components/components/button", {
-    text: "Create access token"
-  } %>
+  <div class="govuk-button-group">
+    <%= render "govuk_publishing_components/components/button", {
+      text: "Create access token"
+    } %>
+    <%= link_to "Cancel", manage_tokens_api_user_path(@api_user), class: "govuk-link govuk-link--no-visited-state" %>
+  <div>
 <% end %>

--- a/app/views/authorisations/new.html.erb
+++ b/app/views/authorisations/new.html.erb
@@ -32,9 +32,9 @@
     label: "Application",
     name: "doorkeeper_access_token[application_id]",
     options: Doorkeeper::Application.all.map { |application| { text: application.name, value: application.id } }
-    } %>
+  } %>
 
   <%= render "govuk_publishing_components/components/button", {
     text: "Create access token"
-    } %>
+  } %>
 <% end %>

--- a/app/views/authorisations/new.html.erb
+++ b/app/views/authorisations/new.html.erb
@@ -26,7 +26,7 @@
    })
 %>
 
-<%= form_for @authorisation, url: [:api_user, :authorisations] do |_| %>
+<%= form_tag api_user_authorisations_path(@api_user), method: :post do %>
   <%= render "govuk_publishing_components/components/select", {
     id: "doorkeeper_access_token_application_id",
     label: "Application",

--- a/app/views/authorisations/new.html.erb
+++ b/app/views/authorisations/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "Create new access token for \"#{@api_user.name}\"" %>
+<% content_for :title, "Create new access token for #{@api_user.name}" %>
 <% content_for :breadcrumbs,
    render("govuk_publishing_components/components/breadcrumbs", {
      collapse_on_mobile: true,
@@ -12,7 +12,7 @@
          url: api_users_path,
        },
        {
-         title: "Edit API user",
+         title: @api_user.name,
          url: edit_api_user_path(@api_user),
        },
        {

--- a/app/views/authorisations/new.html.erb
+++ b/app/views/authorisations/new.html.erb
@@ -30,9 +30,9 @@
 
 <%= form_tag api_user_authorisations_path(@api_user), method: :post do %>
   <%= render "govuk_publishing_components/components/select", {
-    id: "doorkeeper_access_token_application_id",
+    id: "authorisation_application_id",
     label: "Application",
-    name: "doorkeeper_access_token[application_id]",
+    name: "authorisation[application_id]",
     options: Doorkeeper::Application.all.map { |application| { text: application.name, value: application.id } }
   } %>
 

--- a/app/views/layouts/admin_layout.html.erb
+++ b/app/views/layouts/admin_layout.html.erb
@@ -33,6 +33,8 @@
         } %>
       <% end %>
 
+      <%= yield(:custom_alerts) %>
+
       <%= yield(:error_summary) %>
 
       <div class="govuk-grid-row">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -102,7 +102,7 @@ Rails.application.routes.draw do
       get :manage_permissions
       get :manage_tokens
     end
-    resources :authorisations, only: %i[new create] do
+    resources :authorisations, only: %i[new create edit] do
       member do
         post :revoke
       end

--- a/test/controllers/api_users_controller_test.rb
+++ b/test/controllers/api_users_controller_test.rb
@@ -198,9 +198,7 @@ class ApiUsersControllerTest < ActionController::TestCase
 
         edit_token_path = edit_api_user_authorisation_path(@api_user, token)
 
-        assert_select "table#authorisations tbody td", text: application.name do |td|
-          assert_select td.first.parent, "a[href='#{edit_token_path}']", text: "Revoke"
-        end
+        assert_select "a[href='#{edit_token_path}']", text: "Revoke token giving #{@api_user.name} access to #{application.name}"
       end
 
       should "not show API user's revoked access tokens" do

--- a/test/controllers/api_users_controller_test.rb
+++ b/test/controllers/api_users_controller_test.rb
@@ -190,18 +190,16 @@ class ApiUsersControllerTest < ActionController::TestCase
         end
       end
 
-      should "show button for revoking API user's access token for an application" do
+      should "show link for revoking API user's access token for an application" do
         application = create(:application)
         token = create(:access_token, resource_owner_id: @api_user.id, application:)
 
         get :manage_tokens, params: { id: @api_user }
 
-        revoke_token_path = revoke_api_user_authorisation_path(@api_user, token)
+        edit_token_path = edit_api_user_authorisation_path(@api_user, token)
 
         assert_select "table#authorisations tbody td", text: application.name do |td|
-          assert_select td.first.parent, "form[action='#{revoke_token_path}']" do
-            assert_select "input[type='submit']", value: "Revoke"
-          end
+          assert_select td.first.parent, "a[href='#{edit_token_path}']", text: "Revoke"
         end
       end
 

--- a/test/controllers/api_users_controller_test.rb
+++ b/test/controllers/api_users_controller_test.rb
@@ -185,8 +185,8 @@ class ApiUsersControllerTest < ActionController::TestCase
 
         get :manage_tokens, params: { id: @api_user }
 
-        assert_select "table#authorisations tbody td", text: application.name do |td|
-          assert_select td.first.parent, "code", text: /^#{token[0..7]}/
+        assert_select ".govuk-summary-card__title", text: application.name do |divs|
+          assert_select divs.first.parent.parent, "code", text: /^#{token[0..7]}/
         end
       end
 
@@ -207,7 +207,7 @@ class ApiUsersControllerTest < ActionController::TestCase
 
         get :manage_tokens, params: { id: @api_user }
 
-        assert_select "table#authorisations tbody td", text: application.name, count: 0
+        assert_select ".govuk-summary-card__title", text: application.name, count: 0
       end
 
       should "not show API user's access tokens for retired applications" do
@@ -216,7 +216,7 @@ class ApiUsersControllerTest < ActionController::TestCase
 
         get :manage_tokens, params: { id: @api_user }
 
-        assert_select "table#authorisations tbody td", text: application.name, count: 0
+        assert_select ".govuk-summary-card__title", text: application.name, count: 0
       end
     end
 

--- a/test/controllers/authorisations_controller_test.rb
+++ b/test/controllers/authorisations_controller_test.rb
@@ -44,7 +44,7 @@ class AuthorisationsControllerTest < ActionController::TestCase
     context "POST create" do
       should "create a new access token and populate flash with it" do
         assert_difference "Doorkeeper::AccessToken.count", 1 do
-          post :create, params: { api_user_id: @api_user.id, doorkeeper_access_token: { application_id: @application.id } }
+          post :create, params: { api_user_id: @api_user.id, authorisation: { application_id: @application.id } }
         end
 
         token = Doorkeeper::AccessToken.last
@@ -52,7 +52,7 @@ class AuthorisationsControllerTest < ActionController::TestCase
       end
 
       should "add a 'signin' permission for the authorised application" do
-        post :create, params: { api_user_id: @api_user.id, doorkeeper_access_token: { application_id: @application.id } }
+        post :create, params: { api_user_id: @api_user.id, authorisation: { application_id: @application.id } }
 
         assert @api_user.has_access_to?(@application)
       end
@@ -60,7 +60,7 @@ class AuthorisationsControllerTest < ActionController::TestCase
       should "not duplicate 'signin' permission for the authorised application if it already exists" do
         @api_user.grant_application_signin_permission(@application)
 
-        post :create, params: { api_user_id: @api_user.id, doorkeeper_access_token: { application_id: @application.id } }
+        post :create, params: { api_user_id: @api_user.id, authorisation: { application_id: @application.id } }
 
         assert_equal [SupportedPermission::SIGNIN_NAME], @api_user.permissions_for(@application)
       end

--- a/test/controllers/authorisations_controller_test.rb
+++ b/test/controllers/authorisations_controller_test.rb
@@ -25,7 +25,7 @@ class AuthorisationsControllerTest < ActionController::TestCase
         end
       end
 
-      should "should show a form to authorise api access to a particular application" do
+      should "should show a form to authorise API access to a particular application" do
         get :new, params: { api_user_id: @api_user.id }
         assert_select "option[value='#{@application.id}']", @application.name
       end

--- a/test/controllers/authorisations_controller_test.rb
+++ b/test/controllers/authorisations_controller_test.rb
@@ -26,7 +26,7 @@ class AuthorisationsControllerTest < ActionController::TestCase
       end
 
       should "should show a form to authorise API access to a particular application" do
-        get :new, params: { api_user_id: @api_user.id }
+        get :new, params: { api_user_id: @api_user }
         assert_select "option[value='#{@application.id}']", @application.name
       end
 
@@ -64,7 +64,7 @@ class AuthorisationsControllerTest < ActionController::TestCase
       end
 
       should "not be able to authorise API users" do
-        get :new, params: { api_user_id: @api_user.id }
+        get :new, params: { api_user_id: @api_user }
 
         assert_not_authorised
       end
@@ -90,7 +90,7 @@ class AuthorisationsControllerTest < ActionController::TestCase
 
       should "create a new access token and populate flash with it" do
         assert_difference "Doorkeeper::AccessToken.count", 1 do
-          post :create, params: { api_user_id: @api_user.id, authorisation: { application_id: @application.id } }
+          post :create, params: { api_user_id: @api_user, authorisation: { application_id: @application } }
         end
 
         token = Doorkeeper::AccessToken.last
@@ -98,7 +98,7 @@ class AuthorisationsControllerTest < ActionController::TestCase
       end
 
       should "add a 'signin' permission for the authorised application" do
-        post :create, params: { api_user_id: @api_user.id, authorisation: { application_id: @application.id } }
+        post :create, params: { api_user_id: @api_user, authorisation: { application_id: @application } }
 
         assert @api_user.has_access_to?(@application)
       end
@@ -106,7 +106,7 @@ class AuthorisationsControllerTest < ActionController::TestCase
       should "not duplicate 'signin' permission for the authorised application if it already exists" do
         @api_user.grant_application_signin_permission(@application)
 
-        post :create, params: { api_user_id: @api_user.id, authorisation: { application_id: @application.id } }
+        post :create, params: { api_user_id: @api_user, authorisation: { application_id: @application } }
 
         assert_equal [SupportedPermission::SIGNIN_NAME], @api_user.permissions_for(@application)
       end
@@ -123,7 +123,7 @@ class AuthorisationsControllerTest < ActionController::TestCase
       should "not be able to revoke API user's authorisations" do
         access_token = create(:access_token, resource_owner_id: @api_user.id)
 
-        post :revoke, params: { api_user_id: @api_user.id, id: access_token.id }
+        post :revoke, params: { api_user_id: @api_user, id: access_token }
 
         assert_not_authorised
       end

--- a/test/controllers/authorisations_controller_test.rb
+++ b/test/controllers/authorisations_controller_test.rb
@@ -30,6 +30,12 @@ class AuthorisationsControllerTest < ActionController::TestCase
         assert_select "option[value='#{@application.id}']", @application.name
       end
 
+      should "should show cancel link to return to manage tokens page" do
+        get :new, params: { api_user_id: @api_user.id }
+
+        assert_select "a[href='#{manage_tokens_api_user_path(@api_user)}']", text: "Cancel"
+      end
+
       should "authorize access if AuthorisationPolicy#new? returns true" do
         policy = stub_everything("policy", new?: true).responds_like_instance_of(AuthorisationPolicy)
         AuthorisationPolicy.stubs(:new).returns(policy)

--- a/test/integration/manage_api_users_test.rb
+++ b/test/integration/manage_api_users_test.rb
@@ -91,6 +91,7 @@ class ManageApiUsersTest < ActionDispatch::IntegrationTest
       click_link "Manage tokens"
 
       assert page.has_selector?("td:first-child", text: @application.name)
+      click_link "Revoke"
       click_button "Revoke"
 
       assert page.has_text?("Access for #{@application.name} was revoked")

--- a/test/integration/manage_api_users_test.rb
+++ b/test/integration/manage_api_users_test.rb
@@ -54,8 +54,9 @@ class ManageApiUsersTest < ActionDispatch::IntegrationTest
       click_button "Create access token"
 
       token = @api_user.authorisations.last.token
-      assert page.has_selector?("div.alert-danger", text: "Make sure to copy the access token for Whitehall now. You won't be able to see it again!")
-      assert page.has_selector?("div.alert-info", text: "Access token for Whitehall: #{token}")
+      assert page.has_selector?("div[role='alert']", text: /Make sure to copy the access token for Whitehall now. You won't be able to see it again!/)
+      assert page.has_selector?("div[role='alert'] label", text: /Access token for Whitehall/)
+      assert page.has_selector?("div[role='alert'] input[value='#{token}']")
 
       # shows truncated token
       assert page.has_selector?("code", text: (token[0..7]).to_s)
@@ -90,12 +91,12 @@ class ManageApiUsersTest < ActionDispatch::IntegrationTest
       click_link @api_user.name
       click_link "Manage tokens"
 
-      assert page.has_selector?("td:first-child", text: @application.name)
+      assert page.has_selector?(".govuk-summary-card__title", text: @application.name)
       click_link "Revoke"
       click_button "Revoke"
 
       assert page.has_text?("Access for #{@application.name} was revoked")
-      assert_not page.has_selector?("td:first-child", text: @application.name)
+      assert_not page.has_selector?(".govuk-summary-card__title", text: @application.name)
 
       click_link @api_user.name
       click_link "View account access log"

--- a/test/policies/api_user_policy_test.rb
+++ b/test/policies/api_user_policy_test.rb
@@ -4,7 +4,7 @@ require "support/policy_helpers"
 class ApiUserPolicyTest < ActiveSupport::TestCase
   include PolicyHelpers
 
-  %i[new create index edit update revoke manage_permissions manage_tokens suspension].each do |permission_name|
+  %i[new create index edit update manage_permissions manage_tokens suspension].each do |permission_name|
     context permission_name do
       should "allow only for superadmins" do
         assert permit?(create(:superadmin_user), User, permission_name)

--- a/test/policies/authorisation_policy_test.rb
+++ b/test/policies/authorisation_policy_test.rb
@@ -1,0 +1,19 @@
+require "test_helper"
+require "support/policy_helpers"
+
+class AuthorisationPolicyTest < ActiveSupport::TestCase
+  include PolicyHelpers
+
+  %i[new create revoke].each do |permission_name|
+    context permission_name do
+      should "allow only for superadmins" do
+        assert permit?(create(:superadmin_user), User, permission_name)
+
+        assert forbid?(create(:admin_user), User, permission_name)
+        assert forbid?(create(:super_organisation_admin_user), User, permission_name)
+        assert forbid?(create(:organisation_admin_user), User, permission_name)
+        assert forbid?(create(:user), User, permission_name)
+      end
+    end
+  end
+end

--- a/test/policies/authorisation_policy_test.rb
+++ b/test/policies/authorisation_policy_test.rb
@@ -4,7 +4,7 @@ require "support/policy_helpers"
 class AuthorisationPolicyTest < ActiveSupport::TestCase
   include PolicyHelpers
 
-  %i[new create revoke].each do |permission_name|
+  %i[new create edit revoke].each do |permission_name|
     context permission_name do
       should "allow only for superadmins" do
         assert permit?(create(:superadmin_user), User, permission_name)

--- a/test/support/pundit_helpers.rb
+++ b/test/support/pundit_helpers.rb
@@ -1,8 +1,8 @@
 module PunditHelpers
-  def stub_policy(current_user, record, method_and_return_value)
-    policy_class = Pundit::PolicyFinder.new(record).policy
+  def stub_policy(current_user, record, **options)
+    policy_class = options.delete(:policy_class) || Pundit::PolicyFinder.new(record).policy
     record = record.last if record.is_a?(Array)
-    policy = stub_everything("policy", method_and_return_value).responds_like_instance_of(policy_class)
+    policy = stub_everything("policy", options).responds_like_instance_of(policy_class)
     policy_class.stubs(:new).with(current_user, record).returns(policy)
   end
 


### PR DESCRIPTION
Trello: https://trello.com/c/75Jyg8zR

The majority of the commits in this branch are refactorings or other improvements intended to make the actual changes easier. The two key commits where the actual changes are made are:
* [Split out new page for revoking API user access tokens](https://github.com/alphagov/signon/pull/2616/commits/870045ef63737922a02d65352b3e3fb9f0cc0bdf)
* [Move API user manage tokens page to GOV.UK Design System](https://github.com/alphagov/signon/pull/2616/commits/32a74fa7de4614666680d54300f3c05a4a854012)

I've also made a few tweaks to other pages relating to API users in order to make all the pages more consistent with each other and with other pages across the site.

I considered displaying each token's expired/valid status on the manage tokens page using the [`tag` component](https://design-system.service.gov.uk/components/tag/), but since it wasn't in the Figma design, I decided it was out-of-scope for the moment.

I think the copy in the success alerts isn't great, but I've left it unchanged for now. I'm keen that we do a review/audit of all flash messages across the site once we've moved the whole app to use the GOV.UK Design System.

I considered renaming the `AuthorisationsController` to be more about access tokens, but the most obvious name would be `Doorkeeper::AccessTokensController` (to match the model class), but this might imply that the controller is somehow provided by Doorkeeper and in any case, I think Doorkeeper might already provide such a controller!

The Figma design never envisaged the "manage permission" and "manage tokens" pages being split out. We split them to make it easier to make the changes incrementally. Once the work on the "manage permissions" page is complete, we might want to consider combining them back into the "edit API user" page as per the Figma design.

### Manage tokens for API user page
<img width="912" alt="Screenshot 2024-01-04 at 13 25 14" src="https://github.com/alphagov/signon/assets/3169/e196fbf0-e5f1-45d5-b73a-3d8d57346e19">

### Create new access token page
<img width="909" alt="Screenshot 2024-01-04 at 13 25 52" src="https://github.com/alphagov/signon/assets/3169/58f1bd2d-6b58-47ad-9c32-57d5d18c11bb">

### Manage tokens for API user page with new token details
<img width="909" alt="Screenshot 2024-01-04 at 13 26 38" src="https://github.com/alphagov/signon/assets/3169/e2bd0473-7fb4-4aee-a422-0e87d0fad5cd">

### Revoke token for API user page
<img width="907" alt="Screenshot 2024-01-04 at 13 27 25" src="https://github.com/alphagov/signon/assets/3169/61192e6e-5111-4f61-b15c-fb4c8c628e8f">

### Manage tokens for API user page with revocation success message
<img width="907" alt="Screenshot 2024-01-04 at 13 28 05" src="https://github.com/alphagov/signon/assets/3169/34d5d2d2-8b6d-4f76-ad4a-1abd45a0d22f">
