### PR TITLE
Refactor supported permissions method

### DIFF
--- a/app/models/supported_permission.rb
+++ b/app/models/supported_permission.rb
@@ -14,10 +14,16 @@ class SupportedPermission < ApplicationRecord
   scope :grantable_from_ui, -> { where(grantable_from_ui: true) }
   scope :default, -> { where(default: true) }
   scope :signin, -> { where(name: SIGNIN_NAME) }
+  scope :excluding_signin, -> { where.not(name: SIGNIN_NAME) }
   scope :excluding_application, ->(application) { where.not(application:) }
 
   def signin?
     name.try(:downcase) == SIGNIN_NAME
+  end
+
+  def self.sort_with_signin_first(supported_permissions)
+    signin_permission = supported_permissions.find(&:signin?)
+    ([signin_permission] + supported_permissions.excluding_signin.order(:name)).compact
   end
 
 private

--- a/test/models/supported_permission_test.rb
+++ b/test/models/supported_permission_test.rb
@@ -77,4 +77,32 @@ class SupportedPermissionTest < ActiveSupport::TestCase
 
     assert_same_elements ["included-permission", SupportedPermission::SIGNIN_NAME], SupportedPermission.excluding_application(excluded_application).pluck(:name)
   end
+
+  context ".sort_with_signin_first" do
+    setup do
+      @application = create(:application, with_delegatable_supported_permissions: %w[d a c2 b c1])
+    end
+
+    context "without a signin permission" do
+      should "return the permissions, sorted alphanumerically by name" do
+        assert_equal(
+          %w[a b c1 c2 d],
+          SupportedPermission
+            .sort_with_signin_first(@application.supported_permissions.excluding_signin)
+            .map(&:name),
+        )
+      end
+    end
+
+    context "with a signin permission" do
+      should "return the permissions, sorted alphanumerically by name, but with signin first" do
+        assert_equal(
+          %w[signin a b c1 c2 d],
+          SupportedPermission
+          .sort_with_signin_first(@application.supported_permissions)
+          .map(&:name),
+        )
+      end
+    end
+  end
 end


### PR DESCRIPTION
The `sorted_supported_permissions_grantable_from_ui` method was getting a little complex, with a lot of conditional logic. This separates out the sorting and filtering, with the former the responsibility of the `SupportedPermission` model, and the latter remaining the responsibility of the `Doorkeeper::Application` model based on the passed in arguments

In the `Doorkeeper::Application` tests, we're using [Mocha's with][1] with a block using [Minitest's assert_same_elements][2] to check that the array argument contains the same elements regardless of order

Mocha does have various [ParameterMatchers][3], which can be used with `with`, but unfortunately not an equivalent of `assert_same_elements` or something like [Jest's expect.arrayContaining][4]

[1]: https://mocha.jamesmead.org/Mocha/Expectation.html#with-instance_method
[2]: https://www.rubydoc.info/gems/minitest-rails-shoulda/0.4.1/MiniTest%2FAssertions:assert_same_elements
[3]: https://mocha.jamesmead.org/Mocha/ParameterMatchers.html
[4]: https://jestjs.io/docs/expect#expectarraycontainingarray

---

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
