### PR TITLE
Refactor API Users Controller #update tests

### DIFF
--- a/test/controllers/api_users/permissions_controller_test.rb
+++ b/test/controllers/api_users/permissions_controller_test.rb
@@ -230,17 +230,6 @@ class ApiUsers::PermissionsControllerTest < ActionController::TestCase
       assert_equal application.id, flash[:application_id]
     end
 
-    should "raise an exception if the user cannot be found" do
-      application = create(:application)
-
-      current_user = create(:superadmin_user)
-      sign_in current_user
-
-      assert_raises(ActiveRecord::RecordNotFound) do
-        patch :update, params: { api_user_id: "unknown-id", application_id: application, application: { supported_permission_ids: %w[id] } }
-      end
-    end
-
     should "prevent unauthorised users" do
       application = create(:application)
       api_user = create(:api_user)

--- a/test/controllers/api_users/permissions_controller_test.rb
+++ b/test/controllers/api_users/permissions_controller_test.rb
@@ -313,6 +313,23 @@ class ApiUsers::PermissionsControllerTest < ActionController::TestCase
       end
     end
 
+    should "prevent access if the user does not have an access token for the application" do
+      application = create(:application)
+      permission = create(:supported_permission, application:)
+
+      api_user = create(:api_user, with_signin_permissions_for: [application])
+
+      sign_in create(:superadmin_user)
+
+      assert_raises(ActiveRecord::RecordNotFound) do
+        patch :update, params: {
+          api_user_id: api_user,
+          application_id: application,
+          application: { supported_permission_ids: [permission] },
+        }
+      end
+    end
+
     should "prevent updating permissions for retired applications" do
       application = create(:application, retired: true)
       permission = create(:supported_permission, application:)

--- a/test/controllers/api_users/permissions_controller_test.rb
+++ b/test/controllers/api_users/permissions_controller_test.rb
@@ -139,31 +139,6 @@ class ApiUsers::PermissionsControllerTest < ActionController::TestCase
       assert_same_elements [application.signin_permission, new_permission], api_user.reload.supported_permissions
     end
 
-    should "prevent permissions being added for apps that the current user does not have access to" do
-      organisation = create(:organisation)
-
-      application1 = create(:application)
-      application2 = create(:application, with_non_delegatable_supported_permissions: %w[app2-permission])
-
-      api_user = create(:api_user, organisation:)
-      create(:access_token, application: application1, resource_owner_id: api_user.id)
-      create(:access_token, application: application2, resource_owner_id: api_user.id)
-
-      current_user = create(:superadmin_user)
-      current_user.grant_application_signin_permission(application1)
-      sign_in current_user
-
-      stub_policy current_user, api_user, update?: true
-
-      app2_permission = application2.supported_permissions.find_by!(name: "app2-permission")
-
-      patch :update, params: { api_user_id: api_user, application_id: application1, application: { supported_permission_ids: [app2_permission.id] } }
-
-      api_user.reload
-
-      assert_equal [], api_user.supported_permissions
-    end
-
     should "not remove permissions the user already has that are not grantable from ui" do
       application = create(:application, with_non_delegatable_supported_permissions: %w[other], with_non_delegatable_supported_permissions_not_grantable_from_ui: %w[not_from_ui])
       api_user = create(:api_user)

--- a/test/controllers/api_users/permissions_controller_test.rb
+++ b/test/controllers/api_users/permissions_controller_test.rb
@@ -136,7 +136,7 @@ class ApiUsers::PermissionsControllerTest < ActionController::TestCase
       }
 
       assert_redirected_to api_user_applications_path(api_user)
-      assert_same_elements [application.signin_permission, new_permission], api_user.reload.supported_permissions
+      assert_same_elements [application.signin_permission, new_permission], api_user.supported_permissions
     end
 
     should "when updating permissions for app A, prevent additionally adding or removing permissions for app B" do
@@ -167,8 +167,6 @@ class ApiUsers::PermissionsControllerTest < ActionController::TestCase
         application_id: application_a,
         application: { supported_permission_ids: [application_a_new_permission.id, application_b_new_permission.id] },
       }
