### PR TITLE
Upgrade to govuk_publishing_components version that uses GOV.UK Frontend V5.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem "rotp"
 gem "rqrcode"
 gem "sentry-sidekiq"
 gem "sprockets-rails"
-gem "uglifier"
+gem "terser"
 gem "uuid"
 gem "whenever"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -197,7 +197,7 @@ GEM
     govuk_personalisation (0.16.0)
       plek (>= 1.9.0)
       rails (>= 6, < 8)
-    govuk_publishing_components (39.2.4)
+    govuk_publishing_components (40.0.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -704,13 +704,13 @@ GEM
     stringio (3.1.1)
     strscan (3.1.0)
     systemu (2.6.5)
+    terser (1.2.3)
+      execjs (>= 0.3.0, < 3)
     thor (1.3.1)
     timecop (0.9.10)
     timeout (0.4.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    uglifier (4.2.0)
-      execjs (>= 0.3.0, < 3)
     unicode-display_width (2.5.0)
     uuid (2.3.9)
       macaddr (~> 1.0)
@@ -785,8 +785,8 @@ DEPENDENCIES
   shoulda-context
   simplecov
   sprockets-rails
+  terser
   timecop
-  uglifier
   uuid
   webmock
   whenever

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,3 +1,4 @@
 //= link_tree ../images
 //= link_tree ../builds
 //= link application.js
+//= link es6-components.js

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,5 +1,15 @@
 //= require govuk_publishing_components/dependencies
-//= require govuk_publishing_components/all_components
+//= require govuk_publishing_components/components/button
+//= require govuk_publishing_components/components/checkboxes
+//= require govuk_publishing_components/components/copy-to-clipboard
+//= require govuk_publishing_components/components/details
+//= require govuk_publishing_components/components/error-summary
+//= require govuk_publishing_components/components/layout-header
+//= require govuk_publishing_components/components/option-select
+//= require govuk_publishing_components/components/skip-link
+//= require govuk_publishing_components/components/table
+//= require govuk_publishing_components/components/tabs
+
 //= require_tree ./modules
 //= require_tree ./components
 //= require rails-ujs

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,14 +1,8 @@
 //= require govuk_publishing_components/dependencies
-//= require govuk_publishing_components/components/button
-//= require govuk_publishing_components/components/checkboxes
 //= require govuk_publishing_components/components/copy-to-clipboard
 //= require govuk_publishing_components/components/details
-//= require govuk_publishing_components/components/error-summary
-//= require govuk_publishing_components/components/layout-header
 //= require govuk_publishing_components/components/option-select
-//= require govuk_publishing_components/components/skip-link
 //= require govuk_publishing_components/components/table
-//= require govuk_publishing_components/components/tabs
 
 //= require_tree ./modules
 //= require_tree ./components

--- a/app/assets/javascripts/es6-components.js
+++ b/app/assets/javascripts/es6-components.js
@@ -1,0 +1,15 @@
+// These modules from govuk_publishing_components
+// depend on govuk-frontend modules. govuk-frontend
+// now targets browsers that support `type="module"`.
+//
+// To gracefully prevent execution of these scripts
+// on browsers that don't support ES6, this script
+// should be included in a `type="module"` script tag
+// which will ensure they are never loaded.
+
+//= require govuk_publishing_components/components/button
+//= require govuk_publishing_components/components/checkboxes
+//= require govuk_publishing_components/components/error-summary
+//= require govuk_publishing_components/components/layout-header
+//= require govuk_publishing_components/components/skip-link
+//= require govuk_publishing_components/components/tabs

--- a/app/assets/stylesheets/components/_table.scss
+++ b/app/assets/stylesheets/components/_table.scss
@@ -2,9 +2,9 @@
 @import "govuk/components/table/table";
 
 $table-border-width: 1px;
-$table-border-colour: govuk-colour("mid-grey", $legacy: "grey-2");
+$table-border-colour: govuk-colour("mid-grey");
 $table-header-border-width: 2px;
-$table-header-background-colour: govuk-colour("light-grey", $legacy: "grey-3");
+$table-header-background-colour: govuk-colour("light-grey");
 $vertical-row-bottom-border-width: 3px;
 $vertical-on-smallscreen-breakpoint: 940px;
 $sort-link-active-colour: govuk-colour("white");
@@ -12,7 +12,7 @@ $sort-link-arrow-size: 14px;
 $sort-link-arrow-size-small: 8px;
 $sort-link-arrow-spacing: calc($sort-link-arrow-size / 2);
 $table-row-hover-background-colour: rgba(43, 140, 196, .2);
-$table-row-even-background-colour: govuk-colour("light-grey", $legacy: "grey-4");
+$table-row-even-background-colour: govuk-colour("light-grey");
 
 /* stylelint-disable */
 .govuk-table__cell:empty,

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,6 +1,6 @@
 <%= render "layouts/google_tag_manager" %>
 
-<%= render 'govuk_publishing_components/components/layout_for_admin',
+<%= render "govuk_publishing_components/components/layout_for_admin",
   product_name: "Signon",
   environment: GovukPublishingComponents::AppHelpers::Environment.current_acceptance_environment,
   browser_title: yield(:title) do %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -94,6 +94,8 @@
     ]
   } %>
 
+  <%= javascript_include_tag "es6-components", type: "module" %>
+
   <%# TODO: replace with component %>
   <script class="analytics">
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -26,6 +26,9 @@ Rails.application.configure do
   # Compress CSS using a preprocessor.
   # config.assets.css_compressor = :sass
 
+  # Compress JavaScript
+  config.assets.js_compressor = :terser
+
   # Do not fall back to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false
 


### PR DESCRIPTION
I've followed the instructions for [Upgrading to GOV.UK Frontend v5 in the govuk_publishing_components gem](https://docs.google.com/document/d/1uwip7pzQwM7t5ghn9_8KrsWXLePSRUltFPZ5fYw6Ab8/edit). And, as predicted, this app didn't require _all that many_ changes

https://trello.com/c/aZ4vNT80/1240-upgrade-govukpublishingcomponents-for-signon