### PR TITLE
Refactor build user update params

### DIFF
--- a/app/controllers/account/permissions_controller.rb
+++ b/app/controllers/account/permissions_controller.rb
@@ -18,7 +18,7 @@ class Account::PermissionsController < ApplicationController
   def update
     authorize [:account, @application], :edit_permissions?
 
-    UserUpdate.new(current_user, build_user_update_params(current_user, @permissions.pluck(:id)), current_user, user_ip_address).call
+    UserUpdate.new(current_user, build_user_update_params(current_user, @permissions.pluck(:id), update_params[:supported_permission_ids].map(&:to_i)), current_user, user_ip_address).call
 
     flash[:application_id] = @application.id
     redirect_to account_applications_path
@@ -38,11 +38,10 @@ private
     @permissions = @application.sorted_supported_permissions_grantable_from_ui(include_signin: false)
   end
 
-  def build_user_update_params(user, updatable_permission_ids)
+  def build_user_update_params(user, updatable_permission_ids, selected_permission_ids)
     permissions_user_has = user.supported_permissions.pluck(:id)
-    selected_permissions = update_params[:supported_permission_ids].map(&:to_i)
-    permissions_to_add = updatable_permission_ids.intersection(selected_permissions)
-    permissions_to_remove = updatable_permission_ids.difference(selected_permissions)
+    permissions_to_add = updatable_permission_ids.intersection(selected_permission_ids)
+    permissions_to_remove = updatable_permission_ids.difference(selected_permission_ids)
 
     { supported_permission_ids: (permissions_user_has + permissions_to_add - permissions_to_remove).sort }
   end

--- a/app/controllers/account/permissions_controller.rb
+++ b/app/controllers/account/permissions_controller.rb
@@ -18,7 +18,7 @@ class Account::PermissionsController < ApplicationController
   def update
     authorize [:account, @application], :edit_permissions?
 
-    UserUpdate.new(current_user, build_user_update_params, current_user, user_ip_address).call
+    UserUpdate.new(current_user, build_user_update_params(current_user), current_user, user_ip_address).call
 
     flash[:application_id] = @application.id
     redirect_to account_applications_path
@@ -38,8 +38,8 @@ private
     @permissions = @application.sorted_supported_permissions_grantable_from_ui(include_signin: false)
   end
 
-  def build_user_update_params
-    permissions_user_has = current_user.supported_permissions.pluck(:id)
+  def build_user_update_params(user)
+    permissions_user_has = user.supported_permissions.pluck(:id)
     updatable_permissions_for_this_app = @permissions.pluck(:id)
     selected_permissions = update_params[:supported_permission_ids].map(&:to_i)
     permissions_to_add = updatable_permissions_for_this_app.intersection(selected_permissions)

--- a/app/controllers/account/permissions_controller.rb
+++ b/app/controllers/account/permissions_controller.rb
@@ -18,7 +18,7 @@ class Account::PermissionsController < ApplicationController
   def update
     authorize [:account, @application], :edit_permissions?
 
-    UserUpdate.new(current_user, build_user_update_params(current_user), current_user, user_ip_address).call
+    UserUpdate.new(current_user, build_user_update_params(current_user, @permissions.pluck(:id)), current_user, user_ip_address).call
 
     flash[:application_id] = @application.id
     redirect_to account_applications_path
@@ -38,12 +38,11 @@ private
     @permissions = @application.sorted_supported_permissions_grantable_from_ui(include_signin: false)
   end
 
-  def build_user_update_params(user)
+  def build_user_update_params(user, updatable_permission_ids)
     permissions_user_has = user.supported_permissions.pluck(:id)
-    updatable_permissions_for_this_app = @permissions.pluck(:id)
     selected_permissions = update_params[:supported_permission_ids].map(&:to_i)
-    permissions_to_add = updatable_permissions_for_this_app.intersection(selected_permissions)
-    permissions_to_remove = updatable_permissions_for_this_app.difference(selected_permissions)
+    permissions_to_add = updatable_permission_ids.intersection(selected_permissions)
+    permissions_to_remove = updatable_permission_ids.difference(selected_permissions)
 
     { supported_permission_ids: (permissions_user_has + permissions_to_add - permissions_to_remove).sort }
   end

--- a/app/controllers/account/permissions_controller.rb
+++ b/app/controllers/account/permissions_controller.rb
@@ -18,7 +18,12 @@ class Account::PermissionsController < ApplicationController
   def update
     authorize [:account, @application], :edit_permissions?
 
-    supported_permission_ids = build_user_update_params(current_user, @permissions.pluck(:id), update_params[:supported_permission_ids].map(&:to_i))
+    supported_permission_ids = UserUpdatePermissionBuilder.new(
+      user: current_user,
+      updatable_permission_ids: @permissions.pluck(:id),
+      selected_permission_ids: update_params[:supported_permission_ids].map(&:to_i),
+    ).build
+
     UserUpdate.new(current_user, { supported_permission_ids: }, current_user, user_ip_address).call
 
     flash[:application_id] = @application.id
@@ -37,13 +42,5 @@ private
 
   def set_permissions
     @permissions = @application.sorted_supported_permissions_grantable_from_ui(include_signin: false)
-  end
-
-  def build_user_update_params(user, updatable_permission_ids, selected_permission_ids)
-    permissions_user_has = user.supported_permissions.pluck(:id)
-    permissions_to_add = updatable_permission_ids.intersection(selected_permission_ids)
-    permissions_to_remove = updatable_permission_ids.difference(selected_permission_ids)
-
-    (permissions_user_has + permissions_to_add - permissions_to_remove).sort
   end
 end

--- a/app/controllers/account/permissions_controller.rb
+++ b/app/controllers/account/permissions_controller.rb
@@ -18,7 +18,8 @@ class Account::PermissionsController < ApplicationController
   def update
     authorize [:account, @application], :edit_permissions?
 
-    UserUpdate.new(current_user, build_user_update_params(current_user, @permissions.pluck(:id), update_params[:supported_permission_ids].map(&:to_i)), current_user, user_ip_address).call
+    supported_permission_ids = build_user_update_params(current_user, @permissions.pluck(:id), update_params[:supported_permission_ids].map(&:to_i))
+    UserUpdate.new(current_user, { supported_permission_ids: }, current_user, user_ip_address).call
 
     flash[:application_id] = @application.id
     redirect_to account_applications_path
@@ -43,6 +44,6 @@ private
     permissions_to_add = updatable_permission_ids.intersection(selected_permission_ids)
     permissions_to_remove = updatable_permission_ids.difference(selected_permission_ids)
 
-    { supported_permission_ids: (permissions_user_has + permissions_to_add - permissions_to_remove).sort }
+    (permissions_user_has + permissions_to_add - permissions_to_remove).sort
   end
 end

--- a/app/controllers/api_users/permissions_controller.rb
+++ b/app/controllers/api_users/permissions_controller.rb
@@ -11,7 +11,7 @@ class ApiUsers::PermissionsController < ApplicationController
   def update
     authorize @api_user
 
-    UserUpdate.new(@api_user, build_user_update_params(@api_user), current_user, user_ip_address).call
+    UserUpdate.new(@api_user, build_user_update_params(@api_user, @permissions.pluck(:id)), current_user, user_ip_address).call
 
     flash[:application_id] = @application.id
     redirect_to api_user_applications_path(@api_user)
@@ -35,12 +35,11 @@ private
     @permissions = @application.sorted_supported_permissions_grantable_from_ui(include_signin: false)
   end
 
-  def build_user_update_params(user)
+  def build_user_update_params(user, updatable_permission_ids)
     permissions_user_has = user.supported_permissions.pluck(:id)
-    updatable_permissions_for_this_app = @permissions.pluck(:id)
     selected_permissions = update_params[:supported_permission_ids].map(&:to_i)
-    permissions_to_add = updatable_permissions_for_this_app.intersection(selected_permissions)
-    permissions_to_remove = updatable_permissions_for_this_app.difference(selected_permissions)
+    permissions_to_add = updatable_permission_ids.intersection(selected_permissions)
+    permissions_to_remove = updatable_permission_ids.difference(selected_permissions)
 
     { supported_permission_ids: (permissions_user_has + permissions_to_add - permissions_to_remove).sort }
   end

--- a/app/controllers/api_users/permissions_controller.rb
+++ b/app/controllers/api_users/permissions_controller.rb
@@ -11,7 +11,7 @@ class ApiUsers::PermissionsController < ApplicationController
   def update
     authorize @api_user
 
-    UserUpdate.new(@api_user, build_user_update_params, current_user, user_ip_address).call
+    UserUpdate.new(@api_user, build_user_update_params(@api_user), current_user, user_ip_address).call
 
     flash[:application_id] = @application.id
     redirect_to api_user_applications_path(@api_user)
@@ -35,8 +35,8 @@ private
     @permissions = @application.sorted_supported_permissions_grantable_from_ui(include_signin: false)
   end
 
-  def build_user_update_params
-    permissions_user_has = @api_user.supported_permissions.pluck(:id)
+  def build_user_update_params(user)
+    permissions_user_has = user.supported_permissions.pluck(:id)
     updatable_permissions_for_this_app = @permissions.pluck(:id)
     selected_permissions = update_params[:supported_permission_ids].map(&:to_i)
     permissions_to_add = updatable_permissions_for_this_app.intersection(selected_permissions)

--- a/app/controllers/api_users/permissions_controller.rb
+++ b/app/controllers/api_users/permissions_controller.rb
@@ -11,7 +11,8 @@ class ApiUsers::PermissionsController < ApplicationController
   def update
     authorize @api_user
 
-    UserUpdate.new(@api_user, build_user_update_params(@api_user, @permissions.pluck(:id), update_params[:supported_permission_ids].map(&:to_i)), current_user, user_ip_address).call
+    supported_permission_ids = build_user_update_params(@api_user, @permissions.pluck(:id), update_params[:supported_permission_ids].map(&:to_i))
+    UserUpdate.new(@api_user, { supported_permission_ids: }, current_user, user_ip_address).call
 
     flash[:application_id] = @application.id
     redirect_to api_user_applications_path(@api_user)
@@ -40,6 +41,6 @@ private
     permissions_to_add = updatable_permission_ids.intersection(selected_permission_ids)
     permissions_to_remove = updatable_permission_ids.difference(selected_permission_ids)
 
-    { supported_permission_ids: (permissions_user_has + permissions_to_add - permissions_to_remove).sort }
+    (permissions_user_has + permissions_to_add - permissions_to_remove).sort
   end
 end

--- a/app/controllers/api_users/permissions_controller.rb
+++ b/app/controllers/api_users/permissions_controller.rb
@@ -11,7 +11,7 @@ class ApiUsers::PermissionsController < ApplicationController
   def update
     authorize @api_user
 
-    UserUpdate.new(@api_user, build_user_update_params(@api_user, @permissions.pluck(:id)), current_user, user_ip_address).call
+    UserUpdate.new(@api_user, build_user_update_params(@api_user, @permissions.pluck(:id), update_params[:supported_permission_ids].map(&:to_i)), current_user, user_ip_address).call
 
     flash[:application_id] = @application.id
     redirect_to api_user_applications_path(@api_user)
@@ -35,11 +35,10 @@ private
     @permissions = @application.sorted_supported_permissions_grantable_from_ui(include_signin: false)
   end
 
-  def build_user_update_params(user, updatable_permission_ids)
+  def build_user_update_params(user, updatable_permission_ids, selected_permission_ids)
     permissions_user_has = user.supported_permissions.pluck(:id)