-
-      api_user.reload
 
       assert_same_elements [
         application_a_new_permission,
@@ -210,7 +208,7 @@ class ApiUsers::PermissionsControllerTest < ActionController::TestCase
         old_non_grantable_permission,
         new_grantable_permission,
         application.signin_permission,
-      ], api_user.reload.supported_permissions
+      ], api_user.supported_permissions
     end
 
     should "assign the application id to the application_id flash" do

--- a/test/controllers/api_users/permissions_controller_test.rb
+++ b/test/controllers/api_users/permissions_controller_test.rb
@@ -253,6 +253,24 @@ class ApiUsers::PermissionsControllerTest < ActionController::TestCase
       assert_not_authorised
     end
 
+    should "prevent updating permissions for retired applications" do
+      application = create(:application, retired: true)
+      permission = create(:supported_permission, application:)
+
+      api_user = create(:api_user, with_signin_permissions_for: [application])
+      create(:access_token, resource_owner_id: api_user.id, application:)
+
+      sign_in create(:superadmin_user)
+
+      assert_raises(ActiveRecord::RecordNotFound) do
+        patch :update, params: {
+          api_user_id: api_user,
+          application_id: application,
+          application: { supported_permission_ids: [permission.id] },
+        }
+      end
+    end
+
     should "push permission changes out to apps" do
       application = create(:application)
       permission = create(:supported_permission, application:)

--- a/test/controllers/api_users/permissions_controller_test.rb
+++ b/test/controllers/api_users/permissions_controller_test.rb
@@ -105,246 +105,250 @@ class ApiUsers::PermissionsControllerTest < ActionController::TestCase
   end
 
   context "#update" do
-    should "update non-signin permissions, retaining the signin permission, then redirect to the API applications path" do
-      application = create(:application)
-      old_permission = create(:supported_permission, application:)
-      new_permission = create(:supported_permission, application:)
+    context "when the user's permissions can be updated" do
+      should "update non-signin permissions, retaining the signin permission, then redirect to the API applications path" do
+        application = create(:application)
+        old_permission = create(:supported_permission, application:)
+        new_permission = create(:supported_permission, application:)
 
-      api_user = create(:api_user,
-                        with_signin_permissions_for: [application],
-                        with_permissions: { application => [old_permission.name] })
-      create(:access_token, application:, resource_owner_id: api_user.id)
+        api_user = create(:api_user,
+                          with_signin_permissions_for: [application],
+                          with_permissions: { application => [old_permission.name] })
+        create(:access_token, application:, resource_owner_id: api_user.id)
 
-      current_user = create(:superadmin_user)
-      sign_in current_user
+        current_user = create(:superadmin_user)
+        sign_in current_user
 
-      stub_policy current_user, api_user, update?: true
+        stub_policy current_user, api_user, update?: true
 
-      patch :update, params: {
-        api_user_id: api_user,
-        application_id: application,
-        application: { supported_permission_ids: [new_permission.id] },
-      }
+        patch :update, params: {
+          api_user_id: api_user,
+          application_id: application,
+          application: { supported_permission_ids: [new_permission.id] },
+        }
 
-      assert_redirected_to api_user_applications_path(api_user)
-      assert_same_elements [application.signin_permission, new_permission], api_user.supported_permissions
-    end
+        assert_redirected_to api_user_applications_path(api_user)
+        assert_same_elements [application.signin_permission, new_permission], api_user.supported_permissions
+      end
 
-    should "assign the application id to the application_id flash" do
-      application = create(:application)
-      permission = create(:supported_permission, application:)
+      should "assign the application id to the application_id flash" do
+        application = create(:application)
+        permission = create(:supported_permission, application:)
 
-      api_user = create(:api_user, with_signin_permissions_for: [application])
-      create(:access_token, application:, resource_owner_id: api_user.id)
+        api_user = create(:api_user, with_signin_permissions_for: [application])
+        create(:access_token, application:, resource_owner_id: api_user.id)
 
-      current_user = create(:superadmin_user)
-      sign_in current_user
+        current_user = create(:superadmin_user)
+        sign_in current_user
 
