### PR TITLE
Revert "Improve User validation messages"

### DIFF
--- a/app/models/reject_non_governmental_email_addresses_validator.rb
+++ b/app/models/reject_non_governmental_email_addresses_validator.rb
@@ -3,7 +3,7 @@ class RejectNonGovernmentalEmailAddressesValidator < ActiveModel::EachValidator
     aol btinternet gmail hotmail outlook yahoo
   ].freeze
 
-  MESSAGE = "Enter a valid workplace email address, like name@department.gov.uk".freeze
+  MESSAGE = "not accepted. Please enter a workplace email to continue.".freeze
 
   def validate_each(record, attribute, value)
     return if value.blank?

--- a/app/views/account/emails/edit.html.erb
+++ b/app/views/account/emails/edit.html.erb
@@ -34,7 +34,7 @@
       title: "There is a problem",
       items: current_user.errors.map do |error|
         {
-          text: error.message,
+          text: error.full_message,
           href: "#user_#{error.attribute}",
         }
       end,
@@ -55,7 +55,7 @@
         value: current_user.email,
         hint: "Your email address will not update until you follow a link to confirm the new address.",
         autocomplete: "email",
-        error_items: current_user.errors.messages_for(:email).map { |message| { text: message } }
+        error_items: current_user.errors.full_messages_for(:email).map { |message| { text: message } }
       } %>
       <%= render "govuk_publishing_components/components/button", {
         text: "Change email"

--- a/app/views/api_users/new.html.erb
+++ b/app/views/api_users/new.html.erb
@@ -25,7 +25,7 @@
           id: "error-summary",
           title: "There was a problem with your new API user",
           items: @api_user.errors.map do |error|
-            { text: error.message, href: "#api_user_#{error.attribute}" }
+            { text: error.full_message, href: "#api_user_#{error.attribute}" }
           end
         } %>
       <% end %>
@@ -34,7 +34,7 @@
         label: { text: "Name" },
         name: "api_user[name]",
         id: "api_user_name",
-        error_items: @api_user.errors.messages_for(:name).map { |message| { text: message } },
+        error_items: @api_user.errors.full_messages_for(:name).map { |message| { text: message } },
         value: @api_user.name,
         autocomplete: "off",
       } %>
@@ -44,7 +44,7 @@
         name: "api_user[email]",
         id: "api_user_email",
         type: "email",
-        error_items: @api_user.errors.messages_for(:email).map { |message| { text: message } },
+        error_items: @api_user.errors.full_messages_for(:email).map { |message| { text: message } },
         value: @api_user.email,
         autocomplete: "off",
       } %>

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -24,7 +24,7 @@
           title: "There was a problem with your new user",
           items: f.object.errors.map do |error|
             {
-              text: error.message,
+              text: error.full_message,
               href: "#user_#{error.attribute}",
             }
           end
@@ -35,7 +35,7 @@
         label: { text: "Name" },
         name: "user[name]",
         id: "user_name",
-        error_items: f.object.errors.messages_for(:name).map { |message| { text: message } },
+        error_items: f.object.errors.full_messages_for(:name).map { |message| { text: message } },
         value: f.object.name,
         autocomplete: "off",
       } %>
@@ -44,7 +44,7 @@
         label: { text: "Email" },
         name: "user[email]",
         id: "user_email",
-        error_items: f.object.errors.messages_for(:email).map { |message| { text: message } },
+        error_items: f.object.errors.full_messages_for(:email).map { |message| { text: message } },
         value: f.object.email,
         autocomplete: "off",
       } %>

--- a/app/views/users/emails/edit.html.erb
+++ b/app/views/users/emails/edit.html.erb
@@ -40,7 +40,7 @@
       title: "There is a problem",
       items: @user.errors.map do |error|
         {
-          text: error.message,
+          text: error.full_message,
           href: "#user_#{error.attribute}",
         }
       end,
@@ -61,7 +61,7 @@
         value: @user.email,
         hint: @user.web_user? && @user.invited_but_not_yet_accepted? ? "Changes will trigger a new invitation email." : nil,
         autocomplete: "off",
