### PR TITLE
Show notice when there are non-delegatable perms

### DIFF
--- a/app/controllers/account/permissions_controller.rb
+++ b/app/controllers/account/permissions_controller.rb
@@ -3,6 +3,8 @@ class Account::PermissionsController < ApplicationController
   before_action :set_application
   before_action :set_permissions, only: %i[edit update]
 
+  include ApplicationPermissionsHelper
+
   def show
     authorize [:account, @application], :view_permissions?
 

--- a/app/controllers/users/permissions_controller.rb
+++ b/app/controllers/users/permissions_controller.rb
@@ -4,6 +4,8 @@ class Users::PermissionsController < ApplicationController
   before_action :set_application
   before_action :set_permissions, only: %i[edit update]
 
+  include ApplicationPermissionsHelper
+
   def show
     authorize [{ application: @application, user: @user }], :view_permissions?, policy_class: Users::ApplicationPolicy
 

--- a/app/helpers/application_permissions_helper.rb
+++ b/app/helpers/application_permissions_helper.rb
@@ -22,4 +22,25 @@ module ApplicationPermissionsHelper
 
     paragraph + list
   end
+
+  def notice_about_non_delegatable_permissions(current_user, application, other_grantee = nil)
+    return nil if current_user.govuk_admin?
+    return nil unless application.has_non_delegatable_non_signin_permissions_grantable_from_ui?
+
+    link = if other_grantee
+             link_to(
+               "view all the permissions #{other_grantee.name} has for #{application.name}",
+               user_application_permissions_path(other_grantee, application),
+               class: "govuk-link",
+             )
+           else
+             link_to(
+               "view all the permissions you have for #{application.name}",
+               account_application_permissions_path(application),
+               class: "govuk-link",
+             )
+           end
+
+    "Below, you will only see permissions that you are authorised to manage. You can also #{link}.".html_safe
+  end
 end

--- a/app/models/doorkeeper/application.rb
+++ b/app/models/doorkeeper/application.rb
@@ -67,6 +67,10 @@ class Doorkeeper::Application < ActiveRecord::Base # rubocop:disable Rails/Appli
     (supported_permissions.delegatable.grantable_from_ui - [signin_permission]).any?
   end
 
+  def has_non_delegatable_non_signin_permissions_grantable_from_ui?
+    (supported_permissions.grantable_from_ui.where(delegatable: false) - [signin_permission]).any?
+  end
+
   def url_without_path
     parsed_url = URI.parse(redirect_uri)
     "#{parsed_url.scheme}://#{parsed_url.host}:#{parsed_url.port}"

--- a/app/views/account/permissions/edit.html.erb
+++ b/app/views/account/permissions/edit.html.erb
@@ -29,6 +29,14 @@
   <% end %>
 <% end %>
 
