### PR TITLE
Replace Time.zone.now with Time.current

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -183,7 +183,7 @@ class User < ApplicationRecord
   end
 
   def permissions_synced!(application)
-    application_permissions.where(application_id: application.id).update_all(last_synced_at: Time.zone.now)
+    application_permissions.where(application_id: application.id).update_all(last_synced_at: Time.current)
   end
 
   def revoke_all_authorisations
@@ -244,7 +244,7 @@ class User < ApplicationRecord
     # It means that the password reset flow works when you've been invited but
     # not yet accepted.
     # Devise Invitable used to behave this way and then changed in v1.1.1
-    self.confirmed_at = Time.zone.now
+    self.confirmed_at = Time.current
     super(*args)
   end
 
@@ -458,6 +458,6 @@ private
   end
 
   def update_password_changed
-    self.password_changed_at = Time.zone.now if (new_record? || encrypted_password_changed?) && !password_changed_at_changed?
+    self.password_changed_at = Time.current if (new_record? || encrypted_password_changed?) && !password_changed_at_changed?
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -12,7 +12,7 @@ User.create!(
   email: "test.superadmin@gov.uk",
   password: "6fe552ca-d406-4c54-b7a6-041ed1ade6cd",
   role: Roles::Superadmin.role_name,
-  confirmed_at: Time.zone.now,
+  confirmed_at: Time.current,
   organisation: gds,
 )
 
@@ -21,7 +21,7 @@ User.create!(
   email: "test.admin@gov.uk",
   password: "6fe552ca-d406-4c54-b7a6-041ed1ade6cd",
   role: Roles::Admin.role_name,
-  confirmed_at: Time.zone.now,
+  confirmed_at: Time.current,
   organisation: gds,
 )
 
@@ -30,7 +30,7 @@ User.create!(
   email: "test.super-organisation-admin@gov.uk",
   password: "6fe552ca-d406-4c54-b7a6-041ed1ade6cd",
   role: Roles::SuperOrganisationAdmin.role_name,
-  confirmed_at: Time.zone.now,
+  confirmed_at: Time.current,
   organisation: gds,
 )
 
@@ -39,7 +39,7 @@ User.create!(
   email: "test.organisation-admin@gov.uk",
   password: "6fe552ca-d406-4c54-b7a6-041ed1ade6cd",
   role: Roles::OrganisationAdmin.role_name,
-  confirmed_at: Time.zone.now,
+  confirmed_at: Time.current,
   organisation: gds,
 )
 
@@ -64,7 +64,7 @@ User.create!(
   email: "test.user@gov.uk",
   password: "6fe552ca-d406-4c54-b7a6-041ed1ade6cd",
   role: Roles::Normal.role_name,
-  confirmed_at: Time.zone.now,
+  confirmed_at: Time.current,
   organisation: test_organisation_without_2sv,
 )
 
