### PR TITLE
Use table component on API users application index

### DIFF
--- a/app/helpers/api_users_helper.rb
+++ b/app/helpers/api_users_helper.rb
@@ -19,4 +19,15 @@ module ApiUsersHelper
       )
     end
   end
+
+  def update_permissions_link(application, user)
+    unless application.sorted_supported_permissions_grantable_from_ui(include_signin: false).empty?
+      link_to(edit_api_user_application_permissions_path(user, application), class: "govuk-link") do
+        safe_join(
+          ["Update permissions",
+           content_tag(:span, " for #{application.name}", class: "govuk-visually-hidden")],
+        )
+      end
+    end
+  end
 end

--- a/app/views/api_users/applications/index.html.erb
+++ b/app/views/api_users/applications/index.html.erb
@@ -33,22 +33,18 @@
   <% end %>
 <% end %>
 
-<table class="govuk-table">
-  <caption class="govuk-table__caption govuk-table__caption--m">Apps <%= @api_user.name %> has access to</caption>
-  <thead class="govuk-table__head">
-    <tr class="govuk-table__row">
-      <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Name</th>
-      <th scope="col" class="govuk-table__header govuk-!-width-one-third">Description</th>
-      <th scope="col" class="govuk-table__header"><span class="govuk-visually-hidden">Permissions</span></th>
-    </tr>
-  </thead>
-  <tbody class="govuk-table__body">
-    <% @applications.each do |application| %>
-      <tr class="govuk-table__row">
-        <td class="govuk-table__cell"><%= application.name %></td>
-        <td class="govuk-table__cell"><%= application.description %></td>
-        <td class="govuk-table__cell govuk-!-text-align-right"><%= update_permissions_link(application, @api_user) %></td>
-      </tr>
-    <% end %>
-  </tbody>
-</table>
+<%= render "govuk_publishing_components/components/table", {
+    caption: "Apps #{@api_user.name} has access to",
+    head: [
+      { text: "Name" },
+      { text: "Description" },
+      { text: content_tag(:span, "Permissions", class: "govuk-visually-hidden") },
+    ],
+    rows: @applications.map do |application|
+    [
+      { text: application.name },
+      { text: application.description },
+      { text: update_permissions_link(application, @api_user) || "" }
+    ]
+    end,
+} %>

--- a/app/views/api_users/applications/index.html.erb
+++ b/app/views/api_users/applications/index.html.erb
@@ -47,13 +47,7 @@
       <tr class="govuk-table__row">
         <td class="govuk-table__cell"><%= application.name %></td>
         <td class="govuk-table__cell"><%= application.description %></td>
-        <td class="govuk-table__cell govuk-!-text-align-right">
-          <% unless application.sorted_supported_permissions_grantable_from_ui(include_signin: false).empty? %>
-            <%= link_to edit_api_user_application_permissions_path(@api_user, application), class: "govuk-link" do %>
-              Update permissions<span class="govuk-visually-hidden"> for <%= application.name %></span>
-            <% end %>
-          <% end %>
-        </td>
+        <td class="govuk-table__cell govuk-!-text-align-right"><%= update_permissions_link(application, @api_user) %></td>
       </tr>
     <% end %>
   </tbody>

--- a/test/helpers/api_users_helper_test.rb
+++ b/test/helpers/api_users_helper_test.rb
@@ -1,0 +1,21 @@
+require "test_helper"
+
+class ApiUsersHelperTest < ActionView::TestCase
+  context "#update_permissions_link" do
+    setup do
+      @user = create(:api_user)
+    end
+
+    should "generate a link to edit the permissions" do
+      application = create(:application, with_supported_permissions: %w[permission])
+
+      assert_includes update_permissions_link(application, @user), edit_api_user_application_permissions_path(@user, application)
+    end
+
+    should "return nil when the application has no grantable permissions" do
+      application = create(:application)
+
+      assert_nil update_permissions_link(application, @user)
+    end
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/wSKG73MP
Arises from: #2599 

To ensure we keep up with changes to the design system this PR replaces the table markup on `/app/views/api_users/applications/index.html.erb` with the `table` design system component.

## Before 
<img width="1182" alt="Screenshot 2024-01-10 at 15 08 28" src="https://github.com/alphagov/signon/assets/16707/a6913c17-9973-422c-8fed-bae09ace8985">

## After
<img width="1182" alt="Screenshot 2024-01-10 at 15 08 13" src="https://github.com/alphagov/signon/assets/16707/c4c8a60f-3b45-4fd5-b56d-ade4bac17e09">
