### PR TITLE
Refactor API Users Permissions Controller test

### DIFF
--- a/test/controllers/api_users/permissions_controller_test.rb
+++ b/test/controllers/api_users/permissions_controller_test.rb
@@ -49,7 +49,7 @@ class ApiUsers::PermissionsControllerTest < ActionController::TestCase
     end
 
     should "include a hidden field for the signin permission so that it is not removed" do
-      application = create(:application, with_non_delegatable_supported_permissions: ["perm-1", SupportedPermission::SIGNIN_NAME])
+      application = create(:application, with_non_delegatable_supported_permissions: %w[perm-1])
       api_user = create(:api_user, with_permissions: { application => %w[perm-1] })
       create(:access_token, application:, resource_owner_id: api_user.id)
 

--- a/test/controllers/api_users/permissions_controller_test.rb
+++ b/test/controllers/api_users/permissions_controller_test.rb
@@ -123,9 +123,14 @@ class ApiUsers::PermissionsControllerTest < ActionController::TestCase
       assert_not_authenticated
     end
 
-    should "redirect once the permissions have been updated" do
-      application = create(:application, with_non_delegatable_supported_permissions: %w[new old])
-      api_user = create(:api_user, with_permissions: { application => %w[old] })
+    should "update non-signin permissions, retaining the signin permission, then redirect to the API applications path" do
+      application = create(:application)
+      old_permission = create(:supported_permission, application:)
+      new_permission = create(:supported_permission, application:)
+
+      api_user = create(:api_user,
+                        with_signin_permissions_for: [application],
+                        with_permissions: { application => [old_permission.name] })
       create(:access_token, application:, resource_owner_id: api_user.id)
 
       current_user = create(:superadmin_user)
@@ -133,11 +138,10 @@ class ApiUsers::PermissionsControllerTest < ActionController::TestCase
 
       stub_policy current_user, api_user, update?: true
 
-      new_permission = application.supported_permissions.find_by(name: "new")
-
       patch :update, params: { api_user_id: api_user, application_id: application, application: { supported_permission_ids: [new_permission.id] } }
 
       assert_redirected_to api_user_applications_path(api_user)
+      assert_same_elements [application.signin_permission, new_permission], api_user.reload.supported_permissions
     end
 
     should "prevent permissions being added for apps that the current user does not have access to" do
@@ -163,25 +167,6 @@ class ApiUsers::PermissionsControllerTest < ActionController::TestCase
       api_user.reload
 
       assert_equal [], api_user.supported_permissions
-    end
-
-    should "not remove the signin permission from the app when updating other permissions" do
-      application = create(:application, with_non_delegatable_supported_permissions: %w[other])
-      api_user = create(:api_user)
-      api_user.grant_application_signin_permission(application)
-      create(:access_token, application:, resource_owner_id: api_user.id)
-
-      current_user = create(:superadmin_user)
-      sign_in current_user
-
-      stub_policy current_user, api_user, update?: true
-
-      other_permission = application.supported_permissions.find_by(name: "other")
-
-      patch :update, params: { api_user_id: api_user, application_id: application, application: { supported_permission_ids: [other_permission.id] } }
-
-      api_user.reload
-      assert_same_elements [application.signin_permission, other_permission], api_user.supported_permissions
     end
 
     should "not remove permissions the user already has that are not grantable from ui" do

--- a/test/controllers/api_users/permissions_controller_test.rb
+++ b/test/controllers/api_users/permissions_controller_test.rb
@@ -262,9 +262,7 @@ class ApiUsers::PermissionsControllerTest < ActionController::TestCase
         application: { supported_permission_ids: [forbidden_application_permission.id] },
       }
 
-      api_user.reload
-
-      assert_equal [], api_user.supported_permissions
+      assert_equal [], api_user.reload.supported_permissions
     end
 
     should "when updating permissions for app A, prevent additionally adding or removing permissions for app B" do
@@ -292,14 +290,12 @@ class ApiUsers::PermissionsControllerTest < ActionController::TestCase
 
       patch :update, params: { api_user_id: api_user, application_id: application_a, application: { supported_permission_ids: [application_a_new_permission.id, application_b_new_permission.id] } }
 
-      api_user.reload
-
       assert_same_elements [
         application_a_new_permission,
         application_b_old_permission,
         application_a.signin_permission,
         application_b.signin_permission,
-      ], api_user.supported_permissions
+      ], api_user.reload.supported_permissions
 
       assert_not_includes current_user.supported_permissions, application_a_old_permission
       assert_not_includes current_user.supported_permissions, application_b_new_permission
@@ -330,13 +326,11 @@ class ApiUsers::PermissionsControllerTest < ActionController::TestCase
         application: { supported_permission_ids: [new_grantable_permission.id, new_non_grantable_permission.id] },
       }
 
-      api_user.reload
-
       assert_same_elements [
         old_non_grantable_permission,
         new_grantable_permission,
         application.signin_permission,
-      ], api_user.supported_permissions
+      ], api_user.reload.supported_permissions
     end
 
     should "assign the application id to the application_id flash" do

--- a/test/controllers/api_users/permissions_controller_test.rb
+++ b/test/controllers/api_users/permissions_controller_test.rb
@@ -173,27 +173,6 @@ class ApiUsers::PermissionsControllerTest < ActionController::TestCase
       assert_equal [], api_user.supported_permissions
     end
 
