### PR TITLE
Refactor `ApplicationTableHelper`

### DIFF
--- a/app/helpers/application_table_helper.rb
+++ b/app/helpers/application_table_helper.rb
@@ -58,14 +58,14 @@ module ApplicationTableHelper
 private
 
   def grant_access_link(application, user = nil)
-    link_path = if user
-                  user_application_signin_permission_path(user, application)
-                else
-                  account_application_signin_permission_path(application)
-                end
+    path = if user
+             user_application_signin_permission_path(user, application)
+           else
+             account_application_signin_permission_path(application)
+           end
 
     button_to(
-      link_path,
+      path,
       class: "govuk-button govuk-!-margin-0",
       data: { module: "govuk-button" },
     ) do
@@ -74,14 +74,14 @@ private
   end
 
   def remove_access_link(application, user = nil)
-    link_path = if user
-                  delete_user_application_signin_permission_path(user, application)
-                else
-                  delete_account_application_signin_permission_path(application)
-                end
+    path = if user
+             delete_user_application_signin_permission_path(user, application)
+           else
+             delete_account_application_signin_permission_path(application)
+           end
 
     link_to(
-      link_path,
+      path,
       class: "govuk-button govuk-button--warning govuk-!-margin-0",
       data: { module: "govuk-button" },
     ) do
@@ -90,13 +90,13 @@ private
   end
 
   def view_permissions_link(application, user = nil)
-    link_path = if user
-                  user_application_permissions_path(user, application)
-                else
-                  account_application_permissions_path(application)
-                end
+    path = if user
+             user_application_permissions_path(user, application)
+           else
+             account_application_permissions_path(application)
+           end
 
-    link_to(link_path, class: "govuk-link") do
+    link_to(path, class: "govuk-link") do
       safe_join(
         ["View permissions",
          content_tag(:span, " for #{application.name}", class: "govuk-visually-hidden")],
@@ -107,15 +107,15 @@ private
   def update_permissions_link(application, user = nil)
     return "" if application.sorted_supported_permissions_grantable_from_ui(include_signin: false).none?
 
-    link_path = if user.nil?
-                  edit_account_application_permissions_path(application)
-                elsif user.api_user?
-                  edit_api_user_application_permissions_path(user, application)
-                else
-                  edit_user_application_permissions_path(user, application)
-                end
+    path = if user.nil?
+             edit_account_application_permissions_path(application)
+           elsif user.api_user?
+             edit_api_user_application_permissions_path(user, application)
+           else
+             edit_user_application_permissions_path(user, application)
+           end
 
-    link_to(link_path, class: "govuk-link") do
+    link_to(path, class: "govuk-link") do
       safe_join(
         ["Update permissions",
          content_tag(:span, " for #{application.name}", class: "govuk-visually-hidden")],

--- a/app/helpers/application_table_helper.rb
+++ b/app/helpers/application_table_helper.rb
@@ -68,9 +68,7 @@ private
       path,
       class: "govuk-button govuk-!-margin-0",
       data: { module: "govuk-button" },
-    ) do
-      safe_join(["Grant access", content_tag(:span, " to #{application.name}", class: "govuk-visually-hidden")])
-    end
+    ) { button_or_link_content("Grant access", "to", application.name) }
   end
 
   def remove_access_link(application, user = nil)
@@ -84,9 +82,7 @@ private
       path,
       class: "govuk-button govuk-button--warning govuk-!-margin-0",
       data: { module: "govuk-button" },
-    ) do
-      safe_join(["Remove access", content_tag(:span, " to #{application.name}", class: "govuk-visually-hidden")])
-    end
+    ) { button_or_link_content("Remove access", "to", application.name) }
   end
 
   def view_permissions_link(application, user = nil)
@@ -96,12 +92,7 @@ private
              account_application_permissions_path(application)
            end
 
-    link_to(path, class: "govuk-link") do
-      safe_join(
-        ["View permissions",
-         content_tag(:span, " for #{application.name}", class: "govuk-visually-hidden")],
-      )
-    end
+    link_to(path, class: "govuk-link") { button_or_link_content("View permissions", "for", application.name) }
   end
 
   def update_permissions_link(application, user = nil)
