### PR TITLE
Fix users with access link

### DIFF
--- a/app/helpers/users_with_access_helper.rb
+++ b/app/helpers/users_with_access_helper.rb
@@ -10,7 +10,7 @@ module UsersWithAccessHelper
                ""
              end
 
-    "#{link_to(user.name, edit_user_path(user))}#{status}".html_safe
+    "#{link_to(user.name, edit_user_path(user), class: 'govuk-link')}#{status}".html_safe
   end
 
   def user_name_format(user)

--- a/app/helpers/users_with_access_helper.rb
+++ b/app/helpers/users_with_access_helper.rb
@@ -1,16 +1,16 @@
 module UsersWithAccessHelper
   def formatted_user_name(user)
     status = if user.invited_but_not_yet_accepted?
-               " (invited)"
+               "(invited)"
              elsif user.suspended?
-               " (suspended)"
+               "(suspended)"
              elsif user.access_locked?
-               " (access locked)"
-             else
-               ""
+               "(access locked)"
              end
 
-    "#{link_to(user.name, edit_user_path(user), class: 'govuk-link')}#{status}".html_safe
+    link = link_to(user.name, edit_user_path(user), class: "govuk-link")
+
+    [link, status].compact.join(" ").html_safe
   end
 
   def user_name_format(user)

--- a/test/helpers/users_with_access_helper_test.rb
+++ b/test/helpers/users_with_access_helper_test.rb
@@ -29,14 +29,14 @@ class UsersWithAccessHelperTest < ActionView::TestCase
     assert_equal '<a class="govuk-link" href="/users/1/edit">User Name</a> (access locked)', formatted_user_name(user)
   end
 
-  test "formatted_user_name_class is blank for usable accounts" do
+  test "user_name_format is blank for usable accounts" do
     user = build(:user)
     user.stubs(:unusable_account?).returns(false)
 
     assert user_name_format(user).blank?
   end
 
-  test "formatted_user_name_class strikes through unusable accounts" do
+  test "user_name_format strikes through unusable accounts" do
     user = build(:user)
     user.stubs(:unusable_account?).returns(true)
 

--- a/test/helpers/users_with_access_helper_test.rb
+++ b/test/helpers/users_with_access_helper_test.rb
@@ -5,28 +5,28 @@ class UsersWithAccessHelperTest < ActionView::TestCase
     user = build(:user, id: 1, name: "User Name")
     user.stubs(:unusable_account?).returns(false)
 
-    assert_equal '<a href="/users/1/edit">User Name</a>', formatted_user_name(user)
+    assert_equal '<a class="govuk-link" href="/users/1/edit">User Name</a>', formatted_user_name(user)
   end
 
   test "formatted_user_name indicates invited but not accepted accounts" do
     user = build(:user, id: 1, name: "User Name")
     user.stubs(:invited_but_not_yet_accepted?).returns(true)
 
-    assert_equal '<a href="/users/1/edit">User Name</a> (invited)', formatted_user_name(user)
+    assert_equal '<a class="govuk-link" href="/users/1/edit">User Name</a> (invited)', formatted_user_name(user)
   end
 
   test "formatted_user_name indicates suspended accounts" do
     user = build(:user, id: 1, name: "User Name")
     user.stubs(:suspended?).returns(true)
 
-    assert_equal '<a href="/users/1/edit">User Name</a> (suspended)', formatted_user_name(user)
+    assert_equal '<a class="govuk-link" href="/users/1/edit">User Name</a> (suspended)', formatted_user_name(user)
   end
 
   test "formatted_user_name indicates access locked accounts" do
     user = build(:user, id: 1, name: "User Name")
     user.stubs(:access_locked?).returns(true)
 
-    assert_equal '<a href="/users/1/edit">User Name</a> (access locked)', formatted_user_name(user)
+    assert_equal '<a class="govuk-link" href="/users/1/edit">User Name</a> (access locked)', formatted_user_name(user)
   end
 
   test "formatted_user_name_class is blank for usable accounts" do


### PR DESCRIPTION
This adds the `govuk-link` class to a link that was missing it

---

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
