### PR TITLE
Refactor roles

### DIFF
--- a/app/controllers/account/roles_controller.rb
+++ b/app/controllers/account/roles_controller.rb
@@ -8,7 +8,7 @@ class Account::RolesController < ApplicationController
     role = params[:user][:role]
 
     if UserUpdate.new(current_user, { role: }, current_user, user_ip_address).call
-      redirect_to account_path, notice: "Your role is now #{role.humanize}"
+      redirect_to account_path, notice: "Your role is now #{Roles.find(role).display_name}"
     else
       flash[:alert] = "There was a problem changing your role."
       render :edit

--- a/app/controllers/api_users_controller.rb
+++ b/app/controllers/api_users_controller.rb
@@ -48,7 +48,7 @@ private
   def sanitise(permitted_user_params)
     UserParameterSanitiser.new(
       user_params: permitted_user_params.to_h,
-      current_user_role: current_user.role.to_sym,
+      current_user_role: current_user.role_name.to_sym,
     ).sanitise
   end
 

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -62,7 +62,7 @@ private
   end
 
   def invitee_requires_2sv(params)
-    organisation(params)&.require_2sv? || Roles.admin_names.include?(params[:role])
+    organisation(params)&.require_2sv? || Roles.find(params[:role])&.require_2sv? || false
   end
 
   def redirect_if_invitee_already_exists

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -62,7 +62,7 @@ private
   end
 
   def invitee_requires_2sv(params)
-    organisation(params)&.require_2sv? || User.admin_roles.include?(params[:role])
+    organisation(params)&.require_2sv? || Roles.admin_names.include?(params[:role])
   end
 
   def redirect_if_invitee_already_exists

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -70,7 +70,7 @@ private
   def user_params
     UserParameterSanitiser.new(
       user_params: params.require(:user).permit(:require_2sv).to_h,
-      current_user_role: current_user.role.to_sym,
+      current_user_role: current_user.role_name.to_sym,
     ).sanitise
   end
 

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -68,8 +68,8 @@ module UsersHelper
   end
 
   def options_for_role_select(selected: nil)
-    current_user.manageable_role_names.map do |role|
-      { text: Roles.find(role).display_name, value: role }.tap do |option|
+    current_user.manageable_roles.map do |role|
+      { text: role.display_name, value: role.name }.tap do |option|
         option[:selected] = true if option[:value] == selected
       end
     end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -68,7 +68,7 @@ module UsersHelper
   end
 
   def options_for_role_select(selected: nil)
-    current_user.manageable_roles.map do |role|
+    current_user.manageable_role_names.map do |role|
       { text: Roles.find(role).display_name, value: role }.tap do |option|
         option[:selected] = true if option[:value] == selected
       end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -62,17 +62,13 @@ module UsersHelper
     end
   end
 
-  def assignable_user_roles
-    current_user.manageable_roles
-  end
-
   def user_name(user)
     anchor_tag = link_to(user.name, edit_user_path(user), class: "govuk-link")
     user.suspended? ? content_tag(:del, anchor_tag) : anchor_tag
   end
 
   def options_for_role_select(selected: nil)
-    assignable_user_roles.map do |role|
+    current_user.manageable_roles.map do |role|
       { text: Roles.find(role).display_name, value: role }.tap do |option|
         option[:selected] = true if option[:value] == selected
       end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -134,7 +134,7 @@ module UsersHelper
   end
 
   def summary_list_item_for_role(user)
-    item = { field: "Role", value: user.role.humanize.capitalize }
+    item = { field: "Role", value: user.role.humanize }
     item[:edit] = { href: edit_user_role_path(user) } if policy(user).assign_role?
     item
   end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -73,7 +73,7 @@ module UsersHelper
 
   def options_for_role_select(selected: nil)
     assignable_user_roles.map do |role|
-      { text: role.humanize, value: role }.tap do |option|
+      { text: Roles.find(role).display_name, value: role }.tap do |option|
         option[:selected] = true if option[:value] == selected
       end
     end
@@ -134,7 +134,7 @@ module UsersHelper
   end
 
   def summary_list_item_for_role(user)
-    item = { field: "Role", value: user.role.humanize }
+    item = { field: "Role", value: user.role_display_name }
     item[:edit] = { href: edit_user_role_path(user) } if policy(user).assign_role?
     item
   end

--- a/app/models/batch_invitation_user.rb
+++ b/app/models/batch_invitation_user.rb
@@ -94,7 +94,7 @@ private
   def sanitise_attributes_for_inviting_user_role(raw_attributes, inviting_user)
     UserParameterSanitiser.new(
       user_params: raw_attributes,
-      current_user_role: inviting_user.role.to_sym,
+      current_user_role: inviting_user.role_name.to_sym,
     ).sanitise
   end
 

--- a/app/models/doorkeeper/application.rb
+++ b/app/models/doorkeeper/application.rb
@@ -39,7 +39,7 @@ class Doorkeeper::Application < ActiveRecord::Base # rubocop:disable Rails/Appli
   end
 
   def supported_permission_strings(user = nil)
-    if user && %w[organisation_admin super_organisation_admin].include?(user.role)
+    if user && user.publishing_manager?
       supported_permissions.delegatable.pluck(:name) & user.permissions_for(self)
     else
       supported_permissions.pluck(:name)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -325,7 +325,7 @@ class User < ApplicationRecord
   def set_2sv_for_admin_roles
     return unless GovukEnvironment.production?
 
-    self.require_2sv = true if role_changed? && (govuk_admin? || publishing_manager?)
+    self.require_2sv = true if role_changed? && role_class.require_2sv?
   end
 
   def reset_2sv_exemption_reason
@@ -424,7 +424,7 @@ private
   end
 
   def user_can_be_exempted_from_2sv
-    errors.add(:reason_for_2sv_exemption, "#{role} users cannot be exempted from 2SV. Remove the user's exemption to change their role.") if exempt_from_2sv? && !normal?
+    errors.add(:reason_for_2sv_exemption, "#{role} users cannot be exempted from 2SV. Remove the user's exemption to change their role.") if exempt_from_2sv? && role_class.require_2sv?
   end
 
   def organisation_admin_belongs_to_organisation

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -431,7 +431,7 @@ private
   end
 
   def organisation_admin_belongs_to_organisation
-    if %w[organisation_admin super_organisation_admin].include?(role) && organisation_id.blank?
+    if publishing_manager? && organisation_id.blank?
       errors.add(:organisation_id, "can't be 'None' for #{role.titleize}")
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -43,7 +43,7 @@ class User < ApplicationRecord
          :confirmable,
          :password_archivable # in signon/lib/devise/models/password_archivable.rb
 
-  delegate :manageable_roles, :manageable_role_names, to: :role_class
+  delegate :manageable_roles, to: :role_class
   delegate :display_name, to: :role_class, prefix: :role
 
   encrypts :otp_secret_key

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -306,7 +306,7 @@ class User < ApplicationRecord
   end
 
   def can_manage?(other_user)
-    manageable_roles.include?(other_user.role)
+    role_class.can_manage?(other_user.role)
   end
 
   def manageable_organisations

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -307,7 +307,7 @@ class User < ApplicationRecord
   end
 
   def can_manage?(other_user)
-    role_class.can_manage?(other_user.role)
+    role_class.can_manage?(other_user.role_class)
   end
 
   def manageable_organisations

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -50,6 +50,7 @@ class User < ApplicationRecord
   validates :name, presence: true
   validates :email, reject_non_governmental_email_addresses: true
   validates :reason_for_suspension, presence: true, if: proc { |u| u.suspended? }
+  validates :role, inclusion: { in: Roles.names }
   validate :user_can_be_exempted_from_2sv
   validate :organisation_admin_belongs_to_organisation
   validate :email_is_ascii_only

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -43,7 +43,7 @@ class User < ApplicationRecord
          :confirmable,
          :password_archivable # in signon/lib/devise/models/password_archivable.rb
 
-  delegate :manageable_roles, to: :role_class
+  delegate :manageable_role_names, to: :role_class
   delegate :display_name, to: :role_class, prefix: :role
 
   encrypts :otp_secret_key

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -44,6 +44,7 @@ class User < ApplicationRecord
          :password_archivable # in signon/lib/devise/models/password_archivable.rb
 
   delegate :manageable_roles, to: :role_class
+  delegate :display_name, to: :role_class, prefix: :role
 
   encrypts :otp_secret_key
 
@@ -424,12 +425,12 @@ private
   end
 
   def user_can_be_exempted_from_2sv
-    errors.add(:reason_for_2sv_exemption, "cannot be blank for #{role.humanize} users. Remove the user's exemption to change their role.") if exempt_from_2sv? && role_class.require_2sv?
+    errors.add(:reason_for_2sv_exemption, "cannot be blank for #{role_display_name} users. Remove the user's exemption to change their role.") if exempt_from_2sv? && role_class.require_2sv?
   end
 
   def organisation_admin_belongs_to_organisation
     if publishing_manager? && organisation_id.blank?
-      errors.add(:organisation_id, "can't be 'None' for #{role.humanize}")
+      errors.add(:organisation_id, "can't be 'None' for #{role_display_name}")
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -43,7 +43,7 @@ class User < ApplicationRecord
          :confirmable,
          :password_archivable # in signon/lib/devise/models/password_archivable.rb
 
-  delegate :manageable_role_names, to: :role_class
+  delegate :manageable_roles, :manageable_role_names, to: :role_class
   delegate :display_name, to: :role_class, prefix: :role
 
   encrypts :otp_secret_key

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -305,10 +305,6 @@ class User < ApplicationRecord
     two_step_status == TWO_STEP_STATUS_NOT_SET_UP
   end
 
-  def role_class
-    Roles.const_get(role.classify)
-  end
-
   def can_manage?(other_user)
     manageable_roles.include?(other_user.role)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -45,6 +45,7 @@ class User < ApplicationRecord
 
   delegate :manageable_roles, to: :role_class
   delegate :display_name, to: :role_class, prefix: :role
+  delegate :name, to: :role_class, prefix: :role, allow_nil: true
 
   encrypts :otp_secret_key
 
@@ -237,7 +238,7 @@ class User < ApplicationRecord
 
   # Required for devise_invitable to set role and permissions
   def self.inviter_role(inviter)
-    inviter.nil? ? :default : inviter.role.to_sym
+    inviter.nil? ? :default : inviter.role_name.to_sym
   end
 
   def invite!(*args)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -429,7 +429,7 @@ private
 
   def organisation_admin_belongs_to_organisation
     if publishing_manager? && organisation_id.blank?
-      errors.add(:organisation_id, "can't be 'None' for #{role.titleize}")
+      errors.add(:organisation_id, "can't be 'None' for #{role.humanize}")
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -424,7 +424,7 @@ private
   end
 
   def user_can_be_exempted_from_2sv
-    errors.add(:reason_for_2sv_exemption, "#{role} users cannot be exempted from 2SV. Remove the user's exemption to change their role.") if exempt_from_2sv? && role_class.require_2sv?
+    errors.add(:reason_for_2sv_exemption, "cannot be blank for #{role.humanize} users. Remove the user's exemption to change their role.") if exempt_from_2sv? && role_class.require_2sv?
   end
 
   def organisation_admin_belongs_to_organisation

--- a/app/models/users_filter.rb
+++ b/app/models/users_filter.rb
@@ -49,12 +49,12 @@ class UsersFilter
   end
 
   def role_option_select_options(aria_controls_id: nil)
-    @current_user.manageable_role_names.map do |role|
+    @current_user.manageable_roles.map do |role|
       {
-        label: Roles.find(role).display_name,
+        label: role.display_name,
         controls: aria_controls_id,
-        value: role,
-        checked: Array(options[:roles]).include?(role),
+        value: role.name,
+        checked: Array(options[:roles]).include?(role.name),
       }.compact
     end
   end

