### PR TITLE
Add admin UI to view application access events and monthly stats

### DIFF
--- a/app/controllers/doorkeeper_applications_controller.rb
+++ b/app/controllers/doorkeeper_applications_controller.rb
@@ -25,12 +25,17 @@ class DoorkeeperApplicationsController < ApplicationController
   end
 
   def access_logs
-    smokey_uids = User.where("name LIKE 'Smokey%'").pluck(:uid)
-    @logs = @application.event_logs
+    relation = @application.event_logs
       .includes(:user)
       .where(event_id: 47)
-      .where.not(uid: smokey_uids)
       .order(created_at: :desc)
+
+    unless params[:include_smokey_users] == "true"
+      smokey_uids = User.where("name LIKE 'Smokey%'").pluck(:uid)
+      relation = relation.where.not(uid: smokey_uids)
+    end
+
+    @logs = relation
       .page(params[:page])
       .per(100)
   end
@@ -55,6 +60,7 @@ private
       :home_uri,
       :supports_push_updates,
       :api_only,
+      :include_smokey_users,
     )
   end
 end

--- a/app/controllers/doorkeeper_applications_controller.rb
+++ b/app/controllers/doorkeeper_applications_controller.rb
@@ -24,6 +24,17 @@ class DoorkeeperApplicationsController < ApplicationController
     @users = query.page(params[:page]).per(100)
   end
 
+  def access_logs
+    smokey_uids = User.where("name LIKE 'Smokey%'").pluck(:uid)
+    @logs = @application.event_logs
+      .includes(:user)
+      .where(event_id: 47)
+      .where.not(uid: smokey_uids)
+      .order(created_at: :desc)
+      .page(params[:page])
+      .per(100)
+  end
+
 private
 
   def load_and_authorize_application

--- a/app/controllers/doorkeeper_applications_controller.rb
+++ b/app/controllers/doorkeeper_applications_controller.rb
@@ -27,7 +27,7 @@ class DoorkeeperApplicationsController < ApplicationController
   def access_logs
     relation = @application.event_logs
       .includes(:user)
-      .where(event_id: 47)
+      .where(event_id: EventLog::SUCCESSFUL_USER_APPLICATION_AUTHORIZATION.id)
       .order(created_at: :desc)
 
     unless params[:include_smokey_users] == "true"
@@ -46,7 +46,7 @@ class DoorkeeperApplicationsController < ApplicationController
 
   def monthly_access_stats
     relation = @application.event_logs
-                .where(event_id: 47)
+                .where(event_id: EventLog::SUCCESSFUL_USER_APPLICATION_AUTHORIZATION.id)
                 .group("DATE_FORMAT(created_at, '%Y-%m')")
                 .order(Arel.sql("DATE_FORMAT(created_at, '%Y-%m') DESC"))
 

--- a/app/controllers/doorkeeper_applications_controller.rb
+++ b/app/controllers/doorkeeper_applications_controller.rb
@@ -44,6 +44,25 @@ class DoorkeeperApplicationsController < ApplicationController
       .per(100)
   end
 
+  def monthly_access_stats
+    relation = @application.event_logs
+                .where(event_id: 47)
+                .group("DATE_FORMAT(created_at, '%Y-%m')")
+                .order(Arel.sql("DATE_FORMAT(created_at, '%Y-%m') DESC"))
+
+    unless params[:include_smokey_users] == "true"
+      smokey_uids = User.where("name LIKE 'Smokey%'").pluck(:uid)
+      relation = relation.where.not(uid: smokey_uids)
+    end
+
+    @monthly_access_stats = relation
+                .pluck(
+                  Arel.sql("DATE_FORMAT(created_at, '%Y-%m')"),
+                  Arel.sql("COUNT(*)"),
+                  Arel.sql("COUNT(DISTINCT uid)"),
+                )
+  end
+
 private
 
   def load_and_authorize_application

--- a/app/controllers/doorkeeper_applications_controller.rb
+++ b/app/controllers/doorkeeper_applications_controller.rb
@@ -35,6 +35,10 @@ class DoorkeeperApplicationsController < ApplicationController
       relation = relation.where.not(uid: smokey_uids)
     end
 
+    if params[:month].present?
+      relation = relation.where("DATE_FORMAT(created_at, '%Y-%m')=?", params[:month])
+    end
+
     @logs = relation
       .page(params[:page])
       .per(100)
