### PR TITLE
Refactor applications tables

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -85,3 +85,12 @@ $govuk-page-width: 1140px;
     float: right;
   }
 }
+
+.govuk-table--with-actions {
+  .govuk-table__cell:last-child {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    gap: 10px;
+  }
+}

--- a/app/helpers/api_users_helper.rb
+++ b/app/helpers/api_users_helper.rb
@@ -19,15 +19,4 @@ module ApiUsersHelper
       )
     end
   end
-
-  def update_permissions_link(application, user)
-    unless application.sorted_supported_permissions_grantable_from_ui(include_signin: false).empty?
-      link_to(edit_api_user_application_permissions_path(user, application), class: "govuk-link") do
-        safe_join(
-          ["Update permissions",
-           content_tag(:span, " for #{application.name}", class: "govuk-visually-hidden")],
-        )
-      end
-    end
-  end
 end

--- a/app/helpers/application_table_helper.rb
+++ b/app/helpers/application_table_helper.rb
@@ -1,4 +1,6 @@
 module ApplicationTableHelper
+  include Pundit::Authorization
+
   def update_permissions_link(application, user = nil)
     link_path = if user.nil?
                   edit_account_application_permissions_path(application)
@@ -46,6 +48,14 @@ module ApplicationTableHelper
       data: { module: "govuk-button" },
     ) do
       safe_join(["Remove access", content_tag(:span, " to #{application.name}", class: "govuk-visually-hidden")])
+    end
+  end
+
+  def account_applications_permissions_link(application)
+    if policy([:account, application]).edit_permissions?
+      update_permissions_link(application)
+    elsif policy([:account, application]).view_permissions?
+      view_permissions_link(application)
     end
   end
 end

--- a/app/helpers/application_table_helper.rb
+++ b/app/helpers/application_table_helper.rb
@@ -17,4 +17,13 @@ module ApplicationTableHelper
       end
     end
   end
+
+  def view_permissions_link(application)
+    link_to(account_application_permissions_path(application), class: "govuk-link") do
+      safe_join(
+        ["View permissions",
+         content_tag(:span, " for #{application.name}", class: "govuk-visually-hidden")],
+      )
+    end
+  end
 end

--- a/app/helpers/application_table_helper.rb
+++ b/app/helpers/application_table_helper.rb
@@ -18,8 +18,14 @@ module ApplicationTableHelper
     end
   end
 
