### PR TITLE
Removed unused method

### DIFF
--- a/app/models/user_application_permission.rb
+++ b/app/models/user_application_permission.rb
@@ -8,10 +8,6 @@ class UserApplicationPermission < ApplicationRecord
 
   before_validation :assign_application_id
 
-  def self.for(user:, supported_permission:, application: nil)
-    new(user:, supported_permission:, application: application || supported_permission.application)
-  end
-
 private
 
   # application_id is duplicated across supported_permissions and user_application_permissions

--- a/test/models/user_application_permission_test.rb
+++ b/test/models/user_application_permission_test.rb
@@ -1,37 +1,6 @@
 require "test_helper"
 
 class UserApplicationPermissionTest < ActiveSupport::TestCase
-  context ".for" do
-    setup do
-      @user = build(:user)
-      @supported_permission = build(:supported_permission)
-      @application = build(:application, supported_permissions: [@supported_permission])
-    end
-
-    context "for a user, supported permission, and application" do
-      setup { @result = UserApplicationPermission.for(user: @user, supported_permission: @supported_permission, application: @application) }
-
-      should "return a UserApplicationPermission with the given associations" do
-        assert @result.instance_of?(UserApplicationPermission)
-        assert_equal @user, @result.user
-        assert_equal @supported_permission, @result.supported_permission
-        assert_equal @application, @result.application
-      end
-
-      should "not persist the UserApplicationPermission" do
-        assert_not @result.persisted?
-      end
-    end
-
-    context "without an application" do
-      should "infer the application from the supported permission" do
-        result = UserApplicationPermission.for(user: @user, supported_permission: @supported_permission)
-
-        assert_equal @application, result.application
-      end
-    end
-  end
-
   context "validations" do
     setup do
       @user = create(:user)


### PR DESCRIPTION
[Trello](https://trello.com/c/NZhboqgE/1184-investigate-and-restore-expected-behaviour-for-signin-as-a-delegatable-permission-allowing-other-permissions-to-be-delegated)

This was used by the `UserApplicationPermissionPolicy`, which was deleted in 2a78b5c

---

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