-      stub_policy current_user, api_user, update?: true
+        stub_policy current_user, api_user, update?: true
 
-      patch :update, params: {
-        api_user_id: api_user,
-        application_id: application,
-        application: { supported_permission_ids: [permission.id] },
-      }
+        patch :update, params: {
+          api_user_id: api_user,
+          application_id: application,
+          application: { supported_permission_ids: [permission.id] },
+        }
 
-      assert_equal application.id, flash[:application_id]
-    end
+        assert_equal application.id, flash[:application_id]
+      end
 
-    should "push permission changes out to apps" do
-      application = create(:application)
-      permission = create(:supported_permission, application:)
+      should "push permission changes out to apps" do
+        application = create(:application)
+        permission = create(:supported_permission, application:)
 
-      api_user = create(:api_user, with_signin_permissions_for: [application])
-      create(:access_token, application:, resource_owner_id: api_user.id)
+        api_user = create(:api_user, with_signin_permissions_for: [application])
+        create(:access_token, application:, resource_owner_id: api_user.id)
 
-      sign_in create(:superadmin_user)
+        sign_in create(:superadmin_user)
 
-      PermissionUpdater.expects(:perform_on).with(api_user)
+        PermissionUpdater.expects(:perform_on).with(api_user)
 
-      patch :update, params: {
-        api_user_id: api_user,
-        application_id: application,
-        application: { supported_permission_ids: [permission.id] },
-      }
-    end
-
-    should "allow updating when the user has revoked access tokens when there is at least one non-revoked access token" do
-      application = create(:application)
-      permission = create(:supported_permission, application:)
-
-      api_user = create(:api_user, with_signin_permissions_for: [application])
-      create(:access_token, resource_owner_id: api_user.id, application:, revoked_at: Time.current)
-      create(:access_token, resource_owner_id: api_user.id, application:)
-
-      current_user = create(:superadmin_user)
-      sign_in current_user
-
-      stub_policy current_user, api_user, update?: true
-
-      assert_nothing_raised do
         patch :update, params: {
           api_user_id: api_user,
           application_id: application,
           application: { supported_permission_ids: [permission.id] },
         }
       end
-    end
 
-    should "when updating permissions for app A, prevent additionally adding or removing permissions for app B" do
-      application_a = create(:application)
-      application_a_old_permission = create(:supported_permission, application: application_a)
-      application_a_new_permission = create(:supported_permission, application: application_a)
+      should "allow updating when the user has revoked access tokens when there is at least one non-revoked access token" do
+        application = create(:application)
+        permission = create(:supported_permission, application:)
 
-      application_b = create(:application)
-      application_b_old_permission = create(:supported_permission, application: application_b)
-      application_b_new_permission = create(:supported_permission, application: application_b)
+        api_user = create(:api_user, with_signin_permissions_for: [application])
+        create(:access_token, resource_owner_id: api_user.id, application:, revoked_at: Time.current)
+        create(:access_token, resource_owner_id: api_user.id, application:)
 
-      api_user = create(:api_user,
-                        with_signin_permissions_for: [application_a, application_b],
-                        with_permissions: {
-                          application_a => [application_a_old_permission.name],
-                          application_b => [application_b_old_permission.name],
-                        })
-      create(:access_token, application: application_a, resource_owner_id: api_user.id)
-      create(:access_token, application: application_b, resource_owner_id: api_user.id)
+        current_user = create(:superadmin_user)
+        sign_in current_user
 
-      current_user = create(:superadmin_user)
-      sign_in current_user
+        stub_policy current_user, api_user, update?: true
 