@@ -115,11 +106,13 @@ private
              edit_user_application_permissions_path(user, application)
            end
 
-    link_to(path, class: "govuk-link") do
-      safe_join(
-        ["Update permissions",
-         content_tag(:span, " for #{application.name}", class: "govuk-visually-hidden")],
-      )
-    end
+    link_to(path, class: "govuk-link") { button_or_link_content("Update permissions", "for", application.name) }
+  end
+
+  def button_or_link_content(visible_text, visually_hidden_join_word, application_name)
+    safe_join([
+      visible_text,
+      content_tag(:span, " #{visually_hidden_join_word} #{application_name}", class: "govuk-visually-hidden"),
+    ])
   end
 end

--- a/app/helpers/application_table_helper.rb
+++ b/app/helpers/application_table_helper.rb
@@ -1,55 +1,35 @@
 module ApplicationTableHelper
   include Pundit::Authorization
 
-  def update_permissions_link(application, user = nil)
-    link_path = if user.nil?
-                  edit_account_application_permissions_path(application)
-                elsif user.api_user?
-                  edit_api_user_application_permissions_path(user, application)
-                else
-                  edit_user_application_permissions_path(user, application)
-                end
-
-    if application.sorted_supported_permissions_grantable_from_ui(include_signin: false).any?
-      link_to(link_path, class: "govuk-link") do
-        safe_join(
-          ["Update permissions",
-           content_tag(:span, " for #{application.name}", class: "govuk-visually-hidden")],
-        )
-      end
+  def account_applications_grant_access_link(application)
+    if policy([:account, Doorkeeper::Application]).grant_signin_permission?
+      grant_access_link(application)
     else
       ""
     end
   end
 
-  def view_permissions_link(application, user = nil)
-    link_path = if user
-                  user_application_permissions_path(user, application)
-                else
-                  account_application_permissions_path(application)
-                end
-
-    link_to(link_path, class: "govuk-link") do
-      safe_join(
-        ["View permissions",
-         content_tag(:span, " for #{application.name}", class: "govuk-visually-hidden")],
-      )
+  def users_applications_grant_access_link(application, user)
+    if policy(UserApplicationPermission.for(user, application)).create?
+      grant_access_link(application, user)
+    else
+      ""
     end
   end
 
-  def remove_access_link(application, user = nil)
-    link_path = if user
-                  delete_user_application_signin_permission_path(user, application)
-                else
-                  delete_account_application_signin_permission_path(application)
-                end
+  def account_applications_remove_access_link(application)
+    if policy([:account, application]).remove_signin_permission?
+      remove_access_link(application)
+    else
+      ""
+    end
+  end
 
-    link_to(
-      link_path,
-      class: "govuk-button govuk-button--warning govuk-!-margin-0",
-      data: { module: "govuk-button" },
-    ) do
-      safe_join(["Remove access", content_tag(:span, " to #{application.name}", class: "govuk-visually-hidden")])
+  def users_applications_remove_access_link(application, user)
+    if policy(UserApplicationPermission.for(user, application)).delete?
+      remove_access_link(application, user)
+    else
+      ""
     end
   end
 
@@ -71,21 +51,11 @@ module ApplicationTableHelper
     end
   end
 
-  def users_applications_remove_access_link(application, user)
-    if policy(UserApplicationPermission.for(user, application)).delete?
-      remove_access_link(application, user)
-    else
-      ""
-    end
+  def api_users_applications_permissions_link(application, user)
+    update_permissions_link(application, user)
   end
 
-  def account_applications_remove_access_link(application)
-    if policy([:account, application]).remove_signin_permission?
-      remove_access_link(application)
-    else
-      ""
-    end
-  end
+private
 
   def grant_access_link(application, user = nil)
     link_path = if user
@@ -103,17 +73,53 @@ module ApplicationTableHelper
     end
   end
 
-  def users_applications_grant_access_link(application, user)
-    if policy(UserApplicationPermission.for(user, application)).create?
-      grant_access_link(application, user)
-    else
-      ""
+  def remove_access_link(application, user = nil)
+    link_path = if user
+                  delete_user_application_signin_permission_path(user, application)
+                else
+                  delete_account_application_signin_permission_path(application)
+                end
+
+    link_to(
+      link_path,
+      class: "govuk-button govuk-button--warning govuk-!-margin-0",
+      data: { module: "govuk-button" },
+    ) do
+      safe_join(["Remove access", content_tag(:span, " to #{application.name}", class: "govuk-visually-hidden")])
     end
   end
 
-  def account_applications_grant_access_link(application)
-    if policy([:account, Doorkeeper::Application]).grant_signin_permission?
-      grant_access_link(application)
+  def view_permissions_link(application, user = nil)
+    link_path = if user
+                  user_application_permissions_path(user, application)
+                else
+                  account_application_permissions_path(application)
+                end
+
+    link_to(link_path, class: "govuk-link") do
+      safe_join(
+        ["View permissions",
+         content_tag(:span, " for #{application.name}", class: "govuk-visually-hidden")],
+      )
+    end
+  end
+
+  def update_permissions_link(application, user = nil)
+    link_path = if user.nil?
+                  edit_account_application_permissions_path(application)
+                elsif user.api_user?
+                  edit_api_user_application_permissions_path(user, application)
+                else
+                  edit_user_application_permissions_path(user, application)
+                end
+
+    if application.sorted_supported_permissions_grantable_from_ui(include_signin: false).any?
+      link_to(link_path, class: "govuk-link") do
+        safe_join(
+          ["Update permissions",
+           content_tag(:span, " for #{application.name}", class: "govuk-visually-hidden")],
+        )
+      end
     else
       ""
     end

--- a/app/helpers/application_table_helper.rb
+++ b/app/helpers/application_table_helper.rb
@@ -105,6 +105,8 @@ private
   end
 
   def update_permissions_link(application, user = nil)
+    return "" if application.sorted_supported_permissions_grantable_from_ui(include_signin: false).none?
+
     link_path = if user.nil?
                   edit_account_application_permissions_path(application)
                 elsif user.api_user?
@@ -113,15 +115,11 @@ private
                   edit_user_application_permissions_path(user, application)
                 end
 
-    if application.sorted_supported_permissions_grantable_from_ui(include_signin: false).any?
-      link_to(link_path, class: "govuk-link") do
-        safe_join(
-          ["Update permissions",
-           content_tag(:span, " for #{application.name}", class: "govuk-visually-hidden")],
-        )
-      end
-    else
-      ""
+    link_to(link_path, class: "govuk-link") do
+      safe_join(
+        ["Update permissions",
+         content_tag(:span, " for #{application.name}", class: "govuk-visually-hidden")],
+      )
     end
   end
 end

--- a/app/views/api_users/applications/index.html.erb
+++ b/app/views/api_users/applications/index.html.erb
@@ -42,7 +42,7 @@
     [
       { text: application.name },
       { text: application.description },
-      { text: update_permissions_link(application, @api_user) }
+      { text: api_users_applications_permissions_link(application, @api_user) }
     ]
     end,
 } %>

--- a/test/helpers/application_table_helper_test.rb
+++ b/test/helpers/application_table_helper_test.rb
@@ -216,4 +216,14 @@ class ApplicationTableHelperTest < ActionView::TestCase
       assert account_applications_grant_access_link(@application).empty?
     end
   end
+
+  context "#api_users_applications_permissions_link" do
+    should "generate an update link when the user can edit permissions" do
+      application = create(:application, with_supported_permissions: %w[permission])
+      user = create(:superadmin_user)
+      stubs(:current_user).returns(user)
+
+      assert_includes api_users_applications_permissions_link(application, user), "Update permissions"
+    end
+  end
 end

--- a/test/helpers/application_table_helper_test.rb
+++ b/test/helpers/application_table_helper_test.rb
@@ -3,81 +3,79 @@ require "test_helper"
 class ApplicationTableHelperTest < ActionView::TestCase
   include PunditHelpers
 
