### PR TITLE
Configure dependabot to monitor GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,11 @@ updates:
     schedule:
       interval: daily
 
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+
   # Ruby needs to be upgraded manually in multiple places, so cannot
   # be upgraded by Dependabot. That effectively makes the below
   # config redundant, as ruby is the only updatable thing in the


### PR DESCRIPTION
I saw that @brucebolt had added this to a number of other repos (e.g. https://github.com/alphagov/collections/pull/3495) and thought it made sense to add it here too.

More information in the [GitHub Docs][1].

[1]: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot
