### PR TITLE
Improve User validation error messages

### DIFF
--- a/app/models/reject_non_governmental_email_addresses_validator.rb
+++ b/app/models/reject_non_governmental_email_addresses_validator.rb
@@ -3,8 +3,6 @@ class RejectNonGovernmentalEmailAddressesValidator < ActiveModel::EachValidator
     aol btinternet gmail hotmail outlook yahoo
   ].freeze
 
-  MESSAGE = "Enter a valid workplace email address, like name@department.gov.uk".freeze
-
   def validate_each(record, attribute, value)
     return if value.blank?
 
@@ -13,7 +11,7 @@ class RejectNonGovernmentalEmailAddressesValidator < ActiveModel::EachValidator
     return if domain_part.blank?
 
     if keyword_matchers.any? { |keyword| keyword.match?(domain_part) }
-      record.errors.add(attribute, (options[:message] || MESSAGE))
+      record.errors.add(attribute, (options[:message] || :non_government))
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -449,7 +449,7 @@ private
   end
 
   def organisation_has_mandatory_2sv
-    errors.add(:require_2sv, "2-step verification is mandatory for all users from this organisation") if organisation && organisation.require_2sv? && !require_2sv
+    errors.add(:require_2sv, :blank) if organisation && organisation.require_2sv? && !require_2sv
   end
 
   def fix_apostrophe_in_email

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -430,7 +430,7 @@ private
   end
 
   def user_can_be_exempted_from_2sv
-    errors.add(:reason_for_2sv_exemption, "cannot be present for #{role_display_name} users. Remove the user's exemption to change their role.") if exempt_from_2sv? && role.require_2sv?
+    errors.add(:reason_for_2sv_exemption, :present, role_display_name:) if exempt_from_2sv? && role.require_2sv?
   end
 
   def organisation_admin_belongs_to_organisation

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -430,7 +430,7 @@ private
   end
 
   def user_can_be_exempted_from_2sv
-    errors.add(:reason_for_2sv_exemption, "cannot be blank for #{role_display_name} users. Remove the user's exemption to change their role.") if exempt_from_2sv? && role.require_2sv?
+    errors.add(:reason_for_2sv_exemption, "cannot be present for #{role_display_name} users. Remove the user's exemption to change their role.") if exempt_from_2sv? && role.require_2sv?
   end
 
   def organisation_admin_belongs_to_organisation

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -435,7 +435,7 @@ private
 
   def organisation_admin_belongs_to_organisation
     if publishing_manager? && organisation_id.blank?
-      errors.add(:organisation_id, "can't be 'None' for #{role_display_name}")
+      errors.add(:organisation_id, :blank, role_display_name:)
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -440,7 +440,7 @@ private
   end
 
   def email_is_ascii_only
-    errors.add(:email, "can't contain non-ASCII characters") unless email.blank? || email.ascii_only?
+    errors.add(:email, :non_ascii) unless email.blank? || email.ascii_only?
   end
 
   def exemption_from_2sv_data_is_complete

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -444,7 +444,7 @@ private
   end
 
   def exemption_from_2sv_data_is_complete
-    errors.add(:expiry_date_for_2sv_exemption, "must be present if exemption reason is present") if reason_for_2sv_exemption.present? && expiry_date_for_2sv_exemption.nil?
+    errors.add(:expiry_date_for_2sv_exemption, :blank) if reason_for_2sv_exemption.present? && expiry_date_for_2sv_exemption.nil?
     errors.add(:reason_for_2sv_exemption, "must be present if exemption expiry date is present") if expiry_date_for_2sv_exemption.present? && reason_for_2sv_exemption.blank?
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -445,7 +445,7 @@ private
 
   def exemption_from_2sv_data_is_complete
     errors.add(:expiry_date_for_2sv_exemption, :blank) if reason_for_2sv_exemption.present? && expiry_date_for_2sv_exemption.nil?
-    errors.add(:reason_for_2sv_exemption, "must be present if exemption expiry date is present") if expiry_date_for_2sv_exemption.present? && reason_for_2sv_exemption.blank?
+    errors.add(:reason_for_2sv_exemption, :blank) if expiry_date_for_2sv_exemption.present? && reason_for_2sv_exemption.blank?
   end
 
   def organisation_has_mandatory_2sv

--- a/app/views/account/emails/edit.html.erb
+++ b/app/views/account/emails/edit.html.erb
@@ -34,7 +34,7 @@
       title: "There is a problem",
       items: current_user.errors.map do |error|
         {
-          text: error.message,
+          text: error.full_message,
           href: "#user_#{error.attribute}",
         }
       end,
@@ -55,7 +55,7 @@
         value: current_user.email,
         hint: "Your email address will not update until you follow a link to confirm the new address.",
         autocomplete: "email",
-        error_items: current_user.errors.messages_for(:email).map { |message| { text: message } }
+        error_items: current_user.errors.full_messages_for(:email).map { |message| { text: message } }
       } %>
       <%= render "govuk_publishing_components/components/button", {
         text: "Change email"

--- a/app/views/api_users/new.html.erb
+++ b/app/views/api_users/new.html.erb
@@ -25,7 +25,7 @@
           id: "error-summary",
           title: "There was a problem with your new API user",
           items: @api_user.errors.map do |error|
-            { text: error.message, href: "#api_user_#{error.attribute}" }
+            { text: error.full_message, href: "#api_user_#{error.attribute}" }
           end
         } %>
       <% end %>
@@ -34,7 +34,7 @@
         label: { text: "Name" },
         name: "api_user[name]",
         id: "api_user_name",
-        error_items: @api_user.errors.messages_for(:name).map { |message| { text: message } },
+        error_items: @api_user.errors.full_messages_for(:name).map { |message| { text: message } },
         value: @api_user.name,
         autocomplete: "off",
       } %>