-    selected_permissions = update_params[:supported_permission_ids].map(&:to_i)
-    permissions_to_add = updatable_permission_ids.intersection(selected_permissions)
-    permissions_to_remove = updatable_permission_ids.difference(selected_permissions)
+    permissions_to_add = updatable_permission_ids.intersection(selected_permission_ids)
+    permissions_to_remove = updatable_permission_ids.difference(selected_permission_ids)
 
     { supported_permission_ids: (permissions_user_has + permissions_to_add - permissions_to_remove).sort }
   end

--- a/app/controllers/users/permissions_controller.rb
+++ b/app/controllers/users/permissions_controller.rb
@@ -19,7 +19,7 @@ class Users::PermissionsController < ApplicationController
   def update
     authorize UserApplicationPermission.for(@user, @application)
 
-    UserUpdate.new(@user, build_user_update_params, current_user, user_ip_address).call
+    UserUpdate.new(@user, build_user_update_params(@user), current_user, user_ip_address).call
 
     flash[:application_id] = @application.id
     redirect_to user_applications_path(@user)
@@ -43,8 +43,8 @@ private
     @permissions = @application.sorted_supported_permissions_grantable_from_ui(include_signin: false)
   end
 
-  def build_user_update_params
-    permissions_user_has = @user.supported_permissions.pluck(:id)
+  def build_user_update_params(user)
+    permissions_user_has = user.supported_permissions.pluck(:id)
     updatable_permissions_for_this_app = @permissions.pluck(:id)
     selected_permissions = update_params[:supported_permission_ids].map(&:to_i)
     permissions_to_add = updatable_permissions_for_this_app.intersection(selected_permissions)

--- a/app/controllers/users/permissions_controller.rb
+++ b/app/controllers/users/permissions_controller.rb
@@ -19,7 +19,12 @@ class Users::PermissionsController < ApplicationController
   def update
     authorize UserApplicationPermission.for(@user, @application)
 
-    supported_permission_ids = build_user_update_params(@user, @permissions.pluck(:id), update_params[:supported_permission_ids].map(&:to_i))
+    supported_permission_ids = UserUpdatePermissionBuilder.new(
+      user: @user,
+      updatable_permission_ids: @permissions.pluck(:id),
+      selected_permission_ids: update_params[:supported_permission_ids].map(&:to_i),
+    ).build
+
     UserUpdate.new(@user, { supported_permission_ids: }, current_user, user_ip_address).call
 
     flash[:application_id] = @application.id
@@ -42,13 +47,5 @@ private
 
   def set_permissions
     @permissions = @application.sorted_supported_permissions_grantable_from_ui(include_signin: false)
-  end
-
-  def build_user_update_params(user, updatable_permission_ids, selected_permission_ids)
-    permissions_user_has = user.supported_permissions.pluck(:id)
-    permissions_to_add = updatable_permission_ids.intersection(selected_permission_ids)
-    permissions_to_remove = updatable_permission_ids.difference(selected_permission_ids)
-
-    (permissions_user_has + permissions_to_add - permissions_to_remove).sort
   end
 end

--- a/app/controllers/users/permissions_controller.rb
+++ b/app/controllers/users/permissions_controller.rb
@@ -19,7 +19,8 @@ class Users::PermissionsController < ApplicationController
   def update
     authorize UserApplicationPermission.for(@user, @application)
 
-    UserUpdate.new(@user, build_user_update_params(@user, @permissions.pluck(:id), update_params[:supported_permission_ids].map(&:to_i)), current_user, user_ip_address).call
+    supported_permission_ids = build_user_update_params(@user, @permissions.pluck(:id), update_params[:supported_permission_ids].map(&:to_i))
+    UserUpdate.new(@user, { supported_permission_ids: }, current_user, user_ip_address).call
 
     flash[:application_id] = @application.id
     redirect_to user_applications_path(@user)
@@ -48,6 +49,6 @@ private
     permissions_to_add = updatable_permission_ids.intersection(selected_permission_ids)
     permissions_to_remove = updatable_permission_ids.difference(selected_permission_ids)
 
-    { supported_permission_ids: (permissions_user_has + permissions_to_add - permissions_to_remove).sort }
+    (permissions_user_has + permissions_to_add - permissions_to_remove).sort
   end
 end

