### PR TITLE
Make factory-made permission delegability explicit

### DIFF
--- a/test/controllers/account/permissions_controller_test.rb
+++ b/test/controllers/account/permissions_controller_test.rb
@@ -12,8 +12,8 @@ class Account::PermissionsControllerTest < ActionController::TestCase
 
     should "exclude permissions that aren't grantable from the UI" do
       application = create(:application,
-                           with_supported_permissions: %w[perm-1],
-                           with_supported_permissions_not_grantable_from_ui: %w[perm-2])
+                           with_non_delegatable_supported_permissions: %w[perm-1],
+                           with_non_delegatable_supported_permissions_not_grantable_from_ui: %w[perm-2])
       user = create(:admin_user, with_signin_permissions_for: [application])
 
       sign_in user
@@ -46,7 +46,7 @@ class Account::PermissionsControllerTest < ActionController::TestCase
 
     should "order permissions by whether the user has access and then alphabetically" do
       application = create(:application,
-                           with_supported_permissions: %w[aaa bbb ttt uuu])
+                           with_non_delegatable_supported_permissions: %w[aaa bbb ttt uuu])
       user = create(:admin_user,
                     with_signin_permissions_for: [application],
                     with_permissions: { application => %w[aaa ttt] })
@@ -105,7 +105,7 @@ class Account::PermissionsControllerTest < ActionController::TestCase
     end
 
     should "include a hidden field for the signin permission so that it is not removed" do
-      application = create(:application, with_supported_permissions: ["perm-1", SupportedPermission::SIGNIN_NAME])
+      application = create(:application, with_non_delegatable_supported_permissions: ["perm-1", SupportedPermission::SIGNIN_NAME])
       user = create(:admin_user, with_permissions: { application => ["perm-1", SupportedPermission::SIGNIN_NAME] })
       sign_in user
 
@@ -167,7 +167,7 @@ class Account::PermissionsControllerTest < ActionController::TestCase
 
     should "prevent permissions being added for apps that the current user does not have access to" do
       application1 = create(:application)
-      application2 = create(:application, with_supported_permissions: %w[app2-permission])
+      application2 = create(:application, with_delegatable_supported_permissions: %w[app2-permission])
 
       current_user = create(:organisation_admin_user)
       current_user.grant_application_signin_permission(application1)
@@ -186,7 +186,7 @@ class Account::PermissionsControllerTest < ActionController::TestCase
     end
 
     should "not remove the signin permission from the app when updating other permissions" do
-      application = create(:application, with_supported_permissions: %w[other])
+      application = create(:application, with_non_delegatable_supported_permissions: %w[other])
 
       current_user = create(:admin_user)
       current_user.grant_application_signin_permission(application)
@@ -203,7 +203,7 @@ class Account::PermissionsControllerTest < ActionController::TestCase
     end
 
     should "not remove permissions the user already has that are not grantable from ui" do
-      application = create(:application, with_supported_permissions: %w[other], with_supported_permissions_not_grantable_from_ui: %w[not_from_ui])
+      application = create(:application, with_non_delegatable_supported_permissions: %w[other], with_non_delegatable_supported_permissions_not_grantable_from_ui: %w[not_from_ui])
 
       current_user = create(:admin_user)
       current_user.grant_application_signin_permission(application)
@@ -224,7 +224,7 @@ class Account::PermissionsControllerTest < ActionController::TestCase
     end
 
     should "prevent permissions being added for other apps" do
-      other_application = create(:application, with_supported_permissions: %w[other])
+      other_application = create(:application, with_non_delegatable_supported_permissions: %w[other])
       application = create(:application)
 
       current_user = create(:admin_user)
@@ -244,7 +244,7 @@ class Account::PermissionsControllerTest < ActionController::TestCase
     end
 
     should "prevent permissions being added that are not grantable from the ui" do
-      application = create(:application, with_supported_permissions_not_grantable_from_ui: %w[not_from_ui])
+      application = create(:application, with_non_delegatable_supported_permissions_not_grantable_from_ui: %w[not_from_ui])
 
       current_user = create(:admin_user)
       current_user.grant_application_signin_permission(application)
@@ -262,7 +262,7 @@ class Account::PermissionsControllerTest < ActionController::TestCase
     end
 
     should "assign the application id to the application_id flash" do
-      application = create(:application, with_supported_permissions: %w[new])
+      application = create(:application, with_non_delegatable_supported_permissions: %w[new])
       user = create(:admin_user, with_permissions: { application => [SupportedPermission::SIGNIN_NAME] })
       sign_in user
 

--- a/test/controllers/api_users/applications_controller_test.rb
+++ b/test/controllers/api_users/applications_controller_test.rb
@@ -75,7 +75,7 @@ class ApiUsers::ApplicationsControllerTest < ActionController::TestCase
 
     should "display a flash message showing the permissions the user has" do
       api_user = create(:api_user)
-      application = create(:application, name: "app-name", with_supported_permissions: %w[foo])
+      application = create(:application, name: "app-name", with_non_delegatable_supported_permissions: %w[foo])
       create(:access_token, application:, resource_owner_id: api_user.id)
 
       current_user = create(:admin_user)
@@ -107,7 +107,7 @@ class ApiUsers::ApplicationsControllerTest < ActionController::TestCase
 
     should "display a link to edit permissions if the user is authorised to edit permissions" do
       api_user = create(:api_user)
-      application = create(:application, name: "app-name", with_supported_permissions: %w[foo])
+      application = create(:application, name: "app-name", with_non_delegatable_supported_permissions: %w[foo])
       create(:access_token, application:, resource_owner_id: api_user.id)
 
       current_user = create(:admin_user)

--- a/test/controllers/api_users/permissions_controller_test.rb
+++ b/test/controllers/api_users/permissions_controller_test.rb
@@ -49,7 +49,7 @@ class ApiUsers::PermissionsControllerTest < ActionController::TestCase
     end
 
     should "include a hidden field for the signin permission so that it is not removed" do