--- a/app/models/users_filter.rb
+++ b/app/models/users_filter.rb
@@ -51,7 +51,7 @@ class UsersFilter
   def role_option_select_options(aria_controls_id: nil)
     @current_user.manageable_roles.map do |role|
       {
-        label: role.humanize,
+        label: Roles.find(role).display_name,
         controls: aria_controls_id,
         value: role,
         checked: Array(options[:roles]).include?(role),

--- a/app/models/users_filter.rb
+++ b/app/models/users_filter.rb
@@ -49,7 +49,7 @@ class UsersFilter
   end
 
   def role_option_select_options(aria_controls_id: nil)
-    @current_user.manageable_roles.map do |role|
+    @current_user.manageable_role_names.map do |role|
       {
         label: Roles.find(role).display_name,
         controls: aria_controls_id,

--- a/app/models/users_filter.rb
+++ b/app/models/users_filter.rb
@@ -51,7 +51,7 @@ class UsersFilter
   def role_option_select_options(aria_controls_id: nil)
     @current_user.manageable_roles.map do |role|
       {
-        label: role.humanize.capitalize,
+        label: role.humanize,
         controls: aria_controls_id,
         value: role,
         checked: Array(options[:roles]).include?(role),

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -14,15 +14,15 @@ class UserPolicy < BasePolicy
 
   def edit?
     case current_user.role
-    when Roles::Superadmin.role_name
+    when Roles::Superadmin.name
       true
-    when Roles::Admin.role_name
+    when Roles::Admin.name
       can_manage?
-    when Roles::SuperOrganisationAdmin.role_name
+    when Roles::SuperOrganisationAdmin.name
       can_manage? && (record_in_own_organisation? || record_in_child_organisation?)
-    when Roles::OrganisationAdmin.role_name
+    when Roles::OrganisationAdmin.name
       can_manage? && record_in_own_organisation?
-    when Roles::Normal.role_name
+    when Roles::Normal.name
       false
     else
       raise "Unknown role: #{current_user.role}"

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -62,11 +62,11 @@ private
       if current_user.superadmin?
         scope.web_users
       elsif current_user.admin?
-        scope.web_users.where(role: current_user.manageable_role_names)
+        scope.web_users.where(role: current_user.manageable_roles.map(&:name))
       elsif current_user.super_organisation_admin?
-        scope.web_users.where(role: current_user.manageable_role_names).where(organisation: current_user.organisation.subtree)
+        scope.web_users.where(role: current_user.manageable_roles.map(&:name)).where(organisation: current_user.organisation.subtree)
       elsif current_user.organisation_admin?
-        scope.web_users.where(role: current_user.manageable_role_names).where(organisation: current_user.organisation)
+        scope.web_users.where(role: current_user.manageable_roles.map(&:name)).where(organisation: current_user.organisation)
       else
         scope.none
       end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -1,11 +1,11 @@
 class UserPolicy < BasePolicy
   def index?
-    %w[superadmin admin super_organisation_admin organisation_admin].include? current_user.role
+    current_user.govuk_admin? || %w[super_organisation_admin organisation_admin].include? current_user.role
   end
 
   # invitations#new
   def new?
-    %w[superadmin admin].include? current_user.role
+    current_user.govuk_admin?
   end
   alias_method :assign_organisation?, :new?
 

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -62,11 +62,11 @@ private
       if current_user.superadmin?
         scope.web_users
       elsif current_user.admin?
-        scope.web_users.where(role: current_user.manageable_roles)
+        scope.web_users.where(role: current_user.manageable_role_names)
       elsif current_user.super_organisation_admin?
-        scope.web_users.where(role: current_user.manageable_roles).where(organisation: current_user.organisation.subtree)
+        scope.web_users.where(role: current_user.manageable_role_names).where(organisation: current_user.organisation.subtree)
       elsif current_user.organisation_admin?
-        scope.web_users.where(role: current_user.manageable_roles).where(organisation: current_user.organisation)
+        scope.web_users.where(role: current_user.manageable_role_names).where(organisation: current_user.organisation)
       else
         scope.none
       end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -1,6 +1,6 @@
 class UserPolicy < BasePolicy
   def index?
-    current_user.govuk_admin? || %w[super_organisation_admin organisation_admin].include? current_user.role
+    current_user.govuk_admin? || current_user.publishing_manager?
   end
 
   # invitations#new

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -13,7 +13,7 @@ class UserPolicy < BasePolicy
   alias_method :create?, :new?
 
   def edit?
-    case current_user.role
+    case current_user.role_name
     when Roles::Superadmin.name
       true
     when Roles::Admin.name
@@ -25,7 +25,7 @@ class UserPolicy < BasePolicy
     when Roles::Normal.name
       false
     else
-      raise "Unknown role: #{current_user.role}"
+      raise "Unknown role: #{current_user.role_name}"
     end
   end
   alias_method :update?, :edit?

--- a/app/presenters/user_export_presenter.rb
+++ b/app/presenters/user_export_presenter.rb
@@ -35,7 +35,7 @@ class UserExportPresenter
     [
       user.name,
       user.email,
-      user.role.humanize,
+      user.role_display_name,
       user.organisation.try(:name),
       user.sign_in_count,
       user.current_sign_in_at.try(:to_formatted_s, :db),

--- a/app/views/account/roles/edit.html.erb
+++ b/app/views/account/roles/edit.html.erb
@@ -24,7 +24,7 @@
             id: "user_role",
             name: "user[role]",
             label: "Role",
-            options: current_user.manageable_role_names.map { |role| { text: Roles.find(role).display_name, value: role, selected: current_user.role == role } }
+            options: current_user.manageable_roles.map { |role| { text: role.display_name, value: role.name, selected: current_user.role == role.name } }
             } %>
         <%= render "govuk_publishing_components/components/button", {
           text: "Change role"

--- a/app/views/account/roles/edit.html.erb
+++ b/app/views/account/roles/edit.html.erb
@@ -24,7 +24,7 @@
             id: "user_role",
             name: "user[role]",
             label: "Role",
-            options: current_user.manageable_roles.map { |role| { text: Roles.find(role).display_name, value: role, selected: current_user.role == role } }
+            options: current_user.manageable_role_names.map { |role| { text: Roles.find(role).display_name, value: role, selected: current_user.role == role } }
             } %>
         <%= render "govuk_publishing_components/components/button", {
           text: "Change role"

--- a/app/views/account/roles/edit.html.erb
+++ b/app/views/account/roles/edit.html.erb
@@ -24,7 +24,7 @@
             id: "user_role",
             name: "user[role]",
             label: "Role",
-            options: current_user.manageable_roles.map { |role| { text: role.humanize, value: role, selected: current_user.role == role } }
+            options: current_user.manageable_roles.map { |role| { text: Roles.find(role).display_name, value: role, selected: current_user.role == role } }
             } %>
         <%= render "govuk_publishing_components/components/button", {
           text: "Change role"
@@ -32,7 +32,7 @@
       <% end %>
     <% else %>
       <%= render "govuk_publishing_components/components/inset_text", {
-        text: current_user.role.humanize,
+        text: current_user.role_display_name,
       } %>
     <% end %>
   </div>

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -62,7 +62,7 @@
           name: "user[role]",
           label: "Role",
           hint: user_role_select_hint,
-          options: options_for_role_select(selected: f.object.role),
+          options: options_for_role_select(selected: f.object.role_name),
         } %>
       <% end %>
 

--- a/app/views/doorkeeper_applications/users_with_access.html.erb
+++ b/app/views/doorkeeper_applications/users_with_access.html.erb
@@ -34,7 +34,7 @@
     [
       { text: formatted_user_name(user), format: user_name_format(user) },
       { text: user.email, format: 'email' },
-      { text: user.role.humanize },
+      { text: user.role_display_name },
       { text: user.organisation_name },
       { text: user.sign_in_count },
       { text: formatted_last_sign_in(user) },

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -39,7 +39,7 @@
           [
             { text: user_name(user) },
             { text: user.email },
-            { text: user.role.humanize },
+            { text: user.role_display_name },
             { text: status(user) },
             { text: two_step_status(user) },
           ]

--- a/app/views/users/roles/edit.html.erb
+++ b/app/views/users/roles/edit.html.erb
@@ -40,7 +40,7 @@
     <%= form_for @user, url: user_role_path(@user) do %>
       <% if @user.exempt_from_2sv? %>
         <%= render "govuk_publishing_components/components/inset_text", {
-          text: "This user's role is set to #{@user.role.humanize}. They are currently exempted from 2-step verification, meaning that their role cannot be changed as admins are required to have 2-step verification.",
+          text: "This user's role is set to #{@user.role_display_name}. They are currently exempted from 2-step verification, meaning that their role cannot be changed as admins are required to have 2-step verification.",
         } %>
       <% else %>
         <%= render "govuk_publishing_components/components/select", {
@@ -48,7 +48,7 @@
           name: "user[role]",
           label: "Role",
           hint: user_role_select_hint,
-          options: current_user.manageable_roles.map { |role| { text: role.humanize, value: role, selected: @user.role == role } },
+          options: current_user.manageable_roles.map { |role| { text: Roles.find(role).display_name, value: role, selected: @user.role == role } },
           error_message: @user.errors[:role].any? ? @user.errors.full_messages_for(:role).to_sentence : nil
         } %>
         <div class="govuk-button-group">

--- a/app/views/users/roles/edit.html.erb
+++ b/app/views/users/roles/edit.html.erb
@@ -48,7 +48,7 @@
           name: "user[role]",
           label: "Role",
           hint: user_role_select_hint,
-          options: current_user.manageable_roles.map { |role| { text: Roles.find(role).display_name, value: role, selected: @user.role == role } },
+          options: current_user.manageable_role_names.map { |role| { text: Roles.find(role).display_name, value: role, selected: @user.role == role } },
           error_message: @user.errors[:role].any? ? @user.errors.full_messages_for(:role).to_sentence : nil
         } %>
         <div class="govuk-button-group">

--- a/app/views/users/roles/edit.html.erb
+++ b/app/views/users/roles/edit.html.erb
@@ -48,7 +48,7 @@
           name: "user[role]",
           label: "Role",
           hint: user_role_select_hint,
-          options: current_user.manageable_role_names.map { |role| { text: Roles.find(role).display_name, value: role, selected: @user.role == role } },
+          options: current_user.manageable_roles.map { |role| { text: role.display_name, value: role.name, selected: @user.role == role.name } },
           error_message: @user.errors[:role].any? ? @user.errors.full_messages_for(:role).to_sentence : nil
         } %>
         <div class="govuk-button-group">

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -11,7 +11,7 @@ User.create!(
   name: "Test Superadmin",
   email: "test.superadmin@gov.uk",
   password: "6fe552ca-d406-4c54-b7a6-041ed1ade6cd",
-  role: Roles::Superadmin.role_name,
+  role: Roles::Superadmin.name,
   confirmed_at: Time.current,
   organisation: gds,
 )
@@ -20,7 +20,7 @@ User.create!(
   name: "Test Admin",
   email: "test.admin@gov.uk",
   password: "6fe552ca-d406-4c54-b7a6-041ed1ade6cd",
-  role: Roles::Admin.role_name,
+  role: Roles::Admin.name,
   confirmed_at: Time.current,
   organisation: gds,
 )
@@ -29,7 +29,7 @@ User.create!(
   name: "Test Super Organisation Admin",
   email: "test.super-organisation-admin@gov.uk",
   password: "6fe552ca-d406-4c54-b7a6-041ed1ade6cd",
-  role: Roles::SuperOrganisationAdmin.role_name,
+  role: Roles::SuperOrganisationAdmin.name,
   confirmed_at: Time.current,
   organisation: gds,
 )
@@ -38,7 +38,7 @@ User.create!(
   name: "Test Organisation Admin",
   email: "test.organisation-admin@gov.uk",
   password: "6fe552ca-d406-4c54-b7a6-041ed1ade6cd",
-  role: Roles::OrganisationAdmin.role_name,
+  role: Roles::OrganisationAdmin.name,
   confirmed_at: Time.current,
   organisation: gds,
 )
@@ -63,7 +63,7 @@ User.create!(
   name: "Test User",
   email: "test.user@gov.uk",
   password: "6fe552ca-d406-4c54-b7a6-041ed1ade6cd",
-  role: Roles::Normal.role_name,
+  role: Roles::Normal.name,
   confirmed_at: Time.current,
   organisation: test_organisation_without_2sv,
 )
@@ -99,7 +99,7 @@ User.create!(
   name: "Test User with 2SV enabled",
   email: "test.user.2sv@gov.uk",
   password: "6fe552ca-d406-4c54-b7a6-041ed1ade6cd",
-  role: Roles::Normal.role_name,
+  role: Roles::Normal.name,
   confirmed_at: Time.current,
   organisation: test_organisation_without_2sv,
   require_2sv: true,
@@ -110,7 +110,7 @@ User.create!(
   name: "Test User from organisation with mandatory 2SV",
   email: "test.user.2sv.organisation@gov.uk",
   password: "6fe552ca-d406-4c54-b7a6-041ed1ade6cd",
-  role: Roles::Normal.role_name,
+  role: Roles::Normal.name,
   confirmed_at: Time.current,
   organisation: test_organisation_with_2sv,
   require_2sv: true,
@@ -122,7 +122,7 @@ User.create!(
   api_user: true,
   email: "test.apiuser@gov.uk",
   password: "6fe552ca-d406-4c54-b7a6-041ed1ade6cd",
-  role: Roles::Normal.role_name,
+  role: Roles::Normal.name,
   confirmed_at: Time.current,
   require_2sv: false,
 )

--- a/lib/roles.rb
+++ b/lib/roles.rb
@@ -17,9 +17,9 @@ module Roles
     all.map(&:name)
   end
 
-  names.each do |role_name|
-    define_method("#{role_name}?") do
-      role == role_name
+  names.each do |name|
+    define_method("#{name}?") do
+      role == name
     end
   end
 

--- a/lib/roles.rb
+++ b/lib/roles.rb
@@ -1,5 +1,3 @@
-Dir["#{File.dirname(__FILE__)}/roles/*.rb"].sort.each { |file| require file }
-
 module Roles
   def self.included(base)
     base.extend ClassMethods
@@ -17,15 +15,17 @@ module Roles
 
   module ClassMethods
     def role_classes
-      class_names = Roles.constants.select { |c| Roles.const_get(c).is_a?(Class) && Roles.const_get(c) != Roles::Base }
-
-      class_names.map do |role_class|
-        "Roles::#{role_class}".constantize
-      end
+      [
+        Roles::Admin,
+        Roles::Normal,
+        Roles::OrganisationAdmin,
+        Roles::Superadmin,
+        Roles::SuperOrganisationAdmin,
+      ]
     end
 
     def admin_role_classes
-      role_classes - [Roles::Normal, Roles::Base]
+      role_classes - [Roles::Normal]
     end
 
     def admin_roles

--- a/lib/roles.rb
+++ b/lib/roles.rb
@@ -10,7 +10,7 @@ module Roles
   end
 
   def self.find(role_name)
-    Roles.const_get(role_name.classify)
+    all.find { |role| role.role_name == role_name }
   end
 
   def self.names

--- a/lib/roles.rb
+++ b/lib/roles.rb
@@ -19,12 +19,8 @@ module Roles
 
   all.each do |klass|
     define_method("#{klass.name}?") do
-      role == klass.name
+      role&.name == klass.name
     end
-  end
-
-  def role_class
-    Roles.find(role)
   end
 
   def govuk_admin?

--- a/lib/roles.rb
+++ b/lib/roles.rb
@@ -42,6 +42,6 @@ module Roles
   end
 
   def publishing_manager?
-    [Roles::SuperOrganisationAdmin.role_name, Roles::OrganisationAdmin.role_name].include? role
+    super_organisation_admin? || organisation_admin?
   end
 end

--- a/lib/roles.rb
+++ b/lib/roles.rb
@@ -21,7 +21,7 @@ module Roles
         Roles::OrganisationAdmin,
         Roles::Superadmin,
         Roles::SuperOrganisationAdmin,
-      ]
+      ].sort_by(&:level)
     end
 
     def admin_role_classes
@@ -33,7 +33,7 @@ module Roles
     end
 
     def roles
-      role_classes.sort_by(&:level).map(&:role_name)
+      role_classes.map(&:role_name)
     end
   end
 

--- a/lib/roles.rb
+++ b/lib/roles.rb
@@ -29,6 +29,10 @@ module Roles
     end
   end
 
+  def role_class
+    Roles.const_get(role.classify)
+  end
+
   def govuk_admin?
     superadmin? || admin?
   end

--- a/lib/roles.rb
+++ b/lib/roles.rb
@@ -1,4 +1,14 @@
 module Roles
+  def self.all
+    [
+      Roles::Admin,
+      Roles::Normal,
+      Roles::OrganisationAdmin,
+      Roles::Superadmin,
+      Roles::SuperOrganisationAdmin,
+    ].sort_by(&:level)
+  end
+
   def self.included(base)
     base.extend ClassMethods
 
@@ -14,18 +24,8 @@ module Roles
   end
 
   module ClassMethods
-    def role_classes
-      [
-        Roles::Admin,
-        Roles::Normal,
-        Roles::OrganisationAdmin,
-        Roles::Superadmin,
-        Roles::SuperOrganisationAdmin,
-      ].sort_by(&:level)
-    end
-
     def admin_role_classes
-      role_classes - [Roles::Normal]
+      Roles.all - [Roles::Normal]
     end
 
     def admin_roles
@@ -33,7 +33,7 @@ module Roles
     end
 
     def roles
-      role_classes.map(&:role_name)
+      Roles.all.map(&:role_name)
     end
   end
 

--- a/lib/roles.rb
+++ b/lib/roles.rb
@@ -17,11 +17,9 @@ module Roles
     all.map(&:role_name)
   end
 
-  def self.included(base)
-    Roles.names.each do |role_name|
-      define_method("#{role_name}?") do
-        role == role_name
-      end
+  names.each do |role_name|
+    define_method("#{role_name}?") do
+      role == role_name
     end
   end
 

--- a/lib/roles.rb
+++ b/lib/roles.rb
@@ -13,10 +13,6 @@ module Roles
     all.find { |role| role.name == role_name }
   end
 
-  def self.names
-    all.map(&:name)
-  end
-
   all.each do |klass|
     define_method("#{klass.name}?") do
       role&.name == klass.name

--- a/lib/roles.rb
+++ b/lib/roles.rb
@@ -9,6 +9,10 @@ module Roles
     ].sort_by(&:level)
   end
 
+  def self.admin
+    all - [Roles::Normal]
+  end
+
   def self.names
     all.map(&:role_name)
   end
@@ -24,12 +28,8 @@ module Roles
   end
 
   module ClassMethods
-    def admin_role_classes
-      Roles.all - [Roles::Normal]
-    end
-
     def admin_roles
-      admin_role_classes.map(&:role_name)
+      Roles.admin.map(&:role_name)
     end
   end
 

--- a/lib/roles.rb
+++ b/lib/roles.rb
@@ -17,9 +17,9 @@ module Roles
     all.map(&:name)
   end
 
-  names.each do |name|
-    define_method("#{name}?") do
-      role == name
+  all.each do |klass|
+    define_method("#{klass.name}?") do
+      role == klass.name
     end
   end
 

--- a/lib/roles.rb
+++ b/lib/roles.rb
@@ -9,14 +9,18 @@ module Roles
     ].sort_by(&:level)
   end
 
