### PR TITLE
Add migration to clean up `UserApplicationPermission`s

### DIFF
--- a/db/migrate/20240423105028_remove_user_application_permissions_with_deleted_supported_permission.rb
+++ b/db/migrate/20240423105028_remove_user_application_permissions_with_deleted_supported_permission.rb
@@ -1,0 +1,27 @@
+class RemoveUserApplicationPermissionsWithDeletedSupportedPermission < ActiveRecord::Migration[7.1]
+  def change
+    return unless SupportedPermission.find_by(id: 2316).nil?
+
+    user_application_permissions_to_destroy = UserApplicationPermission.where(supported_permission_id: 2316)
+    initiator = User.find_by(email: "ynda.jas@digital.cabinet-office.gov.uk")
+
+    ActiveRecord::Base.transaction do
+      user_application_permissions_to_destroy.each do |user_application_permission|
+        user = user_application_permission.user
+        application_id = user_application_permission.application_id
+
+        raise "Could not destroy UserApplicationPermission with ID #{user_application_permission.id}" unless user_application_permission.destroy
+
+        next unless user
+
+        EventLog.record_event(
+          user,
+          EventLog::PERMISSIONS_REMOVED,
+          initiator:,
+          application_id:,
+          trailing_message: "(previously deleted permission with ID 2316 removed via migration)",
+        )
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_28_080000) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_23_105028) do
   create_table "batch_invitation_application_permissions", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "batch_invitation_id", null: false
     t.integer "supported_permission_id", null: false


### PR DESCRIPTION
[Trello](https://trello.com/c/J0Aq6mq6/1115-investigate-a-weird-nomethoderror-bug-with-permissions-that-mara-found)

We've been seeing `NoMethodError`s raised when trying to fetch certain users' current permissions in the permissions update flow

It appears that the `SupportedPermission` with ID `2316` has been deleted, but that the associated `UserApplicationPermission`s were not, despite the model callbacks that should destroy dependencies. There are 46 `UserApplicationPermission`s with a `supported_permission_id` of `2316`. This is currently the only `supported_permission_id` without a corresponding `SupportedPermission` that appears in any `UserApplicationPermission`s, so hopefully the missed callbacks were an isolated incident. This commit therefore adds a migration to deal with this specific issue rather than making changes to application code. If the issue resurfaces with another `supported_permission_id`, we can investigate further

---

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
