### PR TITLE
Refactor API Users Permissions Controller #edit tests

### DIFF
--- a/test/controllers/api_users/permissions_controller_test.rb
+++ b/test/controllers/api_users/permissions_controller_test.rb
@@ -49,7 +49,7 @@ class ApiUsers::PermissionsControllerTest < ActionController::TestCase
     end
 
     should "include a hidden field for the signin permission so that it is not removed" do
-      application = create(:application, with_non_delegatable_supported_permissions: ["perm-1", SupportedPermission::SIGNIN_NAME])
+      application = create(:application, with_non_delegatable_supported_permissions: %w[perm-1])
       api_user = create(:api_user, with_permissions: { application => %w[perm-1] })
       create(:access_token, application:, resource_owner_id: api_user.id)
 

--- a/test/controllers/api_users/permissions_controller_test.rb
+++ b/test/controllers/api_users/permissions_controller_test.rb
@@ -95,6 +95,7 @@ class ApiUsers::PermissionsControllerTest < ActionController::TestCase
 
         application = create(:application, retired: true)
         api_user = create(:api_user)
+        create(:access_token, resource_owner_id: api_user.id, application:)
 
         assert_raises(ActiveRecord::RecordNotFound) do
           get :edit, params: { api_user_id: api_user, application_id: application }

--- a/test/controllers/api_users/permissions_controller_test.rb
+++ b/test/controllers/api_users/permissions_controller_test.rb
@@ -26,12 +26,13 @@ class ApiUsers::PermissionsControllerTest < ActionController::TestCase
       assert_not_authorised
     end
 
-    should "display checkboxes for the grantable permissions" do
+    should "render a page with checkboxes for the grantable permissions and a hidden field for the signin permission so that it is not removed" do
       application = create(:application)
-      perm1 = create(:supported_permission, application:, name: "perm-1")
-      perm2 = create(:supported_permission, application:, name: "perm-2")
-      perm3 = create(:supported_permission, application:, name: "perm-3", grantable_from_ui: false)
-      api_user = create(:api_user, with_permissions: { application => %w[perm-1] })
+      old_grantable_permission = create(:supported_permission, application:)
+      new_grantable_permission = create(:supported_permission, application:)
+      new_non_grantable_permission = create(:supported_permission, application:, grantable_from_ui: false)
+
+      api_user = create(:api_user, with_permissions: { application => [old_grantable_permission.name] })
       create(:access_token, application:, resource_owner_id: api_user.id)
 
       current_user = create(:superadmin_user)
@@ -42,25 +43,10 @@ class ApiUsers::PermissionsControllerTest < ActionController::TestCase
 
       get :edit, params: { api_user_id: api_user, application_id: application }
 
-      assert_select "input[type='checkbox'][checked='checked'][name='application[supported_permission_ids][]'][value='#{perm1.id}']"
-      assert_select "input[type='checkbox'][name='application[supported_permission_ids][]'][value='#{perm2.id}']"
-      assert_select "input[type='checkbox'][name='application[supported_permission_ids][]'][value='#{perm3.id}']", count: 0
+      assert_select "input[type='checkbox'][checked='checked'][name='application[supported_permission_ids][]'][value='#{old_grantable_permission.id}']"
+      assert_select "input[type='checkbox'][name='application[supported_permission_ids][]'][value='#{new_grantable_permission.id}']"
+      assert_select "input[type='checkbox'][name='application[supported_permission_ids][]'][value='#{new_non_grantable_permission.id}']", count: 0
       assert_select "input[type='checkbox'][name='application[supported_permission_ids][]'][value='#{application.signin_permission.id}']", count: 0
-    end
-
-    should "include a hidden field for the signin permission so that it is not removed" do
-      application = create(:application, with_non_delegatable_supported_permissions: %w[perm-1])
-      api_user = create(:api_user, with_permissions: { application => %w[perm-1] })
-      create(:access_token, application:, resource_owner_id: api_user.id)
-
-      current_user = create(:superadmin_user)
-      sign_in current_user
-
-      stub_policy_for_navigation_links(current_user)
-      stub_policy current_user, api_user, edit?: true
-
-      get :edit, params: { api_user_id: api_user, application_id: application }
-
       assert_select "input[type='hidden'][value='#{application.signin_permission.id}']"
     end
 

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -12,10 +12,8 @@ FactoryBot.define do
     role { Roles::Normal.name }
 
     after(:create) do |user, evaluator|
-      if evaluator.with_permissions
-        evaluator.with_permissions.each do |app_or_name, permission_names|
-          user.grant_application_permissions(find_application(app_or_name), permission_names)
-        end
+      evaluator.with_permissions.each do |app_or_name, permission_names|
+        user.grant_application_permissions(find_application(app_or_name), permission_names)
       end
 
       evaluator.with_signin_permissions_for.each do |app_or_name|
@@ -124,10 +122,8 @@ FactoryBot.define do
     api_user { true }
 
     after(:create) do |user, evaluator|
-      if evaluator.with_permissions
-        evaluator.with_permissions.each do |app_or_name, permission_names|
-          user.grant_application_permissions(find_application(app_or_name), permission_names)
-        end
+      evaluator.with_permissions.each do |app_or_name, permission_names|
+        user.grant_application_permissions(find_application(app_or_name), permission_names)
       end
     end
   end


### PR DESCRIPTION
[Trello card](https://trello.com/c/mppostUR/1289-refactor-apiuserspermissionscontrollertest)

# Changes in this PR

Refactors the API Users Permissions Controller tests for the `#edit` action to make things a bit easier to read and ensure we're testing the right things to prevent false positives.

This is a rework of #3107, in which I felt I tried to change too much in one go, was difficult to review and modify. In splitting out PRs into smaller chunks, I'm hoping they'll be easier to review and unblock possible parallel work.

Up next, we'll be refactoring tests for the `#update` action.

## Caveat

We're a little unsure about the need for `signin` permissions with API users at the moment, as tests appear to be passing for the right reason without us assigning them to test users. We'll be investigating them shortly, but to keep changes small and incremental, I've not touched that functionality in these tests yet - we should tidy that up in future work.

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