-      application = create(:application, with_supported_permissions: ["perm-1", SupportedPermission::SIGNIN_NAME])
+      application = create(:application, with_non_delegatable_supported_permissions: ["perm-1", SupportedPermission::SIGNIN_NAME])
       api_user = create(:api_user, with_permissions: { application => %w[perm-1] })
       create(:access_token, application:, resource_owner_id: api_user.id)
 
@@ -124,7 +124,7 @@ class ApiUsers::PermissionsControllerTest < ActionController::TestCase
     end
 
     should "redirect once the permissions have been updated" do
-      application = create(:application, with_supported_permissions: %w[new old])
+      application = create(:application, with_non_delegatable_supported_permissions: %w[new old])
       api_user = create(:api_user, with_permissions: { application => %w[old] })
       create(:access_token, application:, resource_owner_id: api_user.id)
 
@@ -144,7 +144,7 @@ class ApiUsers::PermissionsControllerTest < ActionController::TestCase
       organisation = create(:organisation)
 
       application1 = create(:application)
-      application2 = create(:application, with_supported_permissions: %w[app2-permission])
+      application2 = create(:application, with_non_delegatable_supported_permissions: %w[app2-permission])
 
       api_user = create(:api_user, organisation:)
       create(:access_token, application: application1, resource_owner_id: api_user.id)
@@ -166,7 +166,7 @@ class ApiUsers::PermissionsControllerTest < ActionController::TestCase
     end
 
     should "not remove the signin permission from the app when updating other permissions" do
-      application = create(:application, with_supported_permissions: %w[other])
+      application = create(:application, with_non_delegatable_supported_permissions: %w[other])
       api_user = create(:api_user)
       api_user.grant_application_signin_permission(application)
       create(:access_token, application:, resource_owner_id: api_user.id)
@@ -185,7 +185,7 @@ class ApiUsers::PermissionsControllerTest < ActionController::TestCase
     end
 
     should "not remove permissions the user already has that are not grantable from ui" do
-      application = create(:application, with_supported_permissions: %w[other], with_supported_permissions_not_grantable_from_ui: %w[not_from_ui])
+      application = create(:application, with_non_delegatable_supported_permissions: %w[other], with_non_delegatable_supported_permissions_not_grantable_from_ui: %w[not_from_ui])
       api_user = create(:api_user)
       api_user.grant_application_permission(application, "not_from_ui")
       create(:access_token, application:, resource_owner_id: api_user.id)
@@ -206,7 +206,7 @@ class ApiUsers::PermissionsControllerTest < ActionController::TestCase
     end
 
     should "prevent permissions being added for other apps" do
-      other_application = create(:application, with_supported_permissions: %w[other])
+      other_application = create(:application, with_non_delegatable_supported_permissions: %w[other])
       application = create(:application)
       api_user = create(:api_user)
       create(:access_token, application:, resource_owner_id: api_user.id)
@@ -226,7 +226,7 @@ class ApiUsers::PermissionsControllerTest < ActionController::TestCase
     end
 
     should "prevent permissions being added that are not grantable from the ui" do
-      application = create(:application, with_supported_permissions: %w[other], with_supported_permissions_not_grantable_from_ui: %w[not_from_ui])
+      application = create(:application, with_non_delegatable_supported_permissions: %w[other], with_non_delegatable_supported_permissions_not_grantable_from_ui: %w[not_from_ui])
       api_user = create(:api_user)
       create(:access_token, application:, resource_owner_id: api_user.id)
 
@@ -245,7 +245,7 @@ class ApiUsers::PermissionsControllerTest < ActionController::TestCase
     end
 
     should "assign the application id to the application_id flash" do
-      application = create(:application, with_supported_permissions: %w[permission])
+      application = create(:application, with_non_delegatable_supported_permissions: %w[permission])
       api_user = create(:api_user)
       create(:access_token, application:, resource_owner_id: api_user.id)
 
@@ -290,7 +290,7 @@ class ApiUsers::PermissionsControllerTest < ActionController::TestCase
     should "push permission changes out to apps" do
       sign_in create(:superadmin_user)
 
-      application = create(:application, with_supported_permissions: %w[permission])
+      application = create(:application, with_non_delegatable_supported_permissions: %w[permission])
       api_user = create(:api_user)
       create(:access_token, resource_owner_id: api_user.id, application:)
 
@@ -316,7 +316,7 @@ class ApiUsers::PermissionsControllerTest < ActionController::TestCase
     should "include applications with revoked access tokens when there is at least one non-revoked access token" do
       sign_in create(:superadmin_user)
 
-      application = create(:application, with_supported_permissions: %w[permission])
+      application = create(:application, with_non_delegatable_supported_permissions: %w[permission])
       api_user = create(:api_user)
       create(:access_token, resource_owner_id: api_user.id, application:, revoked_at: Time.current)
       create(:access_token, resource_owner_id: api_user.id, application:)

--- a/test/controllers/batch_invitation_permissions_controller_test.rb
+++ b/test/controllers/batch_invitation_permissions_controller_test.rb
@@ -7,7 +7,7 @@ class BatchInvitationPermissionsControllerTest < ActionController::TestCase
     @user = create(:admin_user)
     sign_in @user
 