@@ -61,6 +65,7 @@ private
       :supports_push_updates,
       :api_only,
       :include_smokey_users,
+      :month,
     )
   end
 end

--- a/app/models/doorkeeper/application.rb
+++ b/app/models/doorkeeper/application.rb
@@ -2,6 +2,7 @@ require "doorkeeper/orm/active_record/application"
 
 class Doorkeeper::Application < ActiveRecord::Base # rubocop:disable Rails/ApplicationRecord
   has_many :supported_permissions, dependent: :destroy
+  has_many :event_logs, class_name: "EventLog"
 
   default_scope { not_retired.ordered_by_name }
 

--- a/app/models/event_log.rb
+++ b/app/models/event_log.rb
@@ -66,6 +66,7 @@ class EventLog < ApplicationRecord
   validates :application_id, presence: { if: proc { |event_log| EVENTS_REQUIRING_APPLICATION.include? event_log.entry } }
 
   belongs_to :initiator, class_name: "User"
+  belongs_to :user, class_name: "User", foreign_key: :uid, primary_key: :uid
   belongs_to :application, class_name: "Doorkeeper::Application"
   belongs_to :user_agent
 

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -6,4 +6,5 @@ class ApplicationPolicy < BasePolicy
   alias_method :update?, :index?
   alias_method :manage_supported_permissions?, :index?
   alias_method :users_with_access?, :index?
+  alias_method :access_logs?, :index?
 end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -7,4 +7,5 @@ class ApplicationPolicy < BasePolicy
   alias_method :manage_supported_permissions?, :index?
   alias_method :users_with_access?, :index?
   alias_method :access_logs?, :index?
+  alias_method :monthly_access_stats?, :index?
 end

--- a/app/views/doorkeeper_applications/access_logs.html.erb
+++ b/app/views/doorkeeper_applications/access_logs.html.erb
@@ -1,0 +1,42 @@
+<% content_for :title, "#{@application.name} access log" %>
+
+<% content_for :breadcrumbs,
+               render("govuk_publishing_components/components/breadcrumbs", {
+                 collapse_on_mobile: true,
+                 breadcrumbs: [
+                   {
+                     title: "Dashboard",
+                     url: root_path,
+                   },
+                   {
+                     title: "Applications",
+                     url: doorkeeper_applications_path,
+                   },
+                   {
+                     title: @application.name,
+                     url: edit_doorkeeper_application_path(@application),
+                   }
+                 ]
+               })
+%>
+
+<% if @logs.any? %>
+  <%= render "components/table", {
+    caption: pluralize(number_with_delimiter(@logs.total_count), "event"),
+    caption_classes: "govuk-heading-m",
+    head: [
+      { text: "Time" },
+      { text: "Event" },
+    ],
+    rows: @logs.map do |log|
+      [ { text: formatted_date(log), format: "event-log-date" },
+        { text: "#{formatted_message(log)} for <strong>#{log.user&.name}</strong>".html_safe } ] unless log.requires_admin? && !current_user.govuk_admin?
+    end.compact
+  } %>
+
+  <%= paginate(@logs, theme: "gds") %>
+<% else %>
+  <%= render "govuk_publishing_components/components/notice", {
+    title: "No activity logged"
+  } %>
+<% end %>

--- a/app/views/doorkeeper_applications/access_logs.html.erb
+++ b/app/views/doorkeeper_applications/access_logs.html.erb
@@ -55,8 +55,12 @@
       { text: "Event" },
     ],
     rows: @logs.map do |log|
-      [ { text: formatted_date(log), format: "event-log-date" },
-        { text: "#{formatted_message(log)} for <strong>#{log.user&.name}</strong>".html_safe } ] unless log.requires_admin? && !current_user.govuk_admin?
+      next if log.requires_admin? && !current_user.govuk_admin?
+
+      [
+        { text: formatted_date(log), format: "event-log-date" },
+        { text: "#{formatted_message(log)} for #{link_to(log.user.name, log.user, class: "govuk-link")}".html_safe },
+      ]
     end.compact
   } %>
 

--- a/app/views/doorkeeper_applications/access_logs.html.erb
+++ b/app/views/doorkeeper_applications/access_logs.html.erb
@@ -46,6 +46,28 @@
 </div>
 </form>
 