-  def view_permissions_link(application)
-    link_to(account_application_permissions_path(application), class: "govuk-link") do
+  def view_permissions_link(application, user = nil)
+    link_path = if user
+                  user_application_permissions_path(user, application)
+                else
+                  account_application_permissions_path(application)
+                end
+
+    link_to(link_path, class: "govuk-link") do
       safe_join(
         ["View permissions",
          content_tag(:span, " for #{application.name}", class: "govuk-visually-hidden")],

--- a/app/helpers/application_table_helper.rb
+++ b/app/helpers/application_table_helper.rb
@@ -1,0 +1,12 @@
+module ApplicationTableHelper
+  def update_permissions_link(application, user)
+    unless application.sorted_supported_permissions_grantable_from_ui(include_signin: false).empty?
+      link_to(edit_api_user_application_permissions_path(user, application), class: "govuk-link") do
+        safe_join(
+          ["Update permissions",
+           content_tag(:span, " for #{application.name}", class: "govuk-visually-hidden")],
+        )
+      end
+    end
+  end
+end

--- a/app/helpers/application_table_helper.rb
+++ b/app/helpers/application_table_helper.rb
@@ -78,4 +78,14 @@ module ApplicationTableHelper
       remove_access_link(application)
     end
   end
+
+  def grant_access_link(application)
+    button_to(
+      account_application_signin_permission_path(application),
+      class: "govuk-button govuk-!-margin-0",
+      data: { module: "govuk-button" },
+    ) do
+      safe_join(["Grant access", content_tag(:span, " to #{application.name}", class: "govuk-visually-hidden")])
+    end
+  end
 end

--- a/app/helpers/application_table_helper.rb
+++ b/app/helpers/application_table_helper.rb
@@ -1,6 +1,8 @@
 module ApplicationTableHelper
-  def update_permissions_link(application, user)
-    link_path = if user.api_user?
+  def update_permissions_link(application, user = nil)
+    link_path = if user.nil?
+                  edit_account_application_permissions_path(application)
+                elsif user.api_user?
                   edit_api_user_application_permissions_path(user, application)
                 else
                   edit_user_application_permissions_path(user, application)

--- a/app/helpers/application_table_helper.rb
+++ b/app/helpers/application_table_helper.rb
@@ -66,4 +66,10 @@ module ApplicationTableHelper
       view_permissions_link(application, user)
     end
   end
+
+  def users_applications_remove_access_link(application, user)
+    if policy(UserApplicationPermission.for(user, application)).delete?
+      remove_access_link(application, user)
+    end
+  end
 end

--- a/app/helpers/application_table_helper.rb
+++ b/app/helpers/application_table_helper.rb
@@ -33,9 +33,15 @@ module ApplicationTableHelper
     end
   end
 
-  def remove_access_link(application)
+  def remove_access_link(application, user = nil)
+    link_path = if user
+                  delete_user_application_signin_permission_path(user, application)
+                else
+                  delete_account_application_signin_permission_path(application)
+                end
+
     link_to(
-      delete_account_application_signin_permission_path(application),
+      link_path,
       class: "govuk-button govuk-button--warning govuk-!-margin-0",
       data: { module: "govuk-button" },
     ) do

--- a/app/helpers/application_table_helper.rb
+++ b/app/helpers/application_table_helper.rb
@@ -58,4 +58,12 @@ module ApplicationTableHelper
       view_permissions_link(application)
     end
   end
+
+  def users_applications_permissions_link(application, user)
+    if policy(UserApplicationPermission.for(user, application)).edit?
+      update_permissions_link(application, user)
+    else
+      view_permissions_link(application, user)
+    end
+  end
 end

--- a/app/helpers/application_table_helper.rb
+++ b/app/helpers/application_table_helper.rb
@@ -72,4 +72,10 @@ module ApplicationTableHelper
       remove_access_link(application, user)
     end
   end
+
+  def account_applications_remove_access_link(application)
+    if policy([:account, application]).remove_signin_permission?
+      remove_access_link(application)
+    end
+  end
 end

--- a/app/helpers/application_table_helper.rb
+++ b/app/helpers/application_table_helper.rb
@@ -1,7 +1,13 @@
 module ApplicationTableHelper
   def update_permissions_link(application, user)
+    link_path = if user.api_user?
+                  edit_api_user_application_permissions_path(user, application)
+                else
+                  edit_user_application_permissions_path(user, application)
+                end
+
     unless application.sorted_supported_permissions_grantable_from_ui(include_signin: false).empty?
-      link_to(edit_api_user_application_permissions_path(user, application), class: "govuk-link") do
+      link_to(link_path, class: "govuk-link") do
         safe_join(
           ["Update permissions",
            content_tag(:span, " for #{application.name}", class: "govuk-visually-hidden")],

--- a/app/helpers/application_table_helper.rb
+++ b/app/helpers/application_table_helper.rb
@@ -79,9 +79,15 @@ module ApplicationTableHelper
     end
   end
 
-  def grant_access_link(application)
+  def grant_access_link(application, user = nil)
+    link_path = if user
+                  user_application_signin_permission_path(user, application)
+                else
+                  account_application_signin_permission_path(application)
+                end
+
     button_to(
-      account_application_signin_permission_path(application),
+      link_path,
       class: "govuk-button govuk-!-margin-0",
       data: { module: "govuk-button" },
     ) do

--- a/app/helpers/application_table_helper.rb
+++ b/app/helpers/application_table_helper.rb
@@ -10,13 +10,15 @@ module ApplicationTableHelper
                   edit_user_application_permissions_path(user, application)
                 end
 
-    unless application.sorted_supported_permissions_grantable_from_ui(include_signin: false).empty?
+    if application.sorted_supported_permissions_grantable_from_ui(include_signin: false).any?
       link_to(link_path, class: "govuk-link") do
         safe_join(
           ["Update permissions",
            content_tag(:span, " for #{application.name}", class: "govuk-visually-hidden")],
         )
       end
+    else
+      ""
     end
   end
 
@@ -56,6 +58,8 @@ module ApplicationTableHelper
       update_permissions_link(application)
     elsif policy([:account, application]).view_permissions?
       view_permissions_link(application)
+    else
+      ""
     end
   end
 
@@ -70,12 +74,16 @@ module ApplicationTableHelper
   def users_applications_remove_access_link(application, user)
     if policy(UserApplicationPermission.for(user, application)).delete?
       remove_access_link(application, user)
+    else
+      ""
     end
   end
 
   def account_applications_remove_access_link(application)
     if policy([:account, application]).remove_signin_permission?
       remove_access_link(application)
+    else
+      ""
     end
   end
 
@@ -98,12 +106,16 @@ module ApplicationTableHelper
   def users_applications_grant_access_link(application, user)
     if policy(UserApplicationPermission.for(user, application)).create?
       grant_access_link(application, user)
+    else
+      ""
     end
   end
 
   def account_applications_grant_access_link(application)
     if policy([:account, Doorkeeper::Application]).grant_signin_permission?
       grant_access_link(application)
+    else
+      ""
     end
   end
 end

--- a/app/helpers/application_table_helper.rb
+++ b/app/helpers/application_table_helper.rb
@@ -100,4 +100,10 @@ module ApplicationTableHelper
       grant_access_link(application, user)
     end
   end
+
+  def account_applications_grant_access_link(application)
+    if policy([:account, Doorkeeper::Application]).grant_signin_permission?
+      grant_access_link(application)
+    end
+  end
 end

--- a/app/helpers/application_table_helper.rb
+++ b/app/helpers/application_table_helper.rb
@@ -94,4 +94,10 @@ module ApplicationTableHelper
       safe_join(["Grant access", content_tag(:span, " to #{application.name}", class: "govuk-visually-hidden")])
     end
   end
+
+  def users_applications_grant_access_link(application, user)
+    if policy(UserApplicationPermission.for(user, application)).create?
+      grant_access_link(application, user)
+    end
+  end
 end

--- a/app/helpers/application_table_helper.rb
+++ b/app/helpers/application_table_helper.rb
@@ -32,4 +32,14 @@ module ApplicationTableHelper
       )
     end
   end
+
+  def remove_access_link(application)
+    link_to(
+      delete_account_application_signin_permission_path(application),
+      class: "govuk-button govuk-button--warning govuk-!-margin-0",
+      data: { module: "govuk-button" },
+    ) do
+      safe_join(["Remove access", content_tag(:span, " to #{application.name}", class: "govuk-visually-hidden")])
+    end
+  end
 end

--- a/app/views/account/applications/index.html.erb
+++ b/app/views/account/applications/index.html.erb
@@ -41,11 +41,7 @@
         <td class="govuk-table__cell"><%= application.name %></td>
         <td class="govuk-table__cell"><%= application.description %></td>
         <td class="govuk-table__cell govuk-!-text-align-right"><%= account_applications_permissions_link(application) %></td>
-        <td class="govuk-table__cell govuk-!-text-align-right">
-          <% if policy([:account, application]).remove_signin_permission? %>
-            <%= remove_access_link(application) %>
-          <% end %>
-        </td>
+        <td class="govuk-table__cell govuk-!-text-align-right"><%= account_applications_remove_access_link(application) %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/account/applications/index.html.erb
+++ b/app/views/account/applications/index.html.erb
@@ -44,9 +44,7 @@
           <% if policy([:account, application]).edit_permissions? %>
             <%= update_permissions_link(application) %>
           <% elsif policy([:account, application]).view_permissions? %>
-            <%= link_to account_application_permissions_path(application), class: "govuk-link" do %>
-                View permissions<span class="govuk-visually-hidden"> for <%= application.name %></span>
-            <% end %>
+            <%= view_permissions_link(application) %>
           <% end %>
         </td>
         <td class="govuk-table__cell govuk-!-text-align-right">

--- a/app/views/account/applications/index.html.erb
+++ b/app/views/account/applications/index.html.erb
@@ -49,11 +49,7 @@
         </td>
         <td class="govuk-table__cell govuk-!-text-align-right">
           <% if policy([:account, application]).remove_signin_permission? %>
-            <%= link_to delete_account_application_signin_permission_path(application),
-                        class: "govuk-button govuk-button--warning govuk-!-margin-0",
-                        data: { module: "govuk-button" } do %>
-                Remove access<span class="govuk-visually-hidden"> to <%= application.name %></span>
-            <% end %>
+            <%= remove_access_link(application) %>
           <% end %>
         </td>
       </tr>

--- a/app/views/account/applications/index.html.erb
+++ b/app/views/account/applications/index.html.erb
@@ -42,11 +42,7 @@
         <td class="govuk-table__cell"><%= application.description %></td>
         <td class="govuk-table__cell govuk-!-text-align-right">
           <% if policy([:account, application]).edit_permissions? %>
-            <% unless application.sorted_supported_permissions_grantable_from_ui(include_signin: false).empty? %>
-              <%= link_to edit_account_application_permissions_path(application), class: "govuk-link" do %>
-                Update permissions<span class="govuk-visually-hidden"> for <%= application.name %></span>
-              <% end %>
-            <% end %>
+            <%= update_permissions_link(application) %>
           <% elsif policy([:account, application]).view_permissions? %>
             <%= link_to account_application_permissions_path(application), class: "govuk-link" do %>
                 View permissions<span class="govuk-visually-hidden"> for <%= application.name %></span>

--- a/app/views/account/applications/index.html.erb
+++ b/app/views/account/applications/index.html.erb
@@ -64,11 +64,7 @@
         <td class="govuk-table__cell"><%= application.description %></td>
         <td class="govuk-table__cell govuk-!-text-align-right">
           <% if policy([:account, Doorkeeper::Application]).grant_signin_permission? %>
-            <%= button_to account_application_signin_permission_path(application),
-                          class: "govuk-button govuk-!-margin-0",
-                          data: { module: "govuk-button" } do %>
-                Grant access<span class="govuk-visually-hidden"> to <%= application.name %></span>
-            <% end %>
+            <%= grant_access_link(application) %>
           <% end %>
         </td>
       </tr>

--- a/app/views/account/applications/index.html.erb
+++ b/app/views/account/applications/index.html.erb
@@ -62,11 +62,7 @@
       <tr class="govuk-table__row">
         <td class="govuk-table__cell"><%= application.name %></td>
         <td class="govuk-table__cell"><%= application.description %></td>
-        <td class="govuk-table__cell govuk-!-text-align-right">
-          <% if policy([:account, Doorkeeper::Application]).grant_signin_permission? %>
-            <%= grant_access_link(application) %>
-          <% end %>
-        </td>
+        <td class="govuk-table__cell govuk-!-text-align-right"><%= account_applications_grant_access_link(application) %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/account/applications/index.html.erb
+++ b/app/views/account/applications/index.html.erb
@@ -40,13 +40,7 @@
       <tr class="govuk-table__row">
         <td class="govuk-table__cell"><%= application.name %></td>
         <td class="govuk-table__cell"><%= application.description %></td>
-        <td class="govuk-table__cell govuk-!-text-align-right">
-          <% if policy([:account, application]).edit_permissions? %>
-            <%= update_permissions_link(application) %>
-          <% elsif policy([:account, application]).view_permissions? %>
-            <%= view_permissions_link(application) %>
-          <% end %>
-        </td>
+        <td class="govuk-table__cell govuk-!-text-align-right"><%= account_applications_permissions_link(application) %></td>
         <td class="govuk-table__cell govuk-!-text-align-right">
           <% if policy([:account, application]).remove_signin_permission? %>
             <%= remove_access_link(application) %>

--- a/app/views/account/applications/index.html.erb
+++ b/app/views/account/applications/index.html.erb
@@ -47,9 +47,8 @@
   </tbody>
 </table>
 
-<h2 class="govuk-heading-m" id="other-apps-table-heading">Apps you don't have access to</h2>
-
 <table class="govuk-table" aria-labelledby="other-apps-table-heading">
+  <caption class="govuk-table__caption govuk-table__caption--m">Apps you don't have access to</caption>
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Name</th>

--- a/app/views/account/applications/index.html.erb
+++ b/app/views/account/applications/index.html.erb
@@ -25,30 +25,31 @@
   <% end %>
 <% end %>
 
+<div class="govuk-table--with-actions">
 <%= render "govuk_publishing_components/components/table", {
     caption: "Apps you have access to",
     head: [
       { text: "Name" },
       { text: "Description" },
-      { text: content_tag(:span, "Permissions", class: "govuk-visually-hidden") },
-      { text: content_tag(:span, "Remove access", class: "govuk-visually-hidden") }
+      { text: content_tag(:span, "Actions", class: "govuk-visually-hidden") },
     ],
     rows: @applications_with_signin.map do |application|
     [
       { text: application.name },
       { text: application.description },
-      { text: account_applications_permissions_link(application) },
-      { text: account_applications_remove_access_link(application) }
+      { text: safe_join([account_applications_permissions_link(application), account_applications_remove_access_link(application)]) },
     ]
     end,
 } %>
+</div>
 
+<div class="govuk-table--with-actions">
 <%= render "govuk_publishing_components/components/table", {
     caption: "Apps you don't have access to",
     head: [
       { text: "Name" },
       { text: "Description" },
-      { text: content_tag(:span, "Grant access", class: "govuk-visually-hidden") }
+      { text: content_tag(:span, "Actions", class: "govuk-visually-hidden") }
     ],
     rows: @applications_without_signin.map do |application|
     [
@@ -58,3 +59,4 @@
     ]
     end,
 } %>
+</div>

--- a/app/views/account/applications/index.html.erb
+++ b/app/views/account/applications/index.html.erb
@@ -25,44 +25,36 @@
   <% end %>
 <% end %>
 
-<table class="govuk-table">
-  <caption class="govuk-table__caption govuk-table__caption--m">Apps you have access to</caption>
-  <thead class="govuk-table__head">
-    <tr class="govuk-table__row">
-      <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Name</th>
-      <th scope="col" class="govuk-table__header govuk-!-width-one-third">Description</th>
-      <th scope="col" class="govuk-table__header"><span class="govuk-visually-hidden">Permissions</span></th>
-      <th scope="col" class="govuk-table__header"><span class="govuk-visually-hidden">Remove access</span></th>
-    </tr>
-  </thead>
-  <tbody class="govuk-table__body">
-    <% @applications_with_signin.each do |application| %>
-      <tr class="govuk-table__row">
-        <td class="govuk-table__cell"><%= application.name %></td>
-        <td class="govuk-table__cell"><%= application.description %></td>
-        <td class="govuk-table__cell govuk-!-text-align-right"><%= account_applications_permissions_link(application) %></td>
-        <td class="govuk-table__cell govuk-!-text-align-right"><%= account_applications_remove_access_link(application) %></td>
-      </tr>
-    <% end %>
-  </tbody>
-</table>
+<%= render "govuk_publishing_components/components/table", {
+    caption: "Apps you have access to",
+    head: [
+      { text: "Name" },
+      { text: "Description" },
+      { text: content_tag(:span, "Permissions", class: "govuk-visually-hidden") },
+      { text: content_tag(:span, "Remove access", class: "govuk-visually-hidden") }
+    ],
+    rows: @applications_with_signin.map do |application|
+    [
+      { text: application.name },
+      { text: application.description },
+      { text: account_applications_permissions_link(application) },
+      { text: account_applications_remove_access_link(application) }
+    ]
+    end,
+} %>
 
-<table class="govuk-table" aria-labelledby="other-apps-table-heading">
-  <caption class="govuk-table__caption govuk-table__caption--m">Apps you don't have access to</caption>
-  <thead class="govuk-table__head">
-    <tr class="govuk-table__row">
-      <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Name</th>
-      <th scope="col" class="govuk-table__header govuk-!-width-one-third">Description</th>
-      <th scope="col" class="govuk-table__header"><span class="govuk-visually-hidden">Grant access</span></th>
-    </tr>
-  </thead>
-  <tbody class="govuk-table__body">
-    <% @applications_without_signin.each do |application| %>
-      <tr class="govuk-table__row">
-        <td class="govuk-table__cell"><%= application.name %></td>
-        <td class="govuk-table__cell"><%= application.description %></td>
-        <td class="govuk-table__cell govuk-!-text-align-right"><%= account_applications_grant_access_link(application) %></td>
-      </tr>
-    <% end %>
-  </tbody>
-</table>
+<%= render "govuk_publishing_components/components/table", {
+    caption: "Apps you don't have access to",
+    head: [
+      { text: "Name" },
+      { text: "Description" },
+      { text: content_tag(:span, "Grant access", class: "govuk-visually-hidden") }
+    ],
+    rows: @applications_without_signin.map do |application|
+    [
+      { text: application.name },
+      { text: application.description },
+      { text: account_applications_grant_access_link(application) }
+    ]
+    end,
+} %>

--- a/app/views/api_users/applications/index.html.erb
+++ b/app/views/api_users/applications/index.html.erb
@@ -30,12 +30,13 @@
   <% end %>
 <% end %>
 
+<div class="govuk-table--with-actions">
 <%= render "govuk_publishing_components/components/table", {
     caption: "Apps #{@api_user.name} has access to",
     head: [
       { text: "Name" },
       { text: "Description" },
-      { text: content_tag(:span, "Permissions", class: "govuk-visually-hidden") },
+      { text: content_tag(:span, "Actions", class: "govuk-visually-hidden") },
     ],
     rows: @applications.map do |application|
     [
@@ -45,3 +46,4 @@
     ]
     end,
 } %>
+</div>

--- a/app/views/api_users/applications/index.html.erb
+++ b/app/views/api_users/applications/index.html.erb
@@ -41,7 +41,7 @@
     [
       { text: application.name },
       { text: application.description },
-      { text: update_permissions_link(application, @api_user) || "" }
+      { text: update_permissions_link(application, @api_user) }
     ]
     end,
 } %>

--- a/app/views/users/applications/index.html.erb
+++ b/app/views/users/applications/index.html.erb
@@ -47,11 +47,7 @@
         <td class="govuk-table__cell"><%= application.description %></td>
         <td class="govuk-table__cell govuk-!-text-align-right">
           <% if policy(UserApplicationPermission.for(@user, application)).edit? %>
-            <% unless application.sorted_supported_permissions_grantable_from_ui(include_signin: false).empty? %>
-              <%= link_to edit_user_application_permissions_path(@user, application), class: "govuk-link" do %>
-                Update permissions<span class="govuk-visually-hidden"> for <%= application.name %></span>
-              <% end %>
-            <% end %>
+            <%= update_permissions_link(application, @user) %>
           <% else %>
             <%= link_to user_application_permissions_path(@user, application), class: "govuk-link" do %>
               View permissions<span class="govuk-visually-hidden"> for <%= application.name %></span>

--- a/app/views/users/applications/index.html.erb
+++ b/app/views/users/applications/index.html.erb
@@ -46,11 +46,7 @@
         <td class="govuk-table__cell"><%= application.name %></td>
         <td class="govuk-table__cell"><%= application.description %></td>
         <td class="govuk-table__cell govuk-!-text-align-right"><%= users_applications_permissions_link(application, @user) %></td>