+  def self.names
+    all.map(&:role_name)
+  end
+
   def self.included(base)
     base.extend ClassMethods
 
     base.instance_eval do
-      validates :role, inclusion: { in: roles }
+      validates :role, inclusion: { in: Roles.names }
     end
 
-    base.roles.each do |role_name|
+    Roles.names.each do |role_name|
       define_method("#{role_name}?") do
         role == role_name
       end
@@ -30,10 +34,6 @@ module Roles
 
     def admin_roles
       admin_role_classes.map(&:role_name)
-    end
-
-    def roles
-      Roles.all.map(&:role_name)
     end
   end
 

--- a/lib/roles.rb
+++ b/lib/roles.rb
@@ -10,11 +10,11 @@ module Roles
   end
 
   def self.find(role_name)
-    all.find { |role| role.role_name == role_name }
+    all.find { |role| role.name == role_name }
   end
 
   def self.names
-    all.map(&:role_name)
+    all.map(&:name)
   end
 
   names.each do |role_name|

--- a/lib/roles.rb
+++ b/lib/roles.rb
@@ -17,19 +17,15 @@ module Roles
     all.map(&:role_name)
   end
 
-  def self.included(base)
-    base.extend ClassMethods
+  def self.admin_names
+    admin.map(&:role_name)
+  end
 
+  def self.included(base)
     Roles.names.each do |role_name|
       define_method("#{role_name}?") do
         role == role_name
       end
-    end
-  end
-
-  module ClassMethods
-    def admin_roles
-      Roles.admin.map(&:role_name)
     end
   end
 

--- a/lib/roles.rb
+++ b/lib/roles.rb
@@ -38,7 +38,7 @@ module Roles
   end
 
   def govuk_admin?
-    [Roles::Superadmin.role_name, Roles::Admin.role_name].include? role
+    superadmin? || admin?
   end
 
   def publishing_manager?

--- a/lib/roles.rb
+++ b/lib/roles.rb
@@ -9,6 +9,10 @@ module Roles
     ].sort_by(&:level)
   end
 
+  def self.find(role_name)
+    Roles.const_get(role_name.classify)
+  end
+
   def self.admin
     all - [Roles::Normal]
   end
@@ -30,7 +34,7 @@ module Roles
   end
 
   def role_class
-    Roles.const_get(role.classify)
+    Roles.find(role)
   end
 
   def govuk_admin?

--- a/lib/roles.rb
+++ b/lib/roles.rb
@@ -13,16 +13,8 @@ module Roles
     Roles.const_get(role_name.classify)
   end
 
-  def self.admin
-    all - [Roles::Normal]
-  end
-
   def self.names
     all.map(&:role_name)
-  end
-
-  def self.admin_names
-    admin.map(&:role_name)
   end
 
   def self.included(base)

--- a/lib/roles.rb
+++ b/lib/roles.rb
@@ -16,10 +16,6 @@ module Roles
   def self.included(base)
     base.extend ClassMethods
 
-    base.instance_eval do
-      validates :role, inclusion: { in: Roles.names }
-    end
-
     Roles.names.each do |role_name|
       define_method("#{role_name}?") do
         role == role_name

--- a/lib/roles/admin.rb
+++ b/lib/roles/admin.rb
@@ -15,7 +15,7 @@ module Roles
       ]
     end
 
-    def self.role_name
+    def self.name
       "admin"
     end
 

--- a/lib/roles/admin.rb
+++ b/lib/roles/admin.rb
@@ -23,10 +23,6 @@ module Roles
       1
     end
 
-    def self.manageable_roles
-      %w[normal organisation_admin super_organisation_admin admin]
-    end
-
     def self.manageable_organisations_for(_)
       Organisation.all
     end

--- a/lib/roles/admin.rb
+++ b/lib/roles/admin.rb
@@ -26,5 +26,9 @@ module Roles
     def self.manageable_organisations_for(_)
       Organisation.all
     end
+
+    def self.require_2sv?
+      true
+    end
   end
 end

--- a/lib/roles/base.rb
+++ b/lib/roles/base.rb
@@ -1,7 +1,11 @@
 module Roles
   class Base
+    def self.manageable_roles
+      Roles.all.select { |role_class| role_class.level >= level }.reverse
+    end
+
     def self.manageable_role_names
-      Roles.all.select { |role_class| role_class.level >= level }.reverse.map(&:name)
+      manageable_roles.map(&:name)
     end
 
     def self.can_manage?(role_name)

--- a/lib/roles/base.rb
+++ b/lib/roles/base.rb
@@ -1,11 +1,11 @@
 module Roles
   class Base
-    def self.manageable_roles
+    def self.manageable_role_names
       Roles.all.select { |role_class| role_class.level >= level }.reverse.map(&:name)
     end
 
     def self.can_manage?(role_name)
-      manageable_roles.include?(role_name)
+      manageable_role_names.include?(role_name)
     end
 
     def self.display_name

--- a/lib/roles/base.rb
+++ b/lib/roles/base.rb
@@ -7,5 +7,9 @@ module Roles
     def self.can_manage?(role_name)
       manageable_roles.include?(role_name)
     end
+
+    def self.display_name
+      name.humanize
+    end
   end
 end

--- a/lib/roles/base.rb
+++ b/lib/roles/base.rb
@@ -1,7 +1,7 @@
 module Roles
   class Base
     def self.manageable_roles
-      User.role_classes.select { |role_class| role_class.level >= level }.sort_by(&:level).reverse.map(&:role_name)
+      User.role_classes.select { |role_class| role_class.level >= level }.reverse.map(&:role_name)
     end
   end
 end

--- a/lib/roles/base.rb
+++ b/lib/roles/base.rb
@@ -1,3 +1,7 @@
 module Roles
-  class Base; end
+  class Base
+    def self.manageable_roles
+      User.role_classes.select { |role_class| role_class.level >= level }.sort_by(&:level).reverse.map(&:role_name)
+    end
+  end
 end

--- a/lib/roles/base.rb
+++ b/lib/roles/base.rb
@@ -1,7 +1,7 @@
 module Roles
   class Base
     def self.manageable_roles
-      User.role_classes.select { |role_class| role_class.level >= level }.reverse.map(&:role_name)
+      Roles.all.select { |role_class| role_class.level >= level }.reverse.map(&:role_name)
     end
   end
 end

--- a/lib/roles/base.rb
+++ b/lib/roles/base.rb
@@ -4,10 +4,6 @@ module Roles
       Roles.all.select { |role_class| role_class.level >= level }.reverse
     end
 
-    def self.manageable_role_names
-      manageable_roles.map(&:name)
-    end
-
     def self.can_manage?(role_class)
       manageable_roles.include?(role_class)
     end

--- a/lib/roles/base.rb
+++ b/lib/roles/base.rb
@@ -1,7 +1,7 @@
 module Roles
   class Base
     def self.manageable_roles
-      Roles.all.select { |role_class| role_class.level >= level }.reverse.map(&:role_name)
+      Roles.all.select { |role_class| role_class.level >= level }.reverse.map(&:name)
     end
 
     def self.can_manage?(role_name)

--- a/lib/roles/base.rb
+++ b/lib/roles/base.rb
@@ -8,8 +8,8 @@ module Roles
       manageable_roles.map(&:name)
     end
 
-    def self.can_manage?(role_name)
-      manageable_role_names.include?(role_name)
+    def self.can_manage?(role_class)
+      manageable_roles.include?(role_class)
     end
 
     def self.display_name

--- a/lib/roles/base.rb
+++ b/lib/roles/base.rb
@@ -3,5 +3,9 @@ module Roles
     def self.manageable_roles
       Roles.all.select { |role_class| role_class.level >= level }.reverse.map(&:role_name)
     end
+
+    def self.can_manage?(role_name)
+      manageable_roles.include?(role_name)
+    end
   end
 end

--- a/lib/roles/normal.rb
+++ b/lib/roles/normal.rb
@@ -4,7 +4,7 @@ module Roles
       %i[uid name email password password_confirmation]
     end
 
-    def self.role_name
+    def self.name
       "normal"
     end
 