+<%= render "govuk_publishing_components/components/details", {
+  title: "About this data"
+} do %>
+<p class="govuk-body">
+  Signon records a "successful authorization" event whenever a user uses Signon to access one of the publishing
+  applications. This is a record of all of these events for <%= @application.name %>.
+</p>
+<p class="govuk-body">
+  Applications cache authentications for around 20 hours, so if a user clicks an application multiple
+  times a day, they may only appear in the event log once.
+</p>
+<p class="govuk-body">
+  <% if DateTime.current.before? DateTime.new(2025, 11, 1)  # This branch can be removed after November 2025 %>
+  Note that authorization data has only been recorded in the Signon event log since November 2023, so it is not
+  possible to view events before that date.
+  <% else %>
+  Note that data in the event log in Signon is only retained for 2 years, so it is not possible to view events
+  before that date.
+  <% end %>
+</p>
+<% end %>
+
 <% if @logs.any? %>
   <%= render "components/table", {
     caption: pluralize(number_with_delimiter(@logs.total_count), "event"),

--- a/app/views/doorkeeper_applications/access_logs.html.erb
+++ b/app/views/doorkeeper_applications/access_logs.html.erb
@@ -1,21 +1,5 @@
 <% content_for :title, "#{@application.name} access log" %>
 
-<form class="govuk-form-group">
-<%= render "govuk_publishing_components/components/checkboxes", {
-  name: "include_smokey_users",
-  items: [
-    {
-      label: "Include Smokey Users",
-      value: "true",
-      checked: params["include_smokey_users"] == "true"
-    }
-  ]
-} %>
-<%= render "govuk_publishing_components/components/button", {
-  text: "Submit"
-} %>
-</form>
-
 <% content_for :breadcrumbs,
                render("govuk_publishing_components/components/breadcrumbs", {
                  collapse_on_mobile: true,
@@ -35,6 +19,32 @@
                  ]
                })
 %>