-  context "#update_permissions_link" do
-    context "when the application has grantable permissions" do
-      setup do
-        @application = create(:application, with_supported_permissions: %w[permission])
-      end
-
-      context "when no user is provided" do
-        should "generate a link to edit own permissions" do
-          assert_includes update_permissions_link(@application), edit_account_application_permissions_path(@application)
-        end
-      end
-
-      context "with a given normal user" do
-        should "generate a link to edit the user's permissions" do
-          user = create(:user)
-
-          assert_includes update_permissions_link(@application, user), edit_user_application_permissions_path(user, @application)
-        end
-      end
-
-      context "with a given API user" do
-        should "generate a link to edit the API user's permissions" do
-          user = create(:api_user)
-
-          assert_includes update_permissions_link(@application, user), edit_api_user_application_permissions_path(user, @application)
-        end
-      end
+  context "#account_applications_grant_access_link" do
+    setup do
+      @user = build(:user)
+      stubs(:current_user).returns(@user)
+      @application = create(:application)
     end
 
-    context "when the application has no grantable permissions" do
-      should "return an empty string" do
-        application = create(:application)
+    should "generate a grant access button when the user can grant siginin permission" do
+      stub_policy @user, [:account, Doorkeeper::Application], grant_signin_permission?: true
+      assert_includes account_applications_grant_access_link(@application), "Grant access"
+    end
 
-        assert update_permissions_link(application).empty?
-      end
+    should "return an empty string when the user cannot grant signin permission" do
+      stub_policy @user, [:account, Doorkeeper::Application], grant_signin_permission?: false
+      assert account_applications_grant_access_link(@application).empty?
     end
   end
 
-  context "#view_permissions_link" do
-    should "generate a link to view the permissions" do
-      application = create(:application, with_supported_permissions: %w[permission])
-
-      assert_includes view_permissions_link(application), account_application_permissions_path(application)
+  context "#users_applications_grant_access_link" do
+    setup do
+      @application = create(:application)
     end
 
-    context "when provided with a user" do
-      setup do
-        @user = create(:user)
-      end
+    should "generate a grant access button when the user can create user application permissions" do
+      user = create(:superadmin_user)
+      stubs(:current_user).returns(user)
 
-      should "generate a link to view the permissions" do
-        application = create(:application, with_supported_permissions: %w[permission])
+      assert_includes users_applications_grant_access_link(@application, user), "Grant access"
+    end
 
-        assert_includes view_permissions_link(application, @user), user_application_permissions_path(@user, application)
-      end
+    should "return an empty string when the user cannot create user application permissions" do
+      user = create(:user)
+      stubs(:current_user).returns(user)
+
+      assert users_applications_grant_access_link(@application, user).empty?
     end
   end
 
-  context "#remove_access_link" do
-    should "generate a link to remove access to the application" do
-      application = create(:application)
-
-      assert_includes remove_access_link(application), delete_account_application_signin_permission_path(application)
+  context "#account_applications_remove_access_link" do
+    setup do
+      @user = build(:user)
+      stubs(:current_user).returns(@user)
+      @application = create(:application)
     end
 
-    context "when provided with a user" do
-      setup do
-        @user = create(:user)
-      end
+    should "generate an update link when the user can remove signing permissions" do
+      stub_policy @user, [:account, @application], remove_signin_permission?: true
+      assert_includes account_applications_remove_access_link(@application), "Remove access"
+    end
 
-      should "generate a link to remove users access to the application" do
-        application = create(:application)
+    should "return an empty string when the user cannot remove sigin permissions" do
+      stub_policy @user, [:account, @application], remove_signin_permission?: false
+      assert account_applications_remove_access_link(@application).empty?
+    end
+  end
 
