### PR TITLE
Add button to delete application supported permissions

### DIFF
--- a/app/controllers/supported_permissions_controller.rb
+++ b/app/controllers/supported_permissions_controller.rb
@@ -35,6 +35,21 @@ class SupportedPermissionsController < ApplicationController
     end
   end
 
+  def confirm_destroy
+    @supported_permission = supported_permission
+  end
+
+  def destroy
+    permission_name = supported_permission.name
+
+    if supported_permission.destroy!
+      redirect_to doorkeeper_application_supported_permissions_path,
+                  notice: "Successfully deleted permission #{permission_name}"
+    else
+      render :index
+    end
+  end
+
 private
 
   def load_and_authorize_application

--- a/app/views/supported_permissions/confirm_destroy.erb
+++ b/app/views/supported_permissions/confirm_destroy.erb
@@ -1,0 +1,42 @@
+<% content_for :title, "Delete #{@supported_permission.name} permission for #{@application.name}" %>
+
+<% content_for :breadcrumbs,
+   render("govuk_publishing_components/components/breadcrumbs", {
+     collapse_on_mobile: true,
+     breadcrumbs: [
+       {
+         title: "Dashboard",
+         url: root_path,
+       },
+       {
+         title: "Applications",
+         url: doorkeeper_applications_path,
+       },
+       {
+         title: @application.name,
+         url: edit_doorkeeper_application_path(@application),
+       },
+       {
+         title: "Permissions",
+         url: doorkeeper_application_supported_permissions_path(@application),
+       }
+     ]
+   })
+%>
+
+<div class="govuk-grid-row">
+  <section class="govuk-grid-column-two-thirds">
+    <%= form_tag doorkeeper_application_supported_permission_path(@application, @supported_permission), method: :delete do %>
+      <p class="govuk-body govuk-!-margin-bottom-6">Are you sure you want to delete the "<%= @supported_permission.name %>" permission for "<%= @application.name %>"?</p>
+
+      <div class="govuk-button-group govuk-!-margin-bottom-6">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Delete",
+          destructive: true,
+        } %>
+        <%= link_to("Cancel", doorkeeper_application_supported_permissions_path, class: "govuk-link govuk-link--no-visited-state") %>
+      </div>
+    <% end %>
+  </section>
+</div>
+

--- a/app/views/supported_permissions/index.html.erb
+++ b/app/views/supported_permissions/index.html.erb
@@ -61,7 +61,7 @@
         text: supported_permission.default? ? 'Yes' : 'No',
       },
       {
-        text: link_to('Edit', edit_doorkeeper_application_supported_permission_path(@application, supported_permission)),
+        text: link_to('Edit', edit_doorkeeper_application_supported_permission_path(@application, supported_permission)) + (link_to("Delete", confirm_destroy_doorkeeper_application_supported_permission_path(@application, supported_permission), class: "govuk-link gem-link--destructive govuk-!-margin-left-2")),
       },
     ]
   end,

--- a/app/views/supported_permissions/index.html.erb
+++ b/app/views/supported_permissions/index.html.erb
@@ -61,7 +61,7 @@
         text: supported_permission.default? ? 'Yes' : 'No',
       },
       {
-        text: link_to('Edit', edit_doorkeeper_application_supported_permission_path(@application, supported_permission)) + (link_to("Delete", confirm_destroy_doorkeeper_application_supported_permission_path(@application, supported_permission), class: "govuk-link gem-link--destructive govuk-!-margin-left-2")),
+        text: link_to('Edit', edit_doorkeeper_application_supported_permission_path(@application, supported_permission), class: "govuk-link") + (link_to("Delete", confirm_destroy_doorkeeper_application_supported_permission_path(@application, supported_permission), class: "govuk-link gem-link--destructive govuk-!-margin-left-2")),
       },
     ]
   end,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -93,7 +93,9 @@ Rails.application.routes.draw do
     member do
       get :users_with_access
     end
-    resources :supported_permissions, only: %i[index new create edit update]
+    resources :supported_permissions, only: %i[index new create edit update destroy] do
+      get :confirm_destroy, on: :member
+    end
   end
 
   resources :api_users, only: %i[new create index edit] do

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -52,15 +52,13 @@ if you just want to get this working, follow the steps below:
   GDS_SSO_STRATEGY=real bundle exec rails s
   ```
 
-## Creating new permissions
+## Creating, editing and deleting permissions
 
-To create a new permission for an existing app, you first need to have the
-"superadmin" role on your account (or have access to someone who does): you'll
-then be able to access the "Administer applications" menu item. Under the
-application you want to change, follow the "Supported Permissions" link and add
-a new permission from there.
-
-Note that this UI won't let you edit or delete existing permissions.
+To manage permissions for an existing app, you first need to have the "superadmin"
+role on your account (or have access to someone who does): you'll then be able to
+access the "Administer applications" menu item. Under the application you want to
+change, follow the "Supported Permissions" link and add, update or delete the
+permission from there.
 
 ## Creating new organisations
 

--- a/test/controllers/supported_permissions_controller_test.rb
+++ b/test/controllers/supported_permissions_controller_test.rb
@@ -97,4 +97,27 @@ class SupportedPermissionsControllerTest < ActionController::TestCase
       assert_not perm.default
     end
   end
+
+  context "GET confirm_destroy" do
+    should "render the permission and application names" do
+      application = create(:application, name: "My first app", with_supported_permissions: %w[permission1])
+
+      get :confirm_destroy, params: { doorkeeper_application_id: application.id, id: application.supported_permissions.first.id }
+
+      assert_select "p.govuk-body", "Are you sure you want to delete the \"permission1\" permission for \"My first app\"?"
+    end
+  end
+
+  context "DELETE destroy" do
+    should "delete the permission" do
+      application = create(:application)
+      supported_permission = create(:supported_permission, application:)
+
+      delete :destroy, params: { doorkeeper_application_id: application.id, id: supported_permission.id }
+
+      assert_redirected_to(controller: "supported_permissions", action: :index)
+      assert_equal "Successfully deleted permission #{supported_permission.name}", flash[:notice]
+      assert_not application.supported_permissions.include?(supported_permission)
+    end
+  end
 end


### PR DESCRIPTION
It is not currently possible to delete a supported permission through the user interface.

This has led to code being run on a Rails console when permissions need to be deleted, which has led to other issues because the wrong method was invoked (`delete` instead of `destroy`, which didn't delete the associated `UserApplicationPermission` records).

Therefore adding a delete button (including confirmation view) to allow to do be done in the user interface.

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

| Action | Screenshot |
| -- | -- |
| Index for supported permissions, showing new 'Delete' link | ![Screenshot showing the index for supported permissions for a fake application.  There is now a red 'Delete' link to the far side of the table entry.](https://github.com/alphagov/signon/assets/6329861/233d9981-dc99-4c16-9572-5beade2a69f8) |
| Confirmation view for deleting a permission | ![Screenshot of the confirmation view for deleting a permission; Main body reads: Are you sure you want to delete the "new" permission for "Test Application 1"?  There is a red 'Delete' button and link labelled 'Cancel'.](https://github.com/alphagov/signon/assets/6329861/984ae14b-4952-4c85-8d7f-044fe71cd24b) |
| Success flash notice after deleting a permission | ![Screenshot showing index page with flash notice that reads Successfully deleted permission new](https://github.com/alphagov/signon/assets/6329861/e1f34a4a-84b4-41c0-9f3a-eef711da1aac) |

[Trello card](https://trello.com/c/95Xkrscy)