### PR TITLE
Fix permissions by non-GDS users Rake task

### DIFF
--- a/lib/tasks/event_log.rake
+++ b/lib/tasks/event_log.rake
@@ -86,7 +86,7 @@ namespace :event_log do
             {
               model_instance:,
               application_id: model_instance.application&.id,
-              permission_names: model_instance.trailing_message[1..-2].split(","),
+              permission_names: model_instance.trailing_message[1..-2].split(", "),
             }
           end
 


### PR DESCRIPTION
[Trello](https://trello.com/c/F4b1rEqL/1293-identify-and-revoke-permissions-which-have-been-inappropriately-granted-to-users-by-org-superorg-admins)

I noticed that some the data had a lot of events in which permissions were added but not listed. Some of the permissions could have been removed, but there were too many. It turns out I was splitting the event log's message incorrectly, so the task was looking for e.g. "Editor" within an array like ["signin", " Editor"]. This revises the split to account for the programmatically-added whitespace, which should (correctly) result in more matches

---

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