-    @app = create(:application, name: "Profound Publisher", with_supported_permissions: %w[reader])
+    @app = create(:application, name: "Profound Publisher", with_non_delegatable_supported_permissions: %w[reader])
 
     @batch_invitation = create(:batch_invitation, user: @user)
     create(

--- a/test/controllers/supported_permissions_controller_test.rb
+++ b/test/controllers/supported_permissions_controller_test.rb
@@ -24,7 +24,7 @@ class SupportedPermissionsControllerTest < ActionController::TestCase
 
   context "GET new" do
     should "render the form" do
-      app = create(:application, name: "My first app", with_supported_permissions: %w[permission1])
+      app = create(:application, name: "My first app", with_non_delegatable_supported_permissions: %w[permission1])
       get :new, params: { doorkeeper_application_id: app.id }
       assert_select "h1", /Add permission/
       assert_select ".govuk-breadcrumbs li", /My first app/
@@ -100,7 +100,7 @@ class SupportedPermissionsControllerTest < ActionController::TestCase
 
   context "GET confirm_destroy" do
     should "render the permission and application names" do
-      application = create(:application, name: "My first app", with_supported_permissions: %w[permission1])
+      application = create(:application, name: "My first app", with_non_delegatable_supported_permissions: %w[permission1])
 
       get :confirm_destroy, params: { doorkeeper_application_id: application.id, id: application.supported_permissions.first.id }
 

--- a/test/controllers/users/permissions_controller_test.rb
+++ b/test/controllers/users/permissions_controller_test.rb
@@ -13,8 +13,8 @@ class Users::PermissionsControllerTest < ActionController::TestCase
 
     should "exclude permissions that aren't grantable from the UI" do
       application = create(:application,
-                           with_supported_permissions: %w[perm-1],
-                           with_supported_permissions_not_grantable_from_ui: %w[perm-2])
+                           with_non_delegatable_supported_permissions: %w[perm-1],
+                           with_non_delegatable_supported_permissions_not_grantable_from_ui: %w[perm-2])
       user = create(:user, with_signin_permissions_for: [application])
 
       current_user = create(:admin_user)
@@ -64,7 +64,7 @@ class Users::PermissionsControllerTest < ActionController::TestCase
 
     should "order permissions by whether the user has access and then alphabetically" do
       application = create(:application,
-                           with_supported_permissions: %w[aaa bbb ttt uuu])
+                           with_non_delegatable_supported_permissions: %w[aaa bbb ttt uuu])
       user = create(:user,
                     with_signin_permissions_for: [application],
                     with_permissions: { application => %w[aaa ttt] })
@@ -145,7 +145,7 @@ class Users::PermissionsControllerTest < ActionController::TestCase
     end
 
     should "include a hidden field for the signin permission so that it is not removed" do
-      application = create(:application, with_supported_permissions: ["perm-1", SupportedPermission::SIGNIN_NAME])
+      application = create(:application, with_non_delegatable_supported_permissions: ["perm-1", SupportedPermission::SIGNIN_NAME])
       user = create(:user, with_permissions: { application => %w[perm-1] })
       user.grant_application_signin_permission(application)
 
@@ -253,7 +253,7 @@ class Users::PermissionsControllerTest < ActionController::TestCase
     end
 
     should "redirect once the permissions have been updated" do
-      application = create(:application, with_supported_permissions: %w[new old])
+      application = create(:application, with_non_delegatable_supported_permissions: %w[new old])
       user = create(:user, with_permissions: { application => %w[old] })
       user.grant_application_signin_permission(application)
 
@@ -274,7 +274,7 @@ class Users::PermissionsControllerTest < ActionController::TestCase
       organisation = create(:organisation)
 
       application1 = create(:application)
-      application2 = create(:application, with_supported_permissions: %w[app2-permission])
+      application2 = create(:application, with_delegatable_supported_permissions: %w[app2-permission])
 
       user = create(:user, organisation:)
       user.grant_application_signin_permission(application1)
@@ -296,7 +296,7 @@ class Users::PermissionsControllerTest < ActionController::TestCase
     end
 
     should "not remove the signin permission from the app when updating other permissions" do
-      application = create(:application, with_supported_permissions: %w[other])
+      application = create(:application, with_non_delegatable_supported_permissions: %w[other])
       user = create(:user)
       user.grant_application_signin_permission(application)
 
@@ -315,7 +315,7 @@ class Users::PermissionsControllerTest < ActionController::TestCase
     end
 
     should "not remove permissions the user already has that are not grantable from ui" do
-      application = create(:application, with_supported_permissions: %w[other], with_supported_permissions_not_grantable_from_ui: %w[not_from_ui])
+      application = create(:application, with_non_delegatable_supported_permissions: %w[other], with_non_delegatable_supported_permissions_not_grantable_from_ui: %w[not_from_ui])
       user = create(:user)
       user.grant_application_signin_permission(application)
       user.grant_application_permission(application, "not_from_ui")
@@ -337,7 +337,7 @@ class Users::PermissionsControllerTest < ActionController::TestCase
     end
 
     should "prevent permissions being added for other apps" do
-      other_application = create(:application, with_supported_permissions: %w[other])
+      other_application = create(:application, with_non_delegatable_supported_permissions: %w[other])
       application = create(:application)
       user = create(:user)
       user.grant_application_signin_permission(application)
@@ -358,7 +358,7 @@ class Users::PermissionsControllerTest < ActionController::TestCase
     end
 
     should "prevent permissions being added that are not grantable from the ui" do
-      application = create(:application, with_supported_permissions_not_grantable_from_ui: %w[not_from_ui])
+      application = create(:application, with_non_delegatable_supported_permissions_not_grantable_from_ui: %w[not_from_ui])
       user = create(:user)
       user.grant_application_signin_permission(application)
 
@@ -378,7 +378,7 @@ class Users::PermissionsControllerTest < ActionController::TestCase
     end
 
     should "assign the application id to the application_id flash" do
-      application = create(:application, with_supported_permissions: %w[new old])
+      application = create(:application, with_non_delegatable_supported_permissions: %w[new old])
       user = create(:user, with_permissions: { application => %w[old] })
       user.grant_application_signin_permission(application)
 

--- a/test/factories/oauth_applications.rb
+++ b/test/factories/oauth_applications.rb
@@ -1,9 +1,10 @@
 FactoryBot.define do
   factory :application, class: Doorkeeper::Application do
     transient do
-      with_supported_permissions { [] }
-      with_supported_permissions_not_grantable_from_ui { [] }
+      with_non_delegatable_supported_permissions { [] }
+      with_non_delegatable_supported_permissions_not_grantable_from_ui { [] }
       with_delegatable_supported_permissions { [] }
+      with_delegatable_supported_permissions_not_grantable_from_ui { [] }
     end
 
     sequence(:name) { |n| "Application #{n}" }
@@ -13,7 +14,7 @@ FactoryBot.define do
     supports_push_updates { false }
 
     after(:create) do |app, evaluator|