+
+<form>
+<%= render "govuk_publishing_components/components/checkboxes", {
+  name: "include_smokey_users",
+  items: [
+    {
+      label: "Include Smokey Users",
+      value: "true",
+      checked: params["include_smokey_users"] == "true"
+    }
+  ]
+} %>
+<%= render "govuk_publishing_components/components/input", {
+  label: {
+    text: "Month"
+  },
+  name: "month",
+  hint: "In YYYY-mm format",
+  value: params["month"]
+} %>
+<div class="govuk-form-group">
+<%= render "govuk_publishing_components/components/button", {
+  text: "Submit"
+} %>
+</div>
+</form>
 
 <% if @logs.any? %>
   <%= render "components/table", {

--- a/app/views/doorkeeper_applications/access_logs.html.erb
+++ b/app/views/doorkeeper_applications/access_logs.html.erb
@@ -1,5 +1,21 @@
 <% content_for :title, "#{@application.name} access log" %>
 
+<form class="govuk-form-group">
+<%= render "govuk_publishing_components/components/checkboxes", {
+  name: "include_smokey_users",
+  items: [
+    {
+      label: "Include Smokey Users",
+      value: "true",
+      checked: params["include_smokey_users"] == "true"
+    }
+  ]
+} %>
+<%= render "govuk_publishing_components/components/button", {
+  text: "Submit"
+} %>
+</form>
+
 <% content_for :breadcrumbs,
                render("govuk_publishing_components/components/breadcrumbs", {
                  collapse_on_mobile: true,

--- a/app/views/doorkeeper_applications/access_logs.html.erb
+++ b/app/views/doorkeeper_applications/access_logs.html.erb
@@ -33,7 +33,7 @@
 } %>
 <%= render "govuk_publishing_components/components/input", {
   label: {
-    text: "Month"
+    text: "Year and month"
   },
   name: "month",
   hint: "In YYYY-mm format",

--- a/app/views/doorkeeper_applications/edit.html.erb
+++ b/app/views/doorkeeper_applications/edit.html.erb
@@ -27,6 +27,10 @@
             access_logs_doorkeeper_application_path(@application),
             class: "govuk-link" %>
 
+<%= link_to "View monthly access stats",
+            monthly_access_stats_doorkeeper_application_path(@application),
+            class: "govuk-link" %>
+
 <div class="govuk-grid-row govuk-!-margin-top-5">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for @application do |f| %>

--- a/app/views/doorkeeper_applications/edit.html.erb
+++ b/app/views/doorkeeper_applications/edit.html.erb
@@ -23,6 +23,10 @@
   doorkeeper_application_supported_permissions_path(@application),
   class: "govuk-link" %>
 
+<%= link_to "View access log",
+            access_logs_doorkeeper_application_path(@application),
+            class: "govuk-link" %>
+
 <div class="govuk-grid-row govuk-!-margin-top-5">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for @application do |f| %>

--- a/app/views/doorkeeper_applications/monthly_access_stats.html.erb
+++ b/app/views/doorkeeper_applications/monthly_access_stats.html.erb
@@ -1,0 +1,61 @@
+<% content_for :title, "Monthly access counts to #{@application.name}" %>
+
+<% content_for :breadcrumbs,
+               render("govuk_publishing_components/components/breadcrumbs", {
+                 collapse_on_mobile: true,
+                 breadcrumbs: [
+                   {
+                     title: "Dashboard",
+                     url: root_path,
+                   },
+                   {
+                     title: "Applications",
+                     url: doorkeeper_applications_path,
+                   },
+                   {
+                     title: @application.name,
+                     url: edit_doorkeeper_application_path(@application),
+                   }
+                 ]
+               })
+%>
+
+
+<form class="govuk-form-group">
+  <%= render "govuk_publishing_components/components/checkboxes", {
+    name: "include_smokey_users",
+    items: [
+      {
+        label: "Include Smokey Users",
+        value: "true",
+        checked: params["include_smokey_users"] == "true"
+      }
+    ]
+  } %>
+  <%= render "govuk_publishing_components/components/button", {
+    text: "Submit"
+  } %>
+</form>
+
+<% if @monthly_access_stats.any? %>
+  <%= render "components/table", {
+    head: [
+      { text: "Month" },
+      { text: "Total authorization count" },
+      { text: "Unique users authorization count" },
+      { text: "Access logs" },
+    ],
+    rows: @monthly_access_stats.map do |month, total_count, unique_users_count|
+      [
+        { text: month },
+        { text: total_count },
+        { text: unique_users_count },
+        { text: link_to("#{month} access logs", access_logs_doorkeeper_application_path(@application, month:), class: "govuk-link")},
+      ]
+    end
+  } %>
+<% else %>
+  <%= render "govuk_publishing_components/components/notice", {
+    title: "No activity logged"
+  } %>
+<% end %>

--- a/app/views/doorkeeper_applications/monthly_access_stats.html.erb
+++ b/app/views/doorkeeper_applications/monthly_access_stats.html.erb
@@ -37,6 +37,35 @@
   } %>
 </form>
 
+<%= render "govuk_publishing_components/components/details", {
+  title: "About this data"
+} do %>
+<p class="govuk-body">
+  Signon records a "successful authorization" event whenever a user uses Signon to access one of the publishing
+  applications. This is a monthly count of all of these events for <%= @application.name %>.
+</p>
+<p class="govuk-body">
+  Applications cache authentications for around 20 hours, so if a user clicks an application multiple
+  times a day, they may only appear in the event log once.
+</p>
+<p class="govuk-body">
+  The total authorization count is the total number of events recorded in the log for the month (if a
+  user accesses the same app multiple times, this number will increase).
+</p>
+<p class="govuk-body">
+  The unique users authorization count is the number of distinct users who recorded events in the log for the month
+  (if a user accesses the same app multiple times in a month, this will only count as one unique user).
+</p>
+<p class="govuk-body">
+  <% if DateTime.current.before? DateTime.new(2025, 11, 1)  # This branch can be removed after November 2025 %>
+  Note that authorization data has only been recorded in the Signon event log since November 2023, so it is not
+  possible to view events before that date.
+  <% else %>
+  Note that data in the event log in Signon is only retained for 2 years, so it is not possible to view events
+  before that date.
+  <% end %>
+</p>
+<% end %>
 <% if @monthly_access_stats.any? %>
   <%= render "components/table", {
     head: [

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -92,6 +92,7 @@ Rails.application.routes.draw do
   resources :doorkeeper_applications, only: %i[index edit update] do
     member do
       get :users_with_access
+      get :access_logs
     end
     resources :supported_permissions, only: %i[index new create edit update destroy] do
       get :confirm_destroy, on: :member

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -93,6 +93,7 @@ Rails.application.routes.draw do
     member do
       get :users_with_access
       get :access_logs
+      get :monthly_access_stats
     end
     resources :supported_permissions, only: %i[index new create edit update destroy] do
       get :confirm_destroy, on: :member

--- a/db/migrate/20240809112119_index_event_logs_columns.rb
+++ b/db/migrate/20240809112119_index_event_logs_columns.rb
@@ -1,0 +1,8 @@
+class IndexEventLogsColumns < ActiveRecord::Migration[7.1]
+  def change
+    change_table :event_logs, bulk: true do
+      add_index :event_logs, :application_id
+      add_index :event_logs, :event_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_29_130154) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_09_112119) do
   create_table "batch_invitation_application_permissions", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "batch_invitation_id", null: false
     t.integer "supported_permission_id", null: false
@@ -51,11 +51,13 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_29_130154) do
     t.integer "user_agent_id"
     t.text "user_agent_string"
     t.string "user_email_string"
+    t.index ["application_id"], name: "index_event_logs_on_application_id"
+    t.index ["event_id"], name: "index_event_logs_on_event_id"
     t.index ["uid", "created_at"], name: "index_event_logs_on_uid_and_created_at"
     t.index ["user_agent_id"], name: "event_logs_user_agent_id_fk"
   end
 
-  create_table "oauth_access_grants", id: :integer, charset: "utf8mb3", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "oauth_access_grants", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "resource_owner_id", null: false
     t.integer "application_id", null: false
     t.string "token", null: false
@@ -69,7 +71,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_29_130154) do
     t.index ["token"], name: "index_oauth_access_grants_on_token", unique: true
   end
 
