### PR TITLE
Allow adding multiple permissions with autocomplete

### DIFF
--- a/app/assets/javascripts/modules/accessible-autocomplete.js
+++ b/app/assets/javascripts/modules/accessible-autocomplete.js
@@ -24,6 +24,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {}
 
     const autocompleteElement = selectElement.parentNode.querySelector('.autocomplete__input')
     enableArrow(autocompleteElement)
+    enableAddButton()
     resetSelectWhenDesynced(selectElement, autocompleteElement)
     enableClearButton(selectElement, autocompleteElement)
   }
@@ -38,6 +39,34 @@ function enableArrow (autocompleteElement) {
     autocompleteElement.click()
     autocompleteElement.focus()
   })
+}
+
+function enableAddButton () {
+  const addButton = document.querySelector('.js-autocomplete__add-button')
+  const addAndFinishButton = document.querySelector('.js-autocomplete__add-and-finish-button')
+  const addMoreInput = document.querySelector('input[name="application[add_more]"]')
+
+  if (addButton) {
+    addAndFinishButton.type = 'button'
+    addMoreInput.value = 'true'
+
+    addAndFinishButton.addEventListener('click', function () {
+      addAndFinish(addMoreInput, addButton)
+    })
+
+    addAndFinishButton.addEventListener('keydown', function (event) {
+      if (event.key === ' ' || event.key === 'Enter') {
+        addAndFinish(addMoreInput, addButton)
+      }
+    })
+
+    addButton.classList.add('js-autocomplete__add-button--enabled')
+  }
+}
+
+function addAndFinish (addMoreInput, addButton) {
+  addMoreInput.value = 'false'
+  addButton.click()
 }
 
 function resetSelectWhenDesynced (selectElement, autocompleteElement) {

--- a/app/assets/stylesheets/components/_accessible-autocomplete.scss
+++ b/app/assets/stylesheets/components/_accessible-autocomplete.scss
@@ -29,7 +29,7 @@
   }
 }
 
