### PR TITLE
Fix test comment

### DIFF
--- a/test/integration/granting_permissions_test.rb
+++ b/test/integration/granting_permissions_test.rb
@@ -340,10 +340,10 @@ class GrantingPermissionsTest < ActionDispatch::IntegrationTest
         click_on "Update permissions for MyApp"
         assert_current_url edit_user_application_permissions_path(user, app)
 
-        # the new permissions form exists
+        # the new permissions does not exist
         assert_no_selector "#new_permission_id", visible: false
 
-        # the current permissions form does not exist
+        # the current permissions form exists
         assert_selector "legend", text: "Current permissions"
         assert_selector ".govuk-hint", text: "Clear the checkbox and save changes to remove a permission."
         assert_selector ".govuk-button", text: "Update permissions"


### PR DESCRIPTION
A quick fix for a couple of comments that incorrectly describe assertions

---
 
This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
