### PR TITLE
Fix delegatable permissions

### DIFF
--- a/app/controllers/account/permissions_controller.rb
+++ b/app/controllers/account/permissions_controller.rb
@@ -14,6 +14,11 @@ class Account::PermissionsController < ApplicationController
   def edit
     authorize [:account, @application], :edit_permissions?
 
+    if @permissions.empty?
+      flash[:alert] = "No permissions found for #{@application.name} that you are authorised to manage."
+      return redirect_to account_applications_path
+    end
+
     @shared_permissions_form_locals = {
       action: account_application_permissions_path(@application),
       application: @application,

--- a/app/controllers/account/permissions_controller.rb
+++ b/app/controllers/account/permissions_controller.rb
@@ -79,6 +79,10 @@ private
   end
 
   def set_permissions
-    @permissions = @application.sorted_supported_permissions_grantable_from_ui(include_signin: false)
+    if current_user.govuk_admin?
+      @permissions = @application.sorted_supported_permissions_grantable_from_ui(include_signin: false)
+    elsif current_user.publishing_manager?
+      @permissions = @application.sorted_supported_permissions_grantable_from_ui(include_signin: false, only_delegatable: true)
+    end
   end
 end

--- a/app/controllers/users/permissions_controller.rb
+++ b/app/controllers/users/permissions_controller.rb
@@ -84,6 +84,10 @@ private
   end
 
   def set_permissions
-    @permissions = @application.sorted_supported_permissions_grantable_from_ui(include_signin: false)
+    if current_user.govuk_admin?
+      @permissions = @application.sorted_supported_permissions_grantable_from_ui(include_signin: false)
+    elsif current_user.publishing_manager?
+      @permissions = @application.sorted_supported_permissions_grantable_from_ui(include_signin: false, only_delegatable: true)
+    end
   end
 end

--- a/app/controllers/users/permissions_controller.rb
+++ b/app/controllers/users/permissions_controller.rb
@@ -15,6 +15,11 @@ class Users::PermissionsController < ApplicationController
   def edit
     authorize [{ application: @application, user: @user }], :edit_permissions?, policy_class: Users::ApplicationPolicy
 
+    if @permissions.empty?
+      flash[:alert] = "No permissions found for #{@application.name} that you are authorised to manage."
+      return redirect_to user_applications_path(@user)
+    end
+
     @shared_permissions_form_locals = {
       action: user_application_permissions_path(@user, @application),
       application: @application,

--- a/app/helpers/application_table_helper.rb
+++ b/app/helpers/application_table_helper.rb
@@ -101,7 +101,11 @@ private
   end
 
   def update_permissions_link(application, user = nil)
-    return "" if application.sorted_supported_permissions_grantable_from_ui(include_signin: false).none?
+    if current_user.govuk_admin?
+      return "" unless application.has_non_signin_permissions_grantable_from_ui?
+    elsif current_user.publishing_manager?
+      return "" unless application.has_delegatable_non_signin_permissions_grantable_from_ui?
+    end
 
     path = if user.nil?
              edit_account_application_permissions_path(application)

--- a/app/models/doorkeeper/application.rb
+++ b/app/models/doorkeeper/application.rb
@@ -42,14 +42,20 @@ class Doorkeeper::Application < ActiveRecord::Base # rubocop:disable Rails/Appli
     supported_permissions.signin.first
   end
 
-  def sorted_supported_permissions_grantable_from_ui(include_signin: true)
-    sorted_permissions = supported_permissions.grantable_from_ui.order(:name)
+  def sorted_supported_permissions_grantable_from_ui(include_signin: true, only_delegatable: false)
+    sorted_permissions = if only_delegatable
+                           supported_permissions.grantable_from_ui.delegatable.order(:name)
+                         else
+                           supported_permissions.grantable_from_ui.order(:name)
+                         end
     sorted_permissions_without_signin = sorted_permissions - [signin_permission]
 
-    if include_signin
-      ([signin_permission] + sorted_permissions_without_signin).compact
-    else
+    return sorted_permissions_without_signin unless include_signin
+
+    if only_delegatable && !signin_permission.delegatable
       sorted_permissions_without_signin
+    else
+      ([signin_permission] + sorted_permissions_without_signin).compact
     end
   end
 

--- a/app/models/doorkeeper/application.rb
+++ b/app/models/doorkeeper/application.rb
@@ -53,6 +53,14 @@ class Doorkeeper::Application < ActiveRecord::Base # rubocop:disable Rails/Appli
     end
   end
 
+  def has_non_signin_permissions_grantable_from_ui?
+    (supported_permissions.grantable_from_ui - [signin_permission]).any?
+  end
+
+  def has_delegatable_non_signin_permissions_grantable_from_ui?
+    (supported_permissions.delegatable.grantable_from_ui - [signin_permission]).any?
+  end
+
   def url_without_path
     parsed_url = URI.parse(redirect_uri)
     "#{parsed_url.scheme}://#{parsed_url.host}:#{parsed_url.port}"

--- a/app/policies/account/application_policy.rb
+++ b/app/policies/account/application_policy.rb
@@ -17,5 +17,8 @@ class Account::ApplicationPolicy < BasePolicy
         current_user.publishing_manager? && record.signin_permission.delegatable?
       )
   end
-  alias_method :edit_permissions?, :remove_signin_permission?
+
+  def edit_permissions?
+    current_user.has_access_to?(record) && (current_user.govuk_admin? || current_user.publishing_manager?)
+  end
 end

--- a/app/policies/supported_permission_policy.rb
+++ b/app/policies/supported_permission_policy.rb
@@ -4,7 +4,10 @@ class SupportedPermissionPolicy < BasePolicy
       if current_user.govuk_admin?
         scope.all
       elsif current_user.publishing_manager?
-        scope.joins(:application).where(oauth_applications: { id: publishing_manager_manageable_application_ids })
+        scope
+          .delegatable
+          .joins(:application)
+          .where(oauth_applications: { id: publishing_manager_manageable_application_ids })
       else
         scope.none
       end
@@ -17,7 +20,6 @@ class SupportedPermissionPolicy < BasePolicy
         .not_api_only
         .includes(:supported_permissions)
         .can_signin(current_user)
-        .with_signin_delegatable
         .pluck(:id)
     end
   end

--- a/app/policies/users/application_policy.rb
+++ b/app/policies/users/application_policy.rb
@@ -23,5 +23,11 @@ class Users::ApplicationPolicy < BasePolicy
   end
 
   alias_method :remove_signin_permission?, :grant_signin_permission?
-  alias_method :edit_permissions?, :grant_signin_permission?
+
+  def edit_permissions?
+    return false unless Pundit.policy(current_user, user).edit?
+    return true if current_user.govuk_admin?
+
+    current_user.publishing_manager? && current_user.has_access_to?(application)
+  end
 end

--- a/test/controllers/account/applications_controller_test.rb
+++ b/test/controllers/account/applications_controller_test.rb
@@ -127,22 +127,28 @@ class Account::ApplicationsControllerTest < ActionController::TestCase
 
         context "editing permissions" do
           context "when the app only has the signin permission" do
-            should "only display a link to view permissions when authorised to view or edit permissions" do
-              stub_policy @user, [:account, @application], view_permissions?: true, edit_permissions?: true
+            %w[govuk_admin publishing_manager].each do |role_group|
+              context "as a #{role_group}" do
+                setup { @user.stubs(:"#{role_group}?").returns(true) }
 
-              get :index
+                should "only display a link to view permissions when authorised to view or edit permissions" do
+                  stub_policy @user, [:account, @application], view_permissions?: true, edit_permissions?: true
 
-              assert_select "a[href='#{edit_account_application_permissions_path(@application)}']", count: 0
-              assert_select "a[href='#{account_application_permissions_path(@application)}']"
-            end
+                  get :index
 
-            should "not display links to view or edit permissions when not authorised to view permissions" do
-              stub_policy @user, [:account, @application], view_permissions?: false, edit_permissions?: true
+                  assert_select "a[href='#{edit_account_application_permissions_path(@application)}']", count: 0
+                  assert_select "a[href='#{account_application_permissions_path(@application)}']"
+                end
 
-              get :index
+                should "not display links to view or edit permissions when not authorised to view permissions" do
+                  stub_policy @user, [:account, @application], view_permissions?: false, edit_permissions?: true
 
-              assert_select "a[href='#{edit_account_application_permissions_path(@application)}']", count: 0
-              assert_select "a[href='#{account_application_permissions_path(@application)}']", count: 0
+                  get :index
+
+                  assert_select "a[href='#{edit_account_application_permissions_path(@application)}']", count: 0
+                  assert_select "a[href='#{account_application_permissions_path(@application)}']", count: 0
+                end
+              end
             end
           end
 

--- a/test/controllers/account/permissions_controller_test.rb
+++ b/test/controllers/account/permissions_controller_test.rb
@@ -144,6 +144,31 @@ class Account::PermissionsControllerTest < ActionController::TestCase
       assert_select "input[type='hidden'][value='#{application.signin_permission.id}']"
     end
 
+    context "when the current user is a publishing manager" do
+      should "exclude non-delegatable permissions" do
+        application = create(:application)
+        old_delegatable_permission = create(:delegatable_supported_permission, application:)
+        old_non_delegatable_permission = create(:non_delegatable_supported_permission, application:)
+        new_delegatable_permission = create(:delegatable_supported_permission, application:)
+        new_non_delegatable_permission = create(:non_delegatable_supported_permission, application:)
+
+        current_user = create(
+          :user,
+          with_signin_permissions_for: [application],
+          with_permissions: { application => [old_delegatable_permission.name, old_non_delegatable_permission.name] },
+        )
+        current_user.stubs(:publishing_manager?).returns(true)
+        sign_in current_user
+
+        get :edit, params: { application_id: application }
+
+        assert_select "input[type='checkbox'][checked='checked'][name='application[supported_permission_ids][]'][value='#{old_delegatable_permission.id}']"
+        assert_select "input[type='checkbox'][name='application[supported_permission_ids][]'][value='#{new_delegatable_permission.id}']"
+        assert_select "input[type='checkbox'][name='application[supported_permission_ids][]'][value='#{old_non_delegatable_permission.id}']", count: 0
+        assert_select "input[type='checkbox'][name='application[supported_permission_ids][]'][value='#{new_non_delegatable_permission.id}']", count: 0
+      end
+    end
+
     context "for apps with greater than eight supported permissions" do
       setup do
         @application = create(:application)
@@ -328,6 +353,35 @@ class Account::PermissionsControllerTest < ActionController::TestCase
       patch :update, params: { application_id: application, application: { supported_permission_ids: [new_permission.id] } }
 
       assert_equal application.id, flash[:application_id]
+    end
+
+    context "when the current user is a publishing manager with access to the app" do
+      should "prevent adding or removing non-delegatable permissions" do
+        application = create(:application)
+        old_delegatable_permission = create(:delegatable_supported_permission, application:)
+        new_delegatable_permission = create(:delegatable_supported_permission, application:)
+        old_non_delegatable_permission = create(:non_delegatable_supported_permission, application:)
+        new_non_delegatable_permission = create(:non_delegatable_supported_permission, application:)
+
+        current_user = create(
+          :user,
+          with_signin_permissions_for: [application],
+          with_permissions: { application => [old_delegatable_permission.name, old_non_delegatable_permission.name] },
+        )
+        current_user.stubs(:publishing_manager?).returns(true)
+        current_user.stubs(:organisation_admin_belongs_to_organisation).returns(true)
+        sign_in current_user
+
+        stub_policy current_user, [:account, application], edit_permissions?: true
+
+        patch(:update, params: { application_id: application, application: { supported_permission_ids: [new_delegatable_permission.id, new_non_delegatable_permission.id] } })
+
+        assert_same_elements [
+          old_non_delegatable_permission,
+          new_delegatable_permission,
+          application.signin_permission,
+        ], current_user.reload.supported_permissions
+      end
     end
 
     context "when current_permission_ids and new_permission_id are provided instead of supported_permission_ids" do

--- a/test/controllers/users/applications_controller_test.rb
+++ b/test/controllers/users/applications_controller_test.rb
@@ -208,71 +208,77 @@ class Users::ApplicationsControllerTest < ActionController::TestCase
 
         context "viewing and editing permissions" do
           context "when there is only a signin permisson" do
-            context "when authorised to view and edit" do
-              should "display only a link to view permissions" do
-                stub_policy(
-                  @current_user,
-                  { application: @application, user: @user },
-                  policy_class: Users::ApplicationPolicy,
-                  edit_permissions?: true,
-                  view_permissions?: true,
-                )
+            %w[govuk_admin publishing_manager].each do |role_group|
+              context "as a #{role_group}" do
+                setup { @current_user.stubs(:"#{role_group}?").returns(true) }
 
-                get :index, params: { user_id: @user }
+                context "when authorised to view and edit" do
+                  should "display only a link to view permissions" do
+                    stub_policy(
+                      @current_user,
+                      { application: @application, user: @user },
+                      policy_class: Users::ApplicationPolicy,
+                      edit_permissions?: true,
+                      view_permissions?: true,
+                    )
 
-                assert_view_permissions_link
-                assert_no_edit_permissions_link
-              end
-            end
+                    get :index, params: { user_id: @user }
 
-            context "when authorised to view but not edit" do
-              should "display only a link to view permissions" do
-                stub_policy(
-                  @current_user,
-                  { application: @application, user: @user },
-                  policy_class: Users::ApplicationPolicy,
-                  edit_permissions?: false,
-                  view_permissions?: true,
-                )
+                    assert_view_permissions_link
+                    assert_no_edit_permissions_link
+                  end
+                end
 
-                get :index, params: { user_id: @user }
+                context "when authorised to view but not edit" do
+                  should "display only a link to view permissions" do
+                    stub_policy(
+                      @current_user,
+                      { application: @application, user: @user },
+                      policy_class: Users::ApplicationPolicy,
+                      edit_permissions?: false,
+                      view_permissions?: true,
+                    )
 
-                assert_view_permissions_link
-                assert_no_edit_permissions_link
-              end
-            end
+                    get :index, params: { user_id: @user }
 
-            context "when authorised to edit but not view" do
-              should "display no links" do
-                stub_policy(
-                  @current_user,
-                  { application: @application, user: @user },
-                  policy_class: Users::ApplicationPolicy,
-                  edit_permissions?: true,
-                  view_permissions?: false,
-                )
+                    assert_view_permissions_link
+                    assert_no_edit_permissions_link
+                  end
+                end
 
-                get :index, params: { user_id: @user }
+                context "when authorised to edit but not view" do
+                  should "display no links" do
+                    stub_policy(
+                      @current_user,
+                      { application: @application, user: @user },
+                      policy_class: Users::ApplicationPolicy,
+                      edit_permissions?: true,
+                      view_permissions?: false,
+                    )
 
-                assert_no_view_permissions_link
-                assert_no_edit_permissions_link
-              end
-            end
+                    get :index, params: { user_id: @user }
 
-            context "when not authorised to edit or view" do
-              should "display no links" do
-                stub_policy(
-                  @current_user,
-                  { application: @application, user: @user },
-                  policy_class: Users::ApplicationPolicy,
-                  edit_permissions?: false,
-                  view_permissions?: false,
-                )
+                    assert_no_view_permissions_link
+                    assert_no_edit_permissions_link
+                  end
+                end
 
-                get :index, params: { user_id: @user }
+                context "when not authorised to edit or view" do
+                  should "display no links" do
+                    stub_policy(
+                      @current_user,
+                      { application: @application, user: @user },
+                      policy_class: Users::ApplicationPolicy,
+                      edit_permissions?: false,
+                      view_permissions?: false,
+                    )
 
-                assert_no_view_permissions_link
-                assert_no_edit_permissions_link
+                    get :index, params: { user_id: @user }
+
+                    assert_no_view_permissions_link
+                    assert_no_edit_permissions_link
+                  end
+                end
               end
             end
           end

--- a/test/integration/granting_permissions_test.rb
+++ b/test/integration/granting_permissions_test.rb
@@ -203,7 +203,7 @@ class GrantingPermissionsTest < ActionDispatch::IntegrationTest
       signin_with(@organisation_admin)
     end
 
-    should "support granting signin permissions to delegatable apps that the organisation admin has access to" do
+    should "support granting access to apps with a delegatable signin permission and to which the organisation admin has access" do
       app = create(:application, name: "MyApp", with_delegatable_supported_permissions: [SupportedPermission::SIGNIN_NAME])
       @organisation_admin.grant_application_signin_permission(app)
 
@@ -214,7 +214,7 @@ class GrantingPermissionsTest < ActionDispatch::IntegrationTest
       assert @user.reload.has_access_to?(app)
     end
 
-    should "not support granting signin permissions to non-delegatable apps that the organisation admin has access to" do
+    should "not support granting access to apps without a delegatable signin permission" do
       app = create(:application, name: "MyApp")
       signin_permission = app.signin_permission
       signin_permission.update!(delegatable: false)
@@ -225,7 +225,7 @@ class GrantingPermissionsTest < ActionDispatch::IntegrationTest
       assert page.has_no_field? "Has access to MyApp?"
     end
 
-    should "not support granting signin permissions to apps that the organisation admin doesn't have access to" do
+    should "not support granting access to apps to which the super organisation admin doesn't have access" do
       create(:application, name: "MyApp", with_delegatable_supported_permissions: [SupportedPermission::SIGNIN_NAME])
 
       visit edit_user_path(@user)

--- a/test/integration/granting_permissions_test.rb
+++ b/test/integration/granting_permissions_test.rb
@@ -40,6 +40,23 @@ class GrantingPermissionsTest < ActionDispatch::IntegrationTest
       assert_not_includes @user.permissions_for(app), "never"
     end
 
+    should "be able to grant delegatable and non-delegatable permissions" do
+      app = create(
+        :application,
+        name: "MyApp",
+        with_delegatable_supported_permissions: %w[delegatable_perm],
+        with_non_delegatable_supported_permissions: %w[non_delegatable_perm],
+      )
+      @user.grant_application_signin_permission(app)
+
+      visit edit_user_path(@user)
+      click_link "Manage permissions"
+      click_link "Update permissions for MyApp"
+
+      assert page.has_field?("delegatable_perm")
+      assert page.has_field?("non_delegatable_perm")
+    end
+
     should "not be able to grant permissions that are not grantable_from_ui" do
       app = create(
         :application,
@@ -95,6 +112,23 @@ class GrantingPermissionsTest < ActionDispatch::IntegrationTest
       assert_includes @user.permissions_for(app), "pre-existing"
       assert_includes @user.permissions_for(app), "adding"
       assert_not_includes @user.permissions_for(app), "never"
+    end
+
+    should "be able to grant delegatable and non-delegatable permissions" do
+      app = create(
+        :application,
+        name: "MyApp",
+        with_delegatable_supported_permissions: %w[delegatable_perm],
+        with_non_delegatable_supported_permissions: %w[non_delegatable_perm],
+      )
+      @user.grant_application_signin_permission(app)
+
+      visit edit_user_path(@user)
+      click_link "Manage permissions"
+      click_link "Update permissions for MyApp"
+
+      assert page.has_field?("delegatable_perm")
+      assert page.has_field?("non_delegatable_perm")
     end
 
     should "not be able to grant permissions that are not grantable_from_ui" do
@@ -175,6 +209,24 @@ class GrantingPermissionsTest < ActionDispatch::IntegrationTest
       assert_not_includes @user.permissions_for(app), "never"
     end
 
+    should "not be able to grant permissions that are non-delegatable" do
+      app = create(
+        :application,
+        name: "MyApp",
+        with_delegatable_supported_permissions: %w[delegatable_perm],
+        with_non_delegatable_supported_permissions: %w[non_delegatable_perm],
+      )
+      @super_org_admin.grant_application_signin_permission(app)
+      @user.grant_application_signin_permission(app)
+
+      visit edit_user_path(@user)
+      click_link "Manage permissions"
+      click_link "Update permissions for MyApp"
+
+      assert page.has_field?("delegatable_perm")
+      assert page.has_no_field?("non_delegatable_perm")
+    end
+
     should "not be able to grant permissions that are not grantable_from_ui" do
       app = create(
         :application,
@@ -252,6 +304,24 @@ class GrantingPermissionsTest < ActionDispatch::IntegrationTest
       assert_includes @user.permissions_for(app), "pre-existing"
       assert_includes @user.permissions_for(app), "adding"
       assert_not_includes @user.permissions_for(app), "never"
+    end
+
+    should "not be able to grant permissions that are non-delegatable" do
+      app = create(
+        :application,
+        name: "MyApp",
+        with_delegatable_supported_permissions: %w[delegatable_perm],
+        with_non_delegatable_supported_permissions: %w[non_delegatable_perm],
+      )
+      @organisation_admin.grant_application_signin_permission(app)
+      @user.grant_application_signin_permission(app)
+
+      visit edit_user_path(@user)
+      click_link "Manage permissions"
+      click_link "Update permissions for MyApp"
+
+      assert page.has_field?("delegatable_perm")
+      assert page.has_no_field?("non_delegatable_perm")
     end
 
     should "not be able to grant permissions that are not grantable_from_ui" do

--- a/test/models/doorkeeper/application_test.rb
+++ b/test/models/doorkeeper/application_test.rb
@@ -127,6 +127,111 @@ class Doorkeeper::ApplicationTest < ActiveSupport::TestCase
     end
   end
 
+  context "has_non_signin_permissions_grantable_from_ui?" do
+    should "return false if no permissions are grantable from the UI" do
+      app = create(
+        :application,
+        with_delegatable_supported_permissions: [],
+        with_delegatable_supported_permissions_not_grantable_from_ui: %w[non-grantable],
+        with_non_delegatable_supported_permissions: [],
+        with_non_delegatable_supported_permissions_not_grantable_from_ui: %w[non-delegatable-non-grantable],
+      )
+
+      assert_not app.has_non_signin_permissions_grantable_from_ui?
+    end
+
+    should "return false if only the signin permission is grantable from the UI" do
+      app_1 = create(
+        :application,
+        with_delegatable_supported_permissions: [SupportedPermission::SIGNIN_NAME],
+        with_delegatable_supported_permissions_not_grantable_from_ui: %w[non-grantable],
+        with_non_delegatable_supported_permissions: [],
+        with_non_delegatable_supported_permissions_not_grantable_from_ui: %w[non-delegatable-non-grantable],
+      )
+
+      app_2 = create(
+        :application,
+        with_delegatable_supported_permissions: [],
+        with_delegatable_supported_permissions_not_grantable_from_ui: %w[non-grantable],
+        with_non_delegatable_supported_permissions: [SupportedPermission::SIGNIN_NAME],
+        with_non_delegatable_supported_permissions_not_grantable_from_ui: %w[non-delegatable-non-grantable],
+      )
+
+      assert_not app_1.has_non_signin_permissions_grantable_from_ui?
+      assert_not app_2.has_non_signin_permissions_grantable_from_ui?
+    end
+
+    should "return true if there are non-signin permissions grantable from the UI" do
+      app_1 = create(
+        :application,
+        with_delegatable_supported_permissions: %w[yay!],
+        with_delegatable_supported_permissions_not_grantable_from_ui: %w[non-grantable],
+        with_non_delegatable_supported_permissions: [],
+        with_non_delegatable_supported_permissions_not_grantable_from_ui: %w[non-delegatable-non-grantable],
+      )
+      app_2 = create(
+        :application,
+        with_delegatable_supported_permissions: [],
+        with_delegatable_supported_permissions_not_grantable_from_ui: %w[non-grantable],
+        with_non_delegatable_supported_permissions: %w[yay!],
+        with_non_delegatable_supported_permissions_not_grantable_from_ui: %w[non-delegatable-non-grantable],
+      )
+
+      assert app_1.has_non_signin_permissions_grantable_from_ui?
+      assert app_2.has_non_signin_permissions_grantable_from_ui?
+    end
+  end
+
+  context "has_delegatable_non_signin_permissions_grantable_from_ui?" do
+    should "return false if no permissions are delegatable" do
+      app = create(
+        :application,
+        with_delegatable_supported_permissions: [],
+        with_delegatable_supported_permissions_not_grantable_from_ui: [],
+        with_non_delegatable_supported_permissions: %w[non-delegatable],
+        with_non_delegatable_supported_permissions_not_grantable_from_ui: %w[non-delegatable-non-grantable],
+      )
+
+      assert_not app.has_delegatable_non_signin_permissions_grantable_from_ui?
+    end
+
+    should "return false if no permissions are grantable from the UI" do
+      app = create(
+        :application,
+        with_delegatable_supported_permissions: [],
+        with_delegatable_supported_permissions_not_grantable_from_ui: %w[non-grantable],
+        with_non_delegatable_supported_permissions: [],
+        with_non_delegatable_supported_permissions_not_grantable_from_ui: %w[non-delegatable-non-grantable],
+      )
+
+      assert_not app.has_delegatable_non_signin_permissions_grantable_from_ui?
+    end
+
+    should "return false if only the signin permission is delegatable and grantable from the UI" do
+      app = create(
+        :application,
+        with_delegatable_supported_permissions: [SupportedPermission::SIGNIN_NAME],
+        with_delegatable_supported_permissions_not_grantable_from_ui: %w[non-grantable],
+        with_non_delegatable_supported_permissions: %w[non-delegatable],
+        with_non_delegatable_supported_permissions_not_grantable_from_ui: %w[non-delegatable-non-grantable],
+      )
+
+      assert_not app.has_delegatable_non_signin_permissions_grantable_from_ui?
+    end
+
+    should "return true if there are delegatable non-signin permissions grantable from the UI" do
+      app = create(
+        :application,
+        with_delegatable_supported_permissions: %w[yay!],
+        with_delegatable_supported_permissions_not_grantable_from_ui: %w[non-grantable],
+        with_non_delegatable_supported_permissions: %w[non-delegatable],
+        with_non_delegatable_supported_permissions_not_grantable_from_ui: %w[non-delegatable-non-grantable],
+      )
+
+      assert app.has_delegatable_non_signin_permissions_grantable_from_ui?
+    end
+  end
+
   context ".all (default scope)" do
     setup do
       @app = create(:application)

--- a/test/policies/account/application_policy_test.rb
+++ b/test/policies/account/application_policy_test.rb
@@ -61,60 +61,100 @@ class Account::ApplicationPolicyTest < ActiveSupport::TestCase
     end
   end
 
-  %i[remove_signin_permission edit_permissions].each do |aliased_method|
-    context "##{aliased_method}?" do
-      setup { @args = [@current_user, @application, aliased_method] }
+  context "#remove_signin_permission?" do
+    setup { @args = [@current_user, @application, :remove_signin_permission] }
 
-      context "when the current user has access to the application" do
-        setup { @current_user.expects(:has_access_to?).returns(true) }
+    context "when the current user has access to the application" do
+      setup { @current_user.expects(:has_access_to?).returns(true) }
 
-        context "when the current user is a GOV.UK admin" do
+      context "when the current user is a GOV.UK admin" do
+        should "be permitted" do
+          @current_user.expects(:govuk_admin?).returns(true)
+
+          assert permit?(*@args)
+        end
+      end
+
+      context "when the current user is a publishing manager" do
+        setup do
+          @current_user.expects(:govuk_admin?).returns(false)
+          @current_user.expects(:publishing_manager?).returns(true)
+        end
+
+        context "when the application's signin permission is delegatable" do
           should "be permitted" do
-            @current_user.expects(:govuk_admin?).returns(true)
+            @application.signin_permission.update!(delegatable: true)
 
             assert permit?(*@args)
           end
         end
 
-        context "when the current user is a publishing manager" do
-          setup do
-            @current_user.expects(:govuk_admin?).returns(false)
-            @current_user.expects(:publishing_manager?).returns(true)
-          end
-
-          context "when the application's signin permission is delegatable" do
-            should "be permitted" do
-              @application.signin_permission.update!(delegatable: true)
-
-              assert permit?(*@args)
-            end
-          end
-
-          context "when the application's signin permission is not delegatable" do
-            should "be forbidden" do
-              @application.signin_permission.update!(delegatable: false)
-
-              assert forbid?(*@args)
-            end
-          end
-        end
-
-        context "when the current user is neither a GOV.UK admin nor a publishing manager" do
+        context "when the application's signin permission is not delegatable" do
           should "be forbidden" do
-            @current_user.expects(:govuk_admin?).returns(false)
-            @current_user.expects(:publishing_manager?).returns(false)
+            @application.signin_permission.update!(delegatable: false)
 
             assert forbid?(*@args)
           end
         end
       end
 
-      context "when the current user does not have access to the application" do
+      context "when the current user is neither a GOV.UK admin nor a publishing manager" do
         should "be forbidden" do
-          @current_user.expects(:has_access_to?).returns(false)
+          @current_user.expects(:govuk_admin?).returns(false)
+          @current_user.expects(:publishing_manager?).returns(false)
 
           assert forbid?(*@args)
         end
+      end
+    end
+
+    context "when the current user does not have access to the application" do
+      should "be forbidden" do
+        @current_user.expects(:has_access_to?).returns(false)
+
+        assert forbid?(*@args)
+      end
+    end
+  end
+
+  context "#edit_permissions?" do
+    setup { @args = [@current_user, @application, :edit_permissions] }
+
+    context "when the current user has access to the application" do
+      setup { @current_user.expects(:has_access_to?).returns(true) }
+
+      context "when the current user is a GOV.UK admin" do
+        should "be permitted" do
+          @current_user.expects(:govuk_admin?).returns(true)
+
+          assert permit?(*@args)
+        end
+      end
+
+      context "when the current user is a publishing manager" do
+        should "be permitted" do
+          @current_user.expects(:govuk_admin?).returns(false)
+          @current_user.expects(:publishing_manager?).returns(true)
+
+          assert permit?(*@args)
+        end
+      end
+
+      context "when the current user is neither a GOV.UK admin nor a publishing manager" do
+        should "be forbidden" do
+          @current_user.expects(:govuk_admin?).returns(false)
+          @current_user.expects(:publishing_manager?).returns(false)
+
+          assert forbid?(*@args)
+        end
+      end
+    end
+
+    context "when the current user does not have access to the application" do
+      should "be forbidden" do
+        @current_user.expects(:has_access_to?).returns(false)
+
+        assert forbid?(*@args)
       end
     end
   end

--- a/test/policies/supported_permission_policy_scope_test.rb
+++ b/test/policies/supported_permission_policy_scope_test.rb
@@ -2,32 +2,26 @@ require "test_helper"
 
 class SupportedPermissionPolicyScopeTest < ActiveSupport::TestCase
   setup do
-    @app_one = create(:application, name: "App one")
-    @app_two = create(:application, name: "App two")
-    @app_three = create(:application, name: "App three")
-    @app_four = create(:application, name: "App four")
-    @api_only_app = create(:application, name: "API-only app", api_only: true)
+    @delegatable_signin_app_one = create(:application, with_delegatable_supported_permissions: [SupportedPermission::SIGNIN_NAME])
+    @delegatable_signin_app_two = create(:application, with_delegatable_supported_permissions: [SupportedPermission::SIGNIN_NAME])
+    @non_delegatable_signin_app_one = create(:application, with_non_delegatable_supported_permissions: [SupportedPermission::SIGNIN_NAME])
+    @non_delegatable_signin_app_two = create(:application, with_non_delegatable_supported_permissions: [SupportedPermission::SIGNIN_NAME])
+    @api_only_app = create(:application, name: "API-only app", api_only: true, with_delegatable_supported_permissions: [SupportedPermission::SIGNIN_NAME])
 
-    @app_one_signin_permission = @app_one.signin_permission.tap { |s| s.update(delegatable: true) }
-    @app_two_signin_permission = @app_two.signin_permission.tap { |s| s.update(delegatable: false) }
-    @app_three_signin_permission = @app_three.signin_permission.tap { |s| s.update(delegatable: true) }
-    @app_four_signin_permission = @app_four.signin_permission.tap { |s| s.update(delegatable: false) }
-    @api_only_app_signin_permission = @api_only_app.signin_permission.tap { |s| s.update(delegatable: true) }
+    @delegatable_signin_app_one_delegatable_permission = create(:delegatable_supported_permission, application: @delegatable_signin_app_one)
+    @delegatable_signin_app_one_non_delegatable_permission = create(:non_delegatable_supported_permission, application: @delegatable_signin_app_one)
 
-    @app_one_hat_permission = create(:non_delegatable_supported_permission, application: @app_one, name: "hat")
-    @app_one_cat_permission = create(:delegatable_supported_permission, application: @app_one, name: "cat")
+    @delegatable_signin_app_two_delegatable_permission = create(:delegatable_supported_permission, application: @delegatable_signin_app_two)
+    @delegatable_signin_app_two_non_delegatable_permission = create(:non_delegatable_supported_permission, application: @delegatable_signin_app_two)
 
-    @app_two_rat_permission = create(:non_delegatable_supported_permission, application: @app_two, name: "rat")
-    @app_two_bat_permission = create(:delegatable_supported_permission, application: @app_two, name: "bat")
+    @non_delegatable_signin_app_one_delegatable_permission = create(:delegatable_supported_permission, application: @non_delegatable_signin_app_one)
+    @non_delegatable_signin_app_one_non_delegatable_permission = create(:non_delegatable_supported_permission, application: @non_delegatable_signin_app_one)
 
-    @app_three_fat_permission = create(:non_delegatable_supported_permission, application: @app_three, name: "fat")
-    @app_three_vat_permission = create(:delegatable_supported_permission, application: @app_three, name: "vat")
+    @non_delegatable_signin_app_two_delegatable_permission = create(:delegatable_supported_permission, application: @non_delegatable_signin_app_two)
+    @non_delegatable_signin_app_two_non_delegatable_permission = create(:non_delegatable_supported_permission, application: @non_delegatable_signin_app_two)
 
-    @app_four_pat_permission = create(:non_delegatable_supported_permission, application: @app_three, name: "pat")
-    @app_four_sat_permission = create(:delegatable_supported_permission, application: @app_three, name: "sat")
-
-    @api_only_app_nat_permission = create(:non_delegatable_supported_permission, application: @api_only_app, name: "nat")
-    @api_only_app_mat_permission = create(:delegatable_supported_permission, application: @api_only_app, name: "mat")
+    @api_only_app_delegatable_permission = create(:delegatable_supported_permission, application: @api_only_app)
+    @api_only_app_non_delegatable_permission = create(:non_delegatable_supported_permission, application: @api_only_app)
   end
 
   context "resolve" do
@@ -36,25 +30,25 @@ class SupportedPermissionPolicyScopeTest < ActiveSupport::TestCase
         user = create(:"#{govuk_admin_role}_user")
         resolved_scope = SupportedPermissionPolicy::Scope.new(user, SupportedPermission.all).resolve
 
-        assert_includes resolved_scope, @app_one_signin_permission
-        assert_includes resolved_scope, @app_one_hat_permission
-        assert_includes resolved_scope, @app_one_cat_permission
+        assert_includes resolved_scope, @delegatable_signin_app_one.signin_permission
+        assert_includes resolved_scope, @delegatable_signin_app_one_delegatable_permission
+        assert_includes resolved_scope, @delegatable_signin_app_one_non_delegatable_permission
 
-        assert_includes resolved_scope, @app_two_signin_permission
-        assert_includes resolved_scope, @app_two_rat_permission
-        assert_includes resolved_scope, @app_two_bat_permission
+        assert_includes resolved_scope, @delegatable_signin_app_two.signin_permission
+        assert_includes resolved_scope, @delegatable_signin_app_two_delegatable_permission
+        assert_includes resolved_scope, @delegatable_signin_app_two_non_delegatable_permission
 
-        assert_includes resolved_scope, @app_three_signin_permission
-        assert_includes resolved_scope, @app_three_fat_permission
-        assert_includes resolved_scope, @app_three_vat_permission
+        assert_includes resolved_scope, @non_delegatable_signin_app_one.signin_permission
+        assert_includes resolved_scope, @non_delegatable_signin_app_one_delegatable_permission
+        assert_includes resolved_scope, @non_delegatable_signin_app_one_non_delegatable_permission
 
-        assert_includes resolved_scope, @app_four_signin_permission
-        assert_includes resolved_scope, @app_four_pat_permission
-        assert_includes resolved_scope, @app_four_sat_permission
+        assert_includes resolved_scope, @non_delegatable_signin_app_two.signin_permission
+        assert_includes resolved_scope, @non_delegatable_signin_app_two_delegatable_permission
+        assert_includes resolved_scope, @non_delegatable_signin_app_two_non_delegatable_permission
 
-        assert_includes resolved_scope, @api_only_app_signin_permission
-        assert_includes resolved_scope, @api_only_app_nat_permission
-        assert_includes resolved_scope, @api_only_app_mat_permission
+        assert_includes resolved_scope, @api_only_app.signin_permission
+        assert_includes resolved_scope, @api_only_app_delegatable_permission
+        assert_includes resolved_scope, @api_only_app_non_delegatable_permission
       end
     end
 
@@ -62,40 +56,42 @@ class SupportedPermissionPolicyScopeTest < ActiveSupport::TestCase
       context "#{publishing_manager_role}s" do
         setup do
           user = create(:"#{publishing_manager_role.tr(' ', '_')}_user").tap do |u|
-            u.grant_application_signin_permission(@app_one)
-            u.grant_application_signin_permission(@app_two)
+            u.grant_application_signin_permission(@delegatable_signin_app_one)
+            u.grant_application_signin_permission(@non_delegatable_signin_app_one)
             u.grant_application_signin_permission(@api_only_app)
           end
 
           @resolved_scope = SupportedPermissionPolicy::Scope.new(user, SupportedPermission.all).resolve
         end
 
-        should "contain all permissions for non-API-only apps with delegatable signin permission that the #{publishing_manager_role} has access to" do
-          assert_includes @resolved_scope, @app_one_signin_permission
-          assert_includes @resolved_scope, @app_one_cat_permission
-          assert_includes @resolved_scope, @app_one_hat_permission
+        should "contain all delegatable permissions for non-API-only apps that the #{publishing_manager_role} has access to" do
+          assert_includes @resolved_scope, @delegatable_signin_app_one.signin_permission
+          assert_includes @resolved_scope, @delegatable_signin_app_one_delegatable_permission
+
+          assert_includes @resolved_scope, @non_delegatable_signin_app_one_delegatable_permission
         end
 
-        should "not contain any permissions for apps with non-delegatable signin permission the #{publishing_manager_role} has access to" do
-          assert_not_includes @resolved_scope, @app_two_signin_permission
-          assert_not_includes @resolved_scope, @app_two_rat_permission
-          assert_not_includes @resolved_scope, @app_two_bat_permission
+        should "not contain any non-delegatable permissions for non-API-only apps the #{publishing_manager_role} has access to" do
+          assert_not_includes @resolved_scope, @delegatable_signin_app_one_non_delegatable_permission
+
+          assert_not_includes @resolved_scope, @non_delegatable_signin_app_one.signin_permission
+          assert_not_includes @resolved_scope, @non_delegatable_signin_app_one_non_delegatable_permission
         end
 
-        should "not contain any permissions for apps the #{publishing_manager_role} does not have access to" do
-          assert_not_includes @resolved_scope, @app_three_signin_permission
-          assert_not_includes @resolved_scope, @app_three_fat_permission
-          assert_not_includes @resolved_scope, @app_three_vat_permission
+        should "not contain any permissions for non-API-only apps the #{publishing_manager_role} does not have access to" do
+          assert_not_includes @resolved_scope, @delegatable_signin_app_two.signin_permission
+          assert_not_includes @resolved_scope, @delegatable_signin_app_two_delegatable_permission
+          assert_not_includes @resolved_scope, @delegatable_signin_app_two_non_delegatable_permission
 
-          assert_not_includes @resolved_scope, @app_four_signin_permission
-          assert_not_includes @resolved_scope, @app_four_pat_permission
-          assert_not_includes @resolved_scope, @app_four_sat_permission
+          assert_not_includes @resolved_scope, @non_delegatable_signin_app_two.signin_permission
+          assert_not_includes @resolved_scope, @non_delegatable_signin_app_two_delegatable_permission
+          assert_not_includes @resolved_scope, @non_delegatable_signin_app_two_non_delegatable_permission
         end
 
         should "not contain any permissions for API-only apps" do
-          assert_not_includes @resolved_scope, @api_only_app_signin_permission
-          assert_not_includes @resolved_scope, @api_only_app_nat_permission
-          assert_not_includes @resolved_scope, @api_only_app_mat_permission
+          assert_not_includes @resolved_scope, @api_only_app.signin_permission
+          assert_not_includes @resolved_scope, @api_only_app_delegatable_permission
+          assert_not_includes @resolved_scope, @api_only_app_non_delegatable_permission
         end
       end
     end


### PR DESCRIPTION
[Trello](https://trello.com/c/NZhboqgE/1184-investigate-and-restore-expected-behaviour-for-signin-as-a-delegatable-permission-allowing-other-permissions-to-be-delegated)

This is the main PR for fixing delegatable permissions. This is the first that will actually change how things work: publishing managers (organisation and super organisation admins) will now only be able to manage permissions marked as delegatable (for users of equal or lower level in the same organisation, or a child organisation for super organisation admins)

---

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
