### PR TITLE
Fix Jasmine specs in govuk-docker on Apple silicon

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "stylelint-config-gds": "^1.1.1"
   },
   "resolutions": {
+    "selenium-webdriver": "4.17.0",
     "stylelint/strip-ansi": "6.0.1",
     "stylelint/string-width": "4.2.3"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2305,14 +2305,14 @@ safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-selenium-webdriver@^4.12.0:
-  version "4.12.0"
-  resolved "https://registry.yarnpkg.com/selenium-webdriver/-/selenium-webdriver-4.12.0.tgz#a8dc8ecf129a2414c2ace6e429aba84722a950a5"
-  integrity sha512-zvPzmTsky6WfO6+BGMj2mCJsw7qKnfQONur2b+pGn8jeTiC+WAUOthZOnaK+HkX5wiU6L4uoMF+JIcOVstp25A==
+selenium-webdriver@4.17.0, selenium-webdriver@^4.12.0:
+  version "4.17.0"
+  resolved "https://registry.yarnpkg.com/selenium-webdriver/-/selenium-webdriver-4.17.0.tgz#f6c93a9df3e0543df7dc2329d81968af42845a7f"
+  integrity sha512-e2E+2XBlGepzwgFbyQfSwo9Cbj6G5fFfs9MzAS00nC99EewmcS2rwn2MwtgfP7I5p1e7DYv4HQJXtWedsu6DvA==
   dependencies:
     jszip "^3.10.1"
     tmp "^0.2.1"
-    ws ">=8.13.0"
+    ws ">=8.14.2"
 
 "semver@2 || 3 || 4 || 5":
   version "5.7.2"
@@ -2905,10 +2905,10 @@ write@1.0.3:
   dependencies:
     mkdirp "^0.5.1"
 
-ws@>=8.13.0:
-  version "8.13.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.13.0.tgz#9a9fb92f93cf41512a0735c8f4dd09b8a1211cd0"
-  integrity sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==
+ws@>=8.14.2:
+  version "8.16.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.16.0.tgz#d1cd774f36fbc07165066a60e40323eab6446fd4"
+  integrity sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==
 
 xdg-basedir@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
We've been seeing the following error running the Jasmine specs in a govuk-docker container running on Apple silicon:

    SessionNotCreatedError: session not created:
      Chrome failed to start: exited normally.

For a full diagnosis of the problem see [this govuk-docker PR][1] which was a first attempt at fixing the problem.

Note that the problem was also triggering a warning like the following even on non-Apple silicon:

    The chromedriver version (120.0.6099.199) detected in PATH at
    /usr/bin/chromedriver might not be compatible with the detected chrome
    version (121.0.6167.85); currently, chromedriver 121.0.6167.85 is
    recommended for chrome 121.*, so it is advised to delete the driver in
    PATH and retry

This PR forces yarn to install v4.17.0 of the `selenium-webdriver` node package which includes [a fix][2] to the `selenium-manager` CLI app included in the `selenium-webdriver` node package so that it now correctly finds the chromium binary. This fixes both the error on Apple silicon and the warning on all devices.

Note that I've opened [a PR][3] on `jasmine-browser-runner` to bump its version of `selenium-webdriver`. Once that PR is merged and released, we should be able to remove the `resolution` entry for `selenium-webdriver`.

[1]: https://github.com/alphagov/govuk-docker/pull/724
[2]: https://github.com/SeleniumHQ/selenium/pull/12890
[3]: https://github.com/jasmine/jasmine-browser-runner/pull/46