### PR TITLE
Add logging to permission removal Rake task

### DIFF
--- a/lib/tasks/permissions.rake
+++ b/lib/tasks/permissions.rake
@@ -27,11 +27,21 @@ namespace :permissions do
       supported_permission: whitehall_managing_editor_permission,
       user_id: User.where.not(organisation_id: gds.id),
     ).pluck(:user_id)
-    user_editor_permissions_to_destroy_ids = UserApplicationPermission.where(
+    editor_permissions_to_destroy = UserApplicationPermission.where(
       supported_permission: whitehall_editor_permission,
       user_id: non_gds_users_with_managing_editor_permission_user_ids,
     )
 
-    user_editor_permissions_to_destroy_ids.destroy_all
+    puts "Number of non-GDS users with both managing editor and editor permissions in Whitehall"
+    puts "Before removing permissions: #{editor_permissions_to_destroy.count}"
+
+    editor_permissions_to_destroy.destroy_all
+
+    count_of_remaining_users_with_both_permissions = UserApplicationPermission.where(
+      supported_permission: whitehall_editor_permission,
+      user_id: non_gds_users_with_managing_editor_permission_user_ids,
+    ).count
+
+    puts "After removing permissions: #{count_of_remaining_users_with_both_permissions}"
   end
 end


### PR DESCRIPTION
[Trello](https://trello.com/c/SlnFFy5r/1192-create-a-template-rake-task-where-we-update-multiple-users-permissions-based-on-a-condition)

This Rake task didn't have any count logging, so in order to be sure it worked, you'd have to run some of the code after (and also ideally before) running the Rake task to check the permission counts. This task has already been run, but we may reuse it in future and/or use it as a template for other similar Rake tasks, so we should make it more of a best practice example now

---

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
