### PR TITLE
Refactor `Account::ApplicationPolicy` test suite

### DIFF
--- a/app/policies/account/application_policy.rb
+++ b/app/policies/account/application_policy.rb
@@ -1,9 +1,9 @@
 class Account::ApplicationPolicy < BasePolicy
-  def index?
+  def show?
     current_user.govuk_admin? || current_user.publishing_manager?
   end
 
-  alias_method :show?, :index?
+  alias_method :index?, :show?
   alias_method :view_permissions?, :index?
 
   def grant_signin_permission?

--- a/test/policies/users/application_policy_test.rb
+++ b/test/policies/users/application_policy_test.rb
@@ -56,7 +56,7 @@ class Users::ApplicationPolicyTest < ActiveSupport::TestCase
             end
           end
 
-          context "when the current user has access to the application but the application's signion permission is not delegatable" do
+          context "when the current user has access to the application but the application's signin permission is not delegatable" do
             should "be forbidden" do
               @current_user.expects(:has_access_to?).with(@application).returns(true)
               @application.signin_permission.update!(delegatable: false)


### PR DESCRIPTION
[Trello](https://trello.com/c/NZhboqgE/1184-investigate-and-restore-expected-behaviour-for-signin-as-a-delegatable-permission-allowing-other-permissions-to-be-delegated)

This brings things more in like with the `Users::ApplicationPolicy` test suite, making more use of stubbing and DRYing things up

---

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