-      stub_policy current_user, api_user, update?: true
-
-      patch :update, params: {
-        api_user_id: api_user,
-        application_id: application_a,
-        application: { supported_permission_ids: [application_a_new_permission.id, application_b_new_permission.id] },
-      }
-
-      assert_same_elements [
-        application_a_new_permission,
-        application_b_old_permission,
-        application_a.signin_permission,
-        application_b.signin_permission,
-      ], api_user.supported_permissions
-
-      assert_not_includes current_user.supported_permissions, application_a_old_permission
-      assert_not_includes current_user.supported_permissions, application_b_new_permission
-    end
-
-    should "prevent permissions that are not grantable from the UI being added or removed" do
-      application = create(:application)
-      old_grantable_permission = create(:supported_permission, application:)
-      new_grantable_permission = create(:supported_permission, application:)
-      old_non_grantable_permission = create(:supported_permission, application:, grantable_from_ui: false)
-      new_non_grantable_permission = create(:supported_permission, application:, grantable_from_ui: false)
-
-      api_user = create(
-        :api_user,
-        with_signin_permissions_for: [application],
-        with_permissions: { application => [old_grantable_permission.name, old_non_grantable_permission.name] },
-      )
-      create(:access_token, application:, resource_owner_id: api_user.id)
-
-      current_user = create(:superadmin_user)
-      sign_in current_user
-
-      stub_policy current_user, api_user, update?: true
-
-      patch :update, params: {
-        api_user_id: api_user,
-        application_id: application,
-        application: { supported_permission_ids: [new_grantable_permission.id, new_non_grantable_permission.id] },
-      }
-
-      assert_same_elements [
-        old_non_grantable_permission,
-        new_grantable_permission,
-        application.signin_permission,
-      ], api_user.supported_permissions
-    end
-
-    should "prevent unauthenticated users" do
-      application = create(:application)
-      api_user = create(:api_user)
-
-      patch :update, params: { api_user_id: api_user, application_id: application }
-
-      assert_not_authenticated
-    end
-
-    should "prevent unauthorised users" do
-      application = create(:application)
-      api_user = create(:api_user)
-      create(:access_token, application:, resource_owner_id: api_user.id)
-
-      current_user = create(:superadmin_user)
-      sign_in current_user
-
-      stub_policy current_user, api_user, update?: false
-
-      patch :update, params: {
-        api_user_id: api_user,
-        application_id: application,
-        application: { supported_permission_ids: [] },
-      }
-
-      assert_not_authorised
-    end
-
-    should "prevent updating permissions if the user only has a revoked access token" do
-      application = create(:application)
-      permission = create(:supported_permission, application:)
-
-      api_user = create(:api_user, with_signin_permissions_for: [application])
-
-      create(:access_token, resource_owner_id: api_user.id, application:, revoked_at: Time.current)
-
-      current_user = create(:superadmin_user)
-      sign_in current_user
-
-      stub_policy current_user, api_user, update?: true
-
-      assert_raises(ActiveRecord::RecordNotFound) do
-        patch :update, params: {
-          api_user_id: api_user,
-          application_id: application,
-          application: { supported_permission_ids: [permission] },
-        }
+        assert_nothing_raised do
+          patch :update, params: {
+            api_user_id: api_user,
+            application_id: application,
+            application: { supported_permission_ids: [permission.id] },
+          }
+        end
       end
     end
 
-    should "prevent access if the user does not have an access token for the application" do
-      application = create(:application)
-      permission = create(:supported_permission, application:)
+    context "when the user's permissions cannot be updated" do
+      should "when updating permissions for app A, prevent additionally adding or removing permissions for app B" do
+        application_a = create(:application)
+        application_a_old_permission = create(:supported_permission, application: application_a)
+        application_a_new_permission = create(:supported_permission, application: application_a)
 
-      api_user = create(:api_user, with_signin_permissions_for: [application])
+        application_b = create(:application)
+        application_b_old_permission = create(:supported_permission, application: application_b)
+        application_b_new_permission = create(:supported_permission, application: application_b)
 
-      sign_in create(:superadmin_user)
+        api_user = create(:api_user,
+                          with_signin_permissions_for: [application_a, application_b],
+                          with_permissions: {
+                            application_a => [application_a_old_permission.name],
+                            application_b => [application_b_old_permission.name],
+                          })
+        create(:access_token, application: application_a, resource_owner_id: api_user.id)
+        create(:access_token, application: application_b, resource_owner_id: api_user.id)
 
