### PR TITLE
Bump Ruby to 3.2.3 for ARM builds.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG ruby_version=3.2.2
+ARG ruby_version=3.2.3
 ARG base_image=ghcr.io/alphagov/govuk-ruby-base:$ruby_version
 ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:$ruby_version
 


### PR DESCRIPTION
## What?
This bumps the version of Ruby to 3.2.3, as we don't have any ARM base/builder images for 3.2.2. This should un-break the build hopefully.