-        assert_includes remove_access_link(application, @user), delete_user_application_signin_permission_path(@user, application)
-      end
+  context "#users_applications_remove_access_link" do
+    setup do
+      @application = create(:application, with_supported_permissions: %w[permission])
+    end
+
+    should "generate a remove access link when the user can delete permissions" do
+      user = create(:superadmin_user)
+      stubs(:current_user).returns(user)
+
+      assert_includes users_applications_remove_access_link(@application, user), "Remove access"
+    end
+
+    should "return an empty string when the user cannot delete permissions" do
+      user = create(:user)
+      stubs(:current_user).returns(user)
+
+      assert users_applications_remove_access_link(@application, user).empty?
     end
   end
 
@@ -124,41 +122,13 @@ class ApplicationTableHelperTest < ActionView::TestCase
     end
   end
 
-  context "#users_applications_remove_access_link" do
-    setup do
-      @application = create(:application, with_supported_permissions: %w[permission])
-    end
-
-    should "generate a remove access link when the user can delete permissions" do
+  context "#api_users_applications_permissions_link" do
+    should "generate an update link when the user can edit permissions" do
+      application = create(:application, with_supported_permissions: %w[permission])
       user = create(:superadmin_user)
       stubs(:current_user).returns(user)
 
-      assert_includes users_applications_remove_access_link(@application, user), "Remove access"
-    end
-
-    should "return an empty string when the user cannot delete permissions" do
-      user = create(:user)
-      stubs(:current_user).returns(user)
-
-      assert users_applications_remove_access_link(@application, user).empty?
-    end
-  end
-
-  context "#account_applications_remove_access_link" do
-    setup do
-      @user = build(:user)
-      stubs(:current_user).returns(@user)
-      @application = create(:application)
-    end
-
-    should "generate an update link when the user can remove signing permissions" do
-      stub_policy @user, [:account, @application], remove_signin_permission?: true
-      assert_includes account_applications_remove_access_link(@application), "Remove access"
-    end
-
-    should "return an empty string when the user cannot remove sigin permissions" do
-      stub_policy @user, [:account, @application], remove_signin_permission?: false
-      assert account_applications_remove_access_link(@application).empty?
+      assert_includes api_users_applications_permissions_link(application, user), "Update permissions"
     end
   end
 
@@ -179,51 +149,81 @@ class ApplicationTableHelperTest < ActionView::TestCase
     end
   end
 
-  context "#users_applications_grant_access_link" do
-    setup do
-      @application = create(:application)
+  context "#remove_access_link" do
+    should "generate a link to remove access to the application" do
+      application = create(:application)
+
+      assert_includes remove_access_link(application), delete_account_application_signin_permission_path(application)
     end
 
-    should "generate a grant access button when the user can create user application permissions" do
-      user = create(:superadmin_user)
-      stubs(:current_user).returns(user)
+    context "when provided with a user" do
+      setup do
+        @user = create(:user)
+      end
 
-      assert_includes users_applications_grant_access_link(@application, user), "Grant access"
-    end
+      should "generate a link to remove users access to the application" do
+        application = create(:application)
 
-    should "return an empty string when the user cannot create user application permissions" do
-      user = create(:user)
-      stubs(:current_user).returns(user)
-
-      assert users_applications_grant_access_link(@application, user).empty?
-    end
-  end
-
-  context "#account_applications_grant_access_link" do
-    setup do
-      @user = build(:user)
-      stubs(:current_user).returns(@user)
-      @application = create(:application)
-    end
-
-    should "generate a grant access button when the user can grant siginin permission" do
-      stub_policy @user, [:account, Doorkeeper::Application], grant_signin_permission?: true
-      assert_includes account_applications_grant_access_link(@application), "Grant access"
-    end
-
-    should "return an empty string when the user cannot grant signin permission" do
-      stub_policy @user, [:account, Doorkeeper::Application], grant_signin_permission?: false
-      assert account_applications_grant_access_link(@application).empty?
+        assert_includes remove_access_link(application, @user), delete_user_application_signin_permission_path(@user, application)
+      end
     end
   end
 
-  context "#api_users_applications_permissions_link" do
-    should "generate an update link when the user can edit permissions" do
+  context "#view_permissions_link" do
+    should "generate a link to view the permissions" do
       application = create(:application, with_supported_permissions: %w[permission])
