### PR TITLE
Show user status as tag instead of strikethrough

### DIFF
--- a/app/helpers/api_users_helper.rb
+++ b/app/helpers/api_users_helper.rb
@@ -4,8 +4,7 @@ module ApiUsersHelper
   end
 
   def api_user_name(user)
-    anchor_tag = link_to(user.name, edit_api_user_path(user), class: "govuk-link")
-    user.suspended? ? content_tag(:del, anchor_tag) : anchor_tag
+    link_to(user.name, edit_api_user_path(user), class: "govuk-link")
   end
 
   def application_list(user)

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -5,6 +5,16 @@ module UsersHelper
     user.status.humanize
   end
 
+  def status_with_tag(user)
+    css_classes = if user.status == User::USER_STATUS_ACTIVE
+                    "govuk-tag--green"
+                  else
+                    "govuk-tag--grey"
+                  end
+
+    govuk_tag(status(user), css_classes)
+  end
+
   def two_step_status(user)
     user.two_step_status.humanize.capitalize
   end
@@ -63,8 +73,7 @@ module UsersHelper
   end
 
   def user_name(user)
-    anchor_tag = link_to(user.name, edit_user_path(user), class: "govuk-link")
-    user.suspended? ? content_tag(:del, anchor_tag) : anchor_tag
+    link_to(user.name, edit_user_path(user), class: "govuk-link")
   end
 
   def options_for_role_select(selected: nil)

--- a/app/views/api_users/index.html.erb
+++ b/app/views/api_users/index.html.erb
@@ -24,7 +24,7 @@
       text: "Apps",
     },
     {
-      text: "Suspended?",
+      text: "Status",
     },
   ],
   rows: @api_users.map do |user|
@@ -39,7 +39,7 @@
         text: application_list(user),
       },
       {
-        text: user.suspended? ? govuk_tag("Yes", "govuk-tag--grey") : govuk_tag("No", "govuk-tag--green"),
+        text: user.suspended? ? govuk_tag("Suspended", "govuk-tag--grey") : govuk_tag("Active", "govuk-tag--green"),
       },
     ]
   end,

--- a/app/views/api_users/index.html.erb
+++ b/app/views/api_users/index.html.erb
@@ -39,7 +39,7 @@
         text: application_list(user),
       },
       {
-        text: user.suspended? ? "Yes" : "No",
+        text: user.suspended? ? govuk_tag("Yes", "govuk-tag--grey") : govuk_tag("No", "govuk-tag--green"),
       },
     ]
   end,

--- a/app/views/api_users/index.html.erb
+++ b/app/views/api_users/index.html.erb
@@ -39,7 +39,7 @@
         text: application_list(user),
       },
       {
-        text: user.suspended? ? govuk_tag("Suspended", "govuk-tag--grey") : govuk_tag("Active", "govuk-tag--green"),
+        text: status_with_tag(user),
       },
     ]
   end,

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -40,7 +40,7 @@
             { text: user_name(user) },
             { text: user.email },
             { text: user.role_display_name },
-            { text: status(user) },
+            { text: status_with_tag(user) },
             { text: two_step_status(user) },
           ]
         end,

--- a/test/helpers/users_helper_test.rb
+++ b/test/helpers/users_helper_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class UsersHelperTest < ActionView::TestCase
+  include ApplicationHelper
+
   test "sync_needed? should work with user permissions not synced yet" do
     application = create(:application)
     user = create(:user)
@@ -14,6 +16,13 @@ class UsersHelperTest < ActionView::TestCase
     assert_equal "Active", status(build(:active_user))
     assert_equal "Locked", status(build(:locked_user))
     assert_equal "Suspended", status(build(:suspended_user))
+  end
+
+  test "status_with_tag should enclose the status in a govuk tag" do
+    assert_equal "<strong class=\"govuk-tag govuk-tag--grey\">Invited</strong>", status_with_tag(build(:invited_user))
+    assert_equal "<strong class=\"govuk-tag govuk-tag--green\">Active</strong>", status_with_tag(build(:active_user))
+    assert_equal "<strong class=\"govuk-tag govuk-tag--grey\">Locked</strong>", status_with_tag(build(:locked_user))
+    assert_equal "<strong class=\"govuk-tag govuk-tag--grey\">Suspended</strong>", status_with_tag(build(:suspended_user))
   end
 
   test "two_step_status should reflect the user's status accurately when the user is exempted from 2sv" do

--- a/test/integration/manage_api_users_test.rb
+++ b/test/integration/manage_api_users_test.rb
@@ -20,7 +20,7 @@ class ManageApiUsersTest < ActionDispatch::IntegrationTest
       assert page.has_selector?("td", text: @api_user.email)
 
       assert page.has_selector?("td", text: @application.name)
-      assert page.has_selector?("td:last-child", text: "No") # suspended?
+      assert page.has_selector?("td:last-child", text: "Active") # status
     end
 
     should "be able to create and edit an API user" do


### PR DESCRIPTION
The strikethrough is not part of the design system, so we've decided to use the govuk-tag style instead.

The design on the card showed green for active users, grey for suspended users, but there were no examples of locked or invited users.

I've chosen to only use green for active users, and grey for all other statuses.

[Trello](https://trello.com/c/ZW8yl3g8/280-review-discuss-other-options-possible-for-displaying-suspended-users-rather-than-strikethrough-since-this-isnt-inline-with-the-d)

## Screenshots

### Users - before
![Screenshot 2024-02-13 at 20 10 33](https://github.com/alphagov/signon/assets/579522/ca4c9c4f-4e4d-4bea-83a1-ea24e2d43c23)

### Users - after
![Screenshot 2024-02-13 at 19 28 38](https://github.com/alphagov/signon/assets/579522/7b1ae2ad-2e38-40ab-a87f-e629773581ed)

### API users - before
![Screenshot 2024-02-14 at 17 00 25](https://github.com/alphagov/signon/assets/579522/ba545ac6-80a1-432e-afd4-8287eac179aa)

### API users - after
![Screenshot 2024-02-15 at 12 41 14](https://github.com/alphagov/signon/assets/579522/9382e9df-78e3-4907-84bc-df9c1f882c60)

This application is owned by the Access & Permissions team.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
