### PR TITLE
Allow table cell text to align left

### DIFF
--- a/app/assets/stylesheets/components/_table.scss
+++ b/app/assets/stylesheets/components/_table.scss
@@ -153,9 +153,8 @@ $table-row-even-background-colour: govuk-colour("light-grey", $legacy: "grey-4")
 
   .govuk-table__cell {
     display: flex;
-    justify-content: space-between;
     min-width: 1px;
-    text-align: right;
+    text-align: left;
   }
 
   @include govuk-media-query($until: $vertical-on-smallscreen-breakpoint) {


### PR DESCRIPTION
For users with certain access needs (for example tunnel vision), the empty space between the table heading (in vertical table mode) and the table cell content causes difficulties, making them lose track of what labels associate with what values.

I found that the text would not become properly left-aligned at all magnification steps until I changed both the `text-align` property of all table cells, and the `justify-content` property.

Suggestions welcome, CSS is not my strongest area.

## Before
![Screenshot 2024-02-15 at 16 56 08](https://github.com/alphagov/signon/assets/579522/afa4e3f0-000a-4e75-a615-ebfadda8eb4a)

## After
![Screenshot 2024-02-15 at 16 55 06](https://github.com/alphagov/signon/assets/579522/17d01db4-4129-41f2-9174-9216f341462d)

This application is owned by the Access & Permissions team.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