-  create_table "oauth_access_tokens", id: :integer, charset: "utf8mb3", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "oauth_access_tokens", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "resource_owner_id", null: false
     t.integer "application_id", null: false
     t.string "token", null: false
@@ -154,7 +156,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_29_130154) do
     t.index ["user_id", "application_id", "supported_permission_id"], name: "index_app_permissions_on_user_and_app_and_supported_permission", unique: true
   end
 
-  create_table "users", id: :integer, charset: "utf8mb3", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "users", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: ""

--- a/test/integration/application_access_log_page_test.rb
+++ b/test/integration/application_access_log_page_test.rb
@@ -49,5 +49,4 @@ class ApplicationAccessLogPageIntegrationTest < ActionDispatch::IntegrationTest
       end
     end
   end
-
 end

--- a/test/integration/application_access_log_page_test.rb
+++ b/test/integration/application_access_log_page_test.rb
@@ -1,0 +1,53 @@
+require "test_helper"
+
+class ApplicationAccessLogPageIntegrationTest < ActionDispatch::IntegrationTest
+  setup do
+    @application = create(:application, name: "app-name", description: "app-description")
+    @user = create(:user, name: "Normal User")
+  end
+
+  test "users don't have permission to view account access log" do
+    visit root_path
+    signin_with(@user)
+
+    visit access_logs_doorkeeper_application_path(@application)
+    flash = find("div[role='alert']")
+    assert flash.has_content?("You do not have permission to perform this action.")
+  end
+
+  context "logged in as an superadmin" do
+    setup do
+      visit new_user_session_path
+      @superadmin = create(:superadmin_user)
+      signin_with(@superadmin)
+    end
+
+    should "have permission to view account access log" do
+      visit access_logs_doorkeeper_application_path(@application)
+      assert_equal page.title, "app-name access log - GOV.UK Signon"
+    end
+
+    context "when there are no matching events" do
+      should "see a message stating that there is no activity logged" do
+        visit access_logs_doorkeeper_application_path(@application)
+        assert_text "app-name access log"
+        assert_text "No activity logged"
+      end
+    end
+
+    context "when there are matching events" do
+      setup do
+        create(:event_log, event_id: 47, application_id: @application.id, uid: @superadmin.uid)
+        create(:event_log, event_id: 47, application_id: @application.id, uid: @user.uid)
+      end
+
+      should "see a list of events for the application" do
+        visit access_logs_doorkeeper_application_path(@application)
+        assert_text "#{@application.name} access log"
+        assert_text "Successful user application authorization for #{@application.name} for #{@superadmin.name}"
+        assert_text "Successful user application authorization for #{@application.name} for #{@user.name}"
+      end
+    end
+  end
+
+end