@@ -44,7 +44,7 @@
         name: "api_user[email]",
         id: "api_user_email",
         type: "email",
-        error_items: @api_user.errors.messages_for(:email).map { |message| { text: message } },
+        error_items: @api_user.errors.full_messages_for(:email).map { |message| { text: message } },
         value: @api_user.email,
         autocomplete: "off",
       } %>

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -24,7 +24,7 @@
           title: "There was a problem with your new user",
           items: f.object.errors.map do |error|
             {
-              text: error.message,
+              text: error.full_message,
               href: "#user_#{error.attribute}",
             }
           end
@@ -35,7 +35,7 @@
         label: { text: "Name" },
         name: "user[name]",
         id: "user_name",
-        error_items: f.object.errors.messages_for(:name).map { |message| { text: message } },
+        error_items: f.object.errors.full_messages_for(:name).map { |message| { text: message } },
         value: f.object.name,
         autocomplete: "off",
       } %>
@@ -44,7 +44,7 @@
         label: { text: "Email" },
         name: "user[email]",
         id: "user_email",
-        error_items: f.object.errors.messages_for(:email).map { |message| { text: message } },
+        error_items: f.object.errors.full_messages_for(:email).map { |message| { text: message } },
         value: f.object.email,
         autocomplete: "off",
       } %>

--- a/app/views/users/emails/edit.html.erb
+++ b/app/views/users/emails/edit.html.erb
@@ -40,7 +40,7 @@
       title: "There is a problem",
       items: @user.errors.map do |error|
         {
-          text: error.message,
+          text: error.full_message,
           href: "#user_#{error.attribute}",
         }
       end,
@@ -61,7 +61,7 @@
         value: @user.email,
         hint: @user.web_user? && @user.invited_but_not_yet_accepted? ? "Changes will trigger a new invitation email." : nil,
         autocomplete: "off",