--- a/app/controllers/users/permissions_controller.rb
+++ b/app/controllers/users/permissions_controller.rb
@@ -19,7 +19,7 @@ class Users::PermissionsController < ApplicationController
   def update
     authorize UserApplicationPermission.for(@user, @application)
 
-    UserUpdate.new(@user, build_user_update_params(@user, @permissions.pluck(:id)), current_user, user_ip_address).call
+    UserUpdate.new(@user, build_user_update_params(@user, @permissions.pluck(:id), update_params[:supported_permission_ids].map(&:to_i)), current_user, user_ip_address).call
 
     flash[:application_id] = @application.id
     redirect_to user_applications_path(@user)
@@ -43,11 +43,10 @@ private
     @permissions = @application.sorted_supported_permissions_grantable_from_ui(include_signin: false)
   end
 
-  def build_user_update_params(user, updatable_permission_ids)
+  def build_user_update_params(user, updatable_permission_ids, selected_permission_ids)
     permissions_user_has = user.supported_permissions.pluck(:id)
-    selected_permissions = update_params[:supported_permission_ids].map(&:to_i)
-    permissions_to_add = updatable_permission_ids.intersection(selected_permissions)
-    permissions_to_remove = updatable_permission_ids.difference(selected_permissions)
+    permissions_to_add = updatable_permission_ids.intersection(selected_permission_ids)
+    permissions_to_remove = updatable_permission_ids.difference(selected_permission_ids)
 
     { supported_permission_ids: (permissions_user_has + permissions_to_add - permissions_to_remove).sort }
   end

--- a/app/controllers/users/permissions_controller.rb
+++ b/app/controllers/users/permissions_controller.rb
@@ -19,7 +19,7 @@ class Users::PermissionsController < ApplicationController
   def update
     authorize UserApplicationPermission.for(@user, @application)
 
-    UserUpdate.new(@user, build_user_update_params(@user), current_user, user_ip_address).call
+    UserUpdate.new(@user, build_user_update_params(@user, @permissions.pluck(:id)), current_user, user_ip_address).call
 
     flash[:application_id] = @application.id
     redirect_to user_applications_path(@user)
@@ -43,12 +43,11 @@ private
     @permissions = @application.sorted_supported_permissions_grantable_from_ui(include_signin: false)
   end
 
-  def build_user_update_params(user)
+  def build_user_update_params(user, updatable_permission_ids)
     permissions_user_has = user.supported_permissions.pluck(:id)
-    updatable_permissions_for_this_app = @permissions.pluck(:id)
     selected_permissions = update_params[:supported_permission_ids].map(&:to_i)
-    permissions_to_add = updatable_permissions_for_this_app.intersection(selected_permissions)
-    permissions_to_remove = updatable_permissions_for_this_app.difference(selected_permissions)
+    permissions_to_add = updatable_permission_ids.intersection(selected_permissions)
+    permissions_to_remove = updatable_permission_ids.difference(selected_permissions)
 
     { supported_permission_ids: (permissions_user_has + permissions_to_add - permissions_to_remove).sort }
   end

--- a/app/models/user_update_permission_builder.rb
+++ b/app/models/user_update_permission_builder.rb
@@ -1,0 +1,15 @@
+class UserUpdatePermissionBuilder
+  def initialize(user:, updatable_permission_ids:, selected_permission_ids:)
+    @user = user
+    @updatable_permission_ids = updatable_permission_ids
+    @selected_permission_ids = selected_permission_ids
+  end
+
+  def build
+    permissions_user_has = @user.supported_permissions.pluck(:id)
+    permissions_to_add = @updatable_permission_ids.intersection(@selected_permission_ids)
+    permissions_to_remove = @updatable_permission_ids.difference(@selected_permission_ids)
+
+    (permissions_user_has + permissions_to_add - permissions_to_remove).sort
+  end
+end

