### PR TITLE
Configure automatic merging for internal deps

### DIFF
--- a/app/helpers/components/.govuk_dependabot_merger.yml
+++ b/app/helpers/components/.govuk_dependabot_merger.yml
@@ -1,0 +1,30 @@
+api_version: 1
+auto_merge:
+  - dependency: gds-api-adapters
+    allowed_semver_bumps:
+      - patch
+      - minor
+  - dependency: govuk_app_config
+    allowed_semver_bumps:
+      - patch
+      - minor
+  - dependency: govuk_publishing_components
+    allowed_semver_bumps:
+      - patch
+      - minor
+  - dependency: govuk_sidekiq
+    allowed_semver_bumps:
+      - patch
+      - minor
+  - dependency: govuk_test
+    allowed_semver_bumps:
+      - patch
+      - minor
+  - dependency: plek
+    allowed_semver_bumps:
+      - patch
+      - minor
+  - dependency: rubocop-govuk
+    allowed_semver_bumps:
+      - patch
+      - minor


### PR DESCRIPTION
[Trello](https://trello.com/c/rIHzlaZq/411-configure-signon-to-automatically-merge-internal-dependencies)

This is the first step in configuring automatic merging for all the internal (GOV.UK) dependencies, per documentation[1].

Only patch and minor versions will be eligible.

The next step will be adding signon to the opted-in repos [2], but it is contingent on getting this config merged.

[1] https://github.com/alphagov/govuk-dependabot-merger?tab=readme-ov-file#usage
[2] https://github.com/alphagov/govuk-dependabot-merger/blob/main/config/repos_opted_in.yml

This application is owned by the Access & Permissions team.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
