### PR TITLE
Use absolute URLs in footer links

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -76,11 +76,11 @@
             text: "How to write, publish, and improve content",
           },
           {
-            href: privacy_notice_path,
+            href: privacy_notice_url,
             text: "Privacy notice",
           },
           {
-            href: accessibility_statement_path,
+            href: accessibility_statement_url,
             text: "Accessibility statement",
           },
           {


### PR DESCRIPTION
The layout_footer component was [changed in Dec 2023][1] to make all links absolute. Unfortunately this broke our privacy notice and accessibility statement links because they became `<Plek.new.website_root>/<path>` (e.g. www.gov.uk/privacy-notice in production). Using the `_url` helper methods should mean that we're correctly linking to these pages in the Signon app.

[1]: https://github.com/alphagov/govuk_publishing_components/commit/1cdd65fa90b895c0b1df64fbd2400d0099b5eb27