-        <td class="govuk-table__cell govuk-!-text-align-right">
-          <% if policy(UserApplicationPermission.for(@user, application)).delete? %>
-            <%= remove_access_link(application, @user) %>
-          <% end %>
-        </td>
+        <td class="govuk-table__cell govuk-!-text-align-right"><%= users_applications_remove_access_link(application, @user) %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/users/applications/index.html.erb
+++ b/app/views/users/applications/index.html.erb
@@ -67,11 +67,7 @@
       <tr class="govuk-table__row">
         <td class="govuk-table__cell"><%= application.name %></td>
         <td class="govuk-table__cell"><%= application.description %></td>
-        <td class="govuk-table__cell govuk-!-text-align-right">
-          <% if policy(UserApplicationPermission.for(@user, application)).create? %>
-            <%= grant_access_link(application, @user) %>
-          <% end %>
-        </td>
+        <td class="govuk-table__cell govuk-!-text-align-right"><%= users_applications_grant_access_link(application, @user) %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/users/applications/index.html.erb
+++ b/app/views/users/applications/index.html.erb
@@ -69,11 +69,7 @@
         <td class="govuk-table__cell"><%= application.description %></td>
         <td class="govuk-table__cell govuk-!-text-align-right">
           <% if policy(UserApplicationPermission.for(@user, application)).create? %>
-            <%= button_to user_application_signin_permission_path(@user, application),
-                          class: "govuk-button govuk-!-margin-0",
-                          data: { module: "govuk-button" } do %>
-                Grant access<span class="govuk-visually-hidden"> to <%= application.name %></span>
-            <% end %>
+            <%= grant_access_link(application, @user) %>
           <% end %>
         </td>
       </tr>

--- a/app/views/users/applications/index.html.erb
+++ b/app/views/users/applications/index.html.erb
@@ -30,44 +30,36 @@
   <% end %>
 <% end %>
 
-<table class="govuk-table">
-  <caption class="govuk-table__caption govuk-table__caption--m">Apps <%= @user.name %> has access to</caption>
-  <thead class="govuk-table__head">
-    <tr class="govuk-table__row">
-      <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Name</th>
-      <th scope="col" class="govuk-table__header govuk-!-width-one-third">Description</th>
-      <th scope="col" class="govuk-table__header"><span class="govuk-visually-hidden">Permissions</span></th>
-      <th scope="col" class="govuk-table__header"><span class="govuk-visually-hidden">Remove access</span></th>
-    </tr>
-  </thead>
-  <tbody class="govuk-table__body">
-    <% @applications_with_signin.each do |application| %>
-      <tr class="govuk-table__row">
-        <td class="govuk-table__cell"><%= application.name %></td>
-        <td class="govuk-table__cell"><%= application.description %></td>
-        <td class="govuk-table__cell govuk-!-text-align-right"><%= users_applications_permissions_link(application, @user) %></td>
-        <td class="govuk-table__cell govuk-!-text-align-right"><%= users_applications_remove_access_link(application, @user) %></td>
-      </tr>
-    <% end %>
-  </tbody>
-</table>
+<%= render "govuk_publishing_components/components/table", {
+    caption: "Apps #{@user.name} has access to",
+    head: [
+      { text: "Name" },
+      { text: "Description" },
+      { text: content_tag(:span, "Permissions", class: "govuk-visually-hidden") },
+      { text: content_tag(:span, "Remove access", class: "govuk-visually-hidden") },
+    ],
+    rows: @applications_with_signin.map do |application|
+    [
+      { text: application.name },
+      { text: application.description },
+      { text: users_applications_permissions_link(application, @user) },
+      { text: users_applications_remove_access_link(application, @user) }
+    ]
+    end,
+} %>
 
-<table class="govuk-table" aria-labelledby="other-apps-table-heading">
-  <caption class="govuk-table__caption govuk-table__caption--m">Apps <%= @user.name %> does not have access to</caption>
-  <thead class="govuk-table__head">
-    <tr class="govuk-table__row">
-      <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Name</th>
-      <th scope="col" class="govuk-table__header govuk-!-width-one-third">Description</th>
-      <th scope="col" class="govuk-table__header"><span class="govuk-visually-hidden">Grant access</span></th>
-    </tr>
-  </thead>
-  <tbody class="govuk-table__body">
-    <% @applications_without_signin.each do |application| %>
-      <tr class="govuk-table__row">
-        <td class="govuk-table__cell"><%= application.name %></td>
-        <td class="govuk-table__cell"><%= application.description %></td>
-        <td class="govuk-table__cell govuk-!-text-align-right"><%= users_applications_grant_access_link(application, @user) %></td>
-      </tr>
-    <% end %>
-  </tbody>
-</table>
+<%= render "govuk_publishing_components/components/table", {
+    caption: "Apps #{@user.name} does not have access to",
+    head: [
+      { text: "Name" },
+      { text: "Description" },
+      { text: content_tag(:span, "Grant access", class: "govuk-visually-hidden") }
+    ],
+    rows: @applications_without_signin.map do |application|
+    [
+      { text: application.name },
+      { text: application.description },
+      { text: users_applications_grant_access_link(application, @user) }
+    ]
+    end,
+} %>

--- a/app/views/users/applications/index.html.erb
+++ b/app/views/users/applications/index.html.erb
@@ -52,9 +52,8 @@
   </tbody>
 </table>
 
-<h2 class="govuk-heading-m" id="other-apps-table-heading">Apps <%= @user.name %> does not have access to</h2>
-
 <table class="govuk-table" aria-labelledby="other-apps-table-heading">
+  <caption class="govuk-table__caption govuk-table__caption--m">Apps <%= @user.name %> does not have access to</caption>
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Name</th>

--- a/app/views/users/applications/index.html.erb
+++ b/app/views/users/applications/index.html.erb
@@ -54,11 +54,7 @@
         </td>
         <td class="govuk-table__cell govuk-!-text-align-right">
           <% if policy(UserApplicationPermission.for(@user, application)).delete? %>
-            <%= link_to delete_user_application_signin_permission_path(@user, application),
-                        class: "govuk-button govuk-button--warning govuk-!-margin-0",
-                        data: { module: "govuk-button" } do %>
-                Remove access<span class="govuk-visually-hidden"> to <%= application.name %></span>
-            <% end %>
+            <%= remove_access_link(application, @user) %>
           <% end %>
         </td>
       </tr>

--- a/app/views/users/applications/index.html.erb
+++ b/app/views/users/applications/index.html.erb
@@ -30,30 +30,31 @@
   <% end %>
 <% end %>
 
+<div class="govuk-table--with-actions">
 <%= render "govuk_publishing_components/components/table", {
     caption: "Apps #{@user.name} has access to",
     head: [
       { text: "Name" },
       { text: "Description" },
-      { text: content_tag(:span, "Permissions", class: "govuk-visually-hidden") },
-      { text: content_tag(:span, "Remove access", class: "govuk-visually-hidden") },
+      { text: content_tag(:span, "Actions", class: "govuk-visually-hidden") },
     ],
     rows: @applications_with_signin.map do |application|
     [
       { text: application.name },
       { text: application.description },
-      { text: users_applications_permissions_link(application, @user) },
-      { text: users_applications_remove_access_link(application, @user) }
+      { text: safe_join([users_applications_permissions_link(application, @user), users_applications_remove_access_link(application, @user)]) },
     ]
     end,
 } %>
+</div>
 
+<div class="govuk-table--with-actions">
 <%= render "govuk_publishing_components/components/table", {
     caption: "Apps #{@user.name} does not have access to",
     head: [
       { text: "Name" },
       { text: "Description" },
-      { text: content_tag(:span, "Grant access", class: "govuk-visually-hidden") }
+      { text: content_tag(:span, "Actions", class: "govuk-visually-hidden") }
     ],
     rows: @applications_without_signin.map do |application|
     [
@@ -63,3 +64,4 @@
     ]
     end,
 } %>
