### PR TITLE
Remove stray slash

### DIFF
--- a/test/controllers/users/applications_controller_test.rb
+++ b/test/controllers/users/applications_controller_test.rb
@@ -245,7 +245,7 @@ class Users::ApplicationsControllerTest < ActionController::TestCase
                 get :index, params: { user_id: @user }
 
                 assert_no_view_permissions_link
-                assert_no_edit_permissions_link\
+                assert_no_edit_permissions_link
               end
             end
           end


### PR DESCRIPTION
Fixes a superficial typo from #3040.  Curiously, this isn't a syntax error, but it is redundant and belongs in the bin

---

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
