### PR TITLE
Ensure the accounts settings page uses a 3 column layout

### DIFF
--- a/app/views/accounts/show.html.erb
+++ b/app/views/accounts/show.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, "Settings" %>
 
 <%= render "govuk_publishing_components/components/cards", {
-  three_column_layout: true,
+  columns: 3,
   items: [
     {
       link: {


### PR DESCRIPTION
## What
Ensure the accounts settings page uses a 3 column layout

## Why
The card component in the govuk_publishing_components gem will be updated to use a one column layout by default in a future release - https://github.com/alphagov/govuk_publishing_components/pull/4118

Setting `columns` to `3` will ensure the accounts settings page still uses a 3 column layout

[Trello card](https://trello.com/c/JFKnseKS/2714-create-a-pr-in-signon-the-only-other-place-in-alphagov-using-the-card-component-to-set-a-3-column-layout-s-m)