-      assert_raises(ActiveRecord::RecordNotFound) do
+        current_user = create(:superadmin_user)
+        sign_in current_user
+
+        stub_policy current_user, api_user, update?: true
+
         patch :update, params: {
           api_user_id: api_user,
-          application_id: application,
-          application: { supported_permission_ids: [permission] },
+          application_id: application_a,
+          application: { supported_permission_ids: [application_a_new_permission.id, application_b_new_permission.id] },
         }
+
+        assert_same_elements [
+          application_a_new_permission,
+          application_b_old_permission,
+          application_a.signin_permission,
+          application_b.signin_permission,
+        ], api_user.supported_permissions
+
+        assert_not_includes current_user.supported_permissions, application_a_old_permission
+        assert_not_includes current_user.supported_permissions, application_b_new_permission
       end
-    end
 
-    should "prevent updating permissions for retired applications" do
-      application = create(:application, retired: true)
-      permission = create(:supported_permission, application:)
+      should "prevent permissions that are not grantable from the UI being added or removed" do
+        application = create(:application)
+        old_grantable_permission = create(:supported_permission, application:)
+        new_grantable_permission = create(:supported_permission, application:)
+        old_non_grantable_permission = create(:supported_permission, application:, grantable_from_ui: false)
+        new_non_grantable_permission = create(:supported_permission, application:, grantable_from_ui: false)
 
-      api_user = create(:api_user, with_signin_permissions_for: [application])
-      create(:access_token, resource_owner_id: api_user.id, application:)
+        api_user = create(
+          :api_user,
+          with_signin_permissions_for: [application],
+          with_permissions: { application => [old_grantable_permission.name, old_non_grantable_permission.name] },
+        )
+        create(:access_token, application:, resource_owner_id: api_user.id)
 
-      sign_in create(:superadmin_user)
+        current_user = create(:superadmin_user)
+        sign_in current_user
 
-      assert_raises(ActiveRecord::RecordNotFound) do
+        stub_policy current_user, api_user, update?: true
+
         patch :update, params: {
           api_user_id: api_user,
           application_id: application,
-          application: { supported_permission_ids: [permission.id] },
+          application: { supported_permission_ids: [new_grantable_permission.id, new_non_grantable_permission.id] },
         }
+
+        assert_same_elements [
+          old_non_grantable_permission,
+          new_grantable_permission,
+          application.signin_permission,
+        ], api_user.supported_permissions
+      end
+
+      should "prevent unauthenticated users" do
+        application = create(:application)
+        api_user = create(:api_user)
+
+        patch :update, params: { api_user_id: api_user, application_id: application }
+
+        assert_not_authenticated
+      end
+
+      should "prevent unauthorised users" do
+        application = create(:application)
+        api_user = create(:api_user)
+        create(:access_token, application:, resource_owner_id: api_user.id)
+
+        current_user = create(:superadmin_user)
+        sign_in current_user
+
+        stub_policy current_user, api_user, update?: false
+
+        patch :update, params: {
+          api_user_id: api_user,
+          application_id: application,
+          application: { supported_permission_ids: [] },
+        }
+
+        assert_not_authorised
+      end
+
+      should "prevent updating permissions if the user only has a revoked access token" do
+        application = create(:application)
+        permission = create(:supported_permission, application:)
+
+        api_user = create(:api_user, with_signin_permissions_for: [application])
+
+        create(:access_token, resource_owner_id: api_user.id, application:, revoked_at: Time.current)
+
+        current_user = create(:superadmin_user)
+        sign_in current_user
+
+        stub_policy current_user, api_user, update?: true
+
+        assert_raises(ActiveRecord::RecordNotFound) do
+          patch :update, params: {
+            api_user_id: api_user,
+            application_id: application,
+            application: { supported_permission_ids: [permission] },
+          }
+        end
+      end
+
+      should "prevent access if the user does not have an access token for the application" do
+        application = create(:application)
+        permission = create(:supported_permission, application:)
+
+        api_user = create(:api_user, with_signin_permissions_for: [application])
+
+        sign_in create(:superadmin_user)
+
+        assert_raises(ActiveRecord::RecordNotFound) do
+          patch :update, params: {
+            api_user_id: api_user,
+            application_id: application,
+            application: { supported_permission_ids: [permission] },
+          }
+        end
+      end
+
+      should "prevent updating permissions for retired applications" do
+        application = create(:application, retired: true)
+        permission = create(:supported_permission, application:)
+
+        api_user = create(:api_user, with_signin_permissions_for: [application])
+        create(:access_token, resource_owner_id: api_user.id, application:)
+
+        sign_in create(:superadmin_user)
+
+        assert_raises(ActiveRecord::RecordNotFound) do
+          patch :update, params: {
+            api_user_id: api_user,
+            application_id: application,
+            application: { supported_permission_ids: [permission.id] },
+          }
+        end
       end
     end
   end