-      user = create(:superadmin_user)
-      stubs(:current_user).returns(user)
 
-      assert_includes api_users_applications_permissions_link(application, user), "Update permissions"
+      assert_includes view_permissions_link(application), account_application_permissions_path(application)
+    end
+
+    context "when provided with a user" do
+      setup do
+        @user = create(:user)
+      end
+
+      should "generate a link to view the permissions" do
+        application = create(:application, with_supported_permissions: %w[permission])
+
+        assert_includes view_permissions_link(application, @user), user_application_permissions_path(@user, application)
+      end
+    end
+  end
+
+  context "#update_permissions_link" do
+    context "when the application has grantable permissions" do
+      setup do
+        @application = create(:application, with_supported_permissions: %w[permission])
+      end
+
+      context "when no user is provided" do
+        should "generate a link to edit own permissions" do
+          assert_includes update_permissions_link(@application), edit_account_application_permissions_path(@application)
+        end
+      end
+
+      context "with a given normal user" do
+        should "generate a link to edit the user's permissions" do
+          user = create(:user)
+
+          assert_includes update_permissions_link(@application, user), edit_user_application_permissions_path(user, @application)
+        end
+      end
+
+      context "with a given API user" do
+        should "generate a link to edit the API user's permissions" do
+          user = create(:api_user)
+
+          assert_includes update_permissions_link(@application, user), edit_api_user_application_permissions_path(user, @application)
+        end
+      end
+    end
+
+    context "when the application has no grantable permissions" do
+      should "return an empty string" do
+        application = create(:application)
+
+        assert update_permissions_link(application).empty?
+      end
     end
   end
 end

--- a/test/helpers/application_table_helper_test.rb
+++ b/test/helpers/application_table_helper_test.rb
@@ -4,39 +4,39 @@ class ApplicationTableHelperTest < ActionView::TestCase
   include PunditHelpers
 
   context "#update_permissions_link" do
-    setup do
-      @user = create(:api_user)
-    end
-
-    should "generate a link to edit the permissions" do
-      application = create(:application, with_supported_permissions: %w[permission])
-
-      assert_includes update_permissions_link(application, @user), edit_api_user_application_permissions_path(@user, application)
-    end
-
-    should "return an empty string when the application has no grantable permissions" do
-      application = create(:application)
-
-      assert update_permissions_link(application, @user).empty?
-    end
-
-    context "for a user" do
+    context "when the application has grantable permissions" do
       setup do
-        @user = create(:user)
+        @application = create(:application, with_supported_permissions: %w[permission])
       end
 
-      should "generate a link to edit the permissions" do
-        application = create(:application, with_supported_permissions: %w[permission])
+      context "when no user is provided" do
+        should "generate a link to edit own permissions" do
+          assert_includes update_permissions_link(@application), edit_account_application_permissions_path(@application)
+        end
+      end
 
-        assert_includes update_permissions_link(application, @user), edit_user_application_permissions_path(@user, application)
+      context "with a given normal user" do
+        should "generate a link to edit the user's permissions" do
+          user = create(:user)
+
+          assert_includes update_permissions_link(@application, user), edit_user_application_permissions_path(user, @application)
+        end
+      end
+
+      context "with a given API user" do
+        should "generate a link to edit the API user's permissions" do
+          user = create(:api_user)
+
+          assert_includes update_permissions_link(@application, user), edit_api_user_application_permissions_path(user, @application)
+        end
       end
     end
 
-    context "when no user is provided" do
-      should "generate a link to edit the permissions" do
-        application = create(:application, with_supported_permissions: %w[permission])
+    context "when the application has no grantable permissions" do
+      should "return an empty string" do
+        application = create(:application)
 
-        assert_includes update_permissions_link(application), edit_account_application_permissions_path(application)
+        assert update_permissions_link(application).empty?
       end
     end
   end

