### PR TITLE
One-off rake task to add the GDS Editor permission 

### DIFF
--- a/lib/tasks/once_off/add_gds_editor_permission.rake
+++ b/lib/tasks/once_off/add_gds_editor_permission.rake
@@ -1,0 +1,13 @@
+namespace :once_off do
+  desc "Update all GDS Users with Imminence signin permission to give them GDS Editor permission"
+  task add_gds_editor_permission: :environment do
+    imminence = Doorkeeper::Application.find_by(name: "Imminence")
+    imminence_signin = imminence.supported_permissions.find_by(name: "signin")
+    imminence_gds_editor = imminence.supported_permissions.find_or_create_by!(name: "GDS Editor", delegatable: false, grantable_from_ui: true, default: false)
+
+    Organisation.where(slug: "government-digital-service").first.users.with_permission(imminence_signin).each do |user|
+      user.supported_permissions << imminence_gds_editor
+      user.save!
+    end
+  end
+end


### PR DESCRIPTION
One-off rake task to add the GDS Editor permission  (if not already present) and grant it to any user who has the Imminence signin permission and is in GDS.

Needed so that GDS people who currently access Imminence will not lose the ability to see all datasets after the organisation data permissions update is merged. We can review and remove permissions later if necessary.

https://trello.com/c/UHBoqLxy/2358-add-per-department-permissions-to-imminence

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