--- a/test/controllers/api_users/permissions_controller_test.rb
+++ b/test/controllers/api_users/permissions_controller_test.rb
@@ -160,24 +160,46 @@ class ApiUsers::PermissionsControllerTest < ActionController::TestCase
       assert_same_elements [other_permission, not_from_ui_permission], api_user.supported_permissions
     end
 
-    should "prevent permissions being added for other apps" do
-      other_application = create(:application, with_non_delegatable_supported_permissions: %w[other])
-      application = create(:application)
-      api_user = create(:api_user)
-      create(:access_token, application:, resource_owner_id: api_user.id)
+    should "when updating permissions for app A, prevent additionally adding or removing permissions for app B" do
+      application_a = create(:application)
+      application_a_old_permission = create(:supported_permission, application: application_a)
+      application_a_new_permission = create(:supported_permission, application: application_a)
+
+      application_b = create(:application)
+      application_b_old_permission = create(:supported_permission, application: application_b)
+      application_b_new_permission = create(:supported_permission, application: application_b)
+
+      api_user = create(:api_user,
+                        with_signin_permissions_for: [application_a, application_b],
+                        with_permissions: {
+                          application_a => [application_a_old_permission.name],
+                          application_b => [application_b_old_permission.name],
+                        })
+      create(:access_token, application: application_a, resource_owner_id: api_user.id)
+      create(:access_token, application: application_b, resource_owner_id: api_user.id)
 
       current_user = create(:superadmin_user)
       sign_in current_user
 
       stub_policy current_user, api_user, update?: true
 
-      other_permission = other_application.supported_permissions.find_by(name: "other")
-
-      patch :update, params: { api_user_id: api_user, application_id: application, application: { supported_permission_ids: [other_permission.id] } }
+      patch :update, params: {
+        api_user_id: api_user,
+        application_id: application_a,
+        application: { supported_permission_ids: [application_a_new_permission.id, application_b_new_permission.id] },
+      }
 
       api_user.reload
 
-      assert_equal [], api_user.supported_permissions
+      assert_same_elements [
+        application_a_new_permission,
+        application_b_old_permission,
+        application_a.signin_permission,
+        application_b.signin_permission,
+      ], api_user.supported_permissions
+
+      assert_not_includes current_user.supported_permissions, application_a_old_permission
+      assert_not_includes current_user.supported_permissions, application_b_new_permission
     end
 
     should "prevent permissions being added that are not grantable from the ui" do

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -125,6 +125,10 @@ FactoryBot.define do
       evaluator.with_permissions.each do |app_or_name, permission_names|
         user.grant_application_permissions(find_application(app_or_name), permission_names)
       end
+
+      evaluator.with_signin_permissions_for.each do |app_or_name|
+        user.grant_application_signin_permission(find_application(app_or_name))
+      end
     end
   end
 end


### PR DESCRIPTION
[Trello card](https://trello.com/c/mppostUR/1289-refactor-apiuserspermissionscontrollertest)

# Changes in this PR

Refactors the API Users Permissions Controller tests for the `#update` action to make things a bit easier to read and ensure we're testing the right things to prevent false positives. It also attempts to bring tests in line with the other Permissions Controller tests.

Like #3110, this is a rework of #3107, in which I felt I tried to change too much in one go, was difficult to review and modify. 

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
