### PR TITLE
Start making ARM builds for Signon

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
   build-and-publish-image:
     if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'v')
     name: Build and publish image
-    uses: alphagov/govuk-infrastructure/.github/workflows/build-and-push-image.yml@main
+    uses: alphagov/govuk-infrastructure/.github/workflows/build-and-push-multiarch-image.yml@main
     with:
       gitRef: ${{ inputs.gitRef || github.event.release.tag_name }}
     permissions:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG base_image=ghcr.io/alphagov/govuk-ruby-base:$ruby_version
 ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:$ruby_version
 
 
-FROM $builder_image AS builder
+FROM --platform=$TARGETPLATFORM $builder_image AS builder
 
 ENV DEVISE_PEPPER=unused \
     DEVISE_SECRET_KEY=unused \
@@ -17,7 +17,7 @@ RUN bootsnap precompile --gemfile .
 RUN rails assets:precompile && rm -fr log
 
 
-FROM $base_image
+FROM --platform=$TARGETPLATFORM $base_image
 
 ENV GOVUK_APP_NAME=signon
 


### PR DESCRIPTION
## What?
This swaps signon to use the multi-architecture workflow so we start getting side-by-side AMD86 and ARM64 builds. So we can start testing an ARM-flavour of Signon in Integration.

Pinging @JonathanHallam for visibility on the Pub Platform team (I think).