### PR TITLE
Remove redundant use of `once` in tests

### DIFF
--- a/test/controllers/api_users/permissions_controller_test.rb
+++ b/test/controllers/api_users/permissions_controller_test.rb
@@ -338,7 +338,7 @@ class ApiUsers::PermissionsControllerTest < ActionController::TestCase
 
       permission = application.supported_permissions.find_by(name: "permission")
 
-      PermissionUpdater.expects(:perform_on).with(api_user).once
+      PermissionUpdater.expects(:perform_on).with(api_user)
 
       patch :update, params: { api_user_id: api_user, application_id: application, application: { supported_permission_ids: [permission.id] } }
     end

--- a/test/controllers/users/emails_controller_test.rb
+++ b/test/controllers/users/emails_controller_test.rb
@@ -243,7 +243,7 @@ class Users::EmailsControllerTest < ActionController::TestCase
 
       should "push changes out to apps" do
         user = create(:user)
-        PermissionUpdater.expects(:perform_on).with(user).once
+        PermissionUpdater.expects(:perform_on).with(user)
 
         put :update, params: { user_id: user, user: { email: "new-user@gov.uk" } }
       end

--- a/test/controllers/users/names_controller_test.rb
+++ b/test/controllers/users/names_controller_test.rb
@@ -164,7 +164,7 @@ class Users::NamesControllerTest < ActionController::TestCase
 
       should "push changes out to apps" do
         user = create(:user)
-        PermissionUpdater.expects(:perform_on).with(user).once
+        PermissionUpdater.expects(:perform_on).with(user)
 
         put :update, params: { user_id: user, user: { name: "new-user-name" } }
       end

--- a/test/controllers/users/organisations_controller_test.rb
+++ b/test/controllers/users/organisations_controller_test.rb
@@ -135,7 +135,7 @@ class Users::OrganisationsControllerTest < ActionController::TestCase
       should "push changes out to apps" do
         user = create(:user, organisation:)
 
-        PermissionUpdater.expects(:perform_on).with(user).once
+        PermissionUpdater.expects(:perform_on).with(user)
 
         put :update, params: { user_id: user, user: { organisation_id: another_organisation } }
       end

--- a/test/controllers/users/roles_controller_test.rb
+++ b/test/controllers/users/roles_controller_test.rb
@@ -133,7 +133,7 @@ class Users::RolesControllerTest < ActionController::TestCase
 
       should "push changes out to apps" do
         user = create(:user_in_organisation)
-        PermissionUpdater.expects(:perform_on).with(user).once
+        PermissionUpdater.expects(:perform_on).with(user)
 
         put :update, params: { user_id: user, user: { role: Roles::OrganisationAdmin.role_name } }
       end

--- a/test/controllers/users/two_step_verification_mandations_controller_test.rb
+++ b/test/controllers/users/two_step_verification_mandations_controller_test.rb
@@ -122,7 +122,7 @@ class Users::TwoStepVerificationMandationsControllerTest < ActionController::Tes
 
       should "push changes out to apps" do
         user = create(:user, require_2sv: false)
-        PermissionUpdater.expects(:perform_on).with(user).once
+        PermissionUpdater.expects(:perform_on).with(user)
 
         put :update, params: { user_id: user, user: { require_2sv: true } }
       end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -429,7 +429,7 @@ class UsersControllerTest < ActionController::TestCase
 
       should "push changes out to apps" do
         another_user = create(:user)
-        PermissionUpdater.expects(:perform_on).with(another_user).once
+        PermissionUpdater.expects(:perform_on).with(another_user)
 
         put :update, params: { id: another_user.id, user: { require_2sv: true } }
       end

--- a/test/integration/sign_out_test.rb
+++ b/test/integration/sign_out_test.rb
@@ -8,7 +8,7 @@ class SignOutTest < ActionDispatch::IntegrationTest
 
   should "perform reauth on downstream apps" do
     signin_with(@user)
-    ReauthEnforcer.expects(:perform_on).with(@user).once
+    ReauthEnforcer.expects(:perform_on).with(@user)
 
     click_link "Sign out"
 

--- a/test/jobs/reauth_enforcer_test.rb
+++ b/test/jobs/reauth_enforcer_test.rb
@@ -7,8 +7,8 @@ class ReauthEnforcerTest < ActiveSupport::TestCase
       uid = "01aac80d-0bbf-4667-9892-3b304654f3de"
 
       mock_client = mock("sso_push_client")
-      mock_client.expects(:reauth_user).with(uid).once
-      SSOPushClient.expects(:new).with(app).returns(mock_client).once
+      mock_client.expects(:reauth_user).with(uid)
+      SSOPushClient.expects(:new).with(app).returns(mock_client)
 
       ReauthEnforcer.new.perform(uid, app.id)
     end

--- a/test/lib/inactive_users_suspender_test.rb
+++ b/test/lib/inactive_users_suspender_test.rb
@@ -66,7 +66,6 @@ class InactiveUsersSuspenderTest < ActiveSupport::TestCase
     users.each do |user|
       EventLog.expects(:record_event)
         .with(responds_with(:email, user.email), EventLog::ACCOUNT_AUTOSUSPENDED)