--- a/test/helpers/application_table_helper_test.rb
+++ b/test/helpers/application_table_helper_test.rb
@@ -24,20 +24,21 @@ class ApplicationTableHelperTest < ActionView::TestCase
   context "#users_applications_grant_access_link" do
     setup do
       @application = create(:application)
+      @grantee = create(:user)
     end
 
     should "generate a grant access button when the user can create user application permissions" do
-      user = create(:superadmin_user)
-      stubs(:current_user).returns(user)
+      granter = create(:superadmin_user)
+      stubs(:current_user).returns(granter)
 
-      assert_includes users_applications_grant_access_link(@application, user), "Grant access"
+      assert_includes users_applications_grant_access_link(@application, @grantee), "Grant access"
     end
 
     should "return an empty string when the user cannot create user application permissions" do
-      user = create(:user)
-      stubs(:current_user).returns(user)
+      granter = create(:user)
+      stubs(:current_user).returns(granter)
 
-      assert users_applications_grant_access_link(@application, user).empty?
+      assert users_applications_grant_access_link(@application, @grantee).empty?
     end
   end
 
@@ -62,20 +63,21 @@ class ApplicationTableHelperTest < ActionView::TestCase
   context "#users_applications_remove_access_link" do
     setup do
       @application = create(:application, with_supported_permissions: %w[permission])
+      @grantee = create(:user)
     end
 
     should "generate a remove access link when the user can delete permissions" do
-      user = create(:superadmin_user)
-      stubs(:current_user).returns(user)
+      granter = create(:superadmin_user)
+      stubs(:current_user).returns(granter)
 
-      assert_includes users_applications_remove_access_link(@application, user), "Remove access"
+      assert_includes users_applications_remove_access_link(@application, @grantee), "Remove access"
     end
 
     should "return an empty string when the user cannot delete permissions" do
-      user = create(:user)
-      stubs(:current_user).returns(user)
+      granter = create(:user)
+      stubs(:current_user).returns(granter)
 
-      assert users_applications_remove_access_link(@application, user).empty?
+      assert users_applications_remove_access_link(@application, @grantee).empty?
     end
   end
 
@@ -105,30 +107,32 @@ class ApplicationTableHelperTest < ActionView::TestCase
   context "#users_applications_permissions_link" do
     setup do
       @application = create(:application, with_supported_permissions: %w[permission])
+      @grantee = create(:user)
     end
 
     should "generate an update link when the user can edit permissions" do
-      user = create(:superadmin_user)
-      stubs(:current_user).returns(user)
+      granter = create(:superadmin_user)
+      stubs(:current_user).returns(granter)
 
-      assert_includes users_applications_permissions_link(@application, user), "Update permissions"
+      assert_includes users_applications_permissions_link(@application, @grantee), "Update permissions"
     end
 
     should "generate a view link when the user cannot edit permissions" do
-      user = create(:user)
-      stubs(:current_user).returns(user)
+      granter = create(:user)
+      stubs(:current_user).returns(granter)
 
-      assert_includes users_applications_permissions_link(@application, user), "View permissions"
+      assert_includes users_applications_permissions_link(@application, @grantee), "View permissions"
     end
   end
 
   context "#api_users_applications_permissions_link" do
     should "generate an update link when the user can edit permissions" do
       application = create(:application, with_supported_permissions: %w[permission])
-      user = create(:superadmin_user)
-      stubs(:current_user).returns(user)
+      granter = create(:superadmin_user)
+      grantee = create(:api_user)
+      stubs(:current_user).returns(granter)
 
-      assert_includes api_users_applications_permissions_link(application, user), "Update permissions"
+      assert_includes api_users_applications_permissions_link(application, grantee), "Update permissions"
     end
   end
 


### PR DESCRIPTION
[Trello](https://trello.com/c/A51nRJZy/1234-refactor-applicationtablehelper)

This is some groundwork for fixing the broken delegatable permissions feature: a minor refactor (mostly a restructure/tidy up) of the `ApplicationsTableHelper`, which is used to generate "Grant access", "Remove access", "View permissions", and "Update permissions" buttons/links on applications pages

---

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
