### PR TITLE
Add Google Tag Manager configuration to Signon

### DIFF
--- a/app/views/layouts/_google_tag_manager.html.erb
+++ b/app/views/layouts/_google_tag_manager.html.erb
@@ -1,0 +1,9 @@
+<% if ENV["GOOGLE_TAG_MANAGER_ID"] %>
+  <% content_for :head do %>
+    <%= render "govuk_publishing_components/components/google_tag_manager_script", {
+      gtm_id: ENV["GOOGLE_TAG_MANAGER_ID"],
+      gtm_auth: ENV["GOOGLE_TAG_MANAGER_AUTH"],
+      gtm_preview: ENV["GOOGLE_TAG_MANAGER_PREVIEW"],
+    } %>
+  <% end %>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,3 +1,5 @@
+<%= render "layouts/google_tag_manager" %>
+
 <%= render 'govuk_publishing_components/components/layout_for_admin',
   product_name: "Signon",
   environment: GovukPublishingComponents::AppHelpers::Environment.current_acceptance_environment,


### PR DESCRIPTION
Based on the work we did previously on publisher in https://github.com/alphagov/publisher/pull/1963

There are no other calls to content_for :head in this application, so it should be fine to call it directly here.

Tested locally with:

    GOOGLE_TAG_MANAGER_AUTH=some-auth
    GOOGLE_TAG_MANAGER_ID=some-id
    GOOGLE_TAG_MANAGER_PREVIEW=some-preview

Gives this snippet in the head:

    //<![CDATA[
    (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
      'https://www.googletagmanager.com/gtm.js?id='+i+dl+'&gtm_cookies_win=x&gtm_auth=some-auth&gtm_preview=some-preview';f.parentNode.insertBefore(j,f);
    })(window,document,'script','dataLayer','some-id');
    //]]>

We'll need a follow up PR to pass these environment variables through in govuk-helm-charts.