+</div>

--- a/app/views/users/applications/index.html.erb
+++ b/app/views/users/applications/index.html.erb
@@ -45,13 +45,7 @@
       <tr class="govuk-table__row">
         <td class="govuk-table__cell"><%= application.name %></td>
         <td class="govuk-table__cell"><%= application.description %></td>
-        <td class="govuk-table__cell govuk-!-text-align-right">
-          <% if policy(UserApplicationPermission.for(@user, application)).edit? %>
-            <%= update_permissions_link(application, @user) %>
-          <% else %>
-            <%= view_permissions_link(application, @user) %>
-          <% end %>
-        </td>
+        <td class="govuk-table__cell govuk-!-text-align-right"><%= users_applications_permissions_link(application, @user) %></td>
         <td class="govuk-table__cell govuk-!-text-align-right">
           <% if policy(UserApplicationPermission.for(@user, application)).delete? %>
             <%= remove_access_link(application, @user) %>

--- a/app/views/users/applications/index.html.erb
+++ b/app/views/users/applications/index.html.erb
@@ -49,9 +49,7 @@
           <% if policy(UserApplicationPermission.for(@user, application)).edit? %>
             <%= update_permissions_link(application, @user) %>
           <% else %>
-            <%= link_to user_application_permissions_path(@user, application), class: "govuk-link" do %>
-              View permissions<span class="govuk-visually-hidden"> for <%= application.name %></span>
-            <% end %>
+            <%= view_permissions_link(application, @user) %>
           <% end %>
         </td>
         <td class="govuk-table__cell govuk-!-text-align-right">

--- a/test/controllers/users/applications_controller_test.rb
+++ b/test/controllers/users/applications_controller_test.rb
@@ -93,8 +93,7 @@ class Users::ApplicationsControllerTest < ActionController::TestCase
 
       get :index, params: { user_id: user }
 
-      heading_id = css_select("h2:contains('Apps #{user.name} does not have access to')").attribute("id").value
-      assert_select "table[aria-labelledby='#{heading_id}']" do
+      assert_select "table:has( > caption[text()='Apps #{user.name} does not have access to'])" do
         assert_select "tr td", text: "app-name"
       end
     end

--- a/test/helpers/application_table_helper_test.rb
+++ b/test/helpers/application_table_helper_test.rb
@@ -45,5 +45,17 @@ class ApplicationTableHelperTest < ActionView::TestCase
 
       assert_includes view_permissions_link(application), account_application_permissions_path(application)
     end
+
+    context "when provided with a user" do
+      setup do
+        @user = create(:user)
+      end
+
+      should "generate a link to view the permissions" do
+        application = create(:application, with_supported_permissions: %w[permission])
+
+        assert_includes view_permissions_link(application, @user), user_application_permissions_path(@user, application)
+      end
+    end
   end
 end

--- a/test/helpers/application_table_helper_test.rb
+++ b/test/helpers/application_table_helper_test.rb
@@ -143,4 +143,22 @@ class ApplicationTableHelperTest < ActionView::TestCase
       assert_nil users_applications_remove_access_link(@application, user)
     end
   end
+
+  context "#account_applications_remove_access_link" do
+    setup do
+      @user = build(:user)
+      stubs(:current_user).returns(@user)
+      @application = create(:application)
+    end
+
+    should "generate an update link when the user can remove signing permissions" do
+      stub_policy @user, [:account, @application], remove_signin_permission?: true
+      assert_includes account_applications_remove_access_link(@application), "Remove access"
+    end
+
+    should "return nil when the user cannot remove sigin permissions" do
+      stub_policy @user, [:account, @application], remove_signin_permission?: false
+      assert_nil account_applications_remove_access_link(@application)
+    end
+  end
 end

--- a/test/helpers/application_table_helper_test.rb
+++ b/test/helpers/application_table_helper_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class ApiUsersHelperTest < ActionView::TestCase
+class ApplicationTableHelperTest < ActionView::TestCase
   context "#update_permissions_link" do
     setup do
       @user = create(:api_user)

--- a/test/helpers/application_table_helper_test.rb
+++ b/test/helpers/application_table_helper_test.rb
@@ -58,4 +58,12 @@ class ApplicationTableHelperTest < ActionView::TestCase
       end
     end
   end
+
+  context "#remove_access_link" do
+    should "generate a link to remove access to the application" do
+      application = create(:application)
+
+      assert_includes remove_access_link(application), delete_account_application_signin_permission_path(application)
+    end
+  end
 end

--- a/test/helpers/application_table_helper_test.rb
+++ b/test/helpers/application_table_helper_test.rb
@@ -178,4 +178,24 @@ class ApplicationTableHelperTest < ActionView::TestCase
       end
     end
   end
+
+  context "#users_applications_grant_access_link" do
+    setup do
+      @application = create(:application)
+    end
+
+    should "generate a grant access button when the user can create user application permissions" do
+      user = create(:superadmin_user)
+      stubs(:current_user).returns(user)
+
+      assert_includes users_applications_grant_access_link(@application, user), "Grant access"
+    end
+
+    should "return nil when the user cannot create user application permissions" do
+      user = create(:user)
+      stubs(:current_user).returns(user)
+
+      assert_nil users_applications_grant_access_link(@application, user)
+    end
+  end
 end

--- a/test/helpers/application_table_helper_test.rb
+++ b/test/helpers/application_table_helper_test.rb
@@ -198,4 +198,22 @@ class ApplicationTableHelperTest < ActionView::TestCase
       assert_nil users_applications_grant_access_link(@application, user)
     end
   end
+
+  context "#account_applications_grant_access_link" do
+    setup do
+      @user = build(:user)
+      stubs(:current_user).returns(@user)
+      @application = create(:application)
+    end
+
+    should "generate a grant access button when the user can grant siginin permission" do
+      stub_policy @user, [:account, Doorkeeper::Application], grant_signin_permission?: true
+      assert_includes account_applications_grant_access_link(@application), "Grant access"
+    end
+
+    should "return nil when the user cannot grant signin permission" do
+      stub_policy @user, [:account, Doorkeeper::Application], grant_signin_permission?: false
+      assert_nil account_applications_grant_access_link(@application)
+    end
+  end
 end