-      evaluator.with_supported_permissions.each do |permission_name|
+      evaluator.with_non_delegatable_supported_permissions.each do |permission_name|
         # we create signin in an after_create on application.
         # this line takes care of tests creating signin in order to look complete or modify delegatable on it.
         app.signin_permission.update(delegatable: false) && next if permission_name == SupportedPermission::SIGNIN_NAME
@@ -21,7 +22,7 @@ FactoryBot.define do
         create(:supported_permission, application: app, name: permission_name)
       end
 
-      evaluator.with_supported_permissions_not_grantable_from_ui.each do |permission_name|
+      evaluator.with_non_delegatable_supported_permissions_not_grantable_from_ui.each do |permission_name|
         next if permission_name == SupportedPermission::SIGNIN_NAME
 
         create(:supported_permission, application: app, name: permission_name, grantable_from_ui: false)
@@ -31,6 +32,12 @@ FactoryBot.define do
         next if permission_name == SupportedPermission::SIGNIN_NAME
 
         create(:delegatable_supported_permission, application: app, name: permission_name)
+      end
+
+      evaluator.with_delegatable_supported_permissions_not_grantable_from_ui.each do |permission_name|
+        next if permission_name == SupportedPermission::SIGNIN_NAME
+
+        create(:delegatable_supported_permission, application: app, name: permission_name, grantable_from_ui: false)
       end
     end
   end

--- a/test/helpers/application_permissions_helper_test.rb
+++ b/test/helpers/application_permissions_helper_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class ApplicationPermissionsHelperTest < ActionView::TestCase
   context "#message_for_success" do
     setup do
-      @application = create(:application, name: "Whitehall", with_supported_permissions: ["Permission 1"])
+      @application = create(:application, name: "Whitehall", with_non_delegatable_supported_permissions: ["Permission 1"])
       user = create(:user, with_permissions: { @application => ["Permission 1", SupportedPermission::SIGNIN_NAME] })
       stubs(:current_user).returns(user)
     end

--- a/test/helpers/application_table_helper_test.rb
+++ b/test/helpers/application_table_helper_test.rb
@@ -78,7 +78,7 @@ class ApplicationTableHelperTest < ActionView::TestCase
 
   context "#users_applications_remove_access_link" do
     setup do
-      @application = create(:application, with_supported_permissions: %w[permission])
+      @application = create(:application, with_non_delegatable_supported_permissions: %w[permission])
       @grantee = create(:user)
     end
 
@@ -101,7 +101,7 @@ class ApplicationTableHelperTest < ActionView::TestCase
     setup do
       @user = build(:user)
       stubs(:current_user).returns(@user)
-      @application = create(:application, with_supported_permissions: %w[permission])
+      @application = create(:application, with_non_delegatable_supported_permissions: %w[permission])
     end
 
     should "generate both view and update links when the user can both view and edit permissions" do
@@ -139,7 +139,7 @@ class ApplicationTableHelperTest < ActionView::TestCase
 
   context "#users_applications_permissions_links" do
     setup do
-      @application = create(:application, with_supported_permissions: %w[permission])
+      @application = create(:application, with_non_delegatable_supported_permissions: %w[permission])
       @current_user = build(:user)
       stubs(:current_user).returns(@current_user)
       @grantee = create(:user)
@@ -208,7 +208,7 @@ class ApplicationTableHelperTest < ActionView::TestCase
 
   context "#api_users_applications_permissions_link" do
     should "generate an update link when the user can edit permissions" do
-      application = create(:application, with_supported_permissions: %w[permission])
+      application = create(:application, with_non_delegatable_supported_permissions: %w[permission])
       granter = create(:superadmin_user)
       grantee = create(:api_user)
       stubs(:current_user).returns(granter)
@@ -256,7 +256,7 @@ class ApplicationTableHelperTest < ActionView::TestCase
 
   context "#view_permissions_link" do
     should "generate a link to view the permissions" do
-      application = create(:application, with_supported_permissions: %w[permission])
+      application = create(:application, with_non_delegatable_supported_permissions: %w[permission])
 
       assert_includes view_permissions_link(application), account_application_permissions_path(application)
     end
@@ -267,7 +267,7 @@ class ApplicationTableHelperTest < ActionView::TestCase
       end
 
       should "generate a link to view the permissions" do
-        application = create(:application, with_supported_permissions: %w[permission])
+        application = create(:application, with_non_delegatable_supported_permissions: %w[permission])
 
         assert_includes view_permissions_link(application, @user), user_application_permissions_path(@user, application)
       end
@@ -277,7 +277,7 @@ class ApplicationTableHelperTest < ActionView::TestCase
   context "#update_permissions_link" do
     context "when the application has grantable permissions" do
       setup do
-        @application = create(:application, with_supported_permissions: %w[permission])
+        @application = create(:application, with_non_delegatable_supported_permissions: %w[permission])
       end
 
       context "when no user is provided" do

--- a/test/integration/account_applications_test.rb
+++ b/test/integration/account_applications_test.rb
@@ -123,7 +123,7 @@ class AccountApplicationsTest < ActionDispatch::IntegrationTest
 
   context "viewing permissions for an app" do
     setup do
-      @application = create(:application, name: "app-name", description: "app-description", with_supported_permissions: %w[perm1 perm2])
+      @application = create(:application, name: "app-name", description: "app-description", with_non_delegatable_supported_permissions: %w[perm1 perm2])
       @application.signin_permission.update!(delegatable: false)
     end
 
@@ -160,7 +160,7 @@ class AccountApplicationsTest < ActionDispatch::IntegrationTest
     context "as a #{user_role}" do
       should "support granting self app-specific permissions" do
         user = create(:"#{user_role}_user")
-        application = create(:application, name: "app-name", description: "app-description", with_supported_permissions: %w[perm1 perm2])
+        application = create(:application, name: "app-name", description: "app-description", with_non_delegatable_supported_permissions: %w[perm1 perm2])
         application.signin_permission.update!(delegatable: true)
         user.grant_application_signin_permission(application)
         user.grant_application_permission(application, "perm1")
@@ -189,7 +189,7 @@ class AccountApplicationsTest < ActionDispatch::IntegrationTest
     should "support granting self app-specific permissions" do
       user = create(:superadmin_user)
 
