### PR TITLE
Add link to GOV.UK status page to footer

### DIFF
--- a/app/views/layouts/admin_layout.html.erb
+++ b/app/views/layouts/admin_layout.html.erb
@@ -78,6 +78,10 @@
           {
             href: privacy_notice_path,
             text: "Privacy notice",
+          },
+          {
+            href: "https://status.publishing.service.gov.uk/",
+            text: "Check if publishing apps are working or if there’s any maintenance planned",
           }
         ].compact
       }


### PR DESCRIPTION
c.f. https://github.com/alphagov/whitehall/pull/8727

I considered using `Plek.external_url_for` to generate the URL based for the "status" app (like the code is already doing for the "support" app), but it doesn't look like there's an equivalent of that app in any other environments, so it didn't seem worthwhile.

<img width="626" alt="Screenshot 2024-01-17 at 10 09 31" src="https://github.com/alphagov/signon/assets/3169/ea7f53af-aa9a-421d-9650-7674dbfc0200">