--- a/test/integration/application_access_log_page_test.rb
+++ b/test/integration/application_access_log_page_test.rb
@@ -37,8 +37,9 @@ class ApplicationAccessLogPageIntegrationTest < ActionDispatch::IntegrationTest
 
     context "when there are matching events" do
       setup do
-        create(:event_log, event_id: 47, application_id: @application.id, uid: @superadmin.uid)
-        create(:event_log, event_id: 47, application_id: @application.id, uid: @user.uid)
+        event_id = 47
+        create(:event_log, event_id:, application_id: @application.id, uid: @superadmin.uid)
+        create(:event_log, event_id:, application_id: @application.id, uid: @user.uid)
       end
 
       should "see a list of events for the application" do

--- a/test/integration/application_monthly_access_stats_page_test.rb
+++ b/test/integration/application_monthly_access_stats_page_test.rb
@@ -57,5 +57,4 @@ class ApplicationMonthlyAccessStatsPageIntegrationTest < ActionDispatch::Integra
       end
     end
   end
-
 end

--- a/test/integration/application_monthly_access_stats_page_test.rb
+++ b/test/integration/application_monthly_access_stats_page_test.rb
@@ -37,11 +37,12 @@ class ApplicationMonthlyAccessStatsPageIntegrationTest < ActionDispatch::Integra
 
     context "when there are matching events" do
       setup do
-        create(:event_log, created_at: Date.new(2020, 1, 1), event_id: 47, application_id: @application.id, uid: @superadmin.uid)
-        create(:event_log, created_at: Date.new(2020, 1, 1), event_id: 47, application_id: @application.id, uid: @superadmin.uid)
-        create(:event_log, created_at: Date.new(2020, 1, 1), event_id: 47, application_id: @application.id, uid: @user.uid)
-        create(:event_log, created_at: Date.new(2020, 2, 1), event_id: 47, application_id: @application.id, uid: @superadmin.uid)
-        create(:event_log, created_at: Date.new(2020, 2, 1), event_id: 47, application_id: @application.id, uid: @user.uid)
+        event_id = EventLog::SUCCESSFUL_USER_APPLICATION_AUTHORIZATION.id
+        create(:event_log, created_at: Date.new(2020, 1, 1), event_id:, application_id: @application.id, uid: @superadmin.uid)
+        create(:event_log, created_at: Date.new(2020, 1, 1), event_id:, application_id: @application.id, uid: @superadmin.uid)
+        create(:event_log, created_at: Date.new(2020, 1, 1), event_id:, application_id: @application.id, uid: @user.uid)
+        create(:event_log, created_at: Date.new(2020, 2, 1), event_id:, application_id: @application.id, uid: @superadmin.uid)
+        create(:event_log, created_at: Date.new(2020, 2, 1), event_id:, application_id: @application.id, uid: @user.uid)
       end
 
       should "see a list of events for the application" do

