### PR TITLE
Remove redundant RootController code

### DIFF
--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -3,11 +3,7 @@ class RootController < ApplicationController
   skip_after_action :verify_authorized
 
   def index
-    applications = Doorkeeper::Application.not_api_only.with_home_uri.can_signin(current_user)
-
-    @applications_and_permissions = applications.map do |application|
-      [application, current_user.application_permissions.where(application_id: application.id)]
-    end
+    @applications = Doorkeeper::Application.not_api_only.with_home_uri.can_signin(current_user)
   end
 
   def signin_required

--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -35,13 +35,13 @@
       } %>
     <% end %>
 
-    <% if @applications_and_permissions.empty? %>
+    <% if @applications.empty? %>
       <p class="govuk-body">
         You haven’t been assigned to any applications yet
       </p>
     <% end %>
 
-    <% @applications_and_permissions.each do |application, permissions| %>
+    <% @applications.each do |application| %>
       <div class="app-application-list__item">
         <h3 class="govuk-heading-m govuk-!-margin-bottom-1">
           <%= link_to application.name, application.home_uri, class: "govuk-link" %>


### PR DESCRIPTION
In 8ad9b99, I removed `UserPermissionsControllerMethods`, which is where this code previously lived, since this was the only place it was being used. However, it looks like we don't even use the permissions, so we can just pass down the applications that we get in a previous line

---

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