-    should "not remove permissions the user already has that are not grantable from ui" do
-      application = create(:application, with_non_delegatable_supported_permissions: %w[other], with_non_delegatable_supported_permissions_not_grantable_from_ui: %w[not_from_ui])
-      api_user = create(:api_user)
-      api_user.grant_application_permission(application, "not_from_ui")
-      create(:access_token, application:, resource_owner_id: api_user.id)
-
-      current_user = create(:superadmin_user)
-      sign_in current_user
-
-      stub_policy current_user, api_user, update?: true
-
-      other_permission = application.supported_permissions.find_by(name: "other")
-      not_from_ui_permission = application.supported_permissions.find_by(name: "not_from_ui")
-
-      patch :update, params: { api_user_id: api_user, application_id: application, application: { supported_permission_ids: [other_permission.id] } }
-
-      api_user.reload
-
-      assert_same_elements [other_permission, not_from_ui_permission], api_user.supported_permissions
-    end
-
     should "when updating permissions for app A, prevent additionally adding or removing permissions for app B" do
       application_a = create(:application, with_non_delegatable_supported_permissions: %w[other])
       application_a_old_permission = create(:supported_permission, application: application_a)
@@ -232,9 +211,18 @@ class ApiUsers::PermissionsControllerTest < ActionController::TestCase
       assert_not_includes current_user.supported_permissions, application_b_new_permission
     end
 
-    should "prevent permissions being added that are not grantable from the ui" do
-      application = create(:application, with_non_delegatable_supported_permissions: %w[other], with_non_delegatable_supported_permissions_not_grantable_from_ui: %w[not_from_ui])
-      api_user = create(:api_user)
+    should "prevent permissions that are not grantable from the UI being added or removed" do
+      application = create(:application)
+      old_grantable_permission = create(:supported_permission, application:)
+      new_grantable_permission = create(:supported_permission, application:)
+      old_non_grantable_permission = create(:supported_permission, application:, grantable_from_ui: false)
+      new_non_grantable_permission = create(:supported_permission, application:, grantable_from_ui: false)
+
+      api_user = create(
+        :api_user,
+        with_signin_permissions_for: [application],
+        with_permissions: { application => [old_grantable_permission.name, old_non_grantable_permission.name] },
+      )
       create(:access_token, application:, resource_owner_id: api_user.id)
 
       current_user = create(:superadmin_user)
@@ -242,13 +230,19 @@ class ApiUsers::PermissionsControllerTest < ActionController::TestCase
 
       stub_policy current_user, api_user, update?: true
 
-      not_from_ui_permission = application.supported_permissions.find_by(name: "not_from_ui")
-
-      patch :update, params: { api_user_id: api_user, application_id: application, application: { supported_permission_ids: [not_from_ui_permission.id] } }
+      patch :update, params: {
+        api_user_id: api_user,
+        application_id: application,
+        application: { supported_permission_ids: [new_grantable_permission.id, new_non_grantable_permission.id] },
+      }
 
       api_user.reload
 
-      assert_equal [], api_user.supported_permissions
+      assert_same_elements [
+        old_non_grantable_permission,
+        new_grantable_permission,
+        application.signin_permission,
+      ], api_user.supported_permissions
     end
 
     should "assign the application id to the application_id flash" do

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -14,22 +14,12 @@ FactoryBot.define do
     after(:create) do |user, evaluator|
       if evaluator.with_permissions
         evaluator.with_permissions.each do |app_or_name, permission_names|
-          app = if app_or_name.is_a?(String)
-                  Doorkeeper::Application.where(name: app_or_name).first!
-                else
-                  app_or_name
-                end
-          user.grant_application_permissions(app, permission_names)
+          user.grant_application_permissions(find_application(app_or_name), permission_names)
         end
       end
 
       evaluator.with_signin_permissions_for.each do |app_or_name|
-        app = if app_or_name.is_a?(String)
-                Doorkeeper::Application.where(name: app_or_name).first!
-              else
-                app_or_name
-              end
-        user.grant_application_signin_permission(app)
+        user.grant_application_signin_permission(find_application(app_or_name))
       end
     end
 
@@ -123,6 +113,7 @@ FactoryBot.define do
   factory :api_user do
     transient do
       with_permissions { {} }
+      with_signin_permissions_for { [] }
     end
 
     sequence(:email) { |n| "api-#{n}@example.com" }
@@ -135,13 +126,12 @@ FactoryBot.define do
     after(:create) do |user, evaluator|
       if evaluator.with_permissions
         evaluator.with_permissions.each do |app_or_name, permission_names|
-          app = if app_or_name.is_a?(String)
-                  Doorkeeper::Application.where(name: app_or_name).first!
-                else
-                  app_or_name
-                end
-          user.grant_application_permissions(app, permission_names)
+          user.grant_application_permissions(find_application(app_or_name), permission_names)
         end
+      end
+
+      evaluator.with_signin_permissions_for.each do |app_or_name|
+        user.grant_application_signin_permission(find_application(app_or_name))
       end
     end
   end
@@ -155,5 +145,13 @@ def api_user_with_token(name, token_count: 2)
         :access_token, resource_owner_id: api_user.id, application_id: app.id
       )
     end
+  end
+end
+
+def find_application(app_or_name)
+  if app_or_name.is_a?(String)
+    Doorkeeper::Application.where(name: app_or_name).first!
+  else
+    app_or_name
   end
 end


### PR DESCRIPTION
The sequel to https://github.com/alphagov/signon/pull/3079, largely following the approach taken in refactoring the controller tests for the Account and User Permissions Controllers to bring them all in line with each others' style.

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
