### PR TITLE
Use `Users::ApplicationPolicy` in `Users::ApplicationsController`

### DIFF
--- a/app/controllers/users/applications_controller.rb
+++ b/app/controllers/users/applications_controller.rb
@@ -3,14 +3,14 @@ class Users::ApplicationsController < ApplicationController
 
   def show
     user = User.find(params[:user_id])
-    authorize user, :edit?
+    authorize [{ user: }], policy_class: Users::ApplicationPolicy
 
     redirect_to user_applications_path(user)
   end
 
   def index
     @user = User.find(params[:user_id])
-    authorize @user, :edit?
+    authorize [{ user: @user }], policy_class: Users::ApplicationPolicy
 
     @applications_with_signin = Doorkeeper::Application.not_api_only.can_signin(@user)
     @applications_without_signin = Doorkeeper::Application.not_api_only.without_signin_permission_for(@user)

--- a/app/policies/users/application_policy.rb
+++ b/app/policies/users/application_policy.rb
@@ -8,6 +8,13 @@ class Users::ApplicationPolicy < BasePolicy
     @application = record[:application]
   end
 
+  def show?
+    Pundit.policy(current_user, user).edit?
+  end
+
+  alias_method :index?, :show?
+  alias_method :view_permissions?, :show?
+
   def grant_signin_permission?
     return false unless Pundit.policy(current_user, user).edit?
     return true if current_user.govuk_admin?
@@ -17,8 +24,4 @@ class Users::ApplicationPolicy < BasePolicy
 
   alias_method :remove_signin_permission?, :grant_signin_permission?
   alias_method :edit_permissions?, :grant_signin_permission?
-
-  def view_permissions?
-    Pundit.policy(current_user, user).edit?
-  end
 end

--- a/docs/access_and_permissions.md
+++ b/docs/access_and_permissions.md
@@ -170,7 +170,8 @@ These dependencies determine whether a user can:
 
 ```mermaid
 flowchart LR
-    A(Users::ApplicationsController#show) --authorize user, :edit?--> B(UserPolicy#edit?)
+    A(Users::ApplicationsController#show) --authorize [{ user: }], policy_class: Users::ApplicationPolicy--> B(Users::ApplicationPolicy#show?)
+    B --Pundit.policy(current_user, user).edit?--> C(UserPolicy#edit?)
 ```
 
 #### Users applications index
@@ -184,19 +185,20 @@ These dependencies determine whether a user can:
 
 ```mermaid
 flowchart TD
-    A(Users::ApplicationsController#index) --authorize @user, :edit?--> B(UserPolicy#edit?)
-    C(app/views/users/applications/index.html.erb) --wrap_links_in_actions_markup--> D(ApplicationTableHelper#wrap_links_in_actions_markup)
-    C --users_applications_permissions_links--> E(ApplicationTableHelper#users_applications_permissions_links)
-    E --Users::ApplicationPolicy.new(current_user, { application:, user: }).view_permissions?--> F(Users::ApplicationPolicy#view_permissions?)
-    F --Pundit.policy(current_user, user).edit?--> G(UserPolicy#edit?)
-    E --Users::ApplicationPolicy.new(current_user, { application:, user: }).edit_permissions?--> H(Users::ApplicationPolicy#edit_permissions?)
-    H --Pundit.policy(current_user, user).edit?--> G
-    C --users_applications_remove_access_link--> I(ApplicationTableHelper#users_applications_remove_access_link)
-    I --Users::ApplicationPolicy.new(current_user, { application:, user: }).remove_signin_permission?--> J(Users::ApplicationPolicy#remove_signin_permission?)
-    J --Pundit.policy(current_user, user).edit?--> G
-    C --users_applications_grant_access_link--> K(ApplicationTableHelper#users_applications_grant_access_link)
-    K --Users::ApplicationPolicy.new(current_user, { application:, user: }).grant_signin_permission?--> L(Users::ApplicationPolicy#grant_signin_permission?)
-    L --Pundit.policy(current_user, user).edit?--> G
+    A(Users::ApplicationsController#index) --authorize [{ user: }], policy_class: Users::ApplicationPolicy--> B(Users::ApplicationPolicy#index?)
+    B --Pundit.policy(current_user, user).edit?--> C(UserPolicy#edit?)
+    D(app/views/users/applications/index.html.erb) --wrap_links_in_actions_markup--> E(ApplicationTableHelper#wrap_links_in_actions_markup)
+    D --users_applications_permissions_links--> F(ApplicationTableHelper#users_applications_permissions_links)
+    F --Users::ApplicationPolicy.new(current_user, { application:, user: }).view_permissions?--> G(Users::ApplicationPolicy#view_permissions?)
+    G --Pundit.policy(current_user, user).edit?--> H(UserPolicy#edit?)
+    F --Users::ApplicationPolicy.new(current_user, { application:, user: }).edit_permissions?--> I(Users::ApplicationPolicy#edit_permissions?)
+    I --Pundit.policy(current_user, user).edit?--> H
+    D --users_applications_remove_access_link--> J(ApplicationTableHelper#users_applications_remove_access_link)
+    J --Users::ApplicationPolicy.new(current_user, { application:, user: }).remove_signin_permission?--> K(Users::ApplicationPolicy#remove_signin_permission?)
+    K --Pundit.policy(current_user, user).edit?--> H
+    D --users_applications_grant_access_link--> L(ApplicationTableHelper#users_applications_grant_access_link)
+    L --Users::ApplicationPolicy.new(current_user, { application:, user: }).grant_signin_permission?--> M(Users::ApplicationPolicy#grant_signin_permission?)
+    M --Pundit.policy(current_user, user).edit?--> H
 ```
 
 #### Users permissions show


### PR DESCRIPTION
[Trello](https://trello.com/c/NZhboqgE/1184-investigate-and-restore-expected-behaviour-for-signin-as-a-delegatable-permission-allowing-other-permissions-to-be-delegated)

This is another step to bring the users and account access and permissions flows more in sync

---

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
