### PR TITLE
Another migration to clean up `UserApplicationPermissions`

### DIFF
--- a/db/migrate/20240429130154_remove_user_permissions_with_deleted_permission.rb
+++ b/db/migrate/20240429130154_remove_user_permissions_with_deleted_permission.rb
@@ -1,0 +1,28 @@
+class RemoveUserPermissionsWithDeletedPermission < ActiveRecord::Migration[7.1]
+  def change
+    undeleted_permission = 1152
+    return unless SupportedPermission.find_by(id: undeleted_permission).nil?
+
+    user_application_permissions_to_destroy = UserApplicationPermission.where(supported_permission_id: undeleted_permission)
+    initiator = User.find_by(email: "callum.knights@digital.cabinet-office.gov.uk")
+
+    ActiveRecord::Base.transaction do
+      user_application_permissions_to_destroy.each do |user_application_permission|
+        user = user_application_permission.user
+        application_id = user_application_permission.application_id
+
+        raise "Could not destroy UserApplicationPermission with ID #{user_application_permission.id}" unless user_application_permission.destroy
+
+        next unless user
+
+        EventLog.record_event(
+          user,
+          EventLog::PERMISSIONS_REMOVED,
+          initiator:,
+          application_id:,
+          trailing_message: "(previously deleted permission with ID #{undeleted_permission} removed via migration)",
+        )
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_23_105028) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_29_130154) do
   create_table "batch_invitation_application_permissions", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "batch_invitation_id", null: false
     t.integer "supported_permission_id", null: false


### PR DESCRIPTION
Copy of @yndajas migration to clean up an errant UserApplicationPermission

A different UserApplicationPermission was present in Production vs integration, this removes that permission.

See https://github.com/alphagov/signon/pull/2829 for further context.

Trello: https://trello.com/c/lFr9qVJq/1132-remove-deleted-permissions-from-users

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