--- a/test/integration/application_monthly_access_stats_page_test.rb
+++ b/test/integration/application_monthly_access_stats_page_test.rb
@@ -1,0 +1,61 @@
+require "test_helper"
+
+class ApplicationMonthlyAccessStatsPageIntegrationTest < ActionDispatch::IntegrationTest
+  setup do
+    @application = create(:application, name: "app-name", description: "app-description")
+    @user = create(:user, name: "Normal User")
+  end
+
+  test "users don't have permission to view account access log" do
+    visit root_path
+    signin_with(@user)
+
+    visit monthly_access_stats_doorkeeper_application_path(@application)
+    flash = find("div[role='alert']")
+    assert flash.has_content?("You do not have permission to perform this action.")
+  end
+
+  context "logged in as an superadmin" do
+    setup do
+      visit new_user_session_path
+      @superadmin = create(:superadmin_user)
+      signin_with(@superadmin)
+    end
+
+    should "have permission to view account access log" do
+      visit monthly_access_stats_doorkeeper_application_path(@application)
+      assert_equal page.title, "Monthly access counts to app-name - GOV.UK Signon"
+    end
+
+    context "when there are no matching events" do
+      should "see a message stating that there is no activity logged" do
+        visit monthly_access_stats_doorkeeper_application_path(@application)
+        assert_text "Monthly access counts to app-name"
+        assert_text "No activity logged"
+      end
+    end
+
+    context "when there are matching events" do
+      setup do
+        create(:event_log, created_at: Date.new(2020, 1, 1), event_id: 47, application_id: @application.id, uid: @superadmin.uid)
+        create(:event_log, created_at: Date.new(2020, 1, 1), event_id: 47, application_id: @application.id, uid: @superadmin.uid)
+        create(:event_log, created_at: Date.new(2020, 1, 1), event_id: 47, application_id: @application.id, uid: @user.uid)
+        create(:event_log, created_at: Date.new(2020, 2, 1), event_id: 47, application_id: @application.id, uid: @superadmin.uid)
+        create(:event_log, created_at: Date.new(2020, 2, 1), event_id: 47, application_id: @application.id, uid: @user.uid)
+      end
+
+      should "see a list of events for the application" do
+        visit monthly_access_stats_doorkeeper_application_path(@application)
+        assert_text "Monthly access counts to #{@application.name}"
+
+        assert_text "Month Total authorization count Unique users authorization count Access logs"
+        # Test data has two months - these should be sorted in descending order
+        # 2020-02 has two events for two different users, so we should get 2 2
+        assert_text "2020-02 2 2 2020-02 access logs"
+        # 2020-01 has three events for two different users, so we should get 3 2
+        assert_text "2020-01 3 2 2020-01 access logs"
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
Occasionally, we get asked questions like "how many people actually use this Whitehall?" or "how many people actually use Content Data?".

This feels like information that should be at anyone working on Publishing's fingertips, but it isn't. We can answer things like "how many people have permission to access Content Data?" easily enough, by filtering the Users table. But people who've _actually accessed it_ is a bit of a mystery.

Currently the best bet is to ask a developer to run a SQL query for you, and hope that they don't make one of the many easy-to-make mistakes which would result in you getting the wrong answer.

[In November 2023](https://github.com/alphagov/signon/pull/2471) we added successful authorization events to the event log (which is retained for two years). That means it's reasonably easy to show exactly who's accessed each application, as well as counting the events by month, so long as we don't want to go back by more than 2 years.

This PR adds two views of this data, available only to superadmin users. These are tucked a away in a superadmin-only bit of the interface:

<img width="400" alt="screenshot of the Edit Whitehall page showing two new links - View access log and View monthly access stats" src="https://github.com/user-attachments/assets/1eea9108-04a5-4341-9e79-fd0d9e89619a">

The first - View access log - shows a paginated list of everyone who's accessed a particular app in the last two years, sorted descending on date. Because Smokey has a habit of accessing every app dozens of times a day, I've added a checkbox to explicitly include it and excluded it by default. I've also added a `month` parameter, which can be used to filter the list down to a specific month (pagination by limit / offset is a bit of a clumsy way to find the data you care about otherwise).

<img width="400" alt="screenshot of the Whithall access log, showing 8768 events, such as Rosa signing in to Whitehall" src="https://github.com/user-attachments/assets/97e18e77-8bb3-41fa-a70c-0a617bda5ea9">

The second - View monthly access stats - shows the count of these events by month. Since we often care about the number of unique users accessing an app, it shows the count distinct by user id as well as the total number of times the application has been accessed each month.

The total monthly access stats will be a bit lower than the number of times users click the app, because the apps have a 20 hour cache, so they won't trigger the event we're measuring more than once per user per day(ish). I think this is probably good enough / not massively confusing though.

Again, I've included a checkbox to include Smokey, as including it by default makes the Total authorization count numbers go crazy.

<img width="400" alt="screenshot of the Whithall monthly event counts" src="https://github.com/user-attachments/assets/ccea85b5-cd12-45ec-9f81-b079df713fa4">

I've only written some pretty light integration tests for these two pages. I'm interested in views on whether it's worth writing some more thorough tests (e.g. my tests don't cover the Include Smokey Users checkbox, or the Month filter, or much in the way of complex data).

Oh, also I had to add a couple database indexes to the event_logs table, because it was impossible to query for this data. See the individual commit for more detail on why they're needed / how well they perform.