--- a/test/helpers/application_table_helper_test.rb
+++ b/test/helpers/application_table_helper_test.rb
@@ -14,10 +14,10 @@ class ApplicationTableHelperTest < ActionView::TestCase
       assert_includes update_permissions_link(application, @user), edit_api_user_application_permissions_path(@user, application)
     end
 
-    should "return nil when the application has no grantable permissions" do
+    should "return an empty string when the application has no grantable permissions" do
       application = create(:application)
 
-      assert_nil update_permissions_link(application, @user)
+      assert update_permissions_link(application, @user).empty?
     end
 
     context "for a user" do
@@ -98,9 +98,9 @@ class ApplicationTableHelperTest < ActionView::TestCase
       assert_includes account_applications_permissions_link(@application), "View permissions"
     end
 
-    should "return nil when the user can do neither" do
+    should "return an empty string when the user can do neither" do
       stub_policy @user, [:account, @application]
-      assert_nil account_applications_permissions_link(@application)
+      assert account_applications_permissions_link(@application).empty?
     end
   end
 
@@ -136,11 +136,11 @@ class ApplicationTableHelperTest < ActionView::TestCase
       assert_includes users_applications_remove_access_link(@application, user), "Remove access"
     end
 
-    should "return nil when the user cannot delete permissions" do
+    should "return an empty string when the user cannot delete permissions" do
       user = create(:user)
       stubs(:current_user).returns(user)
 
-      assert_nil users_applications_remove_access_link(@application, user)
+      assert users_applications_remove_access_link(@application, user).empty?
     end
   end
 
@@ -156,9 +156,9 @@ class ApplicationTableHelperTest < ActionView::TestCase
       assert_includes account_applications_remove_access_link(@application), "Remove access"
     end
 
-    should "return nil when the user cannot remove sigin permissions" do
+    should "return an empty string when the user cannot remove sigin permissions" do
       stub_policy @user, [:account, @application], remove_signin_permission?: false
-      assert_nil account_applications_remove_access_link(@application)
+      assert account_applications_remove_access_link(@application).empty?
     end
   end
 
@@ -191,11 +191,11 @@ class ApplicationTableHelperTest < ActionView::TestCase
       assert_includes users_applications_grant_access_link(@application, user), "Grant access"
     end
 
-    should "return nil when the user cannot create user application permissions" do
+    should "return an empty string when the user cannot create user application permissions" do
       user = create(:user)
       stubs(:current_user).returns(user)
 
-      assert_nil users_applications_grant_access_link(@application, user)
+      assert users_applications_grant_access_link(@application, user).empty?
     end
   end
 
@@ -211,9 +211,9 @@ class ApplicationTableHelperTest < ActionView::TestCase
       assert_includes account_applications_grant_access_link(@application), "Grant access"
     end
 
-    should "return nil when the user cannot grant signin permission" do
+    should "return an empty string when the user cannot grant signin permission" do
       stub_policy @user, [:account, Doorkeeper::Application], grant_signin_permission?: false
-      assert_nil account_applications_grant_access_link(@application)
+      assert account_applications_grant_access_link(@application).empty?
     end
   end
 end

--- a/test/helpers/application_table_helper_test.rb
+++ b/test/helpers/application_table_helper_test.rb
@@ -168,5 +168,14 @@ class ApplicationTableHelperTest < ActionView::TestCase
 
       assert_includes grant_access_link(application), account_application_signin_permission_path(application)
     end
+
+    context "when given a user" do
+      should "generate a link to grant the user access to the application" do
+        application = create(:application)
+        user = create(:user)
+
+        assert_includes grant_access_link(application, user), user_application_signin_permission_path(user, application)
+      end
+    end
   end
 end

--- a/test/helpers/application_table_helper_test.rb
+++ b/test/helpers/application_table_helper_test.rb
@@ -103,4 +103,24 @@ class ApplicationTableHelperTest < ActionView::TestCase
       assert_nil account_applications_permissions_link(@application)
     end
   end
+
+  context "#users_applications_permissions_link" do
+    setup do
+      @application = create(:application, with_supported_permissions: %w[permission])
+    end
+
+    should "generate an update link when the user can edit permissions" do
+      user = create(:superadmin_user)
+      stubs(:current_user).returns(user)
+
+      assert_includes users_applications_permissions_link(@application, user), "Update permissions"
+    end
+
+    should "generate a view link when the user cannot edit permissions" do
+      user = create(:user)
+      stubs(:current_user).returns(user)
+
+      assert_includes users_applications_permissions_link(@application, user), "View permissions"
+    end
+  end
 end

--- a/test/helpers/application_table_helper_test.rb
+++ b/test/helpers/application_table_helper_test.rb
@@ -38,4 +38,12 @@ class ApplicationTableHelperTest < ActionView::TestCase
       end
     end
   end
+
+  context "#view_permissions_link" do
+    should "generate a link to view the permissions" do
+      application = create(:application, with_supported_permissions: %w[permission])
+
+      assert_includes view_permissions_link(application), account_application_permissions_path(application)
+    end
+  end
 end

--- a/test/helpers/application_table_helper_test.rb
+++ b/test/helpers/application_table_helper_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class ApplicationTableHelperTest < ActionView::TestCase
+  include PunditHelpers
+
   context "#update_permissions_link" do
     setup do
       @user = create(:api_user)
@@ -76,6 +78,29 @@ class ApplicationTableHelperTest < ActionView::TestCase
 
         assert_includes remove_access_link(application, @user), delete_user_application_signin_permission_path(@user, application)
       end
+    end
+  end
+
+  context "#account_applications_permissions_link" do
+    setup do
+      @user = build(:user)
+      stubs(:current_user).returns(@user)
+      @application = create(:application, with_supported_permissions: %w[permission])
+    end
+
+    should "generate an update link when the user can edit permissions" do
+      stub_policy @user, [:account, @application], edit_permissions?: true
+      assert_includes account_applications_permissions_link(@application), "Update permissions"
+    end
+
+    should "generate a view link when the user can view permissions" do
+      stub_policy @user, [:account, @application], view_permissions?: true
+      assert_includes account_applications_permissions_link(@application), "View permissions"
+    end
+
+    should "return nil when the user can do neither" do
+      stub_policy @user, [:account, @application]
+      assert_nil account_applications_permissions_link(@application)
     end
   end
 end