-      app = create(:application, name: "app-with-9-permissions", description: "app-description", with_supported_permissions: %w[pre-existing removing adding never-1 never-2 never-3 never-4 never-5 never-6])
+      app = create(:application, name: "app-with-9-permissions", description: "app-description", with_non_delegatable_supported_permissions: %w[pre-existing removing adding never-1 never-2 never-3 never-4 never-5 never-6])
       app.signin_permission.update!(delegatable: true)
       user.grant_application_signin_permission(app)
       user.grant_application_permissions(app, %w[pre-existing removing])
@@ -234,7 +234,7 @@ class AccountApplicationsTest < ActionDispatch::IntegrationTest
         app = create(
           :application,
           name: "MyApp",
-          with_supported_permissions: %w[pre-existing never-1 never-2 never-3 never-4 gonna give you up],
+          with_non_delegatable_supported_permissions: %w[pre-existing never-1 never-2 never-3 never-4 gonna give you up],
         )
         app.signin_permission.update!(delegatable: true)
         user.grant_application_signin_permission(app)
@@ -266,7 +266,7 @@ class AccountApplicationsTest < ActionDispatch::IntegrationTest
         app = create(
           :application,
           name: "MyApp",
-          with_supported_permissions: %w[Gotta catch 'em all I know it's my destiny],
+          with_non_delegatable_supported_permissions: %w[Gotta catch 'em all I know it's my destiny],
         )
         app.signin_permission.update!(delegatable: true)
         user.grant_application_signin_permission(app)
@@ -297,7 +297,7 @@ class AccountApplicationsTest < ActionDispatch::IntegrationTest
         app = create(
           :application,
           name: "MyApp",
-          with_supported_permissions: %w[never-1 never-2 never-3 never-4 never-5 gonna let you down],
+          with_non_delegatable_supported_permissions: %w[never-1 never-2 never-3 never-4 never-5 gonna let you down],
         )
         app.signin_permission.update!(delegatable: true)
         user.grant_application_signin_permission(app)
@@ -329,7 +329,7 @@ class AccountApplicationsTest < ActionDispatch::IntegrationTest
         @app = create(
           :application,
           name: "MyApp",
-          with_supported_permissions: %w[pre-existing adding never-1 never-2 never-3 never-4 never-5 never-6 never-7],
+          with_non_delegatable_supported_permissions: %w[pre-existing adding never-1 never-2 never-3 never-4 never-5 never-6 never-7],
         )
         @app.signin_permission.update!(delegatable: true)
         @adding_permission = SupportedPermission.find_by(name: "adding")

--- a/test/integration/api_authentication_test.rb
+++ b/test/integration/api_authentication_test.rb
@@ -10,7 +10,7 @@ class ApiAuthenticationTest < ActionDispatch::IntegrationTest
   end
 
   setup do
-    @app1 = create(:application, name: "MyApp", with_supported_permissions: %w[write])
+    @app1 = create(:application, name: "MyApp", with_non_delegatable_supported_permissions: %w[write])
     @user = create(:user, with_permissions: { @app1 => [SupportedPermission::SIGNIN_NAME, "write"] })
     @user.authorisations.create!(application_id: @app1.id)
   end

--- a/test/integration/granting_permissions_test.rb
+++ b/test/integration/granting_permissions_test.rb
@@ -24,7 +24,7 @@ class GrantingPermissionsTest < ActionDispatch::IntegrationTest
       app = create(
         :application,
         name: "MyApp",
-        with_supported_permissions: %w[pre-existing adding never],
+        with_non_delegatable_supported_permissions: %w[pre-existing adding never],
       )
       @user.grant_application_signin_permission(app)
       @user.grant_application_permission(app, "pre-existing")
@@ -41,7 +41,7 @@ class GrantingPermissionsTest < ActionDispatch::IntegrationTest
     end
 
     should "not be able to grant permissions that are not grantable_from_ui" do
-      app = create(:application, name: "MyApp", with_supported_permissions: %w[perm], with_supported_permissions_not_grantable_from_ui: %w[user_update_permission])
+      app = create(:application, name: "MyApp", with_non_delegatable_supported_permissions: %w[perm], with_non_delegatable_supported_permissions_not_grantable_from_ui: %w[user_update_permission])
       @user.grant_application_signin_permission(app)
 
       visit edit_user_path(@user)
@@ -76,7 +76,7 @@ class GrantingPermissionsTest < ActionDispatch::IntegrationTest
       app = create(
         :application,
         name: "MyApp",
-        with_supported_permissions: %w[pre-existing adding never],
+        with_non_delegatable_supported_permissions: %w[pre-existing adding never],
       )
       @user.grant_application_signin_permission(app)
       @user.grant_application_permission(app, "pre-existing")
@@ -93,7 +93,7 @@ class GrantingPermissionsTest < ActionDispatch::IntegrationTest
     end
 
     should "not be able to grant permissions that are not grantable_from_ui" do
-      app = create(:application, name: "MyApp", with_supported_permissions: %w[perm], with_supported_permissions_not_grantable_from_ui: %w[user_update_permission])
+      app = create(:application, name: "MyApp", with_non_delegatable_supported_permissions: %w[perm], with_non_delegatable_supported_permissions_not_grantable_from_ui: %w[user_update_permission])
       @user.grant_application_signin_permission(app)
 
       visit edit_user_path(@user)
@@ -114,7 +114,7 @@ class GrantingPermissionsTest < ActionDispatch::IntegrationTest
       signin_with(@super_org_admin)
     end
 
-    should "support granting signin permissions to delegatable apps that the super organisation admin has access to" do
+    should "support granting access to apps with a delegatable signin permission and to which the super organisation admin has access" do
       app = create(:application, name: "MyApp", with_delegatable_supported_permissions: [SupportedPermission::SIGNIN_NAME])
       @super_org_admin.grant_application_signin_permission(app)
 
@@ -125,10 +125,8 @@ class GrantingPermissionsTest < ActionDispatch::IntegrationTest
       assert @user.reload.has_access_to?(app)
     end
 
