### PR TITLE
Use GOVUK_ENVIRONMENT instead of GOVUK_ENVIRONMENT_NAME

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ FROM --platform=$TARGETPLATFORM $builder_image AS builder
 
 ENV DEVISE_PEPPER=unused \
     DEVISE_SECRET_KEY=unused \
-    GOVUK_ENVIRONMENT_NAME=unused
+    GOVUK_ENVIRONMENT=unused
 
 WORKDIR $APP_HOME
 COPY Gemfile* .ruby-version ./

--- a/app/models/govuk_environment.rb
+++ b/app/models/govuk_environment.rb
@@ -3,7 +3,7 @@ class GovukEnvironment
     if Rails.env.development? || Rails.env.test?
       "development"
     else
-      ENV.fetch("GOVUK_ENVIRONMENT_NAME")
+      ENV.fetch("GOVUK_ENVIRONMENT")
     end
   end
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -38,4 +38,4 @@ Used to configure Google Analytics in the new `app/views/layouts/admin_layout.ht
 
 Used to configure `GovukAdminTemplate` and in `Healthcheck::ApiTokens#expiring_tokens`.
 
-* `GOVUK_ENVIRONMENT_NAME`
+* `GOVUK_ENVIRONMENT`

--- a/lib/healthcheck/api_tokens.rb
+++ b/lib/healthcheck/api_tokens.rb
@@ -19,7 +19,7 @@ module Healthcheck
         ) tokens
       INNER JOIN users ON users.id = tokens.resource_owner_id
       WHERE tokens.revoked_at IS NULL
-      AND users.email NOT LIKE '%@#{ENV['GOVUK_ENVIRONMENT_NAME']}.publishing.service.gov.uk'
+      AND users.email NOT LIKE '%@#{ENV['GOVUK_ENVIRONMENT']}.publishing.service.gov.uk'
       AND users.name NOT LIKE '%[EKS]'
       AND users.api_user = TRUE
       AND tokens.expires_in < #{WARNING_THRESHOLD}

--- a/test/lib/healthcheck/api_tokens_test.rb
+++ b/test/lib/healthcheck/api_tokens_test.rb
@@ -8,7 +8,7 @@ class PermissionUpdaterTest < ActiveSupport::TestCase
     end
 
     should "return 'OK' when tokens for @<env>.publishing.service.gov.uk are expiring" do
-      user = create(:api_user, email: "#{random_str}@#{ENV['GOVUK_ENVIRONMENT_NAME']}.publishing.service.gov.uk")
+      user = create(:api_user, email: "#{random_str}@#{ENV['GOVUK_ENVIRONMENT']}.publishing.service.gov.uk")
 
       make_api_user_token(
         expires_in: Healthcheck::ApiTokens::WARNING_THRESHOLD,

--- a/test/models/govuk_environment_test.rb
+++ b/test/models/govuk_environment_test.rb
@@ -30,14 +30,14 @@ class GovukEnvironmentTest < ActionMailer::TestCase
         Rails.env.stubs(:test?).returns(false)
       end
 
-      should "return value of GOVUK_ENVIRONMENT_NAME if it is set" do
-        ClimateControl.modify(GOVUK_ENVIRONMENT_NAME: "govuk-environment-name") do
+      should "return value of GOVUK_ENVIRONMENT if it is set" do
+        ClimateControl.modify(GOVUK_ENVIRONMENT: "govuk-environment-name") do
           assert_equal "govuk-environment-name", GovukEnvironment.name
         end
       end
 
-      should "fail fast if GOVUK_ENVIRONMENT_NAME is not set" do
-        ClimateControl.modify(GOVUK_ENVIRONMENT_NAME: nil) do
+      should "fail fast if GOVUK_ENVIRONMENT is not set" do
+        ClimateControl.modify(GOVUK_ENVIRONMENT: nil) do
           assert_raises(KeyError) { GovukEnvironment.name }
         end
       end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,5 @@
 ENV["RAILS_ENV"] = "test"
-ENV["GOVUK_ENVIRONMENT_NAME"] = "test"
+ENV["GOVUK_ENVIRONMENT"] = "test"
 
 require "simplecov"
 SimpleCov.start "rails"


### PR DESCRIPTION
Both environment variables are set to the same value. GOVUK_ENVIRONMENT is used more frequently, renaming for consistency.

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.