-        .once
     end
 
     InactiveUsersSuspender.new.suspend
@@ -80,7 +79,7 @@ class InactiveUsersSuspenderTest < ActiveSupport::TestCase
     users.each do |user|
       UserMailer.expects(:suspension_notification)
         .with(responds_with(:email, user.email))
-        .returns(mailer).once
+        .returns(mailer)
     end
 
     InactiveUsersSuspender.new.suspend

--- a/test/lib/inactive_users_suspension_reminder_test.rb
+++ b/test/lib/inactive_users_suspension_reminder_test.rb
@@ -62,7 +62,7 @@ class InactiveUsersSuspensionReminderTest < ActiveSupport::TestCase
     end
 
     should "send an exception notification if retries fail" do
-      GovukError.expects(:notify).once
+      GovukError.expects(:notify)
       UserMailer.expects(:suspension_reminder).returns(@mailer).times(3)
 
       InactiveUsersSuspensionReminder.new(@users_to_remind, 1).send_reminders

--- a/test/lib/signin_permission_granter_test.rb
+++ b/test/lib/signin_permission_granter_test.rb
@@ -11,8 +11,8 @@ class SigninPermissionGranterTest < ActiveSupport::TestCase
     first_user = create(:user)
     second_user = create(:user)
     user_with_permission = create(:user, with_signin_permissions_for: [@application_supporting_push_updates])
-    first_user.expects(:grant_application_signin_permission).with(@application_supporting_push_updates).once
-    second_user.expects(:grant_application_signin_permission).with(@application_supporting_push_updates).once
+    first_user.expects(:grant_application_signin_permission).with(@application_supporting_push_updates)
+    second_user.expects(:grant_application_signin_permission).with(@application_supporting_push_updates)
     PermissionUpdater.expects(:perform_later).with(anything, @application_supporting_push_updates.id).twice
 
     user_with_permission.expects(:grant_application_permission).never
@@ -23,7 +23,7 @@ class SigninPermissionGranterTest < ActiveSupport::TestCase
   should "not send a push update to an application with updated users if the application does not support it" do
     user = create(:user)
 
-    user.expects(:grant_application_signin_permission).with(@application_not_supporting_push_updates).once
+    user.expects(:grant_application_signin_permission).with(@application_not_supporting_push_updates)
     PermissionUpdater.expects(:perform_later).with(user.id, @application_not_supporting_push_updates.id).never
 
     SigninPermissionGranter.call(users: [user], application: @application_not_supporting_push_updates)

--- a/test/lib/tasks/sync_kubernetes_secrets_test.rb
+++ b/test/lib/tasks/sync_kubernetes_secrets_test.rb
@@ -111,7 +111,7 @@ class KubernetesTaskTest < ActiveSupport::TestCase
         client.expects(:apply_secret).with(
           "signon-token-#{user.name}-#{authorisation.application.name}".parameterize,
           { bearer_token: authorisation.token },
-        ).once
+        )
       end
     end
   end
@@ -121,7 +121,7 @@ class KubernetesTaskTest < ActiveSupport::TestCase
       client.expects(:apply_secret).with(
         "signon-app-#{app.name}".parameterize,
         { oauth_id: app.uid, oauth_secret: app.secret },
-      ).once
+      )
     end
   end
 
@@ -134,6 +134,6 @@ class KubernetesTaskTest < ActiveSupport::TestCase
         data: { "app_names" => "[#{names_list}]",
                 "api_user_emails" => "[#{email_list}]" },
       }),
-    ).once
+    )
   end
 end

--- a/test/models/batch_invitation_user_test.rb
+++ b/test/models/batch_invitation_user_test.rb
@@ -119,7 +119,7 @@ class BatchInvitationUserTest < ActiveSupport::TestCase
       end
 
       should "log the error" do
-        GovukError.expects(:notify).once
+        GovukError.expects(:notify)
 
         user = create(:batch_invitation_user, batch_invitation: @batch_invitation)
         user.invite(@inviting_user, [])
@@ -136,7 +136,7 @@ class BatchInvitationUserTest < ActiveSupport::TestCase
       end
 
       should "log the error" do
-        GovukError.expects(:notify).once
+        GovukError.expects(:notify)
 
         user = create(:batch_invitation_user, batch_invitation: @batch_invitation)
         user.email = nil
@@ -153,7 +153,7 @@ class BatchInvitationUserTest < ActiveSupport::TestCase
       end
 
       should "log the error" do
-        GovukError.expects(:notify).once
+        GovukError.expects(:notify)
 
         user = create(:batch_invitation_user, batch_invitation: @batch_invitation, email: "foo@example.com", organisation_slug: "not-a-real-slug")
         user.invite(@inviting_user, [])


### PR DESCRIPTION
Trello: https://trello.com/c/wSKG73MP
Arises from: #2599 

Using Mocha::ObjectMethods#expects "adds an expectation that the specified method must be called exactly once with any parameters"[1] so we don't need to chain `once` in these cases.

[1] https://mocha.jamesmead.org/Mocha/ObjectMethods.html#expects-instance_method