-    should "not support granting signin permissions to non-delegatable apps that the super organisation admin has access to" do
+    should "not support granting access to apps without a delegatable signin permission" do
       app = create(:application, name: "MyApp")
-      signin_permission = app.signin_permission
-      signin_permission.update!(delegatable: false)
       @super_org_admin.grant_application_signin_permission(app)
 
       visit edit_user_path(@user)
@@ -137,7 +135,7 @@ class GrantingPermissionsTest < ActionDispatch::IntegrationTest
       assert page.has_no_button? "Grant access to MyApp?"
     end
 
-    should "not support granting signin permissions to apps that the super organisation admin doesn't have access to" do
+    should "not support granting access to apps to which the super organisation admin doesn't have access" do
       create(:application, name: "MyApp", with_delegatable_supported_permissions: [SupportedPermission::SIGNIN_NAME])
 
       visit edit_user_path(@user)
@@ -150,7 +148,7 @@ class GrantingPermissionsTest < ActionDispatch::IntegrationTest
       app = create(
         :application,
         name: "MyApp",
-        with_supported_permissions: %w[pre-existing adding never],
+        with_delegatable_supported_permissions: %w[pre-existing adding never],
       )
       @super_org_admin.grant_application_signin_permission(app)
       @user.grant_application_signin_permission(app)
@@ -168,7 +166,7 @@ class GrantingPermissionsTest < ActionDispatch::IntegrationTest
     end
 
     should "not be able to grant permissions that are not grantable_from_ui" do
-      app = create(:application, name: "MyApp", with_supported_permissions_not_grantable_from_ui: %w[user_update_permission])
+      app = create(:application, name: "MyApp", with_delegatable_supported_permissions_not_grantable_from_ui: %w[user_update_permission])
       @super_org_admin.grant_application_signin_permission(app)
 
       visit edit_user_path(@user)
@@ -220,7 +218,7 @@ class GrantingPermissionsTest < ActionDispatch::IntegrationTest
       app = create(
         :application,
         name: "MyApp",
-        with_supported_permissions: %w[pre-existing adding never],
+        with_delegatable_supported_permissions: %w[pre-existing adding never],
       )
       @organisation_admin.grant_application_signin_permission(app)
       @user.grant_application_signin_permission(app)
@@ -238,7 +236,7 @@ class GrantingPermissionsTest < ActionDispatch::IntegrationTest
     end
 
     should "not be able to grant permissions that are not grantable_from_ui" do
-      app = create(:application, name: "MyApp", with_supported_permissions_not_grantable_from_ui: %w[user_update_permission])
+      app = create(:application, name: "MyApp", with_delegatable_supported_permissions_not_grantable_from_ui: %w[user_update_permission])
       @organisation_admin.grant_application_signin_permission(app)
 
       visit edit_user_path(@user)
@@ -257,7 +255,7 @@ class GrantingPermissionsTest < ActionDispatch::IntegrationTest
       app = create(
         :application,
         name: "MyApp",
-        with_supported_permissions: %w[pre-existing removing adding never-1 never-2 never-3 never-4 never-5 never-6],
+        with_non_delegatable_supported_permissions: %w[pre-existing removing adding never-1 never-2 never-3 never-4 never-5 never-6],
       )
       user.grant_application_signin_permission(app)
       user.grant_application_permissions(app, %w[pre-existing removing])
@@ -296,7 +294,7 @@ class GrantingPermissionsTest < ActionDispatch::IntegrationTest
         app = create(
           :application,
           name: "MyApp",
-          with_supported_permissions: %w[pre-existing never-1 never-2 gonna run around and desert you],
+          with_non_delegatable_supported_permissions: %w[pre-existing never-1 never-2 gonna run around and desert you],
         )
         user.grant_application_signin_permission(app)
         user.grant_application_permissions(app, %w[pre-existing])
@@ -328,7 +326,7 @@ class GrantingPermissionsTest < ActionDispatch::IntegrationTest
         app = create(
           :application,
           name: "MyApp",
-          with_supported_permissions: %w[Gotta catch 'em all I know it's my destiny],
+          with_non_delegatable_supported_permissions: %w[Gotta catch 'em all I know it's my destiny],
         )
         @adding_permission = SupportedPermission.find_by(name: "adding")
         user.grant_application_signin_permission(app)
@@ -360,7 +358,7 @@ class GrantingPermissionsTest < ActionDispatch::IntegrationTest
         app = create(
           :application,
           name: "MyApp",
-          with_supported_permissions: %w[never-1 never-2 never-3 never-4 never-5 gonna make you cry],
+          with_non_delegatable_supported_permissions: %w[never-1 never-2 never-3 never-4 never-5 gonna make you cry],
         )
         user.grant_application_signin_permission(app)
 
@@ -392,7 +390,7 @@ class GrantingPermissionsTest < ActionDispatch::IntegrationTest
         @app = create(
           :application,
           name: "MyApp",
-          with_supported_permissions: %w[pre-existing adding never-1 never-2 never-3 never-4 never-5 never-6 never-7],
+          with_non_delegatable_supported_permissions: %w[pre-existing adding never-1 never-2 never-3 never-4 never-5 never-6 never-7],
         )
         @adding_permission = SupportedPermission.find_by(name: "adding")
         @user.grant_application_signin_permission(@app)

--- a/test/integration/manage_api_users_test.rb
+++ b/test/integration/manage_api_users_test.rb
@@ -3,7 +3,7 @@ require_relative "../test_helper"
 class ManageApiUsersTest < ActionDispatch::IntegrationTest
   context "as Superadmin" do
     setup do
-      @application = create(:application, with_supported_permissions: %w[write])
+      @application = create(:application, with_non_delegatable_supported_permissions: %w[write])
 
       @superadmin = create(:superadmin_user)
       visit new_user_session_path
@@ -44,7 +44,7 @@ class ManageApiUsersTest < ActionDispatch::IntegrationTest
     end
 
     should "be able to authorise application access and manage permissions for an API user which should get recorded in event log" do
