### PR TITLE
Remove cookie rotate code

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -78,23 +78,6 @@ module Signon
     # https://github.com/alphagov/govuk-frontend/issues/1350
     config.assets.css_compressor = nil
 
-    # Rotate SHA1 cookies to SHA256 (the new Rails 7 default)
-    # TODO: Remove this after existing user sessions have been rotated
-    # https://guides.rubyonrails.org/v7.0/upgrading_ruby_on_rails.html#key-generator-digest-class-changing-to-use-sha256
-    config.action_dispatch.cookies_rotations.tap do |cookies|
-      salt = Rails.application.config.action_dispatch.authenticated_encrypted_cookie_salt
-      secret_key_base = Rails.application.secrets.secret_key_base
-      next if secret_key_base.blank?
-
-      key_generator = ActiveSupport::KeyGenerator.new(
-        secret_key_base, iterations: 1000, hash_digest_class: OpenSSL::Digest::SHA1
-      )
-      key_len = ActiveSupport::MessageEncryptor.key_len
-      secret = key_generator.generate_key(salt, key_len)
-
-      cookies.rotate :encrypted, secret
-    end
-
     config.show_user_research_recruitment_banner = false
   end
 end


### PR DESCRIPTION
We introduced this cookie rotation code in e711982abbf as part of the upgrade to Rails 7. Since our session cookies do not have a `Max-Age` or `Expires` attribute they are treated by the browsers as Session cookies and expire when the browser window is closed. I think it's safe to assume that all cookies issued under the old scheme (sometime before approximately April 13th 2022 when e711982abbf was made) have now been rotated, so this code can be removed.