### PR TITLE
Fix applications table actions column

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -88,11 +88,15 @@ $govuk-page-width: 1140px;
   }
 }
 
-.govuk-table--with-actions {
-  .govuk-table__cell:last-child {
-    display: flex;
-    justify-content: flex-end;
+.govuk-table__actions {
+  display: flex;
+  flex-direction: column;
+  align-items: end;
+  gap: 10px;
+  
+  @media (min-width: 40.0625em) {
+    flex-direction: row;
     align-items: center;
-    gap: 10px;
+    justify-content: flex-end;
   }
 }

--- a/app/helpers/application_table_helper.rb
+++ b/app/helpers/application_table_helper.rb
@@ -1,6 +1,10 @@
 module ApplicationTableHelper
   include Pundit::Authorization
 
+  def wrap_links_in_actions_markup(links)
+    "<div class=\"govuk-table__actions\">#{links.join}</div>".html_safe
+  end
+
   def account_applications_grant_access_link(application)
     if policy([:account, Doorkeeper::Application]).grant_signin_permission?
       grant_access_link(application)

--- a/app/views/account/applications/index.html.erb
+++ b/app/views/account/applications/index.html.erb
@@ -25,7 +25,6 @@
   <% end %>
 <% end %>
 
-<div class="govuk-table--with-actions">
 <%= render "components/table", {
     caption: "Apps you have access to",
     head: [
@@ -37,11 +36,14 @@
     [
       { text: application.name },
       { text: application.description },
-      { text: safe_join([account_applications_permissions_link(application), account_applications_remove_access_link(application)]) },
+      { text: wrap_links_in_actions_markup([
+        account_applications_permissions_link(application), 
+        account_applications_remove_access_link(application)
+        ])
+      },
     ]
     end,
 } %>
-</div>
 
 <div class="govuk-table--with-actions">
 <%= render "components/table", {
@@ -55,7 +57,7 @@
     [
       { text: application.name },
       { text: application.description },
-      { text: account_applications_grant_access_link(application) }
+      { text: wrap_links_in_actions_markup([account_applications_grant_access_link(application)]) }
     ]
     end,
 } %>

--- a/app/views/api_users/applications/index.html.erb
+++ b/app/views/api_users/applications/index.html.erb
@@ -30,7 +30,6 @@
   <% end %>
 <% end %>
 
-<div class="govuk-table--with-actions">
 <%= render "components/table", {
     caption: "Apps #{@api_user.name} has access to",
     head: [
@@ -42,8 +41,7 @@
     [
       { text: application.name },
       { text: application.description },
-      { text: api_users_applications_permissions_link(application, @api_user) }
+      { text: wrap_links_in_actions_markup([api_users_applications_permissions_link(application, @api_user)]) }
     ]
     end,
 } %>
-</div>

--- a/app/views/users/applications/index.html.erb
+++ b/app/views/users/applications/index.html.erb
@@ -30,7 +30,6 @@
   <% end %>
 <% end %>
 
-<div class="govuk-table--with-actions">
 <%= render "components/table", {
     caption: "Apps #{@user.name} has access to",
     head: [
@@ -42,13 +41,15 @@
     [
       { text: application.name },
       { text: application.description },
-      { text: safe_join([users_applications_permissions_link(application, @user), users_applications_remove_access_link(application, @user)]) },
+      { text: wrap_links_in_actions_markup([
+          users_applications_permissions_link(application, @user),
+          users_applications_remove_access_link(application, @user)
+        ])
+      },
     ]
     end,
 } %>
-</div>
 
-<div class="govuk-table--with-actions">
 <%= render "components/table", {
     caption: "Apps #{@user.name} does not have access to",
     head: [
@@ -60,8 +61,7 @@
     [
       { text: application.name },
       { text: application.description },
-      { text: users_applications_grant_access_link(application, @user) }
+      { text: wrap_links_in_actions_markup([users_applications_grant_access_link(application, @user)]) }
     ]
     end,
 } %>
-</div>

--- a/test/helpers/application_table_helper_test.rb
+++ b/test/helpers/application_table_helper_test.rb
@@ -3,6 +3,22 @@ require "test_helper"
 class ApplicationTableHelperTest < ActionView::TestCase
   include PunditHelpers
 
+  context "#wrap_links_in_actions_markup" do
+    should "wrap an array of links in a container with a class to apply actions styles" do
+      links = [
+        "<a class=\"govuk-link\" href=\"https://www.gov.uk/destination-one\">Destination one</a>",
+        "<a class=\"govuk-link\" href=\"https://www.gov.uk/destination-two\">Destination two</a>",
+      ]
+
+      expected_output = "<div class=\"govuk-table__actions\">
+        <a class=\"govuk-link\" href=\"https://www.gov.uk/destination-one\">Destination one</a>
+        <a class=\"govuk-link\" href=\"https://www.gov.uk/destination-two\">Destination two</a>
+      </div>".gsub(/>\s+</, "><")
+
+      assert_equal expected_output, wrap_links_in_actions_markup(links)
+    end
+  end
+
   context "#account_applications_grant_access_link" do
     setup do
       @user = build(:user)


### PR DESCRIPTION
[Trello](https://trello.com/c/2hbs3qaV/1231-fix-applications-table-alignment-issues)

We've had issues with the height of the final column in the applications tables since at least February. This fixes it

## Screenshots

### Before

![Screenshot 2024-06-27 at 12-45-35 GOV UK apps - GOV UK Signon](https://github.com/alphagov/signon/assets/40244233/1c4fb85e-9e5b-47a1-a9a4-15eb195e707f)

### After

![Screenshot 2024-06-27 at 12-53-55 GOV UK apps - GOV UK Signon](https://github.com/alphagov/signon/assets/40244233/214663e5-bd86-4783-992e-f9d29882b76d)

---

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