--- a/lib/roles/normal.rb
+++ b/lib/roles/normal.rb
@@ -19,5 +19,9 @@ module Roles
     def self.manageable_organisations_for(_)
       Organisation.where("false")
     end
+
+    def self.require_2sv?
+      false
+    end
   end
 end

--- a/lib/roles/normal.rb
+++ b/lib/roles/normal.rb
@@ -16,10 +16,6 @@ module Roles
       []
     end
 
-    def self.manageable_role_names
-      []
-    end
-
     def self.manageable_organisations_for(_)
       Organisation.where("false")
     end

--- a/lib/roles/normal.rb
+++ b/lib/roles/normal.rb
@@ -12,7 +12,7 @@ module Roles
       4
     end
 
-    def self.manageable_roles
+    def self.manageable_role_names
       []
     end
 

--- a/lib/roles/normal.rb
+++ b/lib/roles/normal.rb
@@ -12,6 +12,10 @@ module Roles
       4
     end
 
+    def self.manageable_roles
+      []
+    end
+
     def self.manageable_role_names
       []
     end

--- a/lib/roles/organisation_admin.rb
+++ b/lib/roles/organisation_admin.rb
@@ -14,7 +14,7 @@ module Roles
       ]
     end
 
-    def self.role_name
+    def self.name
       "organisation_admin"
     end
 

--- a/lib/roles/organisation_admin.rb
+++ b/lib/roles/organisation_admin.rb
@@ -22,10 +22,6 @@ module Roles
       3
     end
 
-    def self.manageable_roles
-      %w[normal organisation_admin]
-    end
-
     def self.manageable_organisations_for(user)
       Organisation.where(id: user.organisation)
     end

--- a/lib/roles/organisation_admin.rb
+++ b/lib/roles/organisation_admin.rb
@@ -25,5 +25,9 @@ module Roles
     def self.manageable_organisations_for(user)
       Organisation.where(id: user.organisation)
     end
+
+    def self.require_2sv?
+      true
+    end
   end
 end

--- a/lib/roles/super_organisation_admin.rb
+++ b/lib/roles/super_organisation_admin.rb
@@ -25,5 +25,9 @@ module Roles
     def self.manageable_organisations_for(user)
       Organisation.where(id: user.organisation.subtree)
     end
+
+    def self.require_2sv?
+      true
+    end
   end
 end

--- a/lib/roles/super_organisation_admin.rb
+++ b/lib/roles/super_organisation_admin.rb
@@ -14,7 +14,7 @@ module Roles
       ]
     end
 
-    def self.role_name
+    def self.name
       "super_organisation_admin"
     end
 

--- a/lib/roles/super_organisation_admin.rb
+++ b/lib/roles/super_organisation_admin.rb
@@ -22,10 +22,6 @@ module Roles
       2
     end
 
-    def self.manageable_roles
-      %w[normal organisation_admin super_organisation_admin]
-    end
-
     def self.manageable_organisations_for(user)
       Organisation.where(id: user.organisation.subtree)
     end

--- a/lib/roles/superadmin.rb
+++ b/lib/roles/superadmin.rb
@@ -27,5 +27,9 @@ module Roles
     def self.manageable_organisations_for(_)
       Organisation.all
     end
+
+    def self.require_2sv?
+      true
+    end
   end
 end

--- a/lib/roles/superadmin.rb
+++ b/lib/roles/superadmin.rb
@@ -25,7 +25,7 @@ module Roles
     end
 
     def self.manageable_roles
-      %w[superadmin admin super_organisation_admin organisation_admin normal]
+      %w[normal organisation_admin super_organisation_admin admin superadmin]
     end
 
     def self.manageable_organisations_for(_)

--- a/lib/roles/superadmin.rb
+++ b/lib/roles/superadmin.rb
@@ -24,10 +24,6 @@ module Roles
       0
     end
 
-    def self.manageable_roles
-      %w[normal organisation_admin super_organisation_admin admin superadmin]
-    end
-
     def self.manageable_organisations_for(_)
       Organisation.all
     end

--- a/lib/roles/superadmin.rb
+++ b/lib/roles/superadmin.rb
@@ -16,7 +16,7 @@ module Roles
       ]
     end
 
-    def self.role_name
+    def self.name
       "superadmin"
     end
 

--- a/lib/roles/superadmin.rb
+++ b/lib/roles/superadmin.rb
@@ -25,7 +25,7 @@ module Roles
     end
 
     def self.manageable_roles
-      User.roles
+      %w[superadmin admin super_organisation_admin organisation_admin normal]
     end
 
     def self.manageable_organisations_for(_)

--- a/lib/tasks/permission_promoter.rake
+++ b/lib/tasks/permission_promoter.rake
@@ -12,7 +12,7 @@ namespace :permissions_promoter do
     puts "user ids to update are #{users_to_update.map(&:id)}"
 
     users_to_update.each do |user|
-      user.update(role: Roles::OrganisationAdmin.role_name)
+      user.update(role: Roles::OrganisationAdmin.name)
     end
   end
 end

--- a/lib/tasks/permission_promoter.rake
+++ b/lib/tasks/permission_promoter.rake
@@ -6,7 +6,7 @@ namespace :permissions_promoter do
     gds = Organisation.find_by(name: "Government Digital Service")
     users_to_update = user_application_permissions
                         .map { |user_application_permission| User.find(user_application_permission.user_id) }.uniq
-                        .filter { |user| user.role == "normal" && !user.suspended? && user.organisation != gds }
+                        .filter { |user| user.normal? && !user.suspended? && user.organisation != gds }
 
     puts "found #{users_to_update.size} users with managing editor positions to be updated to organisation admins"
     puts "user ids to update are #{users_to_update.map(&:id)}"

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -134,8 +134,8 @@ namespace :users do
 
   desc "Sets 2sv on all organisation admin and organisation superadmin users"
   task set_2sv_for_org_admins: :environment do
-    org_admin_users = User.where(role: Roles::OrganisationAdmin.role_name)
-    super_org_admin_users = User.where(role: Roles::SuperOrganisationAdmin.role_name)
+    org_admin_users = User.where(role: Roles::OrganisationAdmin.name)
+    super_org_admin_users = User.where(role: Roles::SuperOrganisationAdmin.name)
 
     users_to_update = org_admin_users + super_org_admin_users
 

--- a/test/controllers/account/roles_controller_test.rb
+++ b/test/controllers/account/roles_controller_test.rb
@@ -20,7 +20,7 @@ class Account::RolesControllerTest < ActionController::TestCase
     should "display error when validation fails" do
       UserUpdate.stubs(:new).returns(stub("UserUpdate", call: false))
 
-      put :update, params: { user: { role: Roles::Normal.role_name } }
+      put :update, params: { user: { role: Roles::Normal.name } }
 
       assert_template :edit
       assert_select "*[role='alert']", text: "There was a problem changing your role."

--- a/test/controllers/batch_invitations_controller_test.rb
+++ b/test/controllers/batch_invitations_controller_test.rb
@@ -59,7 +59,7 @@ class BatchInvitationsControllerTest < ActionController::TestCase
     end
 
     should "store organisation info from the uploaded CSV when logged in as an admin" do
-      @user.update!(role: Roles::Admin.role_name)
+      @user.update!(role: Roles::Admin.name)
       post :create,
            params: { batch_invitation: { user_names_and_emails: users_csv("users_with_orgs.csv"), organisation_id: 3 } }
 
@@ -73,7 +73,7 @@ class BatchInvitationsControllerTest < ActionController::TestCase
     end
 
     should "store organisation info from the uploaded CSV when logged in as a superadmin" do
-      @user.update!(role: Roles::Superadmin.role_name)
+      @user.update!(role: Roles::Superadmin.name)
       post :create,
            params: { batch_invitation: { user_names_and_emails: users_csv("users_with_orgs.csv"), organisation_id: 3 } }
 

--- a/test/controllers/invitations_controller_test.rb
+++ b/test/controllers/invitations_controller_test.rb
@@ -188,7 +188,7 @@ class InvitationsControllerTest < ActionController::TestCase
             name: "invitee",
             email: "invitee@gov.uk",
             organisation_id: @organisation,
-            role: Roles::OrganisationAdmin.role_name,
+            role: Roles::OrganisationAdmin.name,
             supported_permission_ids: [permission.to_param],
           },
         }
@@ -198,7 +198,7 @@ class InvitationsControllerTest < ActionController::TestCase
         assert_equal "invitee", invitee.name
         assert_equal "invitee@gov.uk", invitee.email
         assert_equal @organisation, invitee.organisation
-        assert_equal Roles::OrganisationAdmin.role_name, invitee.role
+        assert_equal Roles::OrganisationAdmin.name, invitee.role
         assert_equal [permission], invitee.supported_permissions
       end
 
@@ -228,7 +228,7 @@ class InvitationsControllerTest < ActionController::TestCase
 
         context "when invitee role is set to superadmin" do
           setup do
-            @role = Roles::Superadmin.role_name
+            @role = Roles::Superadmin.name
           end
 
           should "set require_2sv on invitee to true" do
@@ -246,7 +246,7 @@ class InvitationsControllerTest < ActionController::TestCase
 
         context "when invitee role is set to admin" do
           setup do
-            @role = Roles::Admin.role_name
+            @role = Roles::Admin.name
           end
 
           should "set require_2sv on invitee to true" do
@@ -264,7 +264,7 @@ class InvitationsControllerTest < ActionController::TestCase
 
         context "when invitee role is set to organisation admin" do
           setup do
-            @role = Roles::OrganisationAdmin.role_name
+            @role = Roles::OrganisationAdmin.name
           end
 
           should "set require_2sv on invitee to true" do
@@ -282,7 +282,7 @@ class InvitationsControllerTest < ActionController::TestCase
 
         context "when invitee role is set to super organisation admin" do
           setup do
-            @role = Roles::SuperOrganisationAdmin.role_name
+            @role = Roles::SuperOrganisationAdmin.name
           end
 
           should "set require_2sv on invitee to true" do
@@ -343,14 +343,14 @@ class InvitationsControllerTest < ActionController::TestCase
       end
 
       should "keep selected organisation & role if there are validation errors" do
-        post :create, params: { user: { organisation_id: @organisation, role: Roles::Admin.role_name } }
+        post :create, params: { user: { organisation_id: @organisation, role: Roles::Admin.name } }
 
         assert_select "form" do
           assert_select "select[name='user[organisation_id]']" do
             assert_select "option[value='#{@organisation.to_param}'][selected]"
           end
           assert_select "select[name='user[role]']" do
-            assert_select "option[value='#{Roles::Admin.role_name}'][selected]"
+            assert_select "option[value='#{Roles::Admin.name}'][selected]"
           end
         end
       end
@@ -433,13 +433,13 @@ class InvitationsControllerTest < ActionController::TestCase
             name: "invitee",
             email: "invitee@gov.uk",
             organisation_id: @organisation,
-            role: Roles::OrganisationAdmin.role_name,
+            role: Roles::OrganisationAdmin.name,
           },
         }
 
         invitee = User.last
         assert invitee.present?
-        default_role = Roles::Normal.role_name
+        default_role = Roles::Normal.name
         assert_equal default_role, invitee.role
       end
     end
@@ -530,7 +530,7 @@ class InvitationsControllerTest < ActionController::TestCase
       end
 
       should "not allow invitee role to be changed" do
-        new_role = Roles::Superadmin.role_name
+        new_role = Roles::Superadmin.name
 
         put :update, params: { user: { invitation_token: @token, password: @password, password_confirmation: @password, role: new_role } }
 

--- a/test/controllers/invitations_controller_test.rb
+++ b/test/controllers/invitations_controller_test.rb
@@ -198,7 +198,7 @@ class InvitationsControllerTest < ActionController::TestCase
         assert_equal "invitee", invitee.name
         assert_equal "invitee@gov.uk", invitee.email
         assert_equal @organisation, invitee.organisation
-        assert_equal Roles::OrganisationAdmin.name, invitee.role
+        assert_equal Roles::OrganisationAdmin, invitee.role
         assert_equal [permission], invitee.supported_permissions
       end
 
@@ -439,7 +439,7 @@ class InvitationsControllerTest < ActionController::TestCase
 
         invitee = User.last
         assert invitee.present?
-        default_role = Roles::Normal.name
+        default_role = Roles::Normal
         assert_equal default_role, invitee.role
       end
     end

--- a/test/controllers/users/organisations_controller_test.rb
+++ b/test/controllers/users/organisations_controller_test.rb
@@ -187,10 +187,10 @@ class Users::OrganisationsControllerTest < ActionController::TestCase
         put :update, params: { user_id: user, user: { organisation_id: nil } }
 
         assert_select ".govuk-error-summary" do
-          assert_select "a", href: "#user_organisation_id", text: "Organisation can't be 'None' for Organisation Admin"
+          assert_select "a", href: "#user_organisation_id", text: "Organisation can't be 'None' for Organisation admin"
         end
         assert_select ".govuk-form-group" do
-          assert_select ".govuk-error-message", text: "Error: Organisation can't be 'None' for Organisation Admin"
+          assert_select ".govuk-error-message", text: "Error: Organisation can't be 'None' for Organisation admin"
           assert_select "select[name='user[organisation_id]'].govuk-select--error"
         end
       end

