### PR TITLE
Hide certain account activity events from non-admins

### DIFF
--- a/app/models/event_log.rb
+++ b/app/models/event_log.rb
@@ -31,8 +31,8 @@ class EventLog < ApplicationRecord
     TWO_STEP_PROMPT_DEFERRED = LogEntry.new(id: 26, description: "2-step prompt deferred", require_uid: true),
     API_USER_CREATED = LogEntry.new(id: 27, description: "Account created", require_uid: true, require_initiator: true),
     ACCESS_TOKEN_REGENERATED = LogEntry.new(id: 28, description: "Access token re-generated", require_uid: true, require_application: true), # deprecated
-    ACCESS_TOKEN_GENERATED = LogEntry.new(id: 29, description: "Access token generated", require_uid: true, require_application: true, require_initiator: true),
-    ACCESS_TOKEN_REVOKED = LogEntry.new(id: 30, description: "Access token revoked", require_uid: true, require_application: true, require_initiator: true),
+    ACCESS_TOKEN_GENERATED = LogEntry.new(id: 29, description: "Access token generated", require_uid: true, require_application: true, require_initiator: true, access_limited: true),
+    ACCESS_TOKEN_REVOKED = LogEntry.new(id: 30, description: "Access token revoked", require_uid: true, require_application: true, require_initiator: true, access_limited: true),
     PASSWORD_RESET_LOADED_BUT_TOKEN_EXPIRED = LogEntry.new(id: 31, description: "Password reset page loaded but the token has expired", require_uid: true),
     SUCCESSFUL_PASSWORD_RESET = LogEntry.new(id: 32, description: "Password reset successfully", require_uid: true),
     ROLE_CHANGED = LogEntry.new(id: 33, description: "Role changed", require_uid: true, require_initiator: true),
@@ -45,8 +45,8 @@ class EventLog < ApplicationRecord
     TWO_STEP_EXEMPTION_UPDATED = LogEntry.new(id: 40, description: "2-step verification exemption updated", require_uid: true, require_initiator: true),
     TWO_STEP_EXEMPTION_REMOVED = LogEntry.new(id: 41, description: "Exemption from 2-step verification removed", require_uid: true, require_initiator: true),
     TWO_STEP_MANDATED = LogEntry.new(id: 42, description: "2-step verification setup mandated at next login", require_uid: true, require_initiator: true),
-    ACCESS_GRANTS_DELETED = LogEntry.new(id: 43, description: "Access grants deleted", require_uid: true),
-    ACCESS_TOKENS_DELETED = LogEntry.new(id: 44, description: "Access tokens deleted", require_uid: true),
+    ACCESS_GRANTS_DELETED = LogEntry.new(id: 43, description: "Access grants deleted", require_uid: true, access_limited: true),
+    ACCESS_TOKENS_DELETED = LogEntry.new(id: 44, description: "Access tokens deleted", require_uid: true, access_limited: true),
     ACCOUNT_DELETED = LogEntry.new(id: 45, description: "Account deleted", require_uid: true),
     ORGANISATION_CHANGED = LogEntry.new(id: 46, description: "Organisation changed", require_uid: true, require_initiator: true),
     SUCCESSFUL_USER_APPLICATION_AUTHORIZATION = LogEntry.new(id: 47, description: "Successful user application authorization", require_uid: true, require_application: true),
@@ -55,6 +55,7 @@ class EventLog < ApplicationRecord
   EVENTS_REQUIRING_UID = EVENTS.select(&:require_uid?)
   EVENTS_REQUIRING_INITIATOR = EVENTS.select(&:require_initiator?)
   EVENTS_REQUIRING_APPLICATION = EVENTS.select(&:require_application?)
+  ACCESS_LIMITED_EVENTS = EVENTS.select(&:access_limited?)
 
   VALID_OPTIONS = %i[initiator application application_id trailing_message ip_address user_agent_id user_agent_string user_email_string].freeze
 
@@ -74,6 +75,10 @@ class EventLog < ApplicationRecord
 
   def event
     entry.description
+  end
+
+  def requires_admin?
+    ACCESS_LIMITED_EVENTS.include? entry
   end
 
   def entry

--- a/app/models/log_entry.rb
+++ b/app/models/log_entry.rb
@@ -1,12 +1,13 @@
 class LogEntry
   attr_reader :id, :description
 
-  def initialize(id:, description:, require_uid: false, require_initiator: false, require_application: false)
+  def initialize(id:, description:, require_uid: false, require_initiator: false, require_application: false, access_limited: false)
     @id = id
     @description = description
     @require_uid = require_uid
     @require_initiator = require_initiator
     @require_application = require_application
+    @access_limited = access_limited
   end
 
   def require_uid?
@@ -19,5 +20,9 @@ class LogEntry
 
   def require_application?
     @require_application
+  end
+
+  def access_limited?
+    @access_limited
   end
 end

--- a/app/views/shared/_event_logs_table.html.erb
+++ b/app/views/shared/_event_logs_table.html.erb
@@ -8,8 +8,8 @@
     ],
     rows: logs.map do |log|
     [ { text: formatted_date(log), format: "event-log-date" },
-      { text: formatted_message(log) } ]
-    end
+      { text: formatted_message(log) } ] unless log.requires_admin? && !current_user.govuk_admin?
+    end.compact
   } %>
 
   <%= paginate(logs, theme: "gds") %>

--- a/test/integration/account_activities_test.rb
+++ b/test/integration/account_activities_test.rb
@@ -12,5 +12,30 @@ class AccountActivitiesTest < ActionDispatch::IntegrationTest
 
       assert page.has_selector? "td", text: "Successful login"
     end
+    should "not show technical events to normal users" do
+      user = create(:user)
+      EventLog.record_event(user, EventLog::ACCESS_GRANTS_DELETED)
+
+      visit new_user_session_path
+      signin_with user
+
+      visit account_activity_path
+
+      assert page.has_selector? "td", text: "Successful login"
+      assert_no_text "Access grants deleted"
+    end
+
+    should "show technical events to admin/superadmin users" do
+      user = create(:admin_user)
+      EventLog.record_event(user, EventLog::ACCESS_GRANTS_DELETED)
+
+      visit new_user_session_path
+      signin_with user
+
+      visit account_activity_path
+
+      assert page.has_selector? "td", text: "Successful login"
+      assert page.has_selector? "td", text: "Access grants deleted"
+    end
   end
 end


### PR DESCRIPTION
Response to some user concerns about often automated account activity. Decided to restrict visibility of certain events `Access token generated`, `Access token revoked`, `Access grants deleted`, `Access tokens deleted`.

Visibility of these events was causing confusion for some users, so restricting them to admin/superadmin only visibility seemed sensible.

Trello: https://trello.com/c/Vv4Dn2O7/1193-only-display-technical-events-in-user-activity-log-for-admins-superadmins

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
