### PR TITLE
Make secrets sync zero-configuration.

### DIFF
--- a/test/lib/tasks/sync_kubernetes_secrets_test.rb
+++ b/test/lib/tasks/sync_kubernetes_secrets_test.rb
@@ -15,93 +15,30 @@ class KubernetesTaskTest < ActiveSupport::TestCase
         api_user_with_token("user2", token_count: 1),
       ]
 
-      stub_config_map(@client, [], api_users.map(&:email))
       expect_secret_tokens_created_for_only_users(@client, api_users)
 
-      Rake::Task["kubernetes:sync_token_secrets"].execute({
-        config_map_name: "config_map_name",
-      })
+      Rake::Task["kubernetes:sync_token_secrets"].execute
     end
 
-    should "create all token secrets for only users specified" do
-      api_users = [
-        api_user_with_token("user1", token_count: 2),
-        api_user_with_token("user2", token_count: 1),
-      ]
+    should "create token secrets for non-suspended users only" do
+      suspended_user = api_user_with_token("user1", token_count: 1)
+      suspended_user.suspend("test")
+      expected_user = api_user_with_token("user2", token_count: 2)
 
-      specified_user = api_users[0]
+      expect_secret_tokens_created_for_only_users(@client, [expected_user])
 
-      stub_config_map(@client, [], [specified_user.email])
-      expect_secret_tokens_created_for_only_users(@client, [specified_user])
-
-      Rake::Task["kubernetes:sync_token_secrets"].execute({
-        config_map_name: "config_map_name",
-      })
-    end
-
-    should "raise an exception about missing user, but not skip other existing users" do
-      api_users = [
-        api_user_with_token("user1", token_count: 2),
-        api_user_with_token("user2", token_count: 1),
-      ]
-
-      emails = [api_users[0].email, "do-not-exist@example.com", api_users[1].email]
-
-      stub_config_map(@client, [], emails)
-      expect_secret_tokens_created_for_only_users(@client, api_users)
-
-      err = assert_raises StandardError do
-        Rake::Task["kubernetes:sync_token_secrets"].execute({
-          config_map_name: "config_map_name",
-        })
-      end
-
-      assert_match(/do-not-exist@example.com/, err.message)
+      Rake::Task["kubernetes:sync_token_secrets"].execute
     end
   end
 
   context "#sync_app_secrets" do
-    should "create all app secrets for only specified apps" do
+    should "create app secrets for all non-retired apps" do
       app = create(:application)
-      create(:application)
+      create(:application, retired: true)
 
-      stub_config_map(@client, [app.name], [])
       expect_secrets_created_for_only_apps(@client, [app])
 
-      Rake::Task["kubernetes:sync_app_secrets"].execute({
-        config_map_name: "config_map_name",
-      })
-    end
-
-    should "raise an exception about missing app, but not skip other existing apps" do
-      apps = [create(:application), create(:application)]
-      names = [apps[0].name, "Do Not Exist", apps[1].name]
-
-      stub_config_map(@client, names, [])
-      expect_secrets_created_for_only_apps(@client, apps)
-
-      err = assert_raises StandardError do
-        Rake::Task["kubernetes:sync_app_secrets"].execute({
-          config_map_name: "config_map_name",
-        })
-      end
-
-      assert_match(/Do Not Exist/, err.message)
-    end
-
-    should "raise an exception about retired app" do
-      app = create(:application, retired: true)
-
-      stub_config_map(@client, [app.name], [])
-      expect_secrets_created_for_only_apps(@client, [])
-
-      err = assert_raises StandardError do
-        Rake::Task["kubernetes:sync_app_secrets"].execute({
-          config_map_name: "config_map_name",
-        })
-      end
-
-      assert_match(/#{app.name}/, err.message)
+      Rake::Task["kubernetes:sync_app_secrets"].execute
     end
   end
 
@@ -123,17 +60,5 @@ class KubernetesTaskTest < ActiveSupport::TestCase
         { oauth_id: app.uid, oauth_secret: app.secret },
       )
     end
-  end
-
-  def stub_config_map(client, app_names, emails)
-    email_list = emails.map { |e| %("#{e}") }.join(",")
-    names_list = app_names.map { |n| %("#{n}") }.join(",")
-
-    client.stubs(:get_config_map).with("config_map_name").returns(
-      Kubeclient::Resource.new({
-        data: { "app_names" => "[#{names_list}]",
-                "api_user_emails" => "[#{email_list}]" },
-      }),
-    )
   end
 end


### PR DESCRIPTION
We used to have a lot of cruft lying around in Signon, but now it's much tidier. It's now feasible for us to just import the secrets for all active (non-retired) Doorkeeper applications and all non-suspended API users.

This removes an awkward step in setting up or renaming an application which tends to trip people up.