-        error_items: @user.errors.messages_for(:email).map { |message| { text: message } }
+        error_items: @user.errors.full_messages_for(:email).map { |message| { text: message } }
       } %>
       <div class="govuk-button-group">
         <%= render "govuk_publishing_components/components/button", {

--- a/app/views/users/names/edit.html.erb
+++ b/app/views/users/names/edit.html.erb
@@ -27,7 +27,7 @@
       title: "There is a problem",
       items: @user.errors.map do |error|
         {
-          text: error.message,
+          text: error.full_message,
           href: "#user_#{error.attribute}",
         }
       end,
@@ -46,7 +46,7 @@
         id: "user_name",
         value: @user.name,
         autocomplete: "off",
-        error_items: @user.errors.messages_for(:name).map { |message| { text: message } }
+        error_items: @user.errors.full_messages_for(:name).map { |message| { text: message } }
       } %>
       <div class="govuk-button-group">
         <%= render "govuk_publishing_components/components/button", {

--- a/config/application.rb
+++ b/config/application.rb
@@ -79,5 +79,7 @@ module Signon
     config.assets.css_compressor = nil
 
     config.show_user_research_recruitment_banner = false
+
+    config.active_model.i18n_customize_full_message = true
   end
 end

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -6,7 +6,6 @@ en:
       expired: "has expired, please request a new one"
       not_found: "not found"
       already_confirmed: "was already confirmed, please try signing in"
-      weak_password: "not strong enough. Consider adding a number, symbols or more letters to make it stronger."
       not_locked: "was not locked"
       not_saved:
         one: "an error prohibited this %{resource} from being saved:"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -13,32 +13,33 @@ en:
     errors:
       models:
         user:
+          format: "%{message}"
           attributes:
             email:
               blank: "Enter an email for the user"
-              confirmation_period_expired: "needs to be confirmed within %{period}, please request a new one"
+              confirmation_period_expired: "%{attribute} needs to be confirmed within %{period}, please request a new one"
               invalid: "Enter an email address in the correct format, like name@department.gov.uk"
-              non_ascii: "can't contain non-ASCII characters"
+              non_ascii: "%{attribute} can't contain non-ASCII characters"
               non_government: "Enter a valid workplace email address, like name@department.gov.uk"
               taken: "That email address has been taken. Enter another in the correct format, like name@department.gov.uk"
             expiry_date_for_2sv_exemption:
-              blank: "must be present if exemption reason is present"
+              blank: "%{attribute} must be present if exemption reason is present"
             name:
               blank: "Enter a name for the user"
             organisation_id:
-              blank: "can't be 'None' for %{role_display_name}"
+              blank: "%{attribute} can't be 'None' for %{role_display_name}"
             password:
-              blank: "can't be blank"
-              too_long: "is too long (maximum is %{count} characters)"
-              too_short: "is too short (minimum is %{count} characters)"
-              weak_password: "not strong enough. Consider adding a number, symbols or more letters to make it stronger."
+              blank: "%{attribute} can't be blank"
+              too_long: "%{attribute} is too long (maximum is %{count} characters)"
+              too_short: "%{attribute} is too short (minimum is %{count} characters)"
+              weak_password: "%{attribute} not strong enough. Consider adding a number, symbols or more letters to make it stronger."
             password_confirmation:
-              confirmation: "doesn't match %{attribute}"
+              confirmation: "%{attribute} confirmation doesn't match %{attribute}"
             reason_for_2sv_exemption:
-              blank: "must be present if exemption expiry date is present"
-              present: "cannot be present for %{role_display_name} users. Remove the user's exemption to change their role."
+              blank: "%{attribute} must be present if exemption expiry date is present"
+              present: "%{attribute} cannot be present for %{role_display_name} users. Remove the user's exemption to change their role."
             reason_for_suspension:
-              blank: "can't be blank"
+              blank: "%{attribute} can't be blank"
             require_2sv:
               blank: "2-step verification is mandatory for all users from this organisation"
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,6 +24,8 @@ en:
               blank: "Enter a name for the user"
             password:
               blank: "can't be blank"
+              too_long: "is too long (maximum is %{count} characters)"
+              too_short: "is too short (minimum is %{count} characters)"
             reason_for_2sv_exemption:
               blank: "must be present if exemption expiry date is present"
             require_2sv:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,6 +36,7 @@ en:
               confirmation: "doesn't match %{attribute}"
             reason_for_2sv_exemption:
               blank: "must be present if exemption expiry date is present"
+              present: "cannot be present for %{role_display_name} users. Remove the user's exemption to change their role."
             reason_for_suspension:
               blank: "can't be blank"
             require_2sv:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -11,10 +11,15 @@ en:
         password: "Password"
         password_confirmation: "Password confirmation"
     errors:
+      messages:
+        non_government: "not accepted. Please enter a workplace email to continue."
       models:
         user:
           format: "%{message}"
           attributes:
+            current_password:
+              blank: "%{attribute} can't be blank"
+              invalid: "%{attribute} is invalid"
             email:
               blank: "Enter an email for the user"
               confirmation_period_expired: "%{attribute} needs to be confirmed within %{period}, please request a new one"
@@ -24,12 +29,15 @@ en:
               taken: "That email address has been taken. Enter another in the correct format, like name@department.gov.uk"
             expiry_date_for_2sv_exemption:
               blank: "%{attribute} must be present if exemption reason is present"
+            invitation_token:
+              invalid: "%{attribute} is invalid"
             name:
               blank: "Enter a name for the user"
             organisation_id:
               blank: "%{attribute} can't be 'None' for %{role_display_name}"
             password:
               blank: "%{attribute} can't be blank"
+              taken_in_past: "%{attribute} was used previously. Please choose a different one."
               too_long: "%{attribute} is too long (maximum is %{count} characters)"
               too_short: "%{attribute} is too short (minimum is %{count} characters)"
               weak_password: "%{attribute} not strong enough. Consider adding a number, symbols or more letters to make it stronger."
@@ -42,6 +50,10 @@ en:
               blank: "%{attribute} can't be blank"
             require_2sv:
               blank: "2-step verification is mandatory for all users from this organisation"
+            reset_password_token:
+              invalid: "%{attribute} is invalid"
+            role:
+              inclusion: "%{attribute} is not included in the list"
 
   helpers:
     label:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,6 +31,8 @@ en:
               confirmation: "doesn't match %{attribute}"
             reason_for_2sv_exemption:
               blank: "must be present if exemption expiry date is present"
+            reason_for_suspension:
+              blank: "can't be blank"
             require_2sv:
               blank: "2-step verification is mandatory for all users from this organisation"
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -16,6 +16,7 @@ en:
           attributes:
             email:
               blank: "Enter an email for the user"
+              confirmation_period_expired: "needs to be confirmed within %{period}, please request a new one"
               invalid: "Enter an email address in the correct format, like name@department.gov.uk"
               non_ascii: "can't contain non-ASCII characters"
               taken: "That email address has been taken. Enter another in the correct format, like name@department.gov.uk"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -22,6 +22,8 @@ en:
               blank: "must be present if exemption reason is present"
             name:
               blank: "Enter a name for the user"
+            reason_for_2sv_exemption:
+              blank: "must be present if exemption expiry date is present"
 
   helpers:
     label:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -22,6 +22,8 @@ en:
               blank: "must be present if exemption reason is present"
             name:
               blank: "Enter a name for the user"
+            organisation_id:
+              blank: "can't be 'None' for %{role_display_name}"
             password:
               blank: "can't be blank"
               too_long: "is too long (maximum is %{count} characters)"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,6 +24,8 @@ en:
               blank: "Enter a name for the user"
             reason_for_2sv_exemption:
               blank: "must be present if exemption expiry date is present"
+            require_2sv:
+              blank: "2-step verification is mandatory for all users from this organisation"
 
   helpers:
     label:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -26,6 +26,7 @@ en:
               blank: "can't be blank"
               too_long: "is too long (maximum is %{count} characters)"
               too_short: "is too short (minimum is %{count} characters)"
+              weak_password: "not strong enough. Consider adding a number, symbols or more letters to make it stronger."
             reason_for_2sv_exemption:
               blank: "must be present if exemption expiry date is present"
             require_2sv:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -17,6 +17,7 @@ en:
             email:
               blank: "Enter an email for the user"
               invalid: "Enter an email address in the correct format, like name@department.gov.uk"
+              non_ascii: "can't contain non-ASCII characters"
               taken: "That email address has been taken. Enter another in the correct format, like name@department.gov.uk"
             expiry_date_for_2sv_exemption:
               blank: "must be present if exemption reason is present"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -19,6 +19,7 @@ en:
               confirmation_period_expired: "needs to be confirmed within %{period}, please request a new one"
               invalid: "Enter an email address in the correct format, like name@department.gov.uk"
               non_ascii: "can't contain non-ASCII characters"
+              non_government: "Enter a valid workplace email address, like name@department.gov.uk"
               taken: "That email address has been taken. Enter another in the correct format, like name@department.gov.uk"
             expiry_date_for_2sv_exemption:
               blank: "must be present if exemption reason is present"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -27,6 +27,8 @@ en:
               too_long: "is too long (maximum is %{count} characters)"
               too_short: "is too short (minimum is %{count} characters)"
               weak_password: "not strong enough. Consider adding a number, symbols or more letters to make it stronger."
+            password_confirmation:
+              confirmation: "doesn't match %{attribute}"
             reason_for_2sv_exemption:
               blank: "must be present if exemption expiry date is present"
             require_2sv:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -22,6 +22,8 @@ en:
               blank: "must be present if exemption reason is present"
             name:
               blank: "Enter a name for the user"
+            password:
+              blank: "can't be blank"
             reason_for_2sv_exemption:
               blank: "must be present if exemption expiry date is present"
             require_2sv:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -18,6 +18,8 @@ en:
               blank: "Enter an email for the user"
               invalid: "Enter an email address in the correct format, like name@department.gov.uk"
               taken: "That email address has been taken. Enter another in the correct format, like name@department.gov.uk"
+            expiry_date_for_2sv_exemption:
+              blank: "must be present if exemption reason is present"
             name:
               blank: "Enter a name for the user"
 

--- a/test/controllers/users/roles_controller_test.rb
+++ b/test/controllers/users/roles_controller_test.rb
@@ -176,7 +176,7 @@ class Users::RolesControllerTest < ActionController::TestCase
         assert_equal Roles::Normal, user.reload.role
 
         assert_select ".govuk-error-summary" do
-          assert_select "li", text: /cannot be blank for #{Roles::OrganisationAdmin.name.humanize} users/
+          assert_select "li", text: /cannot be present for #{Roles::OrganisationAdmin.name.humanize} users/
         end
       end
 

--- a/test/controllers/users/two_step_verification_mandations_controller_test.rb
+++ b/test/controllers/users/two_step_verification_mandations_controller_test.rb
@@ -159,7 +159,7 @@ class Users::TwoStepVerificationMandationsControllerTest < ActionController::Tes
 
       should "display errors if user is not valid" do
         user = User.new(id: 123)
-        user.errors.add(:require_2sv, "is not valid")
+        user.errors.add(:require_2sv, "%{attribute} is not valid")
 
         User.stubs(:find).returns(user)
         UserUpdate.stubs(:new).returns(stub("user-update", call: false))

--- a/test/models/batch_invitation_user_test.rb
+++ b/test/models/batch_invitation_user_test.rb
@@ -47,7 +47,7 @@ class BatchInvitationUserTest < ActiveSupport::TestCase
       user = build(:batch_invitation_user, email: "piers.quinn@yahoo.co.uk")
 
       assert_not user.valid?
-      assert_includes user.errors[:email], "Enter a valid workplace email address, like name@department.gov.uk"
+      assert_includes user.errors[:email], "not accepted. Please enter a workplace email to continue."
     end
 
     should "not allow user to be updated with a known non-government email address" do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -538,7 +538,7 @@ class UserTest < ActiveSupport::TestCase
     u = create(:user)
     u.suspended_at = 1.minute.ago
     assert_not u.valid?
-    assert_not_empty u.errors[:reason_for_suspension]
+    assert_includes u.errors[:reason_for_suspension], "can't be blank"
   end
 
   test "suspension revokes all authorisations (`Doorkeeper::AccessToken`s)" do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -484,6 +484,12 @@ class UserTest < ActiveSupport::TestCase
 
   # Password Validation
 
+  test "it requires a password to be entered" do
+    u = build(:user, password: "")
+    assert_not u.valid?
+    assert_includes u.errors[:password], "can't be blank"
+  end
+
   test "it requires a password to be at least 10 characters long" do
     u = build(:user, password: "dNG.c0w5!")
     assert_not u.valid?

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -429,7 +429,7 @@ class UserTest < ActiveSupport::TestCase
           user = build(:admin_user, reason_for_2sv_exemption: "reason")
 
           assert_not user.valid?
-          assert_includes user.errors[:reason_for_2sv_exemption], "cannot be blank for Admin users. Remove the user's exemption to change their role."
+          assert_includes user.errors[:reason_for_2sv_exemption], "cannot be present for Admin users. Remove the user's exemption to change their role."
         end
       end
     end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -153,6 +153,7 @@ class UserTest < ActiveSupport::TestCase
       user = build(:user, organisation:)
       assert_not user.valid?
       assert_includes user.errors[:require_2sv], "2-step verification is mandatory for all users from this organisation"
+      assert_includes user.errors.full_messages_for(:require_2sv), "Require 2sv 2-step verification is mandatory for all users from this organisation"
     end
   end
 
@@ -225,6 +226,7 @@ class UserTest < ActiveSupport::TestCase
     @user = create(:user_with_pending_email_change, confirmation_sent_at: 15.days.ago)
     @user.confirm
     assert_includes @user.errors[:email], "needs to be confirmed within 14 days, please request a new one"
+    assert_includes @user.errors.full_messages_for(:email), "Email needs to be confirmed within 14 days, please request a new one"
   end
 
   test "#cancel_email_change!" do
@@ -327,6 +329,7 @@ class UserTest < ActiveSupport::TestCase
 
       assert_not user.valid?
       assert_includes user.errors[:email], "Enter an email for the user"
+      assert_includes user.errors.full_messages_for(:email), "Email Enter an email for the user"
     end
 
     should "require a unique email address" do
@@ -336,6 +339,7 @@ class UserTest < ActiveSupport::TestCase
 
       assert_not user.valid?
       assert_includes user.errors[:email], "That email address has been taken. Enter another in the correct format, like name@department.gov.uk"
+      assert_includes user.errors.full_messages_for(:email), "Email That email address has been taken. Enter another in the correct format, like name@department.gov.uk"
     end
 
     should "accept valid emails" do
@@ -357,6 +361,7 @@ class UserTest < ActiveSupport::TestCase
 
       assert_not user.valid?
       assert_includes user.errors[:email], "Enter a valid workplace email address, like name@department.gov.uk"
+      assert_includes user.errors.full_messages_for(:email), "Email Enter a valid workplace email address, like name@department.gov.uk"
     end
 
     should "not allow user to be updated with a known non-government email address" do
@@ -378,6 +383,7 @@ class UserTest < ActiveSupport::TestCase
 
         assert_not user.valid?, "Expected user to be invalid with email: '#{email}'"
         assert_includes user.errors[:email], "Enter an email address in the correct format, like name@department.gov.uk"
+        assert_includes user.errors.full_messages_for(:email), "Email Enter an email address in the correct format, like name@department.gov.uk"
       end
     end
 
@@ -393,6 +399,7 @@ class UserTest < ActiveSupport::TestCase
 
       assert_not user.valid?
       assert_includes user.errors[:email], "can't contain non-ASCII characters"
+      assert_includes user.errors.full_messages_for(:email), "Email can't contain non-ASCII characters"
     end
   end
 
@@ -402,6 +409,7 @@ class UserTest < ActiveSupport::TestCase
 
       assert_not user.valid?
       assert_includes user.errors[:name], "Enter a name for the user"
+      assert_includes user.errors.full_messages_for(:name), "Name Enter a name for the user"
     end
   end
 
@@ -431,6 +439,7 @@ class UserTest < ActiveSupport::TestCase
 
           assert_not user.valid?
           assert_includes user.errors[:reason_for_2sv_exemption], "cannot be present for Admin users. Remove the user's exemption to change their role."
+          assert_includes user.errors.full_messages_for(:reason_for_2sv_exemption), "Reason for 2sv exemption cannot be present for Admin users. Remove the user's exemption to change their role."
         end
       end
     end
@@ -467,12 +476,14 @@ class UserTest < ActiveSupport::TestCase
         user = build(:two_step_exempted_user, expiry_date_for_2sv_exemption: nil)
         assert_not user.valid?
         assert_includes user.errors[:expiry_date_for_2sv_exemption], "must be present if exemption reason is present"
+        assert_includes user.errors.full_messages_for(:expiry_date_for_2sv_exemption), "Expiry date for 2sv exemption must be present if exemption reason is present"
       end
 
       should "not be valid if 2sv exemption expiry exists without an exemption reason" do
         user = build(:two_step_exempted_user, reason_for_2sv_exemption: nil)
         assert_not user.valid?
         assert_includes user.errors[:reason_for_2sv_exemption], "must be present if exemption expiry date is present"
+        assert_includes user.errors.full_messages_for(:reason_for_2sv_exemption), "Reason for 2sv exemption must be present if exemption expiry date is present"
       end
 
       should "not be valid if 2sv exemption expiry exists with a blank exemption reason" do
@@ -488,24 +499,28 @@ class UserTest < ActiveSupport::TestCase
     u = build(:user, password: "")
     assert_not u.valid?
     assert_includes u.errors[:password], "can't be blank"
+    assert_includes u.errors.full_messages_for(:password), "Password can't be blank"
   end
 
   test "it requires a password to be at least 10 characters long" do
     u = build(:user, password: "dNG.c0w5!")
     assert_not u.valid?
     assert_includes u.errors[:password], "is too short (minimum is 10 characters)"
+    assert_includes u.errors.full_messages_for(:password), "Password is too short (minimum is 10 characters)"
   end
 
   test "it requires a password to be at most 128 characters long" do
     u = build(:user, password: ("4 l0nG sT!,ng " * 10)[0..128])
     assert_not u.valid?
     assert_includes u.errors[:password], "is too long (maximum is 128 characters)"
+    assert_includes u.errors.full_messages_for(:password), "Password is too long (maximum is 128 characters)"
   end
 
   test "it requires a password to be confirmed" do
     u = build(:user, password: "dNG.c0w5!dNG.c0w5!", password_confirmation: "")
     assert_not u.valid?
     assert_includes u.errors[:password_confirmation], "doesn't match Password"
+    assert_includes u.errors.full_messages_for(:password_confirmation), "Password confirmation doesn't match Password"
   end
 
   test "it allows very long passwords with spaces" do
@@ -522,6 +537,7 @@ class UserTest < ActiveSupport::TestCase
     u = build(:user, email: "sherlock.holmes@bakerstreet.com", password: "sherlock holmes baker street")
     assert_not u.valid?
     assert_includes u.errors[:password], "not strong enough. Consider adding a number, symbols or more letters to make it stronger."
+    assert_includes u.errors.full_messages_for(:password), "Password not strong enough. Consider adding a number, symbols or more letters to make it stronger."
   end
 
   test "unlocking an account should randomise the password" do
@@ -539,6 +555,7 @@ class UserTest < ActiveSupport::TestCase
     u.suspended_at = 1.minute.ago
     assert_not u.valid?
     assert_includes u.errors[:reason_for_suspension], "can't be blank"
+    assert_includes u.errors.full_messages_for(:reason_for_suspension), "Reason for suspension can't be blank"
   end
 
   test "suspension revokes all authorisations (`Doorkeeper::AccessToken`s)" do
@@ -581,6 +598,7 @@ class UserTest < ActiveSupport::TestCase
 
     assert_not user.valid?
     assert_includes user.errors[:organisation_id], "can't be 'None' for Organisation admin"
+    assert_includes user.errors.full_messages_for(:organisation_id), "Organisation can't be 'None' for Organisation admin"
   end
 
   test "super organisation admin must belong to an organisation" do
@@ -588,6 +606,7 @@ class UserTest < ActiveSupport::TestCase
 
     assert_not user.valid?
     assert_includes user.errors[:organisation_id], "can't be 'None' for Super organisation admin"
+    assert_includes user.errors.full_messages_for(:organisation_id), "Organisation can't be 'None' for Super organisation admin"
   end
 
   test "it doesn't migrate password unless correct one given" do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -515,7 +515,7 @@ class UserTest < ActiveSupport::TestCase
 
     u = build(:user, email: "sherlock.holmes@bakerstreet.com", password: "sherlock holmes baker street")
     assert_not u.valid?
-    assert_not_empty u.errors[:password]
+    assert_includes u.errors[:password], "not strong enough. Consider adding a number, symbols or more letters to make it stronger."
   end
 
   test "unlocking an account should randomise the password" do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -502,6 +502,12 @@ class UserTest < ActiveSupport::TestCase
     assert_includes u.errors[:password], "is too long (maximum is 128 characters)"
   end
 
+  test "it requires a password to be confirmed" do
+    u = build(:user, password: "dNG.c0w5!dNG.c0w5!", password_confirmation: "")
+    assert_not u.valid?
+    assert_includes u.errors[:password_confirmation], "doesn't match Password"
+  end
+
   test "it allows very long passwords with spaces" do
     u = build(:user, password: ("4 l0nG sT!,ng " * 10)[0..127])
     u.valid?

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -153,7 +153,7 @@ class UserTest < ActiveSupport::TestCase
       user = build(:user, organisation:)
       assert_not user.valid?
       assert_includes user.errors[:require_2sv], "2-step verification is mandatory for all users from this organisation"
-      assert_includes user.errors.full_messages_for(:require_2sv), "Require 2sv 2-step verification is mandatory for all users from this organisation"
+      assert_includes user.errors.full_messages_for(:require_2sv), "2-step verification is mandatory for all users from this organisation"
     end
   end
 
@@ -225,7 +225,7 @@ class UserTest < ActiveSupport::TestCase
   test "email change tokens should expire" do
     @user = create(:user_with_pending_email_change, confirmation_sent_at: 15.days.ago)
     @user.confirm
-    assert_includes @user.errors[:email], "needs to be confirmed within 14 days, please request a new one"
+    assert_includes @user.errors[:email], "Email needs to be confirmed within 14 days, please request a new one"
     assert_includes @user.errors.full_messages_for(:email), "Email needs to be confirmed within 14 days, please request a new one"
   end
 
@@ -329,7 +329,7 @@ class UserTest < ActiveSupport::TestCase
 
       assert_not user.valid?
       assert_includes user.errors[:email], "Enter an email for the user"
-      assert_includes user.errors.full_messages_for(:email), "Email Enter an email for the user"
+      assert_includes user.errors.full_messages_for(:email), "Enter an email for the user"
     end
 
     should "require a unique email address" do
@@ -339,7 +339,7 @@ class UserTest < ActiveSupport::TestCase
 
       assert_not user.valid?
       assert_includes user.errors[:email], "That email address has been taken. Enter another in the correct format, like name@department.gov.uk"
-      assert_includes user.errors.full_messages_for(:email), "Email That email address has been taken. Enter another in the correct format, like name@department.gov.uk"
+      assert_includes user.errors.full_messages_for(:email), "That email address has been taken. Enter another in the correct format, like name@department.gov.uk"
     end
 
     should "accept valid emails" do
@@ -361,7 +361,7 @@ class UserTest < ActiveSupport::TestCase
 
       assert_not user.valid?
       assert_includes user.errors[:email], "Enter a valid workplace email address, like name@department.gov.uk"
-      assert_includes user.errors.full_messages_for(:email), "Email Enter a valid workplace email address, like name@department.gov.uk"
+      assert_includes user.errors.full_messages_for(:email), "Enter a valid workplace email address, like name@department.gov.uk"
     end
 
     should "not allow user to be updated with a known non-government email address" do
@@ -383,7 +383,7 @@ class UserTest < ActiveSupport::TestCase
 
         assert_not user.valid?, "Expected user to be invalid with email: '#{email}'"
         assert_includes user.errors[:email], "Enter an email address in the correct format, like name@department.gov.uk"
-        assert_includes user.errors.full_messages_for(:email), "Email Enter an email address in the correct format, like name@department.gov.uk"
+        assert_includes user.errors.full_messages_for(:email), "Enter an email address in the correct format, like name@department.gov.uk"
       end
     end
 
@@ -398,7 +398,7 @@ class UserTest < ActiveSupport::TestCase
       user = build(:user, email: "mariõs.castle@wii.com") # unicode tilde character
 
       assert_not user.valid?
-      assert_includes user.errors[:email], "can't contain non-ASCII characters"
+      assert_includes user.errors[:email], "Email can't contain non-ASCII characters"
       assert_includes user.errors.full_messages_for(:email), "Email can't contain non-ASCII characters"
     end
   end
@@ -409,7 +409,7 @@ class UserTest < ActiveSupport::TestCase
 
       assert_not user.valid?
       assert_includes user.errors[:name], "Enter a name for the user"
-      assert_includes user.errors.full_messages_for(:name), "Name Enter a name for the user"
+      assert_includes user.errors.full_messages_for(:name), "Enter a name for the user"
     end
   end
 
@@ -438,7 +438,7 @@ class UserTest < ActiveSupport::TestCase
           user = build(:admin_user, reason_for_2sv_exemption: "reason")
 
           assert_not user.valid?
-          assert_includes user.errors[:reason_for_2sv_exemption], "cannot be present for Admin users. Remove the user's exemption to change their role."
+          assert_includes user.errors[:reason_for_2sv_exemption], "Reason for 2sv exemption cannot be present for Admin users. Remove the user's exemption to change their role."
           assert_includes user.errors.full_messages_for(:reason_for_2sv_exemption), "Reason for 2sv exemption cannot be present for Admin users. Remove the user's exemption to change their role."
         end
       end
@@ -475,14 +475,14 @@ class UserTest < ActiveSupport::TestCase
       should "not be valid if 2sv exemption reason exists without expiry date" do
         user = build(:two_step_exempted_user, expiry_date_for_2sv_exemption: nil)
         assert_not user.valid?
-        assert_includes user.errors[:expiry_date_for_2sv_exemption], "must be present if exemption reason is present"
+        assert_includes user.errors[:expiry_date_for_2sv_exemption], "Expiry date for 2sv exemption must be present if exemption reason is present"
         assert_includes user.errors.full_messages_for(:expiry_date_for_2sv_exemption), "Expiry date for 2sv exemption must be present if exemption reason is present"
       end
 
       should "not be valid if 2sv exemption expiry exists without an exemption reason" do
         user = build(:two_step_exempted_user, reason_for_2sv_exemption: nil)
         assert_not user.valid?
-        assert_includes user.errors[:reason_for_2sv_exemption], "must be present if exemption expiry date is present"
+        assert_includes user.errors[:reason_for_2sv_exemption], "Reason for 2sv exemption must be present if exemption expiry date is present"
         assert_includes user.errors.full_messages_for(:reason_for_2sv_exemption), "Reason for 2sv exemption must be present if exemption expiry date is present"
       end
 
@@ -498,28 +498,28 @@ class UserTest < ActiveSupport::TestCase
   test "it requires a password to be entered" do
     u = build(:user, password: "")
     assert_not u.valid?
-    assert_includes u.errors[:password], "can't be blank"
+    assert_includes u.errors[:password], "Password can't be blank"
     assert_includes u.errors.full_messages_for(:password), "Password can't be blank"
   end
 
   test "it requires a password to be at least 10 characters long" do
     u = build(:user, password: "dNG.c0w5!")
     assert_not u.valid?
-    assert_includes u.errors[:password], "is too short (minimum is 10 characters)"
+    assert_includes u.errors[:password], "Password is too short (minimum is 10 characters)"
     assert_includes u.errors.full_messages_for(:password), "Password is too short (minimum is 10 characters)"
   end
 
   test "it requires a password to be at most 128 characters long" do
     u = build(:user, password: ("4 l0nG sT!,ng " * 10)[0..128])
     assert_not u.valid?
-    assert_includes u.errors[:password], "is too long (maximum is 128 characters)"
+    assert_includes u.errors[:password], "Password is too long (maximum is 128 characters)"
     assert_includes u.errors.full_messages_for(:password), "Password is too long (maximum is 128 characters)"
   end
 
   test "it requires a password to be confirmed" do
     u = build(:user, password: "dNG.c0w5!dNG.c0w5!", password_confirmation: "")
     assert_not u.valid?
-    assert_includes u.errors[:password_confirmation], "doesn't match Password"
+    assert_includes u.errors[:password_confirmation], "Password confirmation doesn't match Password"
     assert_includes u.errors.full_messages_for(:password_confirmation), "Password confirmation doesn't match Password"
   end
 
@@ -536,7 +536,7 @@ class UserTest < ActiveSupport::TestCase
 
     u = build(:user, email: "sherlock.holmes@bakerstreet.com", password: "sherlock holmes baker street")
     assert_not u.valid?
-    assert_includes u.errors[:password], "not strong enough. Consider adding a number, symbols or more letters to make it stronger."
+    assert_includes u.errors[:password], "Password not strong enough. Consider adding a number, symbols or more letters to make it stronger."
     assert_includes u.errors.full_messages_for(:password), "Password not strong enough. Consider adding a number, symbols or more letters to make it stronger."
   end
 
@@ -554,7 +554,7 @@ class UserTest < ActiveSupport::TestCase
     u = create(:user)
     u.suspended_at = 1.minute.ago
     assert_not u.valid?
-    assert_includes u.errors[:reason_for_suspension], "can't be blank"
+    assert_includes u.errors[:reason_for_suspension], "Reason for suspension can't be blank"
     assert_includes u.errors.full_messages_for(:reason_for_suspension), "Reason for suspension can't be blank"
   end
 
@@ -597,7 +597,7 @@ class UserTest < ActiveSupport::TestCase
     user = build(:user, role: Roles::OrganisationAdmin.name, organisation_id: nil)
 
     assert_not user.valid?
-    assert_includes user.errors[:organisation_id], "can't be 'None' for Organisation admin"
+    assert_includes user.errors[:organisation_id], "Organisation can't be 'None' for Organisation admin"
     assert_includes user.errors.full_messages_for(:organisation_id), "Organisation can't be 'None' for Organisation admin"
   end
 
@@ -605,7 +605,7 @@ class UserTest < ActiveSupport::TestCase
     user = build(:user, role: Roles::SuperOrganisationAdmin.name, organisation_id: nil)
 
     assert_not user.valid?
-    assert_includes user.errors[:organisation_id], "can't be 'None' for Super organisation admin"
+    assert_includes user.errors[:organisation_id], "Organisation can't be 'None' for Super organisation admin"
     assert_includes user.errors.full_messages_for(:organisation_id), "Organisation can't be 'None' for Super organisation admin"
   end
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -223,7 +223,7 @@ class UserTest < ActiveSupport::TestCase
   test "email change tokens should expire" do
     @user = create(:user_with_pending_email_change, confirmation_sent_at: 15.days.ago)
     @user.confirm
-    assert_equal "needs to be confirmed within 14 days, please request a new one", @user.errors[:email][0]
+    assert_includes @user.errors[:email], "needs to be confirmed within 14 days, please request a new one"
   end
 
   test "#cancel_email_change!" do
@@ -325,7 +325,7 @@ class UserTest < ActiveSupport::TestCase
       user = build(:user, email: nil)
 
       assert_not user.valid?
-      assert_equal ["Enter an email for the user"], user.errors[:email]
+      assert_includes user.errors[:email], "Enter an email for the user"
     end
 
     should "require a unique email address" do
@@ -334,7 +334,7 @@ class UserTest < ActiveSupport::TestCase
       user = build(:user, email:)
 
       assert_not user.valid?
-      assert_equal ["That email address has been taken. Enter another in the correct format, like name@department.gov.uk"], user.errors[:email]
+      assert_includes user.errors[:email], "That email address has been taken. Enter another in the correct format, like name@department.gov.uk"
     end
 
     should "accept valid emails" do
@@ -355,8 +355,7 @@ class UserTest < ActiveSupport::TestCase
       user = build(:user, email: "piers.quinn@yahoo.co.uk")
 
       assert_not user.valid?
-      assert_equal ["Enter a valid workplace email address, like name@department.gov.uk"],
-                   user.errors[:email]
+      assert_includes user.errors[:email], "Enter a valid workplace email address, like name@department.gov.uk"
     end
 
     should "not allow user to be updated with a known non-government email address" do
@@ -377,7 +376,7 @@ class UserTest < ActiveSupport::TestCase
         user.email = email
 
         assert_not user.valid?, "Expected user to be invalid with email: '#{email}'"
-        assert_equal ["Enter an email address in the correct format, like name@department.gov.uk"], user.errors[:email]
+        assert_includes user.errors[:email], "Enter an email address in the correct format, like name@department.gov.uk"
       end
     end
 
@@ -392,7 +391,7 @@ class UserTest < ActiveSupport::TestCase
       user = build(:user, email: "mariõs.castle@wii.com") # unicode tilde character
 
       assert_not user.valid?
-      assert_equal ["can't contain non-ASCII characters"], user.errors[:email]
+      assert_includes user.errors[:email], "can't contain non-ASCII characters"
     end
   end
 
@@ -401,7 +400,7 @@ class UserTest < ActiveSupport::TestCase
       user = build(:user, name: "")
 
       assert_not user.valid?
-      assert_equal ["Enter a name for the user"], user.errors[:name]
+      assert_includes user.errors[:name], "Enter a name for the user"
     end
   end
 
@@ -560,14 +559,14 @@ class UserTest < ActiveSupport::TestCase
     user = build(:user, role: Roles::OrganisationAdmin.name, organisation_id: nil)
 
     assert_not user.valid?
-    assert_equal "can't be 'None' for Organisation admin", user.errors[:organisation_id].first
+    assert_includes user.errors[:organisation_id], "can't be 'None' for Organisation admin"
   end
 
   test "super organisation admin must belong to an organisation" do
     user = build(:user, role: Roles::SuperOrganisationAdmin.name, organisation_id: nil)
 
     assert_not user.valid?
-    assert_equal "can't be 'None' for Super organisation admin", user.errors[:organisation_id].first
+    assert_includes user.errors[:organisation_id], "can't be 'None' for Super organisation admin"
   end
 
   test "it doesn't migrate password unless correct one given" do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -465,6 +465,7 @@ class UserTest < ActiveSupport::TestCase
       should "not be valid if 2sv exemption reason exists without expiry date" do
         user = build(:two_step_exempted_user, expiry_date_for_2sv_exemption: nil)
         assert_not user.valid?
+        assert_includes user.errors[:expiry_date_for_2sv_exemption], "must be present if exemption reason is present"
       end
 
       should "not be valid if 2sv exemption expiry exists without an exemption reason" do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -471,6 +471,7 @@ class UserTest < ActiveSupport::TestCase
       should "not be valid if 2sv exemption expiry exists without an exemption reason" do
         user = build(:two_step_exempted_user, reason_for_2sv_exemption: nil)
         assert_not user.valid?
+        assert_includes user.errors[:reason_for_2sv_exemption], "must be present if exemption expiry date is present"
       end
 
       should "not be valid if 2sv exemption expiry exists with a blank exemption reason" do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -152,6 +152,7 @@ class UserTest < ActiveSupport::TestCase
       organisation = create(:organisation, require_2sv: true)
       user = build(:user, organisation:)
       assert_not user.valid?
+      assert_includes user.errors[:require_2sv], "2-step verification is mandatory for all users from this organisation"
     end
   end
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -493,7 +493,13 @@ class UserTest < ActiveSupport::TestCase
   test "it requires a password to be at least 10 characters long" do
     u = build(:user, password: "dNG.c0w5!")
     assert_not u.valid?
-    assert_not_empty u.errors[:password]
+    assert_includes u.errors[:password], "is too short (minimum is 10 characters)"
+  end
+
+  test "it requires a password to be at most 128 characters long" do
+    u = build(:user, password: ("4 l0nG sT!,ng " * 10)[0..128])
+    assert_not u.valid?
+    assert_includes u.errors[:password], "is too long (maximum is 128 characters)"
   end
 
   test "it allows very long passwords with spaces" do


### PR DESCRIPTION
This PR moves the remaining validation error strings from the `User` class into the `en.yml` locale file. This should make it easier to see at a glance the differences in style between the `User` validation error messages (i.e. some are of the form "Enter an email" and others are of the form "Email can't contain non-ascii characters").

Summary of commits:

- Use `assert_includes` when checking validation error messages in users_test.rb
- Correct a mistake in the validation error when `User#reason_for_2sv_exemption` is present but shouldn't be
- Add tests for 3 validation error messages that weren't tested
- Move remaining validation error messages from strings in `User` to the `en.yml` locale file