-.js-autocomplete__clear-button {
+.js-autocomplete__add-button, .js-autocomplete__clear-button {
   display: none;
 
   &--enabled {

--- a/app/controllers/account/permissions_controller.rb
+++ b/app/controllers/account/permissions_controller.rb
@@ -59,14 +59,19 @@ class Account::PermissionsController < ApplicationController
 
     UserUpdate.new(current_user, { supported_permission_ids: }, current_user, user_ip_address).call
 
-    flash[:application_id] = @application.id
-    redirect_to account_applications_path
+    if update_params[:add_more] == "true"
+      flash[:new_permission_name] = SupportedPermission.find(update_params[:new_permission_id]).name
+      redirect_to edit_account_application_permissions_path(@application)
+    else
+      flash[:application_id] = @application.id
+      redirect_to account_applications_path
+    end
   end
 
 private
 
   def update_params
-    params.require(:application).permit(:new_permission_id, current_permission_ids: [], supported_permission_ids: [])
+    params.require(:application).permit(:new_permission_id, :add_more, current_permission_ids: [], supported_permission_ids: [])
   end
 
   def set_application

--- a/app/controllers/users/permissions_controller.rb
+++ b/app/controllers/users/permissions_controller.rb
@@ -60,14 +60,19 @@ class Users::PermissionsController < ApplicationController
 
     UserUpdate.new(@user, { supported_permission_ids: }, current_user, user_ip_address).call
 
-    flash[:application_id] = @application.id
-    redirect_to user_applications_path(@user)
+    if update_params[:add_more] == "true"
+      flash[:new_permission_name] = SupportedPermission.find(update_params[:new_permission_id]).name
+      redirect_to edit_user_application_permissions_path(@user, @application)
+    else
+      flash[:application_id] = @application.id
+      redirect_to user_applications_path(@user)
+    end
   end
 
 private
 
   def update_params
-    params.require(:application).permit(:new_permission_id, current_permission_ids: [], supported_permission_ids: [])
+    params.require(:application).permit(:new_permission_id, :add_more, current_permission_ids: [], supported_permission_ids: [])
   end
 
   def set_user

--- a/app/views/account/permissions/edit.html.erb
+++ b/app/views/account/permissions/edit.html.erb
@@ -20,6 +20,15 @@
    })
 %>
 
+<% if flash[:new_permission_name] %>
+  <% content_for(:custom_alerts) do %>
+    <%= render "govuk_publishing_components/components/success_alert", {
+        message: "Permission added",
+        description: "You have successfully added the permission '#{flash[:new_permission_name]}'.",
+    } %>
+  <% end %>
+<% end %>
+
 <%= render "shared/permissions_forms", {
   assigned_permissions: @assigned_permissions,
   unassigned_permission_options: @unassigned_permission_options,

--- a/app/views/shared/_add_permissions_with_autocomplete_form.html.erb
+++ b/app/views/shared/_add_permissions_with_autocomplete_form.html.erb
@@ -14,9 +14,19 @@
     <%= hidden_field_tag "application[current_permission_ids][]", id %>
   <% end %>
 
+  <%= hidden_field_tag "application[add_more]", "false" %>
+
   <div class="govuk-button-group">
     <%= render "govuk_publishing_components/components/button", {
-        text: "Add permission"
+        text: "Add",
+        aria_label: "Add permission",
+        classes: "js-autocomplete__add-button"
+    } %>
+
+    <%= render "govuk_publishing_components/components/button", {
+        text: "Add and finish",
+        aria_label: "Add permission and finish",
+        classes: "js-autocomplete__add-and-finish-button"
     } %>
 
     <%= render "govuk_publishing_components/components/button", {

--- a/app/views/users/permissions/edit.html.erb
+++ b/app/views/users/permissions/edit.html.erb
@@ -25,6 +25,15 @@
    })
 %>
 
+<% if flash[:new_permission_name] %>
+  <% content_for(:custom_alerts) do %>
+    <%= render "govuk_publishing_components/components/success_alert", {
+        message: "Permission added",
+        description: "You have successfully added the permission '#{flash[:new_permission_name]}'.",
+    } %>
+  <% end %>
+<% end %>
+
 <%= render "shared/permissions_forms", {
   assigned_permissions: @assigned_permissions,
   unassigned_permission_options: @unassigned_permission_options,

--- a/test/integration/account_applications_test.rb
+++ b/test/integration/account_applications_test.rb
@@ -210,12 +210,12 @@ class AccountApplicationsTest < ActionDispatch::IntegrationTest
       end
 
       click_on "Update permissions for app-with-9-permissions"
-      click_button "Add permission"
+      click_button "Add and finish"
       flash = find("div[role='alert']")
       assert flash.has_content?("You must select a permission.")
 
       select "adding"
-      click_button "Add permission"
+      click_button "Add and finish"
       flash = find("div[role='alert']")
       assert flash.has_content?("pre-existing")
       assert flash.has_content?("adding")
@@ -366,7 +366,7 @@ class AccountApplicationsTest < ActionDispatch::IntegrationTest
 
       should "be able to add permissions" do
         # when I try to add the permission
-        click_button "Add permission"
+        click_button "Add and finish"
 
         # I can see that the permission has been added
         assert_includes @user.permissions_for(@app), "pre-existing"
@@ -374,6 +374,21 @@ class AccountApplicationsTest < ActionDispatch::IntegrationTest
         %w[never-1 never-2 never-3 never-4 never-5 never-6].each do |permission|
           assert_not_includes @user.permissions_for(@app), permission
         end
+
+        assert_current_url account_applications_path
+      end
+
+      should "add permissions then redirect back to the form when clicking 'Add'" do
+        click_button "Add"
+
+        # I can see that the permission has been added
+        assert_includes @user.permissions_for(@app), "pre-existing"
+        assert_includes @user.permissions_for(@app), "adding"
+        %w[never-1 never-2 never-3 never-4 never-5 never-6].each do |permission|
+          assert_not_includes @user.permissions_for(@app), permission
+        end
+
+        assert_current_url edit_account_application_permissions_path(@app)
       end
 
       should "reset the value of the select element when it no longer matches what's shown in the autocomplete input" do
@@ -387,7 +402,7 @@ class AccountApplicationsTest < ActionDispatch::IntegrationTest
         assert_equal "", @select_element.value
 
         # when I try to add the permission
-        click_button "Add permission"
+        click_button "Add and finish"
 
         # I can see that the permission has not been added
         assert_includes @user.permissions_for(@app), "pre-existing"
@@ -405,7 +420,7 @@ class AccountApplicationsTest < ActionDispatch::IntegrationTest
         assert_equal "", @select_element.value
 
         # when I try to add the permission
-        click_button "Add permission"
+        click_button "Add and finish"
 
         # I can see that the permission has not been added
         assert_includes @user.permissions_for(@app), "pre-existing"
@@ -424,7 +439,7 @@ class AccountApplicationsTest < ActionDispatch::IntegrationTest
         assert_equal "", @select_element.value
 
         # when I try to add the permission
-        click_button "Add permission"
+        click_button "Add and finish"
 
         # I can see that the permission has not been added
         assert_includes @user.permissions_for(@app), "pre-existing"
@@ -443,7 +458,7 @@ class AccountApplicationsTest < ActionDispatch::IntegrationTest
         assert_equal "", @select_element.value
 
         # when I try to add the permission
-        click_button "Add permission"
+        click_button "Add and finish"
 
         # I can see that the permission has not been added
         assert_includes @user.permissions_for(@app), "pre-existing"

--- a/test/integration/granting_permissions_test.rb
+++ b/test/integration/granting_permissions_test.rb
@@ -273,12 +273,12 @@ class GrantingPermissionsTest < ActionDispatch::IntegrationTest
       end
 
       click_on "Update permissions for MyApp"
-      click_button "Add permission"
+      click_button "Add and finish"
       flash = find("div[role='alert']")
       assert flash.has_content?("You must select a permission.")
 
       select "adding"
-      click_button "Add permission"
+      click_button "Add and finish"
       assert_includes user.permissions_for(app), "pre-existing"
       assert_includes user.permissions_for(app), "adding"
       %w[removing never-1 never-2 never-3 never-4 never-5 never-6].each do |permission|
@@ -429,7 +429,7 @@ class GrantingPermissionsTest < ActionDispatch::IntegrationTest
 
       should "be able to add permissions" do
         # when I try to add the permission
-        click_button "Add permission"
+        click_button "Add and finish"
 
         # I can see that the permission has been added
         assert_includes @user.permissions_for(@app), "pre-existing"
@@ -437,6 +437,21 @@ class GrantingPermissionsTest < ActionDispatch::IntegrationTest
         %w[never-1 never-2 never-3 never-4 never-5 never-6].each do |permission|
           assert_not_includes @user.permissions_for(@app), permission
         end
+
+        assert_current_url user_applications_path(@user)
+      end
+
+      should "add permissions then redirect back to the form when clicking 'Add'" do
+        click_button "Add"
+
+        # I can see that the permission has been added
+        assert_includes @user.permissions_for(@app), "pre-existing"
+        assert_includes @user.permissions_for(@app), "adding"
+        %w[never-1 never-2 never-3 never-4 never-5 never-6].each do |permission|
+          assert_not_includes @user.permissions_for(@app), permission
+        end
+
+        assert_current_url edit_user_application_permissions_path(@user, @app)
       end
 
       should "reset the value of the select element when it no longer matches what's shown in the autocomplete input" do
@@ -450,7 +465,7 @@ class GrantingPermissionsTest < ActionDispatch::IntegrationTest
         assert_equal "", @select_element.value
 
         # when I try to add the permission
-        click_button "Add permission"
+        click_button "Add and finish"
 
         # I can see that the permission has not been added
         assert_includes @user.permissions_for(@app), "pre-existing"
@@ -468,7 +483,7 @@ class GrantingPermissionsTest < ActionDispatch::IntegrationTest
         assert_equal "", @select_element.value
 
         # when I try to add the permission
-        click_button "Add permission"
+        click_button "Add and finish"
 
         # I can see that the permission has not been added
         assert_includes @user.permissions_for(@app), "pre-existing"
@@ -487,7 +502,7 @@ class GrantingPermissionsTest < ActionDispatch::IntegrationTest
         assert_equal "", @select_element.value
 
         # when I try to add the permission
-        click_button "Add permission"
+        click_button "Add and finish"
 
         # I can see that the permission has not been added
         assert_includes @user.permissions_for(@app), "pre-existing"
@@ -506,7 +521,7 @@ class GrantingPermissionsTest < ActionDispatch::IntegrationTest
         assert_equal "", @select_element.value
 
         # when I try to add the permission
-        click_button "Add permission"
+        click_button "Add and finish"
 
         # I can see that the permission has not been added
         assert_includes @user.permissions_for(@app), "pre-existing"


### PR DESCRIPTION
[Trello](https://trello.com/c/4ABkAgkF/1210-allow-multiple-permissions-to-be-selected-before-being-added)

The new autocomplete form for adding permissions to apps with more than eight supported permissions redirects users to the applications path after adding a permission. Sometimes users want to add multiple permissions at the same time. This offers a middle ground, whereby we still have a single value autocomplete, but there's an option to be redirected back to the form after adding each permission

## Screenshots

### Before

https://github.com/alphagov/signon/assets/40244233/7043870b-7cd9-454e-89dd-54dee5c523e5

### After

https://github.com/alphagov/signon/assets/40244233/70d45b1f-4feb-4cf3-a941-cc972a159e60

---

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