+<% if notice = notice_about_non_delegatable_permissions(current_user, @application, @user) %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= render "govuk_publishing_components/components/inset_text", { text: notice } %>
+    </div>
+  </div>
+<% end %>
+
 <%= render "shared/permissions_forms", {
   assigned_permissions: @assigned_permissions,
   unassigned_permission_options: @unassigned_permission_options,

--- a/app/views/users/permissions/edit.html.erb
+++ b/app/views/users/permissions/edit.html.erb
@@ -34,6 +34,14 @@
   <% end %>
 <% end %>
 
+<% if notice = notice_about_non_delegatable_permissions(current_user, @application, @user) %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= render "govuk_publishing_components/components/inset_text", { text: notice } %>
+    </div>
+  </div>
+<% end %>
+
 <%= render "shared/permissions_forms", {
   assigned_permissions: @assigned_permissions,
   unassigned_permission_options: @unassigned_permission_options,

--- a/test/integration/account_applications_test.rb
+++ b/test/integration/account_applications_test.rb
@@ -252,6 +252,8 @@ class AccountApplicationsTest < ActionDispatch::IntegrationTest
 
         assert page.has_field?("delegatable_perm")
         assert page.has_no_field?("non_delegatable_perm")
+
+        assert_selector ".govuk-inset-text", text: "Below, you will only see permissions that you are authorised to manage. You can also view all the permissions you have for app-name."
       end
 
       should "not be able to grant permissions that are not grantable_from_ui" do

--- a/test/integration/granting_permissions_test.rb
+++ b/test/integration/granting_permissions_test.rb
@@ -225,6 +225,8 @@ class GrantingPermissionsTest < ActionDispatch::IntegrationTest
 
       assert page.has_field?("delegatable_perm")
       assert page.has_no_field?("non_delegatable_perm")
+
+      assert_selector ".govuk-inset-text", text: "Below, you will only see permissions that you are authorised to manage. You can also view all the permissions #{@user.name} has for MyApp."
     end
 
     should "not be able to grant permissions that are not grantable_from_ui" do
@@ -322,6 +324,8 @@ class GrantingPermissionsTest < ActionDispatch::IntegrationTest
 
       assert page.has_field?("delegatable_perm")
       assert page.has_no_field?("non_delegatable_perm")
+
+      assert_selector ".govuk-inset-text", text: "Below, you will only see permissions that you are authorised to manage. You can also view all the permissions #{@user.name} has for MyApp."
     end
 
     should "not be able to grant permissions that are not grantable_from_ui" do

--- a/test/models/doorkeeper/application_test.rb
+++ b/test/models/doorkeeper/application_test.rb
@@ -263,6 +263,56 @@ class Doorkeeper::ApplicationTest < ActiveSupport::TestCase
     end
   end
 
+  context "has_non_delegatable_non_signin_permissions_grantable_from_ui?" do
+    should "return false if no permissions are non-delegatable" do
+      app = create(
+        :application,
+        with_delegatable_supported_permissions: %w[delegtable],
+        with_delegatable_supported_permissions_not_grantable_from_ui: %w[delegatable-non-grantable],
+        with_non_delegatable_supported_permissions: [],
+        with_non_delegatable_supported_permissions_not_grantable_from_ui: [],
+      )
+
+      assert_not app.has_non_delegatable_non_signin_permissions_grantable_from_ui?
+    end
+
+    should "return false if no permissions are grantable from the UI" do
+      app = create(
+        :application,
+        with_delegatable_supported_permissions: [],
+        with_delegatable_supported_permissions_not_grantable_from_ui: %w[non-grantable],
+        with_non_delegatable_supported_permissions: [],
+        with_non_delegatable_supported_permissions_not_grantable_from_ui: %w[non-delegatable-non-grantable],
+      )
+
+      assert_not app.has_non_delegatable_non_signin_permissions_grantable_from_ui?
+    end
+
+    should "return false if only the signin permission is non-delegatable and grantable from the UI" do
+      app = create(
+        :application,
+        with_delegatable_supported_permissions: %w[delegatable],
+        with_delegatable_supported_permissions_not_grantable_from_ui: %w[non-grantable],
+        with_non_delegatable_supported_permissions: [SupportedPermission::SIGNIN_NAME],
+        with_non_delegatable_supported_permissions_not_grantable_from_ui: %w[non-delegatable-non-grantable],
+      )
+
+      assert_not app.has_non_delegatable_non_signin_permissions_grantable_from_ui?
+    end
+
+    should "return true if there are non-delegatable non-signin permissions grantable from the UI" do
+      app = create(
+        :application,
+        with_delegatable_supported_permissions: %w[delegatable],
+        with_delegatable_supported_permissions_not_grantable_from_ui: %w[non-grantable],
+        with_non_delegatable_supported_permissions: %w[yay!],
+        with_non_delegatable_supported_permissions_not_grantable_from_ui: %w[non-delegatable-non-grantable],
+      )
+
+      assert app.has_non_delegatable_non_signin_permissions_grantable_from_ui?
+    end
+  end
+
   context ".all (default scope)" do
     setup do
       @app = create(:application)


### PR DESCRIPTION
[Trello](https://trello.com/c/UGZFWxk3/1292-add-notice-to-edit-permissions-page-about-delegatable-filter)

This will be shown to publishing managers on the edit permissions page when there are non-delegatable non-signin permissions so that they are aware that they aren't seeing all permissions for the given app

## Screenshots

<img width="771" alt="image" src="https://github.com/user-attachments/assets/f6f37cb9-ccf5-4e95-b778-445ae08c2434">

<img width="751" alt="image" src="https://github.com/user-attachments/assets/f9c35252-eca4-4e39-83f4-529d84fc645a">

---

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