--- a/test/helpers/application_table_helper_test.rb
+++ b/test/helpers/application_table_helper_test.rb
@@ -161,4 +161,12 @@ class ApplicationTableHelperTest < ActionView::TestCase
       assert_nil account_applications_remove_access_link(@application)
     end
   end
+
+  context "#grant_access_link" do
+    should "generate a link to grant access to the application" do
+      application = create(:application)
+
+      assert_includes grant_access_link(application), account_application_signin_permission_path(application)
+    end
+  end
 end

--- a/test/helpers/application_table_helper_test.rb
+++ b/test/helpers/application_table_helper_test.rb
@@ -29,5 +29,13 @@ class ApplicationTableHelperTest < ActionView::TestCase
         assert_includes update_permissions_link(application, @user), edit_user_application_permissions_path(@user, application)
       end
     end
+
+    context "when no user is provided" do
+      should "generate a link to edit the permissions" do
+        application = create(:application, with_supported_permissions: %w[permission])
+
+        assert_includes update_permissions_link(application), edit_account_application_permissions_path(application)
+      end
+    end
   end
 end

--- a/test/helpers/application_table_helper_test.rb
+++ b/test/helpers/application_table_helper_test.rb
@@ -17,5 +17,17 @@ class ApplicationTableHelperTest < ActionView::TestCase
 
       assert_nil update_permissions_link(application, @user)
     end
+
+    context "for a user" do
+      setup do
+        @user = create(:user)
+      end
+
+      should "generate a link to edit the permissions" do
+        application = create(:application, with_supported_permissions: %w[permission])
+
+        assert_includes update_permissions_link(application, @user), edit_user_application_permissions_path(@user, application)
+      end
+    end
   end
 end

--- a/test/helpers/application_table_helper_test.rb
+++ b/test/helpers/application_table_helper_test.rb
@@ -123,4 +123,24 @@ class ApplicationTableHelperTest < ActionView::TestCase
       assert_includes users_applications_permissions_link(@application, user), "View permissions"
     end
   end
+
+  context "#users_applications_remove_access_link" do
+    setup do
+      @application = create(:application, with_supported_permissions: %w[permission])
+    end
+
+    should "generate a remove access link when the user can delete permissions" do
+      user = create(:superadmin_user)
+      stubs(:current_user).returns(user)
+
+      assert_includes users_applications_remove_access_link(@application, user), "Remove access"
+    end
+
+    should "return nil when the user cannot delete permissions" do
+      user = create(:user)
+      stubs(:current_user).returns(user)
+
+      assert_nil users_applications_remove_access_link(@application, user)
+    end
+  end
 end

--- a/test/helpers/application_table_helper_test.rb
+++ b/test/helpers/application_table_helper_test.rb
@@ -65,5 +65,17 @@ class ApplicationTableHelperTest < ActionView::TestCase
 
       assert_includes remove_access_link(application), delete_account_application_signin_permission_path(application)
     end
+
+    context "when provided with a user" do
+      setup do
+        @user = create(:user)
+      end
+
+      should "generate a link to remove users access to the application" do
+        application = create(:application)
+
+        assert_includes remove_access_link(application, @user), delete_user_application_signin_permission_path(@user, application)
+      end
+    end
   end
 end

--- a/test/integration/account_applications_test.rb
+++ b/test/integration/account_applications_test.rb
@@ -56,8 +56,7 @@ class AccountApplicationsTest < ActionDispatch::IntegrationTest
 
       visit account_applications_path
 
-      heading = find("h2", text: "Apps you don't have access to")
-      table = find("table[aria-labelledby='#{heading['id']}']")
+      table = find("table caption[text()='Apps you don\\'t have access to']").ancestor("table")
 
       assert table.has_content?("app-name")
       assert table.has_content?("app-description")
@@ -117,8 +116,7 @@ class AccountApplicationsTest < ActionDispatch::IntegrationTest
       click_on "Remove access to app-name"
       click_on "Confirm"
 
-      heading = find("h2", text: "Apps you don't have access to")
-      table = find("table[aria-labelledby='#{heading['id']}']")
+      table = find("table caption[text()='Apps you don\\'t have access to']").ancestor("table")
       assert table.has_content?("app-name")
     end
   end

--- a/test/integration/user_applications_test.rb
+++ b/test/integration/user_applications_test.rb
@@ -11,8 +11,7 @@ class UserApplicationsTest < ActionDispatch::IntegrationTest
 
     visit user_applications_path(user)
 
-    heading = find("h2", text: "Apps user-name does not have access to")
-    table = find("table[aria-labelledby='#{heading['id']}']")
+    table = find("table caption[text()='Apps user-name does not have access to']").ancestor("table")
     assert table.has_content?("app-name")
 
     click_on "Grant access to app-name"
@@ -38,8 +37,7 @@ class UserApplicationsTest < ActionDispatch::IntegrationTest
     click_on "Remove access to app-name"
     click_on "Confirm"
 
-    heading = find("h2", text: "Apps user-name does not have access to")
-    table = find("table[aria-labelledby='#{heading['id']}']")
+    table = find("table caption[text()='Apps user-name does not have access to']").ancestor("table")
     assert table.has_content?("app-name")
   end
 


### PR DESCRIPTION
Trello: https://trello.com/c/yDM25WlZ

This PR removes some duplication of logic in the views that render the `/account/applications`, `/users/:id/applications` and `/api_users/:id/applications` pages. It also removes the hard-coded HTML and instead relies on the `govuk_publishing_components` `table` component to generate the markup. 

In the final commit I introduce a small CSS override modelled on a similar pattern used in Whitehall to align the final "actions" column of the table to the right. 

There are some small visual differences after this refactor (notably we've lost the ability to specify the widths of the first two columns of the tables), but I've gone over these with Calum and we're happy that the changes introduced are acceptable given the overall improvement to consistency and benefits of using the table component. 

## /account/applications After

![Screenshot_2024-01-31_11-14-27](https://github.com/alphagov/signon/assets/16707/ff753ba1-fa8f-47d6-8e13-6e831e81b1c7)

## /account/applications Before

![Screenshot_2024-01-31_11-15-03](https://github.com/alphagov/signon/assets/16707/1238cc3b-eb84-4e7d-b721-36779b8aca5e)