-      create(:application, name: "Whitehall", with_supported_permissions: ["Managing Editor", SupportedPermission::SIGNIN_NAME])
+      create(:application, name: "Whitehall", with_non_delegatable_supported_permissions: ["Managing Editor", SupportedPermission::SIGNIN_NAME])
 
       click_link @api_user.name
       click_link "Manage tokens"

--- a/test/integration/user_applications_test.rb
+++ b/test/integration/user_applications_test.rb
@@ -42,7 +42,7 @@ class UserApplicationsTest < ActionDispatch::IntegrationTest
   end
 
   should "allow admins to update users' permissions for apps" do
-    application = create(:application, name: "app-name", with_supported_permissions: %w[perm1 perm2])
+    application = create(:application, name: "app-name", with_non_delegatable_supported_permissions: %w[perm1 perm2])
     application.signin_permission.update!(delegatable: true)
 
     user = create(:admin_user)

--- a/test/lib/sso_push_client_test.rb
+++ b/test/lib/sso_push_client_test.rb
@@ -14,7 +14,7 @@ class SSOPushClientTest < ActiveSupport::TestCase
   context "update_user" do
     setup do
       @user = create(:user)
-      @application = create(:application, redirect_uri: "https://app.com/callback", with_supported_permissions: %w[user_update_permission])
+      @application = create(:application, redirect_uri: "https://app.com/callback", with_non_delegatable_supported_permissions: %w[user_update_permission])
       @user_hash = UserOAuthPresenter.new(@user, @application).as_hash
     end
 
@@ -37,7 +37,7 @@ class SSOPushClientTest < ActiveSupport::TestCase
   context "reauth" do
     setup do
       @user = create(:user)
-      @application = create(:application, redirect_uri: "https://app.com/callback", with_supported_permissions: %w[user_update_permission])
+      @application = create(:application, redirect_uri: "https://app.com/callback", with_non_delegatable_supported_permissions: %w[user_update_permission])
     end
 
     should "send an empty POST to the app" do

--- a/test/lib/sso_push_credential_test.rb
+++ b/test/lib/sso_push_credential_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class SSOPushCredentialTest < ActiveSupport::TestCase
   setup do
-    @application = create(:application, with_supported_permissions: %w[user_update_permission])
+    @application = create(:application, with_non_delegatable_supported_permissions: %w[user_update_permission])
     @user = SSOPushCredential.user
   end
 

--- a/test/lib/sso_push_error_test.rb
+++ b/test/lib/sso_push_error_test.rb
@@ -4,7 +4,7 @@ require "gds_api/base"
 class SSOPushErrorTest < ActiveSupport::TestCase
   def setup
     @user = create(:user)
-    @application = create(:application, redirect_uri: "https://app.com/callback", with_supported_permissions: %w[user_update_permission])
+    @application = create(:application, redirect_uri: "https://app.com/callback", with_non_delegatable_supported_permissions: %w[user_update_permission])
   end
 
   context "rescuing GdsApi::HTTPErrorResponse" do

--- a/test/lib/tasks/permissions_test.rb
+++ b/test/lib/tasks/permissions_test.rb
@@ -15,8 +15,8 @@ class PermissionsTest < ActiveSupport::TestCase
 
   context "#promote_managing_editors_to_org_admins" do
     setup do
-      @first_app = create(:application, name: "Cat Publisher", with_supported_permissions: ["Managing Editor", "other"])
-      @second_app = create(:application, name: "Dog Publisher", with_supported_permissions: %w[managing_editor other])
+      @first_app = create(:application, name: "Cat Publisher", with_non_delegatable_supported_permissions: ["Managing Editor", "other"])
+      @second_app = create(:application, name: "Dog Publisher", with_non_delegatable_supported_permissions: %w[managing_editor other])
       @task = Rake::Task["permissions:promote_managing_editors_to_org_admins"]
     end
 
@@ -70,7 +70,7 @@ class PermissionsTest < ActiveSupport::TestCase
 
   context "#remove_editor_permission_from_whitehall_managing_editors" do
     setup do
-      @whitehall_app = create(:application, name: "Whitehall", with_supported_permissions: ["Editor", "Managing Editor", "Some Other Permission"])
+      @whitehall_app = create(:application, name: "Whitehall", with_non_delegatable_supported_permissions: ["Editor", "Managing Editor", "Some Other Permission"])
       @task = Rake::Task["permissions:remove_editor_permission_from_whitehall_managing_editors"]
     end
 
@@ -93,7 +93,7 @@ class PermissionsTest < ActiveSupport::TestCase
     end
 
     should "retain both permissions for other apps" do
-      non_whitehall_app = create(:application, name: "Another App", with_supported_permissions: ["Editor", "Managing Editor", "Some Other Permission"])
+      non_whitehall_app = create(:application, name: "Another App", with_non_delegatable_supported_permissions: ["Editor", "Managing Editor", "Some Other Permission"])
       non_gds_managing_editor_and_editor = user_with_permissions(:user, @non_gds_org, { non_whitehall_app => ["Editor", "Managing Editor", "Some Other Permission"] })
 
       @task.invoke

--- a/test/models/doorkeeper/application_test.rb
+++ b/test/models/doorkeeper/application_test.rb
@@ -88,8 +88,8 @@ class Doorkeeper::ApplicationTest < ActiveSupport::TestCase
       application = create(
         :application,
         name: "Whitehall",
-        with_supported_permissions: ["Editor", SupportedPermission::SIGNIN_NAME],
-        with_supported_permissions_not_grantable_from_ui: ["Not grantable"],
+        with_non_delegatable_supported_permissions: ["Editor", SupportedPermission::SIGNIN_NAME],
+        with_non_delegatable_supported_permissions_not_grantable_from_ui: ["Not grantable"],
       )
 
       permission_names = application.sorted_supported_permissions_grantable_from_ui.map(&:name)
@@ -103,7 +103,7 @@ class Doorkeeper::ApplicationTest < ActiveSupport::TestCase
       application = create(
         :application,
         name: "Whitehall",
-        with_supported_permissions: ["Writer", "Editor", SupportedPermission::SIGNIN_NAME],
+        with_non_delegatable_supported_permissions: ["Writer", "Editor", SupportedPermission::SIGNIN_NAME],
       )
 
       permission_names = application.sorted_supported_permissions_grantable_from_ui.map(&:name)