--- a/test/controllers/account/permissions_controller_test.rb
+++ b/test/controllers/account/permissions_controller_test.rb
@@ -124,33 +124,6 @@ class Account::PermissionsControllerTest < ActionController::TestCase
       assert_redirected_to "/users/sign_in"
     end
 
-    should "replace the users permissions with new ones" do
-      application = create(:application, with_supported_permissions: %w[new old])
-      user = create(:admin_user, with_permissions: { application => ["old", SupportedPermission::SIGNIN_NAME] })
-      sign_in user
-
-      new_permission = application.supported_permissions.find_by(name: "new")
-
-      patch :update, params: { application_id: application.id, application: { supported_permission_ids: [new_permission.id] } }
-
-      assert_equal %w[new signin], user.permissions_for(application)
-      assert_redirected_to account_applications_path
-    end
-
-    should "retain permissions for other apps" do
-      other_application = create(:application, with_supported_permissions: %w[other])
-      application = create(:application, with_supported_permissions: %w[new old])
-      user = create(:admin_user, with_permissions: { application => ["old", SupportedPermission::SIGNIN_NAME], other_application => %w[other] })
-      sign_in user
-
-      new_permission = application.supported_permissions.find_by(name: "new")
-
-      patch :update, params: { application_id: application.id, application: { supported_permission_ids: [new_permission.id] } }
-
-      assert_equal %w[new signin], user.permissions_for(application)
-      assert_equal %w[other], user.permissions_for(other_application)
-    end
-
     should "prevent permissions being added for apps that the current user does not have access to" do
       application1 = create(:application)
       application2 = create(:application, with_supported_permissions: %w[app2-permission])

--- a/test/models/user_update_permission_builder_test.rb
+++ b/test/models/user_update_permission_builder_test.rb
@@ -1,0 +1,62 @@
+require "test_helper"
+
+class UserUpdatePermissionBuilderTest < ActiveSupport::TestCase
+  def setup
+    application = create(:application)
+    create(:supported_permission, application:, name: "perm-1")
+    @user = create(:user, with_permissions: { application => %w[perm-1] })
+    @existing_permission_id = @user.supported_permissions.first.id
+  end
+
+  context "#build" do
+    should "should return users existing permission if not updatable and not selected" do
+      builder = UserUpdatePermissionBuilder.new(
+        user: @user,
+        updatable_permission_ids: [],
+        selected_permission_ids: [],
+      )
+
+      assert_equal [@existing_permission_id], builder.build
+    end
+
+    should "should remove users existing permission if updatable and not selected" do
+      builder = UserUpdatePermissionBuilder.new(
+        user: @user,
+        updatable_permission_ids: [@existing_permission_id],
+        selected_permission_ids: [],
+      )
+
+      assert_equal [], builder.build
+    end
+
+    should "should add new permission if updatable and selected" do
+      builder = UserUpdatePermissionBuilder.new(
+        user: @user,
+        updatable_permission_ids: [1],
+        selected_permission_ids: [1],
+      )
+
+      assert_equal [1, @existing_permission_id].sort, builder.build
+    end
+
+    should "should not add new permission if updatable and not selected" do
+      builder = UserUpdatePermissionBuilder.new(
+        user: @user,
+        updatable_permission_ids: [1],
+        selected_permission_ids: [],
+      )
+
+      assert_equal [@existing_permission_id], builder.build
+    end
+
+    should "should not add new permission if not updatable" do
+      builder = UserUpdatePermissionBuilder.new(
+        user: @user,
+        updatable_permission_ids: [1],
+        selected_permission_ids: [2],
+      )
+
+      assert_equal [@existing_permission_id], builder.build
+    end
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/yDM25WlZ

This PR is an attempt to remove some of the duplication we added in c7236440f, edf2e83e and 92c5f5c0 with the `build_user_update_params` controller method. I did consider folding some of this logic into `UserUpdate` but as we're currently thinking about simplifying or removing that altogether (e.g. #2623) I think for now it's an improvement to have the code shared between the three controllers via a simple Ruby object. It'll at least make it easier to move somewhere else in the future. 