### PR TITLE
Fix NoMethodError in SessionsController#create

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -28,7 +28,7 @@ private
         user_agent_id: user_agent_record_id,
       )
     else
-      email = params[:user][:email].to_s
+      email = sign_in_params[:email].to_s
       user = User.find_by(email:)
       if user
         EventLog.record_event(

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -28,7 +28,6 @@ private
         user_agent_id: user_agent_record_id,
       )
     else
-      # Call to_s to flatten out any unexpected params (eg a hash).
       email = params[:user][:email].to_s
       user = User.find_by(email:)
       if user

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -23,4 +23,10 @@ class SessionsControllerTest < ActionController::TestCase
 
     assert_not @controller.signed_in?
   end
+
+  should "not raise exception if user param is not present" do
+    post :create, params: {}
+
+    assert_not @controller.signed_in?
+  end
 end

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -17,4 +17,10 @@ class SessionsControllerTest < ActionController::TestCase
 
     assert_not @controller.signed_in?
   end
+
+  should "not raise exception if email param is a Hash" do
+    post :create, params: { user: { email: { foo: "bar" }, password: @user.password } }
+
+    assert_not @controller.signed_in?
+  end
 end

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -1,0 +1,20 @@
+require "test_helper"
+
+class SessionsControllerTest < ActionController::TestCase
+  setup do
+    @request.env["devise.mapping"] = Devise.mappings[:user]
+    @user = create(:user)
+  end
+
+  should "sign in user if credentials are valid" do
+    post :create, params: { user: { email: @user.email, password: @user.password } }
+
+    assert @controller.signed_in?
+  end
+
+  should "not sign in user if credentials are not valid" do
+    post :create, params: { user: { email: @user.email, password: "incorrect-password" } }
+
+    assert_not @controller.signed_in?
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/qo01Wq1w

We were seeing [the following exception][1] when there was no `user` param in the request:

    NoMethodError: undefined method `[]' for nil:NilClass (NoMethodError)

I've added a test to demonstrate the problem and fixed it by using [`Devise::SessionsController#sign_in_params`][2].

Since `SessionsController` inherits from `Devise::SessionsController`, we probably should have been using this method anyway to properly sanitize the `params`. Using that method also has the benefit of fixing the problem, because it will always return an empty `Hash` rather than `nil`.

I've also taken the opportunity to replace a comment in the implementation with an explanatory test.

As noted in the Trello card, I think we could make further improvements in this controller by making use of [`Warden::Manager` hooks][3] instead of overriding `Devise::SessionsController` action c.f. [these changes][4]. However, I'm short of time, so I'm regarding that work as out-of-scope.

[1]: https://govuk.sentry.io/issues/4838149311/?project=202251
[2]: https://www.rubydoc.info/github/plataformatec/devise/Devise%2FSessionsController:sign_in_params
[3]: https://www.rubydoc.info/github/hassox/warden/Warden/Hooks
[4]: https://github.com/alphagov/signon/pull/2623/commits/9114bdb6971e573e763b9f36d1d02a8398731426#diff-441d219db83f427847d3ecd7a9beb578d99794170944de35500114746651c606