-        error_items: @user.errors.messages_for(:email).map { |message| { text: message } }
+        error_items: @user.errors.full_messages_for(:email).map { |message| { text: message } }
       } %>
       <div class="govuk-button-group">
         <%= render "govuk_publishing_components/components/button", {

--- a/app/views/users/names/edit.html.erb
+++ b/app/views/users/names/edit.html.erb
@@ -27,7 +27,7 @@
       title: "There is a problem",
       items: @user.errors.map do |error|
         {
-          text: error.message,
+          text: error.full_message,
           href: "#user_#{error.attribute}",
         }
       end,
@@ -46,7 +46,7 @@
         id: "user_name",
         value: @user.name,
         autocomplete: "off",
-        error_items: @user.errors.messages_for(:name).map { |message| { text: message } }
+        error_items: @user.errors.full_messages_for(:name).map { |message| { text: message } }
       } %>
       <div class="govuk-button-group">
         <%= render "govuk_publishing_components/components/button", {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -10,16 +10,6 @@ en:
         current_password: "Current password"
         password: "Password"
         password_confirmation: "Password confirmation"
-    errors:
-      models:
-        user:
-          attributes:
-            email:
-              blank: "Enter an email for the user"
-              invalid: "Enter an email address in the correct format, like name@department.gov.uk"
-              taken: "That email address has been taken. Enter another in the correct format, like name@department.gov.uk"
-            name:
-              blank: "Enter a name for the user"
 
   helpers:
     label:

--- a/test/controllers/account/emails_controller_test.rb
+++ b/test/controllers/account/emails_controller_test.rb
@@ -66,10 +66,10 @@ class Account::EmailsControllerTest < ActionController::TestCase
 
       assert_template :edit
       assert_select ".govuk-error-summary" do
-        assert_select "a", href: "#user_email", text: "Enter an email for the user"
+        assert_select "a", href: "#user_email", text: "Email can't be blank"
       end
       assert_select ".govuk-form-group" do
-        assert_select ".govuk-error-message", text: "Error: Enter an email for the user"
+        assert_select ".govuk-error-message", text: "Error: Email can't be blank"
         assert_select "input[name='user[email]'].govuk-input--error"
       end
     end

--- a/test/controllers/api_users_controller_test.rb
+++ b/test/controllers/api_users_controller_test.rb
@@ -96,7 +96,7 @@ class ApiUsersControllerTest < ActionController::TestCase
         post :create, params: { api_user: { name: "Content Store Application", email: "content.store at gov uk" } }
 
         assert_template :new
-        assert_select "div.govuk-error-summary", /Enter an email address in the correct format, like name@department.gov.uk/
+        assert_select "div.govuk-error-summary", /Email is invalid/
       end
     end
 

--- a/test/controllers/users/emails_controller_test.rb
+++ b/test/controllers/users/emails_controller_test.rb
@@ -325,10 +325,10 @@ class Users::EmailsControllerTest < ActionController::TestCase
         put :update, params: { user_id: user, user: { email: "" } }
 
         assert_select ".govuk-error-summary" do
-          assert_select "a", href: "#user_email", text: "Enter an email for the user"
+          assert_select "a", href: "#user_email", text: "Email can't be blank"
         end
         assert_select ".govuk-form-group" do
-          assert_select ".govuk-error-message", text: "Error: Enter an email for the user"
+          assert_select ".govuk-error-message", text: "Error: Email can't be blank"
           assert_select "input[name='user[email]'].govuk-input--error"
         end
       end

--- a/test/controllers/users/names_controller_test.rb
+++ b/test/controllers/users/names_controller_test.rb
@@ -256,10 +256,10 @@ class Users::NamesControllerTest < ActionController::TestCase
         put :update, params: { user_id: user, user: { name: "" } }
 
         assert_select ".govuk-error-summary" do
-          assert_select "a", href: "#user_name", text: "Enter a name for the user"
+          assert_select "a", href: "#user_name", text: "Name can't be blank"
         end
         assert_select ".govuk-form-group" do
-          assert_select ".govuk-error-message", text: "Error: Enter a name for the user"
+          assert_select ".govuk-error-message", text: "Error: Name can't be blank"
           assert_select "input[name='user[name]'].govuk-input--error"
         end
       end

--- a/test/integration/email_change_test.rb
+++ b/test/integration/email_change_test.rb
@@ -42,7 +42,7 @@ class EmailChangeTest < ActionDispatch::IntegrationTest
         signin_with(@admin)
         admin_changes_email_address(user:, new_email: "")
 
-        assert_response_contains("Enter an email for the user")
+        assert_response_contains("Email can't be blank")
         assert_nil last_email
       end
     end
@@ -140,7 +140,7 @@ class EmailChangeTest < ActionDispatch::IntegrationTest
       fill_in "Email", with: ""
       click_button "Change email"
 
-      assert_response_contains "Enter an email for the user"
+      assert_response_contains "Email can't be blank"
 
       assert_nil last_email
     end

--- a/test/integration/inviting_users_test.rb
+++ b/test/integration/inviting_users_test.rb
@@ -195,7 +195,7 @@ class InvitingUsersTest < ActionDispatch::IntegrationTest
       fill_in "Name", with: "Fred Bloggs"
       click_button "Create user and send email"
 
-      assert_response_contains("Enter an email for the user")
+      assert_response_contains("Email can't be blank")
     end
   end
 

--- a/test/models/batch_invitation_user_test.rb
+++ b/test/models/batch_invitation_user_test.rb
@@ -47,7 +47,7 @@ class BatchInvitationUserTest < ActiveSupport::TestCase
       user = build(:batch_invitation_user, email: "piers.quinn@yahoo.co.uk")
 
       assert_not user.valid?
-      assert_includes user.errors[:email], "Enter a valid workplace email address, like name@department.gov.uk"
+      assert_includes user.errors[:email], "not accepted. Please enter a workplace email to continue."
     end
 
     should "not allow user to be updated with a known non-government email address" do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -325,16 +325,7 @@ class UserTest < ActiveSupport::TestCase
       user = build(:user, email: nil)
 
       assert_not user.valid?
-      assert_equal ["Enter an email for the user"], user.errors[:email]
-    end
-
-    should "require a unique email address" do
-      email = "user@example.com"
-      create(:user, email:)
-      user = build(:user, email:)
-
-      assert_not user.valid?
-      assert_equal ["That email address has been taken. Enter another in the correct format, like name@department.gov.uk"], user.errors[:email]
+      assert_equal ["can't be blank"], user.errors[:email]
     end
 
     should "accept valid emails" do
@@ -355,7 +346,7 @@ class UserTest < ActiveSupport::TestCase
       user = build(:user, email: "piers.quinn@yahoo.co.uk")
 
       assert_not user.valid?
-      assert_equal ["Enter a valid workplace email address, like name@department.gov.uk"],
+      assert_equal ["not accepted. Please enter a workplace email to continue."],
                    user.errors[:email]
     end
 
@@ -377,7 +368,7 @@ class UserTest < ActiveSupport::TestCase
         user.email = email
 
         assert_not user.valid?, "Expected user to be invalid with email: '#{email}'"
-        assert_equal ["Enter an email address in the correct format, like name@department.gov.uk"], user.errors[:email]
+        assert_equal ["is invalid"], user.errors[:email]
       end
     end
 
@@ -393,15 +384,6 @@ class UserTest < ActiveSupport::TestCase
 
       assert_not user.valid?
       assert_equal ["can't contain non-ASCII characters"], user.errors[:email]
-    end
-  end
-
-  context "name validation" do
-    should "require a name" do
-      user = build(:user, name: "")
-
-      assert_not user.valid?
-      assert_equal ["Enter a name for the user"], user.errors[:name]
     end
   end
 


### PR DESCRIPTION
This reverts commit 1eb45b8ce50223816ff7ebbe77d997310a1b2576.

The reverted commit left us in an inconsistent state when it came to displaying User validation error messages. Some of the validation error messages were standalone (e.g. "Enter an email for the user") while others only made sense when combined with the attribute (e.g. "Email can't contain non-ASCII characters").

I attempted to fix the problems with this inconsistency in PR #2717 but have now run out of time so have agreed with Craig S that it's better to revert the problematic commit for now.
