### PR TITLE
Fix organisation column in permissions Rake task

### DIFF
--- a/lib/tasks/event_log.rake
+++ b/lib/tasks/event_log.rake
@@ -36,11 +36,11 @@ namespace :event_log do
         event_log.trailing_message[1..-2].gsub(',', ';'),
         event_log.initiator_id,
         event_log.initiator.email,
-        event_log.initiator.organisation_name,
+        "\"#{event_log.initiator.organisation_name}\"",
         event_log.initiator.role_name,
         grantee.id,
         grantee.email,
-        grantee.organisation_name,
+        "\"#{grantee.organisation_name}\"",
         grantee.role_name,
       ].join(',')}\n"
     end


### PR DESCRIPTION
[Trello](https://trello.com/c/jPtUcWij/1256-check-whether-any-user-in-departments-check-whether-any-users-in-non-gds-departments-have-recently-used-the-delegatable-permissi)

The output of this Rake task is a CSV-formatted string. Two of the columns contain organisation names, which themselves occasionally include commas. This wraps the organisation name columns in quote marks to prevent each of these being read as multiple columns

---

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
