### PR TITLE
Increase dependabot PR limit for Ruby gems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ updates:
       interval: daily
     allow:
       - dependency-type: "all"
+    open-pull-requests-limit: 20
 
   - package-ecosystem: npm
     directory: /


### PR DESCRIPTION
Dependabot has a [default limit of 5](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/troubleshooting-dependabot-errors#dependabot-cannot-open-any-more-pull-requests) for the number of pull requests it will open on a repo. We have missed some updates today, since Dependabot has been limited to the numbe of updates it can open.

![Screenshot 2024-07-29 at 10 42 54](https://github.com/user-attachments/assets/47a0f4ff-d1c7-4552-9588-fe4a65b5080c)

Therefore increasing the limit to 20, as we are unlikely to exceed this.