### PR TITLE
Fix current role on edit role pages

### DIFF
--- a/app/views/account/roles/edit.html.erb
+++ b/app/views/account/roles/edit.html.erb
@@ -24,7 +24,7 @@
             id: "user_role",
             name: "user[role]",
             label: "Role",
-            options: current_user.manageable_roles.map { |role| { text: role.display_name, value: role.name, selected: current_user.role == role.name } }
+            options: current_user.manageable_roles.map { |role| { text: role.display_name, value: role.name, selected: current_user.role_name == role.name } }
             } %>
         <%= render "govuk_publishing_components/components/button", {
           text: "Change role"

--- a/app/views/users/roles/edit.html.erb
+++ b/app/views/users/roles/edit.html.erb
@@ -48,7 +48,7 @@
           name: "user[role]",
           label: "Role",
           hint: user_role_select_hint,
-          options: current_user.manageable_roles.map { |role| { text: role.display_name, value: role.name, selected: @user.role == role.name } },
+          options: current_user.manageable_roles.map { |role| { text: role.display_name, value: role.name, selected: @user.role_name == role.name } },
           error_message: @user.errors[:role].any? ? @user.errors.full_messages_for(:role).to_sentence : nil
         } %>
         <div class="govuk-button-group">

--- a/test/integration/account_roles_test.rb
+++ b/test/integration/account_roles_test.rb
@@ -21,6 +21,7 @@ class AccountRolesTest < ActionDispatch::IntegrationTest
 
       visit edit_account_role_path
 
+      assert has_select? "Role", selected: "Superadmin"
       select "Normal", from: "Role"
       click_button "Change role"
 

--- a/test/integration/change_user_role_test.rb
+++ b/test/integration/change_user_role_test.rb
@@ -14,10 +14,11 @@ class ChangeUserRoleTest < ActionDispatch::IntegrationTest
 
   context "when logged in as a super admin" do
     should "be able to change the role of a user who is not exempt from 2SV" do
-      user = create(:user)
+      user = create(:two_step_enabled_organisation_admin)
       sign_in_as_and_edit_user(@super_admin, user)
       click_link "Change Role"
 
+      assert has_select? "Role", selected: "Organisation admin"
       select "Admin", from: "Role"
       click_button "Change role"
 


### PR DESCRIPTION
[Trello](https://trello.com/c/sW9M14wM/1191-change-your-role-input-not-prefilled-with-current-data)

On the pages where a user can edit their or another user's role, the select element always had "Normal" preselected, regardless of the user's actual current role. This was because of a mistake in the preselection logic, which is fixed here

## Screenshots

### Editing own role

#### Current role

<img width="565" alt="image" src="https://github.com/alphagov/signon/assets/40244233/ac9a94e7-af27-4d29-8000-8bef27243bb5">

#### Edit page

##### Before

<img width="329" alt="image" src="https://github.com/alphagov/signon/assets/40244233/ce6b2725-4645-49ab-8f60-dc25eb12422d">

##### After

<img width="336" alt="image" src="https://github.com/alphagov/signon/assets/40244233/b392bf0e-07d3-41c9-917b-d5fe56675d4d">

### Editing other user's role

#### Current role

<img width="516" alt="image" src="https://github.com/alphagov/signon/assets/40244233/02da712a-ed4f-4327-aa3e-34fba32faef7">

#### Edit page

##### Before

<img width="763" alt="image" src="https://github.com/alphagov/signon/assets/40244233/8916ac15-39c4-4d26-8ee3-825a83239c2b">

##### After
<img width="756" alt="image" src="https://github.com/alphagov/signon/assets/40244233/c46ac559-edd8-49bd-b2c6-dda48d78a5a5">


---

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
