### PR TITLE
Re-encrypt all users

### DIFF
--- a/db/migrate/20240228080000_reencrypt_user_otp_keys.rb
+++ b/db/migrate/20240228080000_reencrypt_user_otp_keys.rb
@@ -1,0 +1,5 @@
+class ReencryptUserOtpKeys < ActiveRecord::Migration[7.1]
+  def change
+    User.find_each(&:encrypt)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_19_080657) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_28_080000) do
   create_table "batch_invitation_application_permissions", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "batch_invitation_id", null: false
     t.integer "supported_permission_id", null: false


### PR DESCRIPTION
In Rails 7.0, the [encryption algorithm was changed from SHA-1 to SHA-256](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#active-record-encryption-algorithm-changes) but users who generated their OTP key when we used an older version of Rails  would still have their key stored with SHA-1. Rails 7.0 could support both types of encryption by default, so we saw no issues.

However in Rails 7.1, the option `support_sha1_for_non_deterministic_encryption` is set to `false` by default, meaning users encrypted with SHA-1 would be unable to login.

We therefore changed this setting to `true` [when upgrading to Rails 7.1](https://github.com/alphagov/signon/pull/2745/commits/90d4cf0ea3f0df5013b7fedfeddcd0570b90cc10). By re-encrypting all users with SHA-256, we can disable this setting.

[Trello card](https://trello.com/c/ljplz6sM)

This application is owned by the Access & Permissions team.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