--- a/test/controllers/users/roles_controller_test.rb
+++ b/test/controllers/users/roles_controller_test.rb
@@ -176,7 +176,7 @@ class Users::RolesControllerTest < ActionController::TestCase
         assert_equal Roles::Normal.role_name, user.reload.role
 
         assert_select ".govuk-error-summary" do
-          assert_select "li", text: /#{Roles::OrganisationAdmin.role_name} users cannot be exempted from 2SV/
+          assert_select "li", text: /cannot be blank for #{Roles::OrganisationAdmin.role_name.humanize} users/
         end
       end
 

--- a/test/controllers/users/roles_controller_test.rb
+++ b/test/controllers/users/roles_controller_test.rb
@@ -9,20 +9,20 @@ class Users::RolesControllerTest < ActionController::TestCase
       end
 
       should "display form with role field" do
-        user = create(:user, role: Roles::Normal.role_name)
+        user = create(:user, role: Roles::Normal.name)
 
         get :edit, params: { user_id: user }
 
         assert_template :edit
         assert_select "form[action='#{user_role_path(user)}']" do
-          assert_select "select[name='user[role]'] option", value: Roles::Normal.role_name
+          assert_select "select[name='user[role]'] option", value: Roles::Normal.name
           assert_select "button[type='submit']", text: "Change role"
           assert_select "a[href='#{edit_user_path(user)}']", text: "Cancel"
         end
       end
 
       should "not display form if user is exempt from 2SV" do
-        user = create(:two_step_exempted_user, role: Roles::Normal.role_name)
+        user = create(:two_step_exempted_user, role: Roles::Normal.name)
 
         get :edit, params: { user_id: user }
 
@@ -94,15 +94,15 @@ class Users::RolesControllerTest < ActionController::TestCase
       end
 
       should "update user role" do
-        user = create(:user_in_organisation, role: Roles::Normal.role_name)
+        user = create(:user_in_organisation, role: Roles::Normal.name)
 
-        put :update, params: { user_id: user, user: { role: Roles::OrganisationAdmin.role_name } }
+        put :update, params: { user_id: user, user: { role: Roles::OrganisationAdmin.name } }
 
-        assert_equal Roles::OrganisationAdmin.role_name, user.reload.role
+        assert_equal Roles::OrganisationAdmin.name, user.reload.role
       end
 
       should "record account updated & role change events" do
-        user = create(:user_in_organisation, role: Roles::Normal.role_name)
+        user = create(:user_in_organisation, role: Roles::Normal.name)
 
         @controller.stubs(:user_ip_address).returns("1.1.1.1")
 
@@ -115,79 +115,79 @@ class Users::RolesControllerTest < ActionController::TestCase
 
         EventLog.expects(:record_role_change).with(
           user,
-          Roles::Normal.role_name,
-          Roles::OrganisationAdmin.role_name,
+          Roles::Normal.name,
+          Roles::OrganisationAdmin.name,
           @superadmin,
         )
 
-        put :update, params: { user_id: user, user: { role: Roles::OrganisationAdmin.role_name } }
+        put :update, params: { user_id: user, user: { role: Roles::OrganisationAdmin.name } }
       end
 
       should "should not record role change event if role has not changed" do
-        user = create(:user, role: Roles::Normal.role_name)
+        user = create(:user, role: Roles::Normal.name)
 
         EventLog.expects(:record_role_change).never
 
-        put :update, params: { user_id: user, user: { role: Roles::Normal.role_name } }
+        put :update, params: { user_id: user, user: { role: Roles::Normal.name } }
       end
 
       should "push changes out to apps" do
         user = create(:user_in_organisation)
         PermissionUpdater.expects(:perform_on).with(user)
 
-        put :update, params: { user_id: user, user: { role: Roles::OrganisationAdmin.role_name } }
+        put :update, params: { user_id: user, user: { role: Roles::OrganisationAdmin.name } }
       end
 
       should "redirect to user page and display success notice" do
         user = create(:user_in_organisation, email: "user@gov.uk")
 
-        put :update, params: { user_id: user, user: { role: Roles::OrganisationAdmin.role_name } }
+        put :update, params: { user_id: user, user: { role: Roles::OrganisationAdmin.name } }
 
         assert_redirected_to edit_user_path(user)
         assert_equal "Updated user user@gov.uk successfully", flash[:notice]
       end
 
       should "update user role if UserPolicy#assign_role? returns true" do
-        user = create(:user_in_organisation, role: Roles::Normal.role_name)
+        user = create(:user_in_organisation, role: Roles::Normal.name)
 
         stub_policy(@superadmin, user, assign_role?: true)
 
-        put :update, params: { user_id: user, user: { role: Roles::OrganisationAdmin.role_name } }
+        put :update, params: { user_id: user, user: { role: Roles::OrganisationAdmin.name } }
 
-        assert_equal Roles::OrganisationAdmin.role_name, user.reload.role
+        assert_equal Roles::OrganisationAdmin.name, user.reload.role
       end
 
       should "not update user role if UserPolicy#assign_role? returns false" do
-        user = create(:user_in_organisation, role: Roles::Normal.role_name)
+        user = create(:user_in_organisation, role: Roles::Normal.name)
 
         stub_policy(@superadmin, user, assign_role?: false)
 
-        put :update, params: { user_id: user, user: { role: Roles::OrganisationAdmin.role_name } }
+        put :update, params: { user_id: user, user: { role: Roles::OrganisationAdmin.name } }
 
-        assert_equal Roles::Normal.role_name, user.reload.role
+        assert_equal Roles::Normal.name, user.reload.role
         assert_not_authorised
       end
 
       should "not update user role if user is exempt from 2SV" do
-        user = create(:two_step_exempted_user, :in_organisation, role: Roles::Normal.role_name)
+        user = create(:two_step_exempted_user, :in_organisation, role: Roles::Normal.name)
 
-        put :update, params: { user_id: user, user: { role: Roles::OrganisationAdmin.role_name } }
+        put :update, params: { user_id: user, user: { role: Roles::OrganisationAdmin.name } }
 
-        assert_equal Roles::Normal.role_name, user.reload.role
+        assert_equal Roles::Normal.name, user.reload.role
 
         assert_select ".govuk-error-summary" do
-          assert_select "li", text: /cannot be blank for #{Roles::OrganisationAdmin.role_name.humanize} users/
+          assert_select "li", text: /cannot be blank for #{Roles::OrganisationAdmin.name.humanize} users/
         end
       end
 
       should "redisplay form if role is not valid" do
-        user = create(:user_in_organisation, role: Roles::Normal.role_name)
+        user = create(:user_in_organisation, role: Roles::Normal.name)
 
         put :update, params: { user_id: user, user: { role: "invalid-role" } }
 
         assert_template :edit
         assert_select "form[action='#{user_role_path(user)}']" do
-          assert_select "select[name='user[role]'] option", value: Roles::Normal.role_name
+          assert_select "select[name='user[role]'] option", value: Roles::Normal.name
         end
       end
 
@@ -212,9 +212,9 @@ class Users::RolesControllerTest < ActionController::TestCase
       end
 
       should "not be authorized" do
-        user = create(:user_in_organisation, role: Roles::Normal.role_name)
+        user = create(:user_in_organisation, role: Roles::Normal.name)
 
-        put :update, params: { user_id: user, user: { role: Roles::OrganisationAdmin.role_name } }
+        put :update, params: { user_id: user, user: { role: Roles::OrganisationAdmin.name } }
 
         assert_not_authorised
       end

--- a/test/controllers/users/roles_controller_test.rb
+++ b/test/controllers/users/roles_controller_test.rb
@@ -98,7 +98,7 @@ class Users::RolesControllerTest < ActionController::TestCase
 
         put :update, params: { user_id: user, user: { role: Roles::OrganisationAdmin.name } }
 
-        assert_equal Roles::OrganisationAdmin.name, user.reload.role
+        assert_equal Roles::OrganisationAdmin, user.reload.role
       end
 
       should "record account updated & role change events" do
@@ -154,7 +154,7 @@ class Users::RolesControllerTest < ActionController::TestCase
 
         put :update, params: { user_id: user, user: { role: Roles::OrganisationAdmin.name } }
 
-        assert_equal Roles::OrganisationAdmin.name, user.reload.role
+        assert_equal Roles::OrganisationAdmin, user.reload.role
       end
 
       should "not update user role if UserPolicy#assign_role? returns false" do
@@ -164,7 +164,7 @@ class Users::RolesControllerTest < ActionController::TestCase
 
         put :update, params: { user_id: user, user: { role: Roles::OrganisationAdmin.name } }
 
-        assert_equal Roles::Normal.name, user.reload.role
+        assert_equal Roles::Normal, user.reload.role
         assert_not_authorised
       end
 
@@ -173,7 +173,7 @@ class Users::RolesControllerTest < ActionController::TestCase
 
         put :update, params: { user_id: user, user: { role: Roles::OrganisationAdmin.name } }
 
-        assert_equal Roles::Normal.name, user.reload.role
+        assert_equal Roles::Normal, user.reload.role
 
         assert_select ".govuk-error-summary" do
           assert_select "li", text: /cannot be blank for #{Roles::OrganisationAdmin.name.humanize} users/

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
     password { "this 1s 4 v3333ry s3cur3 p4ssw0rd.!Z" }
     confirmed_at { 1.day.ago }
     sequence(:name) { |n| "user-name-#{n}" }
-    role { Roles::Normal.role_name }
+    role { Roles::Normal.name }
 
     after(:create) do |user, evaluator|
       if evaluator.with_permissions
@@ -82,20 +82,20 @@ FactoryBot.define do
 
   factory :superadmin_user, parent: :user do
     sequence(:email) { |n| "superadmin#{n}@example.com" }
-    role { Roles::Superadmin.role_name }
+    role { Roles::Superadmin.name }
   end
 
   factory :admin_user, parent: :user do
     sequence(:email) { |n| "admin#{n}@example.com" }
-    role { Roles::Admin.role_name }
+    role { Roles::Admin.name }
   end
 
   factory :super_organisation_admin_user, parent: :user_in_organisation do
-    role { Roles::SuperOrganisationAdmin.role_name }
+    role { Roles::SuperOrganisationAdmin.name }
   end
 
   factory :organisation_admin_user, parent: :user_in_organisation do
-    role { Roles::OrganisationAdmin.role_name }
+    role { Roles::OrganisationAdmin.name }
   end
 
   trait :invited do

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
     password { "this 1s 4 v3333ry s3cur3 p4ssw0rd.!Z" }
     confirmed_at { 1.day.ago }
     sequence(:name) { |n| "user-name-#{n}" }
-    role { "normal" }
+    role { Roles::Normal.role_name }
 
     after(:create) do |user, evaluator|
       if evaluator.with_permissions

--- a/test/helpers/users_helper_test.rb
+++ b/test/helpers/users_helper_test.rb
@@ -58,7 +58,9 @@ class UsersHelperTest < ActionView::TestCase
   context "#options_for_role_select" do
     should "return role options suitable for select component" do
       roles = [Roles::Admin.name, Roles::Normal.name]
-      stubs(:assignable_user_roles).returns(roles)
+      current_user = build(:user)
+      current_user.stubs(:manageable_roles).returns(roles)
+      stubs(:current_user).returns(current_user)
 
       options = options_for_role_select(selected: Roles::Normal.name)
 

--- a/test/helpers/users_helper_test.rb
+++ b/test/helpers/users_helper_test.rb
@@ -57,9 +57,9 @@ class UsersHelperTest < ActionView::TestCase
 
   context "#options_for_role_select" do
     should "return role options suitable for select component" do
-      roles = [Roles::Admin.name, Roles::Normal.name]
+      roles = [Roles::Admin, Roles::Normal]
       current_user = build(:user)
-      current_user.stubs(:manageable_role_names).returns(roles)
+      current_user.stubs(:manageable_roles).returns(roles)
       stubs(:current_user).returns(current_user)
 
       options = options_for_role_select(selected: Roles::Normal.name)

--- a/test/helpers/users_helper_test.rb
+++ b/test/helpers/users_helper_test.rb
@@ -57,10 +57,10 @@ class UsersHelperTest < ActionView::TestCase
 
   context "#options_for_role_select" do
     should "return role options suitable for select component" do
-      roles = [Roles::Admin.role_name, Roles::Normal.role_name]
+      roles = [Roles::Admin.name, Roles::Normal.name]
       stubs(:assignable_user_roles).returns(roles)
 
-      options = options_for_role_select(selected: Roles::Normal.role_name)
+      options = options_for_role_select(selected: Roles::Normal.name)
 
       expected_options = [{ text: "Admin", value: "admin" }, { text: "Normal", value: "normal", selected: true }]
       assert_equal expected_options, options

--- a/test/helpers/users_helper_test.rb
+++ b/test/helpers/users_helper_test.rb
@@ -59,7 +59,7 @@ class UsersHelperTest < ActionView::TestCase
     should "return role options suitable for select component" do
       roles = [Roles::Admin.name, Roles::Normal.name]
       current_user = build(:user)