@@ -115,7 +115,7 @@ class Doorkeeper::ApplicationTest < ActiveSupport::TestCase
       application = create(
         :application,
         name: "Whitehall",
-        with_supported_permissions: ["Writer", "Editor", SupportedPermission::SIGNIN_NAME],
+        with_non_delegatable_supported_permissions: ["Writer", "Editor", SupportedPermission::SIGNIN_NAME],
       )
 
       permission_names = application.sorted_supported_permissions_grantable_from_ui(include_signin: false).map(&:name)
@@ -258,7 +258,7 @@ class Doorkeeper::ApplicationTest < ActiveSupport::TestCase
     end
 
     should "not return applications that don't support delegation of signin permission" do
-      create(:application, with_supported_permissions: [SupportedPermission::SIGNIN_NAME])
+      create(:application, with_non_delegatable_supported_permissions: [SupportedPermission::SIGNIN_NAME])
 
       assert_empty Doorkeeper::Application.with_signin_delegatable
     end

--- a/test/models/supported_permission_test.rb
+++ b/test/models/supported_permission_test.rb
@@ -35,7 +35,7 @@ class SupportedPermissionTest < ActiveSupport::TestCase
 
   test "associated user application permissions are destroyed when supported permissions are destroyed" do
     user = create(:user)
-    application = create(:application, with_supported_permissions: %w[managing_editor])
+    application = create(:application, with_non_delegatable_supported_permissions: %w[managing_editor])
     managing_editor_permission = application.supported_permissions.where(name: "managing_editor").first
 
     user.grant_application_permission(application, "managing_editor")
@@ -65,15 +65,15 @@ class SupportedPermissionTest < ActiveSupport::TestCase
   end
 
   test ".signin returns all signin permissions" do
-    app1 = create(:application, with_supported_permissions: %w[app1-permission])
-    app2 = create(:application, with_supported_permissions: %w[app2-permission])
+    app1 = create(:application, with_non_delegatable_supported_permissions: %w[app1-permission])
+    app2 = create(:application, with_non_delegatable_supported_permissions: %w[app2-permission])
 
     assert_same_elements [app1.signin_permission, app2.signin_permission], SupportedPermission.signin
   end
 
   test ".excluding_application returns all permissions except for the provided application" do
-    create(:application, with_supported_permissions: %w[included-permission])
-    excluded_application = create(:application, with_supported_permissions: %w[excluded-permission])
+    create(:application, with_non_delegatable_supported_permissions: %w[included-permission])
+    excluded_application = create(:application, with_non_delegatable_supported_permissions: %w[excluded-permission])
 
     assert_same_elements ["included-permission", SupportedPermission::SIGNIN_NAME], SupportedPermission.excluding_application(excluded_application).pluck(:name)
   end

--- a/test/models/user_o_auth_presenter_test.rb
+++ b/test/models/user_o_auth_presenter_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class UserOAuthPresenterTest < ActiveSupport::TestCase
   setup do
-    @application = create(:application, with_supported_permissions: %w[managing_editor])
+    @application = create(:application, with_non_delegatable_supported_permissions: %w[managing_editor])
   end
 
   should "generate JSON" do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -641,7 +641,7 @@ class UserTest < ActiveSupport::TestCase
     end
 
     should "grant permissions to user and return the created permission" do
-      app = create(:application, with_supported_permissions: ["Create publications", "Delete publications"])
+      app = create(:application, with_non_delegatable_supported_permissions: ["Create publications", "Delete publications"])
       user = create(:user)
 
       permission = user.grant_application_permission(app, "Create publications")
@@ -651,7 +651,7 @@ class UserTest < ActiveSupport::TestCase
     end
 
     should "not grant permission to user for a retired application" do
-      app = create(:application, retired: true, with_supported_permissions: %w[edit])
+      app = create(:application, retired: true, with_non_delegatable_supported_permissions: %w[edit])
       user = create(:user)
 
       signin_permission = user.grant_application_signin_permission(app)
@@ -663,7 +663,7 @@ class UserTest < ActiveSupport::TestCase
     end
 
     should "return multiple permissions in name order" do
-      app = create(:application, with_supported_permissions: %w[edit])
+      app = create(:application, with_non_delegatable_supported_permissions: %w[edit])
       user = create(:user)
 
       user.grant_application_signin_permission(app)

--- a/test/services/user_update_test.rb
+++ b/test/services/user_update_test.rb
@@ -19,7 +19,7 @@ class UserUpdateTest < ActionView::TestCase
   should "records permission changes" do
     parsed_ip_address = IPAddr.new(ip_address, Socket::AF_INET).to_s
 
-    app = create(:application, name: "App", with_supported_permissions: ["Editor", SupportedPermission::SIGNIN_NAME, "Something Else"])
+    app = create(:application, name: "App", with_non_delegatable_supported_permissions: ["Editor", SupportedPermission::SIGNIN_NAME, "Something Else"])
     affected_user.grant_application_permission(app, "Something Else")
 
     perms = app.supported_permissions.first(2).map(&:id)
@@ -41,7 +41,7 @@ class UserUpdateTest < ActionView::TestCase
 
   should "log the addition of a large number of permissions" do
     permissions = (0..100).map { |i| "permission-#{i}" }
-    app = create(:application, name: "App", with_supported_permissions: permissions)
+    app = create(:application, name: "App", with_non_delegatable_supported_permissions: permissions)
 
     params = { supported_permission_ids: app.supported_permissions.map(&:id) }
     UserUpdate.new(affected_user, params, current_user, ip_address).call


### PR DESCRIPTION
Without this, when fixing how delegability affects who can edit permissions, we might get some potential false negatives. For example, if a test seeks to confirm that permissions not being grantable from UI prevents users from doing certain things, but the test is set up with non-delegatable permissions, we might instead be testing the latter

Most tests are using admin users, which are unaffected by delegability. A few tests that use org admins are updated to use delegatable permissions, in preparation for the upcoming changes, where this would otherwise open up the possibility of a false negative

---

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
