### PR TITLE
Fix applications tables column alignment

### DIFF
--- a/app/helpers/components/table_helper.rb
+++ b/app/helpers/components/table_helper.rb
@@ -50,6 +50,7 @@ module Components
 
       def header(str, opt = {})
         classes = %w[govuk-table__header]
+        classes << opt[:classes] if opt[:classes]
         classes << "govuk-table__header--#{opt[:format]}" if opt[:format]
         classes << "govuk-table__header--active" if opt[:sort_direction]
         link_classes = %w[app-table__sort-link]

--- a/app/views/account/applications/index.html.erb
+++ b/app/views/account/applications/index.html.erb
@@ -29,8 +29,8 @@
 <%= render "components/table", {
     caption: "Apps you have access to",
     head: [
-      { text: "Name" },
-      { text: "Description" },
+      { text: "Name", classes: "govuk-!-width-one-quarter" },
+      { text: "Description", classes: "govuk-!-width-one-third" },
       { text: content_tag(:span, "Actions", class: "govuk-visually-hidden") },
     ],
     rows: @applications_with_signin.map do |application|
@@ -47,8 +47,8 @@
 <%= render "components/table", {
     caption: "Apps you don't have access to",
     head: [
-      { text: "Name" },
-      { text: "Description" },
+      { text: "Name", classes: "govuk-!-width-one-quarter" },
+      { text: "Description", classes: "govuk-!-width-one-third" },
       { text: content_tag(:span, "Actions", class: "govuk-visually-hidden") }
     ],
     rows: @applications_without_signin.map do |application|

--- a/app/views/api_users/applications/index.html.erb
+++ b/app/views/api_users/applications/index.html.erb
@@ -34,8 +34,8 @@
 <%= render "components/table", {
     caption: "Apps #{@api_user.name} has access to",
     head: [
-      { text: "Name" },
-      { text: "Description" },
+      { text: "Name", classes: "govuk-!-width-one-quarter" },
+      { text: "Description", classes: "govuk-!-width-one-third" },
       { text: content_tag(:span, "Actions", class: "govuk-visually-hidden") },
     ],
     rows: @applications.map do |application|

--- a/app/views/components/_table.html.erb
+++ b/app/views/components/_table.html.erb
@@ -27,6 +27,7 @@
       <%= t.head do %>
         <% head.each_with_index do |item, cellindex| %>
           <%= t.header item[:text], {
+            classes: item[:classes],
             format: item[:format],
             href: item[:href],
             data_attributes: item[:data_attributes],

--- a/app/views/users/applications/index.html.erb
+++ b/app/views/users/applications/index.html.erb
@@ -34,8 +34,8 @@
 <%= render "components/table", {
     caption: "Apps #{@user.name} has access to",
     head: [
-      { text: "Name" },
-      { text: "Description" },
+      { text: "Name", classes: "govuk-!-width-one-quarter" },
+      { text: "Description", classes: "govuk-!-width-one-third" },
       { text: content_tag(:span, "Actions", class: "govuk-visually-hidden") },
     ],
     rows: @applications_with_signin.map do |application|
@@ -52,8 +52,8 @@
 <%= render "components/table", {
     caption: "Apps #{@user.name} does not have access to",
     head: [
-      { text: "Name" },
-      { text: "Description" },
+      { text: "Name", classes: "govuk-!-width-one-quarter" },
+      { text: "Description", classes: "govuk-!-width-one-third" },
       { text: content_tag(:span, "Actions", class: "govuk-visually-hidden") }
     ],
     rows: @applications_without_signin.map do |application|


### PR DESCRIPTION
[Trello](https://trello.com/c/Vn5vDNV8/1232-fix-applications-tables-column-alignment)

In #2341, the table component from `govuk_publishing_components` was copied over and customised

In #2664, we migrated the applications tables to use this. In the process, we lost the custom classes on the first two columns, which set the widths to 1/4 and 1/3 respectively. This was noted as "acceptable" in the PR body in exchange for improved consistency and other benefits from using the component

However, since we have a custom version of the table component, it's very easy for us to support custom classes. This was in fact done in the same PR that copies the component into the Signon codebase, adding custom class support for the outer table element in 4f09fbc

This adds support for custom classes in the headers, which is then used to restore the old classes and therefore consistent column widths between tables (irrespective of content width)

In #2341, it was suggested that we might try to get the customisations merged upstream - it might be worth exploring that with both this and earlier changes as a separate piece of work

**Note:** this makes existing row alignment issues more apparent in some circumstances. These are fixed separately in #2984 

## Screenshots

### Before

<img width="1185" alt="image" src="https://github.com/alphagov/signon/assets/40244233/1fc1eedf-673c-40de-8edb-6e8e18b779c6">

### After

<img width="1190" alt="image" src="https://github.com/alphagov/signon/assets/40244233/2ea646fa-c9eb-4488-a6d6-d10dcdfcf76d">

---

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
