### PR TITLE
Remove support for SHA-1 encryption

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -100,7 +100,5 @@ module Signon
     config.show_user_research_recruitment_banner = false
 
     config.add_autoload_paths_to_load_path = true
-
-    config.active_record.encryption.support_sha1_for_non_deterministic_encryption = true
   end
 end


### PR DESCRIPTION
This reverts commit 90d4cf0ea3f0df5013b7fedfeddcd0570b90cc10.  Depends on https://github.com/alphagov/signon/pull/2746.

This application is owned by the Access & Permissions team.

[Trello card](https://trello.com/c/ljplz6sM)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
