### PR TITLE
Add Rake task for querying permissions event logs

### DIFF
--- a/lib/tasks/event_log.rake
+++ b/lib/tasks/event_log.rake
@@ -4,4 +4,47 @@ namespace :event_log do
     delete_count = EventLog.where("created_at < ?", 2.years.ago).delete_all
     puts "#{delete_count} event log entries deleted"
   end
+
+  # Run the following, amending the output location/filename based on your
+  # system and preference, to get a local CSV output using this Rake task
+  #
+  # kubectl -n apps exec deploy/signon bundle exec rake 'event_log:get_non_gds_permissions_events_from_last_year' > ~/Downloads/non_gds_permissions_events_from_last_year.csv
+  #
+  desc "Get permissions-related events for non-GDS users from the last year"
+  task get_non_gds_permissions_events_from_last_year: :environment do
+    gds_organisation_id = Organisation.find_by(content_id: Organisation::GDS_ORG_CONTENT_ID).id
+    non_gds_user_ids = User.where.not(organisation_id: gds_organisation_id).pluck(:id)
+    non_gds_user_uids = User.where.not(organisation_id: gds_organisation_id).pluck(:uid)
+
+    event_logs_in_the_last_year = EventLog
+      .where(event_id: [EventLog::PERMISSIONS_ADDED.id, EventLog::PERMISSIONS_REMOVED.id])
+      .where(initiator_id: non_gds_user_ids)
+      .where(uid: non_gds_user_uids) # uid == the uid of the grantee
+      .where("created_at >= :date", date: Time.zone.now.ago(1.year))
+      .includes(:initiator)
+
+    event_logs_csv = "id,datetime,type,application,permissions,granter_id,granter_email,granter_organisation,granter_role,grantee_id,grantee_email,grantee_organisation,grantee_role\n"
+
+    event_logs_in_the_last_year.find_each do |event_log|
+      grantee = User.find_by(uid: event_log.uid)
+
+      event_logs_csv << "#{[
+        event_log.id,
+        event_log.created_at,
+        event_log.event_id == EventLog::PERMISSIONS_ADDED.id ? 'added' : 'removed',
+        event_log.application&.name || "#{Doorkeeper::Application.unscoped.retired.find(event_log.application_id).name} (retired)",
+        event_log.trailing_message[1..-2].gsub(',', ';'),
+        event_log.initiator_id,
+        event_log.initiator.email,
+        event_log.initiator.organisation_name,
+        event_log.initiator.role_name,
+        grantee.id,
+        grantee.email,
+        grantee.organisation_name,
+        grantee.role_name,
+      ].join(',')}\n"
+    end
+
+    puts event_logs_csv
+  end
 end


### PR DESCRIPTION
[Trello](https://trello.com/c/jPtUcWij/1256-check-whether-any-user-in-departments-check-whether-any-users-in-non-gds-departments-have-recently-used-the-delegatable-permissi)

This will help us find out more about which permissions are being added and removed by and for non-GDS users. We want to use this information to inform how we proceed with the work to fix delegatable permissions

---

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