-      current_user.stubs(:manageable_roles).returns(roles)
+      current_user.stubs(:manageable_role_names).returns(roles)
       stubs(:current_user).returns(current_user)
 
       options = options_for_role_select(selected: Roles::Normal.name)

--- a/test/integration/change_user_role_test.rb
+++ b/test/integration/change_user_role_test.rb
@@ -31,7 +31,7 @@ class ChangeUserRoleTest < ActionDispatch::IntegrationTest
 
       assert page.has_no_select?("Role")
 
-      assert page.has_text? "This user's role is set to #{user.role.humanize}. They are currently exempted from 2-step verification, meaning that their role cannot be changed as admins are required to have 2-step verification."
+      assert page.has_text? "This user's role is set to #{user.role_display_name}. They are currently exempted from 2-step verification, meaning that their role cannot be changed as admins are required to have 2-step verification."
     end
   end
 

--- a/test/integration/inviting_users_test.rb
+++ b/test/integration/inviting_users_test.rb
@@ -74,10 +74,10 @@ class InvitingUsersTest < ActionDispatch::IntegrationTest
           check "Mandate 2-step verification for this user"
           click_button "Update user"
 
-          assert_not_nil User.where(email: "fred@example.com", role: "normal").last
+          assert_not_nil User.where(email: "fred@example.com", role: Roles::Normal.role_name).last
           assert_equal "fred@example.com", last_email.to[0]
           assert_match "Make your Signon account more secure", last_email.subject
-          assert User.where(email: "fred@example.com", role: "normal").last.require_2sv?
+          assert User.where(email: "fred@example.com", role: Roles::Normal.role_name).last.require_2sv?
         end
       end
 
@@ -92,10 +92,10 @@ class InvitingUsersTest < ActionDispatch::IntegrationTest
           assert has_field?("Mandate 2-step verification for this user")
           click_button "Update user"
 
-          assert_not_nil User.where(email: "fred@example.com", role: "normal").last
+          assert_not_nil User.where(email: "fred@example.com", role: Roles::Normal.role_name).last
           assert_equal "fred@example.com", last_email.to[0]
           assert_match I18n.t("devise.mailer.invitation_instructions.subject"), last_email.subject
-          assert_equal false, User.where(email: "fred@example.com", role: "normal").last.require_2sv?
+          assert_equal false, User.where(email: "fred@example.com", role: Roles::Normal.role_name).last.require_2sv?
         end
       end
 
@@ -112,10 +112,10 @@ class InvitingUsersTest < ActionDispatch::IntegrationTest
             select "Test Organisation with 2SV", from: "Organisation"
             click_button "Create user and send email"
 
-            assert_not_nil User.where(email: "fred@example.com", role: "normal").last
+            assert_not_nil User.where(email: "fred@example.com", role: Roles::Normal.role_name).last
             assert_equal "fred@example.com", last_email.to[0]
             assert_match I18n.t("devise.mailer.invitation_instructions.subject"), last_email.subject
-            assert User.where(email: "fred@example.com", role: "normal").last.require_2sv?
+            assert User.where(email: "fred@example.com", role: Roles::Normal.role_name).last.require_2sv?
           end
         end
       end

--- a/test/integration/inviting_users_test.rb
+++ b/test/integration/inviting_users_test.rb
@@ -74,10 +74,10 @@ class InvitingUsersTest < ActionDispatch::IntegrationTest
           check "Mandate 2-step verification for this user"
           click_button "Update user"
 
-          assert_not_nil User.where(email: "fred@example.com", role: Roles::Normal.role_name).last
+          assert_not_nil User.where(email: "fred@example.com", role: Roles::Normal.name).last
           assert_equal "fred@example.com", last_email.to[0]
           assert_match "Make your Signon account more secure", last_email.subject
-          assert User.where(email: "fred@example.com", role: Roles::Normal.role_name).last.require_2sv?
+          assert User.where(email: "fred@example.com", role: Roles::Normal.name).last.require_2sv?
         end
       end
 
@@ -92,10 +92,10 @@ class InvitingUsersTest < ActionDispatch::IntegrationTest
           assert has_field?("Mandate 2-step verification for this user")
           click_button "Update user"
 
-          assert_not_nil User.where(email: "fred@example.com", role: Roles::Normal.role_name).last
+          assert_not_nil User.where(email: "fred@example.com", role: Roles::Normal.name).last
           assert_equal "fred@example.com", last_email.to[0]
           assert_match I18n.t("devise.mailer.invitation_instructions.subject"), last_email.subject
-          assert_equal false, User.where(email: "fred@example.com", role: Roles::Normal.role_name).last.require_2sv?
+          assert_equal false, User.where(email: "fred@example.com", role: Roles::Normal.name).last.require_2sv?
         end
       end
 
@@ -112,10 +112,10 @@ class InvitingUsersTest < ActionDispatch::IntegrationTest
             select "Test Organisation with 2SV", from: "Organisation"
             click_button "Create user and send email"
 
-            assert_not_nil User.where(email: "fred@example.com", role: Roles::Normal.role_name).last
+            assert_not_nil User.where(email: "fred@example.com", role: Roles::Normal.name).last
             assert_equal "fred@example.com", last_email.to[0]
             assert_match I18n.t("devise.mailer.invitation_instructions.subject"), last_email.subject
-            assert User.where(email: "fred@example.com", role: Roles::Normal.role_name).last.require_2sv?
+            assert User.where(email: "fred@example.com", role: Roles::Normal.name).last.require_2sv?
           end
         end
       end
@@ -251,10 +251,10 @@ class InvitingUsersTest < ActionDispatch::IntegrationTest
           select "Test Organisation without 2SV", from: "Organisation"
           click_button "Create user and send email"
 
-          assert_not_nil User.where(email: "fred@example.com", role: Roles::Superadmin.role_name).last
+          assert_not_nil User.where(email: "fred@example.com", role: Roles::Superadmin.name).last
           assert_equal "fred@example.com", last_email.to[0]
           assert_match I18n.t("devise.mailer.invitation_instructions.subject"), last_email.subject
-          assert User.where(email: "fred@example.com", role: Roles::Superadmin.role_name).last.require_2sv?
+          assert User.where(email: "fred@example.com", role: Roles::Superadmin.name).last.require_2sv?
         end
       end
 
@@ -267,10 +267,10 @@ class InvitingUsersTest < ActionDispatch::IntegrationTest
           select "Test Organisation without 2SV", from: "Organisation"
           click_button "Create user and send email"
 
-          assert_not_nil User.where(email: "fred@example.com", role: Roles::Admin.role_name).last
+          assert_not_nil User.where(email: "fred@example.com", role: Roles::Admin.name).last
           assert_equal "fred@example.com", last_email.to[0]
           assert_match I18n.t("devise.mailer.invitation_instructions.subject"), last_email.subject
-          assert User.where(email: "fred@example.com", role: Roles::Admin.role_name).last.require_2sv?
+          assert User.where(email: "fred@example.com", role: Roles::Admin.name).last.require_2sv?
         end
       end
     end
@@ -289,10 +289,10 @@ class InvitingUsersTest < ActionDispatch::IntegrationTest
           select "Test Organisation without 2SV", from: "Organisation"
           click_button "Create user and send email"
 
-          assert_not_nil User.where(email: "fred@example.com", role: Roles::Superadmin.role_name).last
+          assert_not_nil User.where(email: "fred@example.com", role: Roles::Superadmin.name).last
           assert_equal "fred@example.com", last_email.to[0]
           assert_match I18n.t("devise.mailer.invitation_instructions.subject"), last_email.subject
-          assert User.where(email: "fred@example.com", role: Roles::Superadmin.role_name).last.require_2sv?
+          assert User.where(email: "fred@example.com", role: Roles::Superadmin.name).last.require_2sv?
         end
       end
 
@@ -305,10 +305,10 @@ class InvitingUsersTest < ActionDispatch::IntegrationTest
           select "Test Organisation without 2SV", from: "Organisation"
           click_button "Create user and send email"
 
-          assert_not_nil User.where(email: "fred@example.com", role: Roles::Admin.role_name).last
+          assert_not_nil User.where(email: "fred@example.com", role: Roles::Admin.name).last
           assert_equal "fred@example.com", last_email.to[0]
           assert_match I18n.t("devise.mailer.invitation_instructions.subject"), last_email.subject
-          assert User.where(email: "fred@example.com", role: Roles::Admin.role_name).last.require_2sv?
+          assert User.where(email: "fred@example.com", role: Roles::Admin.name).last.require_2sv?
         end
       end
     end

--- a/test/lib/roles_test.rb
+++ b/test/lib/roles_test.rb
@@ -22,7 +22,7 @@ class RolesTest < ActiveSupport::TestCase
     end
   end
 
-  context ".admin_role_classes" do
+  context "Roles.admin" do
     should "only include admin role classes" do
       expected_role_classes = [
         Roles::Admin,
@@ -31,7 +31,7 @@ class RolesTest < ActiveSupport::TestCase
         Roles::SuperOrganisationAdmin,
       ]
 
-      assert_same_elements expected_role_classes, Subject.admin_role_classes
+      assert_same_elements expected_role_classes, Roles.admin
     end
   end
 

--- a/test/lib/roles_test.rb
+++ b/test/lib/roles_test.rb
@@ -35,7 +35,7 @@ class RolesTest < ActiveSupport::TestCase
     end
   end
 
-  context ".admin_roles" do
+  context "Roles.admin_names" do
     should "only include admin role names" do
       expected_role_names = [
         Roles::Admin.role_name,
@@ -44,7 +44,7 @@ class RolesTest < ActiveSupport::TestCase
         Roles::SuperOrganisationAdmin.role_name,
       ]
 
-      assert_same_elements expected_role_names, Subject.admin_roles
+      assert_same_elements expected_role_names, Roles.admin_names
     end
   end
 

--- a/test/lib/roles_test.rb
+++ b/test/lib/roles_test.rb
@@ -36,20 +36,20 @@ class RolesTest < ActiveSupport::TestCase
     end
   end
 
-  Roles.names.each do |role_name|
-    context "##{role_name}?" do
+  Roles.all.each do |role| # rubocop:disable Rails/FindEach
+    context "##{role.name}?" do
       setup do
         @subject = Subject.new
       end
 
-      should "return true if subject has the #{role_name} role" do
-        @subject.role = role_name
-        assert @subject.send("#{role_name}?")
+      should "return true if subject has the #{role.name} role" do
+        @subject.role = role.name
+        assert @subject.send("#{role.name}?")
       end
 
-      should "return false if subject does not have #{role_name} role" do
-        @subject.role = "not-#{role_name}"
-        assert_not @subject.send("#{role_name}?")
+      should "return false if subject does not have #{role.name} role" do
+        @subject.role = "not-#{role.name}"
+        assert_not @subject.send("#{role.name}?")
       end
     end
   end

--- a/test/lib/roles_test.rb
+++ b/test/lib/roles_test.rb
@@ -60,19 +60,19 @@ class RolesTest < ActiveSupport::TestCase
     end
 
     should "be true if the role is superadmin" do
-      @subject.role = Roles::Superadmin.role_name
+      @subject.role = Roles::Superadmin.name
       assert @subject.govuk_admin?
     end
 
     should "be true if role is admin" do
-      @subject.role = Roles::Admin.role_name
+      @subject.role = Roles::Admin.name
       assert @subject.govuk_admin?
     end
 
     should "be false if role is anything else" do
       other_role_classes = Roles.all - [Roles::Superadmin, Roles::Admin]
       other_role_classes.each do |role_class|
-        @subject.role = role_class.role_name
+        @subject.role = role_class.name
         assert_not @subject.govuk_admin?
       end
     end
@@ -84,19 +84,19 @@ class RolesTest < ActiveSupport::TestCase
     end
 
     should "be true if the role is super_organisation_admin" do
-      @subject.role = Roles::SuperOrganisationAdmin.role_name
+      @subject.role = Roles::SuperOrganisationAdmin.name
       assert @subject.publishing_manager?
     end
 
     should "be true if role is organisation_admin" do
-      @subject.role = Roles::OrganisationAdmin.role_name
+      @subject.role = Roles::OrganisationAdmin.name
       assert @subject.publishing_manager?
     end
 
     should "be false if role is anything else" do
       other_role_classes = Roles.all - [Roles::SuperOrganisationAdmin, Roles::OrganisationAdmin]
       other_role_classes.each do |role_class|
-        @subject.role = role_class.role_name
+        @subject.role = role_class.name
         assert_not @subject.publishing_manager?
       end
     end

--- a/test/lib/roles_test.rb
+++ b/test/lib/roles_test.rb
@@ -8,7 +8,7 @@ class RolesTest < ActiveSupport::TestCase
     attr_accessor :role
   end
 
-  context ".role_classes" do
+  context "Roles.all" do
     should "include all role classes" do
       expected_role_classes = [
         Roles::Normal,
@@ -18,7 +18,7 @@ class RolesTest < ActiveSupport::TestCase
         Roles::SuperOrganisationAdmin,
       ]
 
-      assert_same_elements expected_role_classes, Subject.role_classes
+      assert_same_elements expected_role_classes, Roles.all
     end
   end
 