@@ -100,7 +100,7 @@ User.create!(
   email: "test.user.2sv@gov.uk",
   password: "6fe552ca-d406-4c54-b7a6-041ed1ade6cd",
   role: Roles::Normal.role_name,
-  confirmed_at: Time.zone.now,
+  confirmed_at: Time.current,
   organisation: test_organisation_without_2sv,
   require_2sv: true,
   otp_secret_key: "I5X6Y3VN3CAATYQRBPAZ7KMFLK2RWYJ5",
@@ -111,7 +111,7 @@ User.create!(
   email: "test.user.2sv.organisation@gov.uk",
   password: "6fe552ca-d406-4c54-b7a6-041ed1ade6cd",
   role: Roles::Normal.role_name,
-  confirmed_at: Time.zone.now,
+  confirmed_at: Time.current,
   organisation: test_organisation_with_2sv,
   require_2sv: true,
   otp_secret_key: "I5X6Y3VN3CAATYQRBPAZ7KMFLK2RWYJ5",
@@ -123,7 +123,7 @@ User.create!(
   email: "test.apiuser@gov.uk",
   password: "6fe552ca-d406-4c54-b7a6-041ed1ade6cd",
   role: Roles::Normal.role_name,
-  confirmed_at: Time.zone.now,
+  confirmed_at: Time.current,
   require_2sv: false,
 )
 

--- a/lib/devise/hooks/two_step_verification.rb
+++ b/lib/devise/hooks/two_step_verification.rb
@@ -4,7 +4,7 @@ module Devise::Hooks::TwoStepVerification
       cookie = auth.env["action_dispatch.cookies"].signed["remember_2sv_session"]
       valid = cookie &&
         cookie["user_id"] == user.id &&
-        cookie["valid_until"] > Time.zone.now &&
+        cookie["valid_until"] > Time.current &&
         cookie["secret_hash"] == Digest::SHA256.hexdigest(user.otp_secret_key)
       unless valid
         auth.session(:user)["need_two_step_verification"] = user.need_two_step_verification?

--- a/lib/devise/models/suspendable.rb
+++ b/lib/devise/models/suspendable.rb
@@ -36,14 +36,14 @@ module Devise
       # rubocop:disable Rails/SaveBang
       def suspend(reason)
         update(reason_for_suspension: reason,
-               suspended_at: Time.zone.now)
+               suspended_at: Time.current)
         revoke_all_authorisations
       end
       # rubocop:enable Rails/SaveBang
 
       def unsuspend
         update(password: SecureRandom.hex,
-               unsuspended_at: Time.zone.now,
+               unsuspended_at: Time.current,
                suspended_at: nil,
                reason_for_suspension: nil)
       end

--- a/lib/inactive_users_suspender.rb
+++ b/lib/inactive_users_suspender.rb
@@ -1,7 +1,7 @@
 class InactiveUsersSuspender
   def suspend
     inactive_users = User.not_recently_unsuspended.last_signed_in_before(User::SUSPENSION_THRESHOLD_PERIOD.ago).each do |user|
-      user.suspended_at = Time.zone.now
+      user.suspended_at = Time.current
       user.reason_for_suspension = reason
       user.save!(validate: false)
 

--- a/test/controllers/api_users/applications_controller_test.rb
+++ b/test/controllers/api_users/applications_controller_test.rb
@@ -44,7 +44,7 @@ class ApiUsers::ApplicationsControllerTest < ActionController::TestCase
     should "not include applications where the access token has been revoked" do
       api_user = create(:api_user)
       application = create(:application, name: "revoked-app-name")
-      create(:access_token, application:, resource_owner_id: api_user.id, revoked_at: Time.zone.now)
+      create(:access_token, application:, resource_owner_id: api_user.id, revoked_at: Time.current)
 
       current_user = create(:admin_user)
       sign_in current_user

--- a/test/controllers/api_users/permissions_controller_test.rb
+++ b/test/controllers/api_users/permissions_controller_test.rb
@@ -80,7 +80,7 @@ class ApiUsers::PermissionsControllerTest < ActionController::TestCase
 
       application = create(:application)
       api_user = create(:api_user)
-      create(:access_token, resource_owner_id: api_user.id, application:, revoked_at: Time.zone.now)
+      create(:access_token, resource_owner_id: api_user.id, application:, revoked_at: Time.current)
 
       assert_raises(ActiveRecord::RecordNotFound) do
         get :edit, params: { api_user_id: api_user, application_id: application }
@@ -92,7 +92,7 @@ class ApiUsers::PermissionsControllerTest < ActionController::TestCase
 
       application = create(:application)
       api_user = create(:api_user)
-      create(:access_token, resource_owner_id: api_user.id, application:, revoked_at: Time.zone.now)
+      create(:access_token, resource_owner_id: api_user.id, application:, revoked_at: Time.current)
       create(:access_token, resource_owner_id: api_user.id, application:)
 
       get :edit, params: { api_user_id: api_user, application_id: application }
@@ -348,7 +348,7 @@ class ApiUsers::PermissionsControllerTest < ActionController::TestCase
 
       application = create(:application)
       api_user = create(:api_user)
-      create(:access_token, resource_owner_id: api_user.id, application:, revoked_at: Time.zone.now)
+      create(:access_token, resource_owner_id: api_user.id, application:, revoked_at: Time.current)
 
       assert_raises(ActiveRecord::RecordNotFound) do
         patch :update, params: { api_user_id: api_user, application_id: application, application: { supported_permission_ids: [] } }
@@ -360,7 +360,7 @@ class ApiUsers::PermissionsControllerTest < ActionController::TestCase
 
       application = create(:application, with_supported_permissions: %w[permission])
       api_user = create(:api_user)
-      create(:access_token, resource_owner_id: api_user.id, application:, revoked_at: Time.zone.now)
+      create(:access_token, resource_owner_id: api_user.id, application:, revoked_at: Time.current)
       create(:access_token, resource_owner_id: api_user.id, application:)
 
       permission = application.supported_permissions.find_by(name: "permission")

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -75,7 +75,7 @@ FactoryBot.define do
     email { "old@email.com" }
     unconfirmed_email { "new@email.com" }
     sequence(:confirmation_token) { |n| "#{n}a1s2d3" } # see `token_sent_to` in ConfirmationTokenHelper
-    confirmation_sent_at { Time.zone.now }
+    confirmation_sent_at { Time.current }
   end
 
   factory :user_with_pending_email_change, parent: :user, traits: [:with_pending_email_change]
@@ -106,16 +106,16 @@ FactoryBot.define do
   factory :invited_user, parent: :user, traits: [:invited]
 
   factory :active_user, parent: :invited_user do
-    invitation_accepted_at { Time.zone.now }
+    invitation_accepted_at { Time.current }
   end
 
   factory :suspended_user, parent: :user do
-    suspended_at { Time.zone.now }
+    suspended_at { Time.current }
     reason_for_suspension { "Testing" }
   end
 
   factory :locked_user, parent: :user do
-    locked_at { Time.zone.now }
+    locked_at { Time.current }
   end
 
   factory :user_in_organisation, parent: :user, traits: [:in_organisation]

--- a/test/helpers/users_with_access_helper_test.rb
+++ b/test/helpers/users_with_access_helper_test.rb
@@ -45,7 +45,7 @@ class UsersWithAccessHelperTest < ActionView::TestCase
 
   test "formatted_last_sign_in returns the time in words when the user has signed in" do
     user = build(:user)
-    user.stubs(:current_sign_in_at).returns(Time.zone.now - 1.second)
+    user.stubs(:current_sign_in_at).returns(Time.current - 1.second)
 
     assert_equal "less than a minute ago", formatted_last_sign_in(user)
   end

--- a/test/integration/admin_user_index_test.rb
+++ b/test/integration/admin_user_index_test.rb
@@ -5,7 +5,7 @@ class AdminUserIndexTest < ActionDispatch::IntegrationTest
     setup do
       use_javascript_driver
 
-      current_time = Time.zone.now
+      current_time = Time.current
       Timecop.freeze(current_time)
 
       @admin = create(:admin_user, name: "Admin User", email: "admin@example.com")

--- a/test/integration/password_reset_test.rb
+++ b/test/integration/password_reset_test.rb
@@ -29,7 +29,7 @@ class PasswordResetTest < ActionDispatch::IntegrationTest
 
   should "not allow password reset for unaccepted invitations" do
     perform_enqueued_jobs do
-      user = create(:user, invitation_sent_at: Time.zone.now, invitation_accepted_at: nil)
+      user = create(:user, invitation_sent_at: Time.current, invitation_accepted_at: nil)
       trigger_reset_for(user.email)
       assert_response_contains(BLANKET_RESET_MESSAGE)
 


### PR DESCRIPTION
Trello: https://trello.com/c/wSKG73MP
Arises from: #2599 

rubocop-govuk enables the "strict" style of the Rails/TimeZone cop[1]. This cop doesn't have a preference[2] for either of the equivalent methods `Time.zone.now` or `Time.current`. Since the latter is shorter and we're currently using a mixture of both I've gone with `Time.current`. I don't think we can enforce this without deviating from rubocop-govuk but hopefully being consistent now will help keep things that way.

[1]
https://github.com/alphagov/rubocop-govuk/blob/97fcbc866aa10a75c7c1c89fc3c2c562cc04fc26/config/rails.yml#L89 [2] https://github.com/rubocop/rubocop-rails/blob/cb01e4d6a33b0e4285b2972f9c64fc45e5776429/lib/rubocop/cop/rails/time_zone.rb#L26
