### PR TITLE
Truncate EventLog#user_email_string to prevent exceptions

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -44,7 +44,7 @@ private
           EventLog::NO_SUCH_ACCOUNT_LOGIN,
           ip_address: user_ip_address,
           user_agent_string: user_agent,
-          user_email_string: email,
+          user_email_string: email.truncate(255),
         )
       end
     end


### PR DESCRIPTION
We've seen a couple of bursts of the following [exception][1]:

    ActiveRecord::ValueTooLong
      Mysql2::Error: Data too long for column 'user_email_string' at row 1

These have been triggered by failed attempts to login in `SessionsController#create` with an email address that is too long for the `event_logs.user_email_string` `VARCHAR(255)` column.

Note that since `users.email` is also a `VARCHAR(255)`, the email addresses associated with the failed logins cannot be legitimate However, it might be useful to see what the email addresses are in case there's some kind of systematic problem. Truncating the value in the one place where it is set should give us a bit more visibility while also avoiding the exception.

I did consider changing `event_logs.user_email_string` to a `TEXT` column like `event_logs.user_agent_string`, but that seemed like overkill.

[1]: https://govuk.sentry.io/issues/4917187628/events/93e09de3842e45d7a3bbb94664fca058/events/?project=202251