@@ -96,7 +96,7 @@ class RolesTest < ActiveSupport::TestCase
     end
 
     should "be false if role is anything else" do
-      other_role_classes = Subject.role_classes - [Roles::Superadmin, Roles::Admin]
+      other_role_classes = Roles.all - [Roles::Superadmin, Roles::Admin]
       other_role_classes.each do |role_class|
         @subject.role = role_class.role_name
         assert_not @subject.govuk_admin?
@@ -120,7 +120,7 @@ class RolesTest < ActiveSupport::TestCase
     end
 
     should "be false if role is anything else" do
-      other_role_classes = Subject.role_classes - [Roles::SuperOrganisationAdmin, Roles::OrganisationAdmin]
+      other_role_classes = Roles.all - [Roles::SuperOrganisationAdmin, Roles::OrganisationAdmin]
       other_role_classes.each do |role_class|
         @subject.role = role_class.role_name
         assert_not @subject.publishing_manager?

--- a/test/lib/roles_test.rb
+++ b/test/lib/roles_test.rb
@@ -22,32 +22,6 @@ class RolesTest < ActiveSupport::TestCase
     end
   end
 
-  context "Roles.admin" do
-    should "only include admin role classes" do
-      expected_role_classes = [
-        Roles::Admin,
-        Roles::Superadmin,
-        Roles::OrganisationAdmin,
-        Roles::SuperOrganisationAdmin,
-      ]
-
-      assert_same_elements expected_role_classes, Roles.admin
-    end
-  end
-
-  context "Roles.admin_names" do
-    should "only include admin role names" do
-      expected_role_names = [
-        Roles::Admin.role_name,
-        Roles::Superadmin.role_name,
-        Roles::OrganisationAdmin.role_name,
-        Roles::SuperOrganisationAdmin.role_name,
-      ]
-
-      assert_same_elements expected_role_names, Roles.admin_names
-    end
-  end
-
   context "Roles.names" do
     should "order roles by their level" do
       expected_ordered_roles = %w[

--- a/test/lib/roles_test.rb
+++ b/test/lib/roles_test.rb
@@ -30,12 +30,12 @@ class RolesTest < ActiveSupport::TestCase
 
       should "return true if subject has the #{role.name} role" do
         @subject.role = role
-        assert @subject.send("#{role.name}?")
+        assert @subject.public_send("#{role.name}?")
       end
 
       should "return false if subject does not have #{role.name} role" do
         @subject.role = Roles::Base
-        assert_not @subject.send("#{role.name}?")
+        assert_not @subject.public_send("#{role.name}?")
       end
     end
   end

--- a/test/lib/roles_test.rb
+++ b/test/lib/roles_test.rb
@@ -22,20 +22,6 @@ class RolesTest < ActiveSupport::TestCase
     end
   end
 
-  context "Roles.names" do
-    should "order roles by their level" do
-      expected_ordered_roles = %w[
-        superadmin
-        admin
-        super_organisation_admin
-        organisation_admin
-        normal
-      ]
-
-      assert_equal expected_ordered_roles, Roles.names
-    end
-  end
-
   Roles.all.each do |role| # rubocop:disable Rails/FindEach
     context "##{role.name}?" do
       setup do

--- a/test/lib/roles_test.rb
+++ b/test/lib/roles_test.rb
@@ -48,7 +48,7 @@ class RolesTest < ActiveSupport::TestCase
     end
   end
 
-  context ".roles" do
+  context "Roles.names" do
     should "order roles by their level" do
       expected_ordered_roles = %w[
         superadmin
@@ -58,24 +58,24 @@ class RolesTest < ActiveSupport::TestCase
         normal
       ]
 
-      assert_equal expected_ordered_roles, Subject.roles
+      assert_equal expected_ordered_roles, Roles.names
     end
   end
 
-  Subject.roles.each do |role|
-    context "##{role}?" do
+  Roles.names.each do |role_name|
+    context "##{role_name}?" do
       setup do
         @subject = Subject.new
       end
 
-      should "return true if subject has the #{role} role" do
-        @subject.role = role
-        assert @subject.send("#{role}?")
+      should "return true if subject has the #{role_name} role" do
+        @subject.role = role_name
+        assert @subject.send("#{role_name}?")
       end
 
-      should "return false if subject does not have #{role} role" do
-        @subject.role = "not-#{role}"
-        assert_not @subject.send("#{role}?")
+      should "return false if subject does not have #{role_name} role" do
+        @subject.role = "not-#{role_name}"
+        assert_not @subject.send("#{role_name}?")
       end
     end
   end

--- a/test/lib/roles_test.rb
+++ b/test/lib/roles_test.rb
@@ -43,12 +43,12 @@ class RolesTest < ActiveSupport::TestCase
       end
 
       should "return true if subject has the #{role.name} role" do
-        @subject.role = role.name
+        @subject.role = role
         assert @subject.send("#{role.name}?")
       end
 
       should "return false if subject does not have #{role.name} role" do
-        @subject.role = "not-#{role.name}"
+        @subject.role = Roles::Base
         assert_not @subject.send("#{role.name}?")
       end
     end
@@ -60,19 +60,19 @@ class RolesTest < ActiveSupport::TestCase
     end
 
     should "be true if the role is superadmin" do
-      @subject.role = Roles::Superadmin.name
+      @subject.role = Roles::Superadmin
       assert @subject.govuk_admin?
     end
 
     should "be true if role is admin" do
-      @subject.role = Roles::Admin.name
+      @subject.role = Roles::Admin
       assert @subject.govuk_admin?
     end
 
     should "be false if role is anything else" do
       other_role_classes = Roles.all - [Roles::Superadmin, Roles::Admin]
       other_role_classes.each do |role_class|
-        @subject.role = role_class.name
+        @subject.role = role_class
         assert_not @subject.govuk_admin?
       end
     end
@@ -84,19 +84,19 @@ class RolesTest < ActiveSupport::TestCase
     end
 
     should "be true if the role is super_organisation_admin" do
-      @subject.role = Roles::SuperOrganisationAdmin.name
+      @subject.role = Roles::SuperOrganisationAdmin
       assert @subject.publishing_manager?
     end
 
     should "be true if role is organisation_admin" do
-      @subject.role = Roles::OrganisationAdmin.name
+      @subject.role = Roles::OrganisationAdmin
       assert @subject.publishing_manager?
     end
 
     should "be false if role is anything else" do
       other_role_classes = Roles.all - [Roles::SuperOrganisationAdmin, Roles::OrganisationAdmin]
       other_role_classes.each do |role_class|
-        @subject.role = role_class.name
+        @subject.role = role_class
         assert_not @subject.publishing_manager?
       end
     end

--- a/test/lib/tasks/permissions_promoter_test.rb
+++ b/test/lib/tasks/permissions_promoter_test.rb
@@ -36,7 +36,7 @@ class PermissionsPromoterTest < ActiveSupport::TestCase
 
     @task.invoke
 
-    assert non_gds_user.reload.role == "normal"
+    assert non_gds_user.reload.normal?
   end
 
   should "not update a non-GDS user who already has an admin role" do
@@ -53,7 +53,7 @@ class PermissionsPromoterTest < ActiveSupport::TestCase
 
     @task.invoke
 
-    assert user.reload.role == "normal"
+    assert user.reload.normal?
   end
 
   should "not update GDS users" do

--- a/test/lib/tasks/permissions_promoter_test.rb
+++ b/test/lib/tasks/permissions_promoter_test.rb
@@ -44,7 +44,7 @@ class PermissionsPromoterTest < ActiveSupport::TestCase
 
     @task.invoke
 
-    assert admin_user.reload.role == Roles::Admin.role_name
+    assert admin_user.reload.admin?
   end
 
   should "not update a non-GDS user who is suspended" do

--- a/test/lib/tasks/permissions_promoter_test.rb
+++ b/test/lib/tasks/permissions_promoter_test.rb
@@ -25,8 +25,8 @@ class PermissionsPromoterTest < ActiveSupport::TestCase
 
       users = [first_non_gds_user, second_non_gds_user].each(&:reload)
 
-      assert users.all? do |user|
-        user.role == Roles::OrganisationAdmin.role_name
+      users.each do |user|
+        assert user.role == Roles::OrganisationAdmin.role_name
       end
     end
   end

--- a/test/lib/tasks/permissions_promoter_test.rb
+++ b/test/lib/tasks/permissions_promoter_test.rb
@@ -26,7 +26,7 @@ class PermissionsPromoterTest < ActiveSupport::TestCase
       users = [first_non_gds_user, second_non_gds_user].each(&:reload)
 
       users.each do |user|
-        assert user.role == Roles::OrganisationAdmin.role_name
+        assert user.organisation_admin?
       end
     end
   end

--- a/test/lib/tasks/permissions_promoter_test.rb
+++ b/test/lib/tasks/permissions_promoter_test.rb
@@ -23,11 +23,8 @@ class PermissionsPromoterTest < ActiveSupport::TestCase
 
       @task.invoke
 
-      users = [first_non_gds_user, second_non_gds_user].each(&:reload)
-
-      users.each do |user|
-        assert user.organisation_admin?
-      end
+      assert first_non_gds_user.reload.organisation_admin?
+      assert second_non_gds_user.reload.organisation_admin?
     end
   end
 

--- a/test/lib/tasks/users_test.rb
+++ b/test/lib/tasks/users_test.rb
@@ -75,7 +75,7 @@ class UsersTaskTest < ActiveSupport::TestCase
     end
 
     should "not require 2SV for normal user" do
-      user = create(:user, role: Roles::Normal.role_name)
+      user = create(:user, role: Roles::Normal.name)
 
       @task.invoke
 

--- a/test/lib/tasks/users_test.rb
+++ b/test/lib/tasks/users_test.rb
@@ -75,7 +75,7 @@ class UsersTaskTest < ActiveSupport::TestCase
     end
 
     should "not require 2SV for normal user" do
-      user = create(:user, role: "normal")
+      user = create(:user, role: Roles::Normal.role_name)
 
       @task.invoke
 

--- a/test/models/event_log_test.rb
+++ b/test/models/event_log_test.rb
@@ -70,7 +70,7 @@ class EventLogTest < ActiveSupport::TestCase
   test "records role changes with the details of the roles" do
     user = create(:user, email: "new@example.com")
     admin = create(:admin_user)
-    event_log = EventLog.record_role_change(user, Roles::Admin.role_name, Roles::Superadmin.role_name, admin)
+    event_log = EventLog.record_role_change(user, Roles::Admin.name, Roles::Superadmin.name, admin)
 
     assert_equal "from admin to superadmin", event_log.trailing_message
   end

--- a/test/models/legacy_users_filter_test.rb
+++ b/test/models/legacy_users_filter_test.rb
@@ -41,9 +41,9 @@ class LegacyUsersFilterTest < ActiveSupport::TestCase
     end
 
     should "transform role legacy filter -> roles array" do
-      filter = LegacyUsersFilter.new({ role: Roles::Admin.role_name })
+      filter = LegacyUsersFilter.new({ role: Roles::Admin.name })
 
-      assert_equal({ roles: [Roles::Admin.role_name] }, filter.options)
+      assert_equal({ roles: [Roles::Admin.name] }, filter.options)
     end
 
     should "transform organisation legacy filter -> organisations array" do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -877,13 +877,13 @@ class UserTest < ActiveSupport::TestCase
     end
   end
 
-  context "#role_class" do
+  context "#role" do
     should "return the role class" do
-      assert_equal Roles::Normal, build(:user).role_class
-      assert_equal Roles::OrganisationAdmin, build(:organisation_admin_user).role_class
-      assert_equal Roles::SuperOrganisationAdmin, build(:super_organisation_admin_user).role_class
-      assert_equal Roles::Admin, build(:admin_user).role_class
-      assert_equal Roles::Superadmin, build(:superadmin_user).role_class
+      assert_equal Roles::Normal, build(:user).role
+      assert_equal Roles::OrganisationAdmin, build(:organisation_admin_user).role
+      assert_equal Roles::SuperOrganisationAdmin, build(:super_organisation_admin_user).role
+      assert_equal Roles::Admin, build(:admin_user).role
+      assert_equal Roles::Superadmin, build(:superadmin_user).role
     end
   end
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -430,7 +430,7 @@ class UserTest < ActiveSupport::TestCase
           user = build(:admin_user, reason_for_2sv_exemption: "reason")
 
           assert_not user.valid?
-          assert_includes user.errors[:reason_for_2sv_exemption], "admin users cannot be exempted from 2SV. Remove the user's exemption to change their role."
+          assert_includes user.errors[:reason_for_2sv_exemption], "cannot be blank for Admin users. Remove the user's exemption to change their role."
         end
       end
     end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -100,7 +100,7 @@ class UserTest < ActiveSupport::TestCase
 
     should "remain true when an admin is demoted" do
       user = create(:admin_user)
-      user.update!(role: "normal")
+      user.update!(role: Roles::Normal.role_name)
       assert user.require_2sv?
     end
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -887,13 +887,13 @@ class UserTest < ActiveSupport::TestCase
     end
   end
 
-  context "#manageable_roles" do
+  context "#manageable_role_names" do
     should "return names of roles that the user is allowed to manage" do
-      assert_equal %w[], build(:user).manageable_roles
-      assert_equal %w[normal organisation_admin], build(:organisation_admin_user).manageable_roles
-      assert_equal %w[normal organisation_admin super_organisation_admin], build(:super_organisation_admin_user).manageable_roles
-      assert_equal %w[normal organisation_admin super_organisation_admin admin], build(:admin_user).manageable_roles
-      assert_equal %w[normal organisation_admin super_organisation_admin admin superadmin], build(:superadmin_user).manageable_roles
+      assert_equal %w[], build(:user).manageable_role_names
+      assert_equal %w[normal organisation_admin], build(:organisation_admin_user).manageable_role_names
+      assert_equal %w[normal organisation_admin super_organisation_admin], build(:super_organisation_admin_user).manageable_role_names
+      assert_equal %w[normal organisation_admin super_organisation_admin admin], build(:admin_user).manageable_role_names
+      assert_equal %w[normal organisation_admin super_organisation_admin admin superadmin], build(:superadmin_user).manageable_role_names
     end
   end
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -887,16 +887,6 @@ class UserTest < ActiveSupport::TestCase
     end
   end
 
-  context "#manageable_role_names" do
-    should "return names of roles that the user is allowed to manage" do
-      assert_equal %w[], build(:user).manageable_role_names
-      assert_equal %w[normal organisation_admin], build(:organisation_admin_user).manageable_role_names
-      assert_equal %w[normal organisation_admin super_organisation_admin], build(:super_organisation_admin_user).manageable_role_names
-      assert_equal %w[normal organisation_admin super_organisation_admin admin], build(:admin_user).manageable_role_names
-      assert_equal %w[normal organisation_admin super_organisation_admin admin superadmin], build(:superadmin_user).manageable_role_names
-    end
-  end
-
   context "#manageable_roles" do
     should "return roles that the user is allowed to manage" do
       assert_equal [], build(:user).manageable_roles

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -897,6 +897,16 @@ class UserTest < ActiveSupport::TestCase
     end
   end
 
+  context "#manageable_roles" do
+    should "return roles that the user is allowed to manage" do
+      assert_equal [], build(:user).manageable_roles
+      assert_equal [Roles::Normal, Roles::OrganisationAdmin], build(:organisation_admin_user).manageable_roles
+      assert_equal [Roles::Normal, Roles::OrganisationAdmin, Roles::SuperOrganisationAdmin], build(:super_organisation_admin_user).manageable_roles
+      assert_equal [Roles::Normal, Roles::OrganisationAdmin, Roles::SuperOrganisationAdmin, Roles::Admin], build(:admin_user).manageable_roles
+      assert_equal [Roles::Normal, Roles::OrganisationAdmin, Roles::SuperOrganisationAdmin, Roles::Admin, Roles::Superadmin], build(:superadmin_user).manageable_roles
+    end
+  end
+
   context "#can_manage?" do
     should "indicate whether user is allowed to manage another user" do
       assert_not build(:user).can_manage?(build(:user))

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -82,37 +82,37 @@ class UserTest < ActiveSupport::TestCase
 
     should "default to true when a user is promoted to admin" do
       user = create(:user)
-      user.update!(role: Roles::Admin.role_name)
+      user.update!(role: Roles::Admin.name)
       assert user.require_2sv?
     end
 
     should "default to true when a user is promoted to superadmin" do
       user = create(:user)
-      user.update!(role: Roles::Superadmin.role_name)
+      user.update!(role: Roles::Superadmin.name)
       assert user.require_2sv?
     end
 
     should "default to true when an admin is promoted to superadmin" do
       user = create(:admin_user)
-      user.update!(role: Roles::Superadmin.role_name)
+      user.update!(role: Roles::Superadmin.name)
       assert user.require_2sv?
     end
 
     should "remain true when an admin is demoted" do
       user = create(:admin_user)
-      user.update!(role: Roles::Normal.role_name)
+      user.update!(role: Roles::Normal.name)
       assert user.require_2sv?
     end
 
     should "default to true when a user is promoted to organisation admin" do
       user = create(:user_in_organisation)
-      user.update!(role: Roles::OrganisationAdmin.role_name)
+      user.update!(role: Roles::OrganisationAdmin.name)
       assert user.require_2sv?
     end
 
     should "default to true when a user is promoted to super organisation admin" do
       user = create(:user_in_organisation)
-      user.update!(role: Roles::SuperOrganisationAdmin.role_name)
+      user.update!(role: Roles::SuperOrganisationAdmin.name)
       assert user.require_2sv?
     end
 
@@ -171,7 +171,7 @@ class UserTest < ActiveSupport::TestCase
 
       context "when promoting a user" do
         should "be true" do
-          @user.update!(role: Roles::Admin.role_name)
+          @user.update!(role: Roles::Admin.name)
 
           assert @user.send_two_step_mandated_notification?
         end
@@ -557,14 +557,14 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test "organisation admin must belong to an organisation" do
-    user = build(:user, role: Roles::OrganisationAdmin.role_name, organisation_id: nil)
+    user = build(:user, role: Roles::OrganisationAdmin.name, organisation_id: nil)
 
     assert_not user.valid?
     assert_equal "can't be 'None' for Organisation admin", user.errors[:organisation_id].first
   end
 
   test "super organisation admin must belong to an organisation" do
-    user = build(:user, role: Roles::SuperOrganisationAdmin.role_name, organisation_id: nil)
+    user = build(:user, role: Roles::SuperOrganisationAdmin.name, organisation_id: nil)
 
     assert_not user.valid?
     assert_equal "can't be 'None' for Super organisation admin", user.errors[:organisation_id].first

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -887,6 +887,20 @@ class UserTest < ActiveSupport::TestCase
     end
   end
 
+  context "#role_name" do
+    should "return the role name" do
+      assert_equal Roles::Normal.name, build(:user).role_name
+      assert_equal Roles::OrganisationAdmin.name, build(:organisation_admin_user).role_name
+      assert_equal Roles::SuperOrganisationAdmin.name, build(:super_organisation_admin_user).role_name
+      assert_equal Roles::Admin.name, build(:admin_user).role_name
+      assert_equal Roles::Superadmin.name, build(:superadmin_user).role_name
+    end
+
+    should "return nil if the role isn't set" do
+      assert_nil build(:user, role: nil).role_name
+    end
+  end
+
   context "#manageable_roles" do
     should "return roles that the user is allowed to manage" do
       assert_equal [], build(:user).manageable_roles

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -430,6 +430,7 @@ class UserTest < ActiveSupport::TestCase
           user = build(:admin_user, reason_for_2sv_exemption: "reason")
 
           assert_not user.valid?
+          assert_includes user.errors[:reason_for_2sv_exemption], "admin users cannot be exempted from 2SV. Remove the user's exemption to change their role."
         end
       end
     end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -892,7 +892,7 @@ class UserTest < ActiveSupport::TestCase
       assert_equal %w[normal organisation_admin], build(:organisation_admin_user).manageable_roles
       assert_equal %w[normal organisation_admin super_organisation_admin], build(:super_organisation_admin_user).manageable_roles
       assert_equal %w[normal organisation_admin super_organisation_admin admin], build(:admin_user).manageable_roles
-      assert_equal User.roles, build(:superadmin_user).manageable_roles
+      assert_equal %w[normal organisation_admin super_organisation_admin admin superadmin], build(:superadmin_user).manageable_roles
     end
   end
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -559,14 +559,14 @@ class UserTest < ActiveSupport::TestCase
     user = build(:user, role: Roles::OrganisationAdmin.role_name, organisation_id: nil)
 
     assert_not user.valid?
-    assert_equal "can't be 'None' for Organisation Admin", user.errors[:organisation_id].first
+    assert_equal "can't be 'None' for Organisation admin", user.errors[:organisation_id].first
   end
 
   test "super organisation admin must belong to an organisation" do
     user = build(:user, role: Roles::SuperOrganisationAdmin.role_name, organisation_id: nil)
 
     assert_not user.valid?
-    assert_equal "can't be 'None' for Super Organisation Admin", user.errors[:organisation_id].first
+    assert_equal "can't be 'None' for Super organisation admin", user.errors[:organisation_id].first
   end
 
   test "it doesn't migrate password unless correct one given" do

--- a/test/models/users_filter_test.rb
+++ b/test/models/users_filter_test.rb
@@ -146,7 +146,7 @@ class UsersFilterTest < ActiveSupport::TestCase
   context "#role_option_select_options" do
     context "when no roles are selected" do
       should "return options for roles manageable by the current user with none checked" do
-        @current_user.stubs(:manageable_roles).returns(%w[normal organisation_admin])
+        @current_user.stubs(:manageable_role_names).returns(%w[normal organisation_admin])
 
         filter = UsersFilter.new(User.all, @current_user, {})
         options = filter.role_option_select_options
@@ -161,7 +161,7 @@ class UsersFilterTest < ActiveSupport::TestCase
 
     context "when some roles are selected" do
       should "return options for roles manageable by the current user with relevant options checked" do
-        @current_user.stubs(:manageable_roles).returns(%w[normal organisation_admin super_organisation_admin])
+        @current_user.stubs(:manageable_role_names).returns(%w[normal organisation_admin super_organisation_admin])
 
         filter = UsersFilter.new(User.all, @current_user, roles: %w[normal super_organisation_admin])
         options = filter.role_option_select_options

--- a/test/models/users_filter_test.rb
+++ b/test/models/users_filter_test.rb
@@ -146,7 +146,7 @@ class UsersFilterTest < ActiveSupport::TestCase
   context "#role_option_select_options" do
     context "when no roles are selected" do
       should "return options for roles manageable by the current user with none checked" do
-        @current_user.stubs(:manageable_role_names).returns(%w[normal organisation_admin])
+        @current_user.stubs(:manageable_roles).returns([Roles::Normal, Roles::OrganisationAdmin])
 
         filter = UsersFilter.new(User.all, @current_user, {})
         options = filter.role_option_select_options
@@ -161,7 +161,7 @@ class UsersFilterTest < ActiveSupport::TestCase
 
     context "when some roles are selected" do
       should "return options for roles manageable by the current user with relevant options checked" do
-        @current_user.stubs(:manageable_role_names).returns(%w[normal organisation_admin super_organisation_admin])
+        @current_user.stubs(:manageable_roles).returns([Roles::Normal, Roles::OrganisationAdmin, Roles::SuperOrganisationAdmin])
 
         filter = UsersFilter.new(User.all, @current_user, roles: %w[normal super_organisation_admin])
         options = filter.role_option_select_options

--- a/test/policies/organisation_policy_test.rb
+++ b/test/policies/organisation_policy_test.rb
@@ -28,8 +28,8 @@ class OrganisationPolicyTest < ActiveSupport::TestCase
 
   context "can_assign" do
     should "allow superadmins and admins to assign a user to any organisation" do
-      assert permit?(create(:user_in_organisation, role: Roles::Superadmin.role_name), build(:organisation), :can_assign)
-      assert permit?(create(:user_in_organisation, role: Roles::Admin.role_name), build(:organisation), :can_assign)
+      assert permit?(create(:user_in_organisation, role: Roles::Superadmin.name), build(:organisation), :can_assign)
+      assert permit?(create(:user_in_organisation, role: Roles::Admin.name), build(:organisation), :can_assign)
     end
 
     should "forbid for super organisation admins" do


### PR DESCRIPTION
We were frequently reaching for the Role name (e.g. "admin") to decide whether a User with that role could do something. This PR replaces these string comparisons by using the `Roles::<class>` objects to encapsulate behaviour associated with each role.

Summary of the commits:

- Replace hardcoded role strings (e.g. "normal") with the name defined in the relevant `Roles::<class>`
- Use role predicate methods (e.g. `User#admin?`) where possible
- Avoid hardcoding role strings in `Roles::<class>.manageable_roles`
- Move instance methods defined in `Roles::ClassMethods` to module methods in `Roles` allowing me to remove `Roles::ClassMethods`.
- Add `Roles.find` to allow us to lookup a role based on its name
- Add `Roles::<class>.require_2sv?` to make roles responsible for knowing whether they require 2sv
- Add `Roles::<class>.display_name` to consistently display roles in a human friendly format
- Return `Roles::<class>` from `User#role`

The intention is that this is a refactoring PR and that none of the behaviour of the system should have changed.

There are lots of commits but they are all relatively small and the commit notes should (hopefully) explain the intention.

Possible future ideas:

- It's not currently clear where methods relating to `User#role` should be defined (e.g. `#admin?` is defined in `Roles` while `#role_display_name` is defined in `User`). I think it would be an improvement if all methods that relied on `User#role` were defined in the same place.
- Rename the `users.role` database column to something like `role_key` to indicate that it's essentially a foreign key used to lookup the corresponding `Roles::<class>`.
	- I think this would allow us to introduce a `User#role=` method that took a `Roles::<class>` and stored its name in `User#role_key`.
- Make use of something like Whitehall's `ActiveRecordLikeInterface` to make the current `Roles::<class>` objects into instances of classes