### PR TITLE
Tidy up Account and Users Permissions Controller tests

### DIFF
--- a/test/controllers/account/permissions_controller_test.rb
+++ b/test/controllers/account/permissions_controller_test.rb
@@ -77,7 +77,7 @@ class Account::PermissionsControllerTest < ActionController::TestCase
 
   context "#edit" do
     context "when a user can edit their permissions" do
-      should "display checkboxes for the grantable permissions" do
+      should "render a page with checkboxes for the grantable permissions and a hidden field for the signin permission so that it is not removed" do
         application = create(:application)
         old_grantable_permission = create(:supported_permission, application:)
         new_grantable_permission = create(:supported_permission, application:)
@@ -97,16 +97,6 @@ class Account::PermissionsControllerTest < ActionController::TestCase
         assert_select "input[type='checkbox'][name='application[supported_permission_ids][]'][value='#{new_grantable_permission.id}']"
         assert_select "input[type='checkbox'][name='application[supported_permission_ids][]'][value='#{new_non_grantable_permission.id}']", count: 0
         assert_select "input[type='checkbox'][name='application[supported_permission_ids][]'][value='#{application.signin_permission.id}']", count: 0
-      end
-
-      should "include a hidden field for the signin permission so that it is not removed" do
-        application = create(:application, with_non_delegatable_supported_permissions: %w[permission])
-        user = create(:admin_user, with_signin_permissions_for: [application])
-
-        sign_in user
-
-        get :edit, params: { application_id: application }
-
         assert_select "input[type='hidden'][value='#{application.signin_permission.id}']"
       end
 

--- a/test/controllers/account/permissions_controller_test.rb
+++ b/test/controllers/account/permissions_controller_test.rb
@@ -2,6 +2,39 @@ require "test_helper"
 
 class Account::PermissionsControllerTest < ActionController::TestCase
   context "#show" do
+    context "when a user can view their permissions" do
+      should "order permissions by whether the user has access and then alphabetically" do
+        application = create(:application,
+                             with_non_delegatable_supported_permissions: %w[uuu aaa ttt bbb])
+        user = create(:admin_user,
+                      with_signin_permissions_for: [application],
+                      with_permissions: { application => %w[aaa ttt] })
+
+        sign_in user
+
+        get :show, params: { application_id: application }
+
+        assert_equal %w[signin aaa ttt bbb uuu], assigns(:permissions).map(&:name)
+      end
+
+      should "exclude permissions that aren't grantable from the UI" do
+        application = create(:application)
+        grantable_permission = create(:supported_permission, application:)
+        non_grantable_permission = create(:supported_permission, application:, grantable_from_ui: false)
+
+        user = create(:admin_user, with_signin_permissions_for: [application])
+
+        sign_in user
+
+        get :show, params: { application_id: application }
+
+        assert_select "td", text: grantable_permission.name
+        assert_select "td", text: non_grantable_permission.name, count: 0
+      end
+    end
+  end
+
+  context "when a user cannot view permissions" do
     should "prevent unauthenticated users" do
       application = create(:application)
 
@@ -40,199 +73,252 @@ class Account::PermissionsControllerTest < ActionController::TestCase
         get :show, params: { application_id: application }
       end
     end
-
-    should "exclude permissions that aren't grantable from the UI" do
-      application = create(:application)
-      grantable_permission = create(:supported_permission, application:)
-      non_grantable_permission = create(:supported_permission, application:, grantable_from_ui: false)
-
-      user = create(:admin_user, with_signin_permissions_for: [application])
-
-      sign_in user
-
-      get :show, params: { application_id: application }
-
-      assert_select "td", text: grantable_permission.name
-      assert_select "td", text: non_grantable_permission.name, count: 0
-    end
-
-    should "order permissions by whether the user has access and then alphabetically" do
-      application = create(:application,
-                           with_non_delegatable_supported_permissions: %w[uuu aaa ttt bbb])
-      user = create(:admin_user,
-                    with_signin_permissions_for: [application],
-                    with_permissions: { application => %w[aaa ttt] })
-
-      sign_in user
-
-      get :show, params: { application_id: application }
-
-      assert_equal %w[signin aaa ttt bbb uuu], assigns(:permissions).map(&:name)
-    end
   end
 
   context "#edit" do
-    should "prevent unauthenticated users" do
-      application = create(:application)
+    context "when a user can edit their permissions" do
+      should "display checkboxes for the grantable permissions" do
+        application = create(:application)
+        old_grantable_permission = create(:supported_permission, application:)
+        new_grantable_permission = create(:supported_permission, application:)
+        new_non_grantable_permission = create(:supported_permission, application:, grantable_from_ui: false)
 
-      get :edit, params: { application_id: application }
+        user = create(
+          :admin_user,
+          with_signin_permissions_for: [application],
+          with_permissions: { application => [old_grantable_permission.name] },
+        )
 
-      assert_redirected_to "/users/sign_in"
-    end
+        sign_in user
 
-    should "prevent unauthorised users" do
-      application = create(:application)
-
-      current_user = create(:admin_user, with_signin_permissions_for: [application])
-      sign_in current_user
-
-      stub_policy current_user, [:account, application], edit_permissions?: false
-
-      get :edit, params: { application_id: application }
-
-      assert_not_authorised
-    end
-
-    should "raise an exception if the application is retired" do
-      sign_in create(:admin_user)
-      application = create(:application, retired: true)
-
-      assert_raises(ActiveRecord::RecordNotFound) do
         get :edit, params: { application_id: application }
+
+        assert_select "input[type='checkbox'][checked='checked'][name='application[supported_permission_ids][]'][value='#{old_grantable_permission.id}']"
+        assert_select "input[type='checkbox'][name='application[supported_permission_ids][]'][value='#{new_grantable_permission.id}']"
+        assert_select "input[type='checkbox'][name='application[supported_permission_ids][]'][value='#{new_non_grantable_permission.id}']", count: 0
+        assert_select "input[type='checkbox'][name='application[supported_permission_ids][]'][value='#{application.signin_permission.id}']", count: 0
       end
-    end
 
-    should "raise an exception if the application is API-only" do
-      sign_in create(:admin_user)
-      application = create(:application, api_only: true)
-
-      assert_raises(ActiveRecord::RecordNotFound) do
-        get :edit, params: { application_id: application }
-      end
-    end
-
-    should "redirect to the applications path if there are no non-signin applications" do
-      application = create(:application)
-      user = create(:admin_user, with_signin_permissions_for: [application])
-      sign_in user
-
-      get :edit, params: { application_id: application }
-
-      assert_redirected_to account_applications_path
-      assert_equal "No permissions found for #{application.name} that you are authorised to manage.", flash[:alert]
-    end
-
-    should "display checkboxes for the grantable permissions" do
-      application = create(:application)
-      old_grantable_permission = create(:supported_permission, application:)
-      new_grantable_permission = create(:supported_permission, application:)
-      new_non_grantable_permission = create(:supported_permission, application:, grantable_from_ui: false)
-
-      user = create(
-        :admin_user,
-        with_signin_permissions_for: [application],
-        with_permissions: { application => [old_grantable_permission.name] },
-      )
-
-      sign_in user
-
-      get :edit, params: { application_id: application }
-
-      assert_select "input[type='checkbox'][checked='checked'][name='application[supported_permission_ids][]'][value='#{old_grantable_permission.id}']"
-      assert_select "input[type='checkbox'][name='application[supported_permission_ids][]'][value='#{new_grantable_permission.id}']"
-      assert_select "input[type='checkbox'][name='application[supported_permission_ids][]'][value='#{new_non_grantable_permission.id}']", count: 0
-      assert_select "input[type='checkbox'][name='application[supported_permission_ids][]'][value='#{application.signin_permission.id}']", count: 0
-    end
-
-    should "include a hidden field for the signin permission so that it is not removed" do
-      application = create(:application, with_non_delegatable_supported_permissions: %w[permission])
-      user = create(:admin_user, with_signin_permissions_for: [application])
-
-      sign_in user
-
-      get :edit, params: { application_id: application }
-
-      assert_select "input[type='hidden'][value='#{application.signin_permission.id}']"
-    end
-
-    context "when the current user is a publishing manager" do
-      should "redirect to the applications path if there are no delegatable non-signin applications" do
+      should "include a hidden field for the signin permission so that it is not removed" do
         application = create(:application, with_non_delegatable_supported_permissions: %w[permission])
+        user = create(:admin_user, with_signin_permissions_for: [application])
 
-        current_user = create(:user, with_signin_permissions_for: [application])
-        current_user.stubs(:publishing_manager?).returns(true)
+        sign_in user
+
+        get :edit, params: { application_id: application }
+
+        assert_select "input[type='hidden'][value='#{application.signin_permission.id}']"
+      end
+
+      context "when the current user is a publishing manager" do
+        should "redirect to the applications path if there are no delegatable non-signin applications" do
+          application = create(:application, with_non_delegatable_supported_permissions: %w[permission])
+
+          current_user = create(:user, with_signin_permissions_for: [application])
+          current_user.stubs(:publishing_manager?).returns(true)
+          sign_in current_user
+
+          get :edit, params: { application_id: application }
+
+          assert_redirected_to account_applications_path
+          assert_equal "No permissions found for #{application.name} that you are authorised to manage.", flash[:alert]
+        end
+
+        should "exclude non-delegatable permissions" do
+          application = create(:application)
+          old_delegatable_permission = create(:delegatable_supported_permission, application:)
+          old_non_delegatable_permission = create(:non_delegatable_supported_permission, application:)
+          new_delegatable_permission = create(:delegatable_supported_permission, application:)
+          new_non_delegatable_permission = create(:non_delegatable_supported_permission, application:)
+
+          current_user = create(
+            :user,
+            with_signin_permissions_for: [application],
+            with_permissions: { application => [old_delegatable_permission.name, old_non_delegatable_permission.name] },
+          )
+          current_user.stubs(:publishing_manager?).returns(true)
+          sign_in current_user
+
+          get :edit, params: { application_id: application }
+
+          assert_select "input[type='checkbox'][checked='checked'][name='application[supported_permission_ids][]'][value='#{old_delegatable_permission.id}']"
+          assert_select "input[type='checkbox'][name='application[supported_permission_ids][]'][value='#{new_delegatable_permission.id}']"
+          assert_select "input[type='checkbox'][name='application[supported_permission_ids][]'][value='#{old_non_delegatable_permission.id}']", count: 0
+          assert_select "input[type='checkbox'][name='application[supported_permission_ids][]'][value='#{new_non_delegatable_permission.id}']", count: 0
+        end
+      end
+
+      context "for apps with greater than eight supported permissions" do
+        setup do
+          @application = create(:application)
+          @old_permissions = create_list(:supported_permission, 2, application: @application)
+          @new_permissions = create_list(:supported_permission, 7, application: @application)
+
+          user = create(
+            :admin_user,
+            with_signin_permissions_for: [@application],
+            with_permissions: { @application => @old_permissions.map(&:name) },
+          )
+
+          sign_in user
+
+          get :edit, params: { application_id: @application }
+        end
+
+        should "display a select component for grantable but non-existing permissions" do
+          assert_select "select[name='application[new_permission_id]']"
+        end
+
+        should "include a hidden field representing whether the user wants to add more permissions, defaulting to false" do
+          assert_select "input[type='hidden'][name='application[add_more]'][value='false']"
+        end
+
+        should "display checkboxes for the existing permissions" do
+          @old_permissions.each do |old_permission|
+            assert_select "input[type='checkbox'][checked='checked'][name='application[supported_permission_ids][]'][value='#{old_permission.id}']"
+          end
+
+          @new_permissions.each do |new_permission|
+            assert_select "input[type='checkbox'][name='application[supported_permission_ids][]'][value='#{new_permission.id}']", count: 0
+          end
+
+          assert_select "input[type='checkbox'][name='application[supported_permission_ids][]'][value='#{@application.signin_permission.id}']", count: 0
+        end
+      end
+    end
+
+    context "when a user cannot edit permissions" do
+      should "prevent unauthenticated users" do
+        application = create(:application)
+
+        get :edit, params: { application_id: application }
+
+        assert_redirected_to "/users/sign_in"
+      end
+
+      should "prevent unauthorised users" do
+        application = create(:application)
+
+        current_user = create(:admin_user, with_signin_permissions_for: [application])
         sign_in current_user
+
+        stub_policy current_user, [:account, application], edit_permissions?: false
+
+        get :edit, params: { application_id: application }
+
+        assert_not_authorised
+      end
+
+      should "raise an exception if the application is retired" do
+        sign_in create(:admin_user)
+        application = create(:application, retired: true)
+
+        assert_raises(ActiveRecord::RecordNotFound) do
+          get :edit, params: { application_id: application }
+        end
+      end
+
+      should "raise an exception if the application is API-only" do
+        sign_in create(:admin_user)
+        application = create(:application, api_only: true)
+
+        assert_raises(ActiveRecord::RecordNotFound) do
+          get :edit, params: { application_id: application }
+        end
+      end
+
+      should "redirect to the applications path if there are no non-signin applications" do
+        application = create(:application)
+        user = create(:admin_user, with_signin_permissions_for: [application])
+        sign_in user
 
         get :edit, params: { application_id: application }
 
         assert_redirected_to account_applications_path
         assert_equal "No permissions found for #{application.name} that you are authorised to manage.", flash[:alert]
       end
+    end
+  end
 
-      should "exclude non-delegatable permissions" do
+  context "#update" do
+    context "when a user can edit their permissions" do
+      should "update non-signin permissions, retaining the signin permission, then redirect to the applications path" do
         application = create(:application)
-        old_delegatable_permission = create(:delegatable_supported_permission, application:)
-        old_non_delegatable_permission = create(:non_delegatable_supported_permission, application:)
-        new_delegatable_permission = create(:delegatable_supported_permission, application:)
-        new_non_delegatable_permission = create(:non_delegatable_supported_permission, application:)
+        old_permission = create(:supported_permission, application:)
+        new_permission = create(:supported_permission, application:)
 
         current_user = create(
-          :user,
+          :admin_user,
           with_signin_permissions_for: [application],
-          with_permissions: { application => [old_delegatable_permission.name, old_non_delegatable_permission.name] },
+          with_permissions: { application => [old_permission.name] },
         )
-        current_user.stubs(:publishing_manager?).returns(true)
+
         sign_in current_user
 
-        get :edit, params: { application_id: application }
+        stub_policy current_user, [:account, application], edit_permissions?: true
 
-        assert_select "input[type='checkbox'][checked='checked'][name='application[supported_permission_ids][]'][value='#{old_delegatable_permission.id}']"
-        assert_select "input[type='checkbox'][name='application[supported_permission_ids][]'][value='#{new_delegatable_permission.id}']"
-        assert_select "input[type='checkbox'][name='application[supported_permission_ids][]'][value='#{old_non_delegatable_permission.id}']", count: 0
-        assert_select "input[type='checkbox'][name='application[supported_permission_ids][]'][value='#{new_non_delegatable_permission.id}']", count: 0
+        patch :update, params: { application_id: application, application: { supported_permission_ids: [new_permission.id] } }
+
+        assert_redirected_to account_applications_path
+        assert_same_elements [application.signin_permission, new_permission], current_user.supported_permissions
       end
     end
 
-    context "for apps with greater than eight supported permissions" do
+    should "assign the application id to the application_id flash" do
+      application = create(:application)
+      old_permission = create(:supported_permission, application:)
+      new_permission = create(:supported_permission, application:)
+
+      user = create(
+        :admin_user,
+        with_signin_permissions_for: [application],
+        with_permissions: { application => [old_permission.name] },
+      )
+      sign_in user
+
+      patch :update, params: { application_id: application, application: { supported_permission_ids: [new_permission.id] } }
+
+      assert_equal application.id, flash[:application_id]
+    end
+
+    context "when current_permission_ids and new_permission_id are provided instead of supported_permission_ids" do
       setup do
         @application = create(:application)
         @old_permissions = create_list(:supported_permission, 2, application: @application)
-        @new_permissions = create_list(:supported_permission, 7, application: @application)
+        @new_permission = create(:supported_permission, application: @application)
 
-        user = create(
+        @current_user = create(
           :admin_user,
           with_signin_permissions_for: [@application],
           with_permissions: { @application => @old_permissions.map(&:name) },
         )
 
-        sign_in user
+        sign_in @current_user
 
-        get :edit, params: { application_id: @application }
+        stub_policy @current_user, [:account, @application], edit_permissions?: true
       end
 
-      should "display a select component for grantable but non-existing permissions" do
-        assert_select "select[name='application[new_permission_id]']"
+      should "use the relevant params to update permissions" do
+        patch :update, params: { application_id: @application, application: { current_permission_ids: [*@old_permissions], new_permission_id: @new_permission.id } }
+
+        assert_redirected_to account_applications_path
+
+        assert_same_elements [*@old_permissions, @new_permission, @application.signin_permission], @current_user.supported_permissions
       end
 
-      should "include a hidden field representing whether the user wants to add more permissions, defaulting to false" do
-        assert_select "input[type='hidden'][name='application[add_more]'][value='false']"
-      end
+      context "when the add_more param is 'true'" do
+        should "update permissions then redirect back to the edit page" do
+          patch :update, params: { application_id: @application, application: { current_permission_ids: [*@old_permissions], new_permission_id: @new_permission.id, add_more: "true" } }
 
-      should "display checkboxes for the existing permissions" do
-        @old_permissions.each do |old_permission|
-          assert_select "input[type='checkbox'][checked='checked'][name='application[supported_permission_ids][]'][value='#{old_permission.id}']"
+          assert_redirected_to edit_account_application_permissions_path(@application)
+
+          assert_same_elements [*@old_permissions, @new_permission, @application.signin_permission], @current_user.supported_permissions
         end
-
-        @new_permissions.each do |new_permission|
-          assert_select "input[type='checkbox'][name='application[supported_permission_ids][]'][value='#{new_permission.id}']", count: 0
-        end
-
-        assert_select "input[type='checkbox'][name='application[supported_permission_ids][]'][value='#{@application.signin_permission.id}']", count: 0
       end
     end
   end
 
-  context "#update" do
+  context "when a user cannot edit their permissions" do
     should "prevent unauthenticated users" do
       application = create(:application)
 
@@ -270,27 +356,6 @@ class Account::PermissionsControllerTest < ActionController::TestCase
       assert_raises(ActiveRecord::RecordNotFound) do
         patch :update, params: { application_id: application, application: { supported_permission_ids: [] } }
       end
-    end
-
-    should "update non-signin permissions, retaining the signin permission, then redirect to the applications path" do
-      application = create(:application)
-      old_permission = create(:supported_permission, application:)
-      new_permission = create(:supported_permission, application:)
-
-      current_user = create(
-        :admin_user,
-        with_signin_permissions_for: [application],
-        with_permissions: { application => [old_permission.name] },
-      )
-
-      sign_in current_user
-
-      stub_policy current_user, [:account, application], edit_permissions?: true
-
-      patch :update, params: { application_id: application, application: { supported_permission_ids: [new_permission.id] } }
-
-      assert_redirected_to account_applications_path
-      assert_same_elements [application.signin_permission, new_permission], current_user.supported_permissions
     end
 
     should "when updating permissions for app A, prevent additionally adding or removing permissions for app B" do
@@ -360,23 +425,6 @@ class Account::PermissionsControllerTest < ActionController::TestCase
       ], current_user.supported_permissions
     end
 
-    should "assign the application id to the application_id flash" do
-      application = create(:application)
-      old_permission = create(:supported_permission, application:)
-      new_permission = create(:supported_permission, application:)
-
-      user = create(
-        :admin_user,
-        with_signin_permissions_for: [application],
-        with_permissions: { application => [old_permission.name] },
-      )
-      sign_in user
-
-      patch :update, params: { application_id: application, application: { supported_permission_ids: [new_permission.id] } }
-
-      assert_equal application.id, flash[:application_id]
-    end
-
     context "when the current user is a publishing manager with access to the app" do
       should "prevent adding or removing non-delegatable permissions" do
         application = create(:application)
@@ -403,42 +451,6 @@ class Account::PermissionsControllerTest < ActionController::TestCase
           new_delegatable_permission,
           application.signin_permission,
         ], current_user.supported_permissions
-      end
-    end
-
-    context "when current_permission_ids and new_permission_id are provided instead of supported_permission_ids" do
-      setup do
-        @application = create(:application)
-        @old_permissions = create_list(:supported_permission, 2, application: @application)
-        @new_permission = create(:supported_permission, application: @application)
-
-        @current_user = create(
-          :admin_user,
-          with_signin_permissions_for: [@application],
-          with_permissions: { @application => @old_permissions.map(&:name) },
-        )
-
-        sign_in @current_user
-
-        stub_policy @current_user, [:account, @application], edit_permissions?: true
-      end
-
-      should "use the relevant params to update permissions" do
-        patch :update, params: { application_id: @application, application: { current_permission_ids: [*@old_permissions], new_permission_id: @new_permission.id } }
-
-        assert_redirected_to account_applications_path
-
-        assert_same_elements [*@old_permissions, @new_permission, @application.signin_permission], @current_user.supported_permissions
-      end
-
-      context "when the add_more param is 'true'" do
-        should "update permissions then redirect back to the edit page" do
-          patch :update, params: { application_id: @application, application: { current_permission_ids: [*@old_permissions], new_permission_id: @new_permission.id, add_more: "true" } }
-
-          assert_redirected_to edit_account_application_permissions_path(@application)
-
-          assert_same_elements [*@old_permissions, @new_permission, @application.signin_permission], @current_user.supported_permissions
-        end
       end
     end
   end

--- a/test/controllers/account/permissions_controller_test.rb
+++ b/test/controllers/account/permissions_controller_test.rb
@@ -290,7 +290,7 @@ class Account::PermissionsControllerTest < ActionController::TestCase
       patch :update, params: { application_id: application, application: { supported_permission_ids: [new_permission.id] } }
 
       assert_redirected_to account_applications_path
-      assert_same_elements [application.signin_permission, new_permission], current_user.reload.supported_permissions
+      assert_same_elements [application.signin_permission, new_permission], current_user.supported_permissions
     end
 
     should "when updating permissions for app A, prevent additionally adding or removing permissions for app B" do
@@ -323,8 +323,6 @@ class Account::PermissionsControllerTest < ActionController::TestCase
           application: { supported_permission_ids: [application_a_new_permission.id, application_b_new_permission.id] },
         },
       )
-
-      current_user.reload
 
       assert_same_elements [
         application_a_new_permission,
@@ -359,7 +357,7 @@ class Account::PermissionsControllerTest < ActionController::TestCase
         old_non_grantable_permission,
         new_grantable_permission,
         application.signin_permission,
-      ], current_user.reload.supported_permissions
+      ], current_user.supported_permissions
     end
 
     should "assign the application id to the application_id flash" do
@@ -404,7 +402,7 @@ class Account::PermissionsControllerTest < ActionController::TestCase
           old_non_delegatable_permission,
           new_delegatable_permission,
           application.signin_permission,
-        ], current_user.reload.supported_permissions
+        ], current_user.supported_permissions
       end
     end
 
@@ -430,7 +428,7 @@ class Account::PermissionsControllerTest < ActionController::TestCase
 
         assert_redirected_to account_applications_path
 
-        assert_same_elements [*@old_permissions, @new_permission, @application.signin_permission], @current_user.reload.supported_permissions
+        assert_same_elements [*@old_permissions, @new_permission, @application.signin_permission], @current_user.supported_permissions
       end
 
       context "when the add_more param is 'true'" do
@@ -439,7 +437,7 @@ class Account::PermissionsControllerTest < ActionController::TestCase
 
           assert_redirected_to edit_account_application_permissions_path(@application)
 
-          assert_same_elements [*@old_permissions, @new_permission, @application.signin_permission], @current_user.reload.supported_permissions
+          assert_same_elements [*@old_permissions, @new_permission, @application.signin_permission], @current_user.supported_permissions
         end
       end
     end

--- a/test/controllers/users/permissions_controller_test.rb
+++ b/test/controllers/users/permissions_controller_test.rb
@@ -420,7 +420,7 @@ class Users::PermissionsControllerTest < ActionController::TestCase
       patch :update, params: { user_id: user, application_id: application, application: { supported_permission_ids: [new_permission.id] } }
 
       assert_redirected_to user_applications_path(user)
-      assert_same_elements [new_permission, application.signin_permission], user.reload.supported_permissions
+      assert_same_elements [new_permission, application.signin_permission], user.supported_permissions
     end
 
     should "when updating permissions for app A, prevent additionally adding or removing permissions for app B" do
@@ -462,8 +462,6 @@ class Users::PermissionsControllerTest < ActionController::TestCase
         },
       )
 
-      user.reload
-
       assert_same_elements [
         application_a_new_permission,
         application_b_old_permission,
@@ -504,7 +502,7 @@ class Users::PermissionsControllerTest < ActionController::TestCase
         old_non_grantable_permission,
         new_grantable_permission,
         application.signin_permission,
-      ], user.reload.supported_permissions
+      ], user.supported_permissions
     end
 
     should "assign the application id to the application_id flash" do
@@ -573,7 +571,7 @@ class Users::PermissionsControllerTest < ActionController::TestCase
           old_non_delegatable_permission,
           new_delegatable_permission,
           application.signin_permission,
-        ], user.reload.supported_permissions
+        ], user.supported_permissions
       end
     end
 
@@ -615,7 +613,7 @@ class Users::PermissionsControllerTest < ActionController::TestCase
 
         assert_redirected_to user_applications_path(@user)
 
-        assert_same_elements [*@old_permissions, @new_permission, @application.signin_permission], @user.reload.supported_permissions
+        assert_same_elements [*@old_permissions, @new_permission, @application.signin_permission], @user.supported_permissions
       end
 
       context "when the add_more param is 'true'" do
@@ -635,7 +633,7 @@ class Users::PermissionsControllerTest < ActionController::TestCase
 
           assert_redirected_to edit_user_application_permissions_path(@user, @application)
 
-          assert_same_elements [*@old_permissions, @new_permission, @application.signin_permission], @user.reload.supported_permissions
+          assert_same_elements [*@old_permissions, @new_permission, @application.signin_permission], @user.supported_permissions
         end
       end
     end

--- a/test/controllers/users/permissions_controller_test.rb
+++ b/test/controllers/users/permissions_controller_test.rb
@@ -2,243 +2,274 @@ require "test_helper"
 
 class Users::PermissionsControllerTest < ActionController::TestCase
   context "#show" do
-    should "prevent unauthenticated users" do
-      application = create(:application)
-      user = create(:user)
+    context "when a user can view another's permissions" do
+      should "order permissions by whether the user has access and then alphabetically" do
+        application = create(:application,
+                             with_non_delegatable_supported_permissions: %w[uuu aaa ttt bbb])
 
-      get :show, params: { user_id: user, application_id: application }
+        user = create(:user,
+                      with_signin_permissions_for: [application],
+                      with_permissions: { application => %w[aaa ttt] })
 
-      assert_redirected_to "/users/sign_in"
-    end
+        current_user = create(:admin_user)
+        sign_in current_user
 
-    should "prevent unauthorised users" do
-      application = create(:application)
-      user = create(:user, with_signin_permissions_for: [application])
+        stub_policy_for_navigation_links current_user
+        stub_policy current_user, user, edit?: true
 
-      current_user = create(:admin_user)
-      sign_in current_user
-
-      stub_policy(
-        current_user,
-        { application:, user: },
-        policy_class: Users::ApplicationPolicy,
-        view_permissions?: false,
-      )
-
-      get :show, params: { user_id: user, application_id: application }
-
-      assert_not_authorised
-    end
-
-    should "raise an exception if the user doesn't have access to the application" do
-      sign_in create(:admin_user)
-
-      application = create(:application)
-      user = create(:user)
-
-      assert_raises(ActiveRecord::RecordNotFound) do
         get :show, params: { user_id: user, application_id: application }
+
+        assert_equal %w[signin aaa ttt bbb uuu], assigns(:permissions).map(&:name)
+      end
+
+      should "exclude permissions that aren't grantable from the UI" do
+        application = create(:application)
+        grantable_permission = create(:supported_permission, application:)
+        non_grantable_permission = create(:supported_permission, application:, grantable_from_ui: false)
+
+        user = create(:user, with_signin_permissions_for: [application])
+
+        current_user = create(:admin_user)
+        sign_in current_user
+
+        stub_policy_for_navigation_links current_user
+        stub_policy current_user, user, edit?: true
+
+        get :show, params: { user_id: user, application_id: application }
+
+        assert_select "td", text: grantable_permission.name
+        assert_select "td", text: non_grantable_permission.name, count: 0
       end
     end
 
-    should "raise an exception if the application is retired" do
-      sign_in create(:admin_user)
+    context "when a user cannot view another's permissions" do
+      should "prevent unauthenticated users" do
+        application = create(:application)
+        user = create(:user)
 
-      application = create(:application, retired: true)
-      user = create(:user, with_signin_permissions_for: [application])
-
-      assert_raises(ActiveRecord::RecordNotFound) do
         get :show, params: { user_id: user, application_id: application }
+
+        assert_redirected_to "/users/sign_in"
       end
-    end
 
-    should "raise an exception if the application is API-only" do
-      sign_in create(:admin_user)
+      should "prevent unauthorised users" do
+        application = create(:application)
+        user = create(:user, with_signin_permissions_for: [application])
 
-      application = create(:application, api_only: true)
-      user = create(:user, with_signin_permissions_for: [application])
+        current_user = create(:admin_user)
+        sign_in current_user
 
-      assert_raises(ActiveRecord::RecordNotFound) do
+        stub_policy(
+          current_user,
+          { application:, user: },
+          policy_class: Users::ApplicationPolicy,
+          view_permissions?: false,
+        )
+
         get :show, params: { user_id: user, application_id: application }
+
+        assert_not_authorised
       end
-    end
 
-    should "exclude permissions that aren't grantable from the UI" do
-      application = create(:application)
-      grantable_permission = create(:supported_permission, application:)
-      non_grantable_permission = create(:supported_permission, application:, grantable_from_ui: false)
+      should "raise an exception if the user doesn't have access to the application" do
+        sign_in create(:admin_user)
 
-      user = create(:user, with_signin_permissions_for: [application])
+        application = create(:application)
+        user = create(:user)
 
-      current_user = create(:admin_user)
-      sign_in current_user
+        assert_raises(ActiveRecord::RecordNotFound) do
+          get :show, params: { user_id: user, application_id: application }
+        end
+      end
 
-      stub_policy_for_navigation_links current_user
-      stub_policy current_user, user, edit?: true
+      should "raise an exception if the application is retired" do
+        sign_in create(:admin_user)
 
-      get :show, params: { user_id: user, application_id: application }
+        application = create(:application, retired: true)
+        user = create(:user, with_signin_permissions_for: [application])
 
-      assert_select "td", text: grantable_permission.name
-      assert_select "td", text: non_grantable_permission.name, count: 0
-    end
+        assert_raises(ActiveRecord::RecordNotFound) do
+          get :show, params: { user_id: user, application_id: application }
+        end
+      end
 
-    should "order permissions by whether the user has access and then alphabetically" do
-      application = create(:application,
-                           with_non_delegatable_supported_permissions: %w[uuu aaa ttt bbb])
+      should "raise an exception if the application is API-only" do
+        sign_in create(:admin_user)
 
-      user = create(:user,
-                    with_signin_permissions_for: [application],
-                    with_permissions: { application => %w[aaa ttt] })
+        application = create(:application, api_only: true)
+        user = create(:user, with_signin_permissions_for: [application])
 
-      current_user = create(:admin_user)
-      sign_in current_user
-
-      stub_policy_for_navigation_links current_user
-      stub_policy current_user, user, edit?: true
-
-      get :show, params: { user_id: user, application_id: application }
-
-      assert_equal %w[signin aaa ttt bbb uuu], assigns(:permissions).map(&:name)
+        assert_raises(ActiveRecord::RecordNotFound) do
+          get :show, params: { user_id: user, application_id: application }
+        end
+      end
     end
   end
 
   context "#edit" do
-    should "prevent unauthenticated users" do
-      application = create(:application)
-      user = create(:user)
+    context "when a user can edit another's permissions" do
+      should "display checkboxes for the grantable permissions" do
+        application = create(:application)
+        old_grantable_permission = create(:supported_permission, application:)
+        new_grantable_permission = create(:supported_permission, application:)
+        new_non_grantable_permission = create(:supported_permission, application:, grantable_from_ui: false)
 
-      get :edit, params: { user_id: user, application_id: application }
+        user = create(
+          :user,
+          with_signin_permissions_for: [application],
+          with_permissions: { application => [old_grantable_permission.name] },
+        )
 
-      assert_redirected_to "/users/sign_in"
-    end
+        current_user = create(:admin_user)
+        sign_in current_user
 
-    should "prevent unauthorised users" do
-      application = create(:application)
-      user = create(:user, with_signin_permissions_for: [application])
+        stub_policy(
+          current_user,
+          { application:, user: },
+          policy_class: Users::ApplicationPolicy,
+          edit_permissions?: true,
+        )
 
-      current_user = create(:admin_user)
-      sign_in current_user
-
-      stub_policy(
-        current_user,
-        { application:, user: },
-        policy_class: Users::ApplicationPolicy,
-        edit_permissions?: false,
-      )
-      get :edit, params: { user_id: user, application_id: application }
-
-      assert_not_authorised
-    end
-
-    should "raise an exception if the user doesn't have access to the application" do
-      sign_in create(:admin_user)
-
-      application = create(:application)
-      user = create(:user)
-
-      assert_raises(ActiveRecord::RecordNotFound) do
         get :edit, params: { user_id: user, application_id: application }
+
+        assert_select "input[type='checkbox'][checked='checked'][name='application[supported_permission_ids][]'][value='#{old_grantable_permission.id}']"
+        assert_select "input[type='checkbox'][name='application[supported_permission_ids][]'][value='#{new_grantable_permission.id}']"
+        assert_select "input[type='checkbox'][name='application[supported_permission_ids][]'][value='#{new_non_grantable_permission.id}']", count: 0
+        assert_select "input[type='checkbox'][name='application[supported_permission_ids][]'][value='#{application.signin_permission.id}']", count: 0
       end
-    end
 
-    should "raise an exception if the application is retired" do
-      sign_in create(:admin_user)
-
-      application = create(:application, retired: true)
-      user = create(:user, with_signin_permissions_for: [application])
-
-      assert_raises(ActiveRecord::RecordNotFound) do
-        get :edit, params: { user_id: user, application_id: application }
-      end
-    end
-
-    should "raise an exception if the application is API-only" do
-      sign_in create(:admin_user)
-
-      application = create(:application, api_only: true)
-      user = create(:user, with_signin_permissions_for: [application])
-
-      assert_raises(ActiveRecord::RecordNotFound) do
-        get :edit, params: { user_id: user, application_id: application }
-      end
-    end
-
-    should "redirect to the applications path if there are no non-signin applications" do
-      application = create(:application)
-      user = create(:user, with_signin_permissions_for: [application])
-
-      current_user = create(:admin_user)
-      sign_in current_user
-
-      stub_policy(
-        current_user,
-        { application:, user: },
-        policy_class: Users::ApplicationPolicy,
-        edit_permissions?: true,
-      )
-
-      get :edit, params: { user_id: user, application_id: application }
-
-      assert_redirected_to user_applications_path(user)
-      assert_equal "No permissions found for #{application.name} that you are authorised to manage.", flash[:alert]
-    end
-
-    should "display checkboxes for the grantable permissions" do
-      application = create(:application)
-      old_grantable_permission = create(:supported_permission, application:)
-      new_grantable_permission = create(:supported_permission, application:)
-      new_non_grantable_permission = create(:supported_permission, application:, grantable_from_ui: false)
-
-      user = create(
-        :user,
-        with_signin_permissions_for: [application],
-        with_permissions: { application => [old_grantable_permission.name] },
-      )
-
-      current_user = create(:admin_user)
-      sign_in current_user
-
-      stub_policy(
-        current_user,
-        { application:, user: },
-        policy_class: Users::ApplicationPolicy,
-        edit_permissions?: true,
-      )
-
-      get :edit, params: { user_id: user, application_id: application }
-
-      assert_select "input[type='checkbox'][checked='checked'][name='application[supported_permission_ids][]'][value='#{old_grantable_permission.id}']"
-      assert_select "input[type='checkbox'][name='application[supported_permission_ids][]'][value='#{new_grantable_permission.id}']"
-      assert_select "input[type='checkbox'][name='application[supported_permission_ids][]'][value='#{new_non_grantable_permission.id}']", count: 0
-      assert_select "input[type='checkbox'][name='application[supported_permission_ids][]'][value='#{application.signin_permission.id}']", count: 0
-    end
-
-    should "include a hidden field for the signin permission so that it is not removed" do
-      application = create(:application, with_non_delegatable_supported_permissions: %w[permission])
-      user = create(:user, with_signin_permissions_for: [application])
-
-      current_user = create(:admin_user)
-      sign_in current_user
-
-      stub_policy(
-        current_user,
-        { application:, user: },
-        policy_class: Users::ApplicationPolicy,
-        edit_permissions?: true,
-      )
-
-      get :edit, params: { user_id: user, application_id: application }
-
-      assert_select "input[type='hidden'][value='#{application.signin_permission.id}']"
-    end
-
-    context "when the current user is a publishing manager" do
-      should "redirect to the applications path if there are no delegatable non-signin applications" do
+      should "include a hidden field for the signin permission so that it is not removed" do
         application = create(:application, with_non_delegatable_supported_permissions: %w[permission])
         user = create(:user, with_signin_permissions_for: [application])
 
-        current_user = create(:user)
-        current_user.stubs(:publishing_manager?).returns(true)
+        current_user = create(:admin_user)
+        sign_in current_user
+
+        stub_policy(
+          current_user,
+          { application:, user: },
+          policy_class: Users::ApplicationPolicy,
+          edit_permissions?: true,
+        )
+
+        get :edit, params: { user_id: user, application_id: application }
+
+        assert_select "input[type='hidden'][value='#{application.signin_permission.id}']"
+      end
+
+      context "for apps with greater than eight supported permissions" do
+        setup do
+          @application = create(:application)
+          @old_permissions = create_list(:supported_permission, 2, application: @application)
+          @new_permissions = create_list(:supported_permission, 7, application: @application)
+
+          user = create(
+            :user,
+            with_signin_permissions_for: [@application],
+            with_permissions: { @application => @old_permissions.map(&:name) },
+          )
+
+          current_user = create(:admin_user)
+          sign_in current_user
+
+          stub_policy(
+            current_user,
+            { application: @application, user: },
+            policy_class: Users::ApplicationPolicy,
+            edit_permissions?: true,
+          )
+
+          get :edit, params: { user_id: user, application_id: @application }
+        end
+
+        should "display a select component for grantable but non-existing permissions" do
+          assert_select "select[name='application[new_permission_id]']"
+        end
+
+        should "include a hidden field representing whether the user wants to add more permissions, defaulting to false" do
+          assert_select "input[type='hidden'][name='application[add_more]'][value='false']"
+        end
+
+        should "display checkboxes for the existing permissions" do
+          @old_permissions.each do |old_permission|
+            assert_select "input[type='checkbox'][checked='checked'][name='application[supported_permission_ids][]'][value='#{old_permission.id}']"
+          end
+
+          @new_permissions.each do |new_permission|
+            assert_select "input[type='checkbox'][name='application[supported_permission_ids][]'][value='#{new_permission.id}']", count: 0
+          end
+
+          assert_select "input[type='checkbox'][name='application[supported_permission_ids][]'][value='#{@application.signin_permission.id}']", count: 0
+        end
+      end
+    end
+
+    context "when a user cannot edit another's permissions" do
+      should "prevent unauthenticated users" do
+        application = create(:application)
+        user = create(:user)
+
+        get :edit, params: { user_id: user, application_id: application }
+
+        assert_redirected_to "/users/sign_in"
+      end
+
+      should "prevent unauthorised users" do
+        application = create(:application)
+        user = create(:user, with_signin_permissions_for: [application])
+
+        current_user = create(:admin_user)
+        sign_in current_user
+
+        stub_policy(
+          current_user,
+          { application:, user: },
+          policy_class: Users::ApplicationPolicy,
+          edit_permissions?: false,
+        )
+        get :edit, params: { user_id: user, application_id: application }
+
+        assert_not_authorised
+      end
+
+      should "raise an exception if the user doesn't have access to the application" do
+        sign_in create(:admin_user)
+
+        application = create(:application)
+        user = create(:user)
+
+        assert_raises(ActiveRecord::RecordNotFound) do
+          get :edit, params: { user_id: user, application_id: application }
+        end
+      end
+
+      should "raise an exception if the application is retired" do
+        sign_in create(:admin_user)
+
+        application = create(:application, retired: true)
+        user = create(:user, with_signin_permissions_for: [application])
+
+        assert_raises(ActiveRecord::RecordNotFound) do
+          get :edit, params: { user_id: user, application_id: application }
+        end
+      end
+
+      should "raise an exception if the application is API-only" do
+        sign_in create(:admin_user)
+
+        application = create(:application, api_only: true)
+        user = create(:user, with_signin_permissions_for: [application])
+
+        assert_raises(ActiveRecord::RecordNotFound) do
+          get :edit, params: { user_id: user, application_id: application }
+        end
+      end
+
+      should "redirect to the applications path if there are no non-signin applications" do
+        application = create(:application)
+        user = create(:user, with_signin_permissions_for: [application])
+
+        current_user = create(:admin_user)
         sign_in current_user
 
         stub_policy(
@@ -254,21 +285,77 @@ class Users::PermissionsControllerTest < ActionController::TestCase
         assert_equal "No permissions found for #{application.name} that you are authorised to manage.", flash[:alert]
       end
 
-      should "exclude non-delegatable permissions" do
+      context "when the current user is a publishing manager" do
+        should "redirect to the applications path if there are no delegatable non-signin applications" do
+          application = create(:application, with_non_delegatable_supported_permissions: %w[permission])
+          user = create(:user, with_signin_permissions_for: [application])
+
+          current_user = create(:user)
+          current_user.stubs(:publishing_manager?).returns(true)
+          sign_in current_user
+
+          stub_policy(
+            current_user,
+            { application:, user: },
+            policy_class: Users::ApplicationPolicy,
+            edit_permissions?: true,
+          )
+
+          get :edit, params: { user_id: user, application_id: application }
+
+          assert_redirected_to user_applications_path(user)
+          assert_equal "No permissions found for #{application.name} that you are authorised to manage.", flash[:alert]
+        end
+
+        should "exclude non-delegatable permissions" do
+          application = create(:application)
+          old_delegatable_permission = create(:delegatable_supported_permission, application:)
+          old_non_delegatable_permission = create(:non_delegatable_supported_permission, application:)
+          new_delegatable_permission = create(:delegatable_supported_permission, application:)
+          new_non_delegatable_permission = create(:non_delegatable_supported_permission, application:)
+
+          user = create(
+            :user,
+            with_signin_permissions_for: [application],
+            with_permissions: { application => [old_delegatable_permission.name, old_non_delegatable_permission.name] },
+          )
+
+          current_user = create(:user)
+          current_user.stubs(:publishing_manager?).returns(true)
+          sign_in current_user
+
+          stub_policy(
+            current_user,
+            { application:, user: },
+            policy_class: Users::ApplicationPolicy,
+            edit_permissions?: true,
+          )
+
+          get :edit, params: { user_id: user, application_id: application }
+
+          assert_select "input[type='checkbox'][checked='checked'][name='application[supported_permission_ids][]'][value='#{old_delegatable_permission.id}']"
+          assert_select "input[type='checkbox'][name='application[supported_permission_ids][]'][value='#{new_delegatable_permission.id}']"
+          assert_select "input[type='checkbox'][name='application[supported_permission_ids][]'][value='#{old_non_delegatable_permission.id}']", count: 0
+          assert_select "input[type='checkbox'][name='application[supported_permission_ids][]'][value='#{new_non_delegatable_permission.id}']", count: 0
+        end
+      end
+    end
+  end
+
+  context "#update" do
+    context "when a user can update another's permissions" do
+      should "update non-signin permissions, retaining the signin permission, then redirect to the applications path" do
         application = create(:application)
-        old_delegatable_permission = create(:delegatable_supported_permission, application:)
-        old_non_delegatable_permission = create(:non_delegatable_supported_permission, application:)
-        new_delegatable_permission = create(:delegatable_supported_permission, application:)
-        new_non_delegatable_permission = create(:non_delegatable_supported_permission, application:)
+        old_permission = create(:supported_permission, application:)
+        new_permission = create(:supported_permission, application:)
 
         user = create(
           :user,
           with_signin_permissions_for: [application],
-          with_permissions: { application => [old_delegatable_permission.name, old_non_delegatable_permission.name] },
+          with_permissions: { application => [old_permission.name] },
         )
 
-        current_user = create(:user)
-        current_user.stubs(:publishing_manager?).returns(true)
+        current_user = create(:admin_user)
         sign_in current_user
 
         stub_policy(
@@ -278,25 +365,21 @@ class Users::PermissionsControllerTest < ActionController::TestCase
           edit_permissions?: true,
         )
 
-        get :edit, params: { user_id: user, application_id: application }
+        patch :update, params: { user_id: user, application_id: application, application: { supported_permission_ids: [new_permission.id] } }
 
-        assert_select "input[type='checkbox'][checked='checked'][name='application[supported_permission_ids][]'][value='#{old_delegatable_permission.id}']"
-        assert_select "input[type='checkbox'][name='application[supported_permission_ids][]'][value='#{new_delegatable_permission.id}']"
-        assert_select "input[type='checkbox'][name='application[supported_permission_ids][]'][value='#{old_non_delegatable_permission.id}']", count: 0
-        assert_select "input[type='checkbox'][name='application[supported_permission_ids][]'][value='#{new_non_delegatable_permission.id}']", count: 0
+        assert_redirected_to user_applications_path(user)
+        assert_same_elements [new_permission, application.signin_permission], user.supported_permissions
       end
-    end
 
-    context "for apps with greater than eight supported permissions" do
-      setup do
-        @application = create(:application)
-        @old_permissions = create_list(:supported_permission, 2, application: @application)
-        @new_permissions = create_list(:supported_permission, 7, application: @application)
+      should "assign the application id to the application_id flash" do
+        application = create(:application)
+        old_permission = create(:supported_permission, application:)
+        new_permission = create(:supported_permission, application:)
 
         user = create(
           :user,
-          with_signin_permissions_for: [@application],
-          with_permissions: { @application => @old_permissions.map(&:name) },
+          with_signin_permissions_for: [application],
+          with_permissions: { application => [old_permission.name] },
         )
 
         current_user = create(:admin_user)
@@ -304,123 +387,141 @@ class Users::PermissionsControllerTest < ActionController::TestCase
 
         stub_policy(
           current_user,
-          { application: @application, user: },
+          { application:, user: },
           policy_class: Users::ApplicationPolicy,
           edit_permissions?: true,
         )
 
-        get :edit, params: { user_id: user, application_id: @application }
+        patch :update, params: { user_id: user, application_id: application, application: { supported_permission_ids: [new_permission.id] } }
+
+        assert_equal application.id, flash[:application_id]
       end
 
-      should "display a select component for grantable but non-existing permissions" do
-        assert_select "select[name='application[new_permission_id]']"
-      end
+      context "when current_permission_ids and new_permission_id are provided instead of supported_permission_ids" do
+        setup do
+          @application = create(:application)
+          @old_permissions = create_list(:supported_permission, 2, application: @application)
+          @new_permission = create(:supported_permission, application: @application)
 
-      should "include a hidden field representing whether the user wants to add more permissions, defaulting to false" do
-        assert_select "input[type='hidden'][name='application[add_more]'][value='false']"
-      end
+          @user = create(
+            :user,
+            with_signin_permissions_for: [@application],
+            with_permissions: { @application => @old_permissions.map(&:name) },
+          )
 
-      should "display checkboxes for the existing permissions" do
-        @old_permissions.each do |old_permission|
-          assert_select "input[type='checkbox'][checked='checked'][name='application[supported_permission_ids][]'][value='#{old_permission.id}']"
+          @current_user = create(:admin_user)
+          sign_in @current_user
+
+          stub_policy(
+            @current_user,
+            { application: @application, user: @user },
+            policy_class: Users::ApplicationPolicy,
+            edit_permissions?: true,
+          )
         end
 
-        @new_permissions.each do |new_permission|
-          assert_select "input[type='checkbox'][name='application[supported_permission_ids][]'][value='#{new_permission.id}']", count: 0
+        should "use the relevant params to update permissions" do
+          patch(
+            :update,
+            params: {
+              user_id: @user,
+              application_id: @application,
+              application: {
+                current_permission_ids: @old_permissions.map(&:id),
+                new_permission_id: @new_permission.id,
+              },
+            },
+          )
+
+          assert_redirected_to user_applications_path(@user)
+
+          assert_same_elements [*@old_permissions, @new_permission, @application.signin_permission], @user.supported_permissions
         end
 
-        assert_select "input[type='checkbox'][name='application[supported_permission_ids][]'][value='#{@application.signin_permission.id}']", count: 0
+        context "when the add_more param is 'true'" do
+          should "update permissions then redirect back to the edit page" do
+            patch(
+              :update,
+              params: {
+                user_id: @user,
+                application_id: @application,
+                application: {
+                  current_permission_ids: @old_permissions.map(&:id),
+                  new_permission_id: @new_permission.id,
+                  add_more: "true",
+                },
+              },
+            )
+
+            assert_redirected_to edit_user_application_permissions_path(@user, @application)
+
+            assert_same_elements [*@old_permissions, @new_permission, @application.signin_permission], @user.supported_permissions
+          end
+        end
       end
     end
-  end
 
-  context "#update" do
-    should "prevent unauthenticated users" do
-      application = create(:application)
-      user = create(:user)
+    context "when a user cannot update another's permissions" do
+      should "prevent unauthenticated users" do
+        application = create(:application)
+        user = create(:user)
 
-      patch :update, params: { user_id: user, application_id: application }
+        patch :update, params: { user_id: user, application_id: application }
 
-      assert_redirected_to "/users/sign_in"
-    end
+        assert_redirected_to "/users/sign_in"
+      end
 
-    should "prevent unauthorised users" do
-      application = create(:application)
-      user = create(:user, with_signin_permissions_for: [application])
+      should "prevent unauthorised users" do
+        application = create(:application)
+        user = create(:user, with_signin_permissions_for: [application])
 
-      current_user = create(:admin_user)
-      sign_in current_user
+        current_user = create(:admin_user)
+        sign_in current_user
 
-      stub_policy(
-        current_user,
-        { application:, user: },
-        policy_class: Users::ApplicationPolicy,
-        edit_permissions?: false,
-      )
+        stub_policy(
+          current_user,
+          { application:, user: },
+          policy_class: Users::ApplicationPolicy,
+          edit_permissions?: false,
+        )
 
-      patch :update, params: { user_id: user, application_id: application, application: { supported_permission_ids: [] } }
-
-      assert_not_authorised
-    end
-
-    should "raise an exception if the user doesn't have access to the application" do
-      sign_in create(:admin_user)
-
-      application = create(:application)
-      user = create(:user)
-
-      assert_raises(ActiveRecord::RecordNotFound) do
         patch :update, params: { user_id: user, application_id: application, application: { supported_permission_ids: [] } }
+
+        assert_not_authorised
       end
-    end
 
-    should "raise an exception if the application is retired" do
-      sign_in create(:admin_user)
+      should "raise an exception if the user doesn't have access to the application" do
+        sign_in create(:admin_user)
 
-      application = create(:application, retired: true)
-      user = create(:user, with_signin_permissions_for: [application])
+        application = create(:application)
+        user = create(:user)
 
-      assert_raises(ActiveRecord::RecordNotFound) do
-        patch :update, params: { user_id: user, application_id: application, application: { supported_permission_ids: [] } }
+        assert_raises(ActiveRecord::RecordNotFound) do
+          patch :update, params: { user_id: user, application_id: application, application: { supported_permission_ids: [] } }
+        end
       end
-    end
 
-    should "raise an exception if the application is API-only" do
-      sign_in create(:admin_user)
+      should "raise an exception if the application is retired" do
+        sign_in create(:admin_user)
 
-      application = create(:application, api_only: true)
-      user = create(:user, with_signin_permissions_for: [application])
+        application = create(:application, retired: true)
+        user = create(:user, with_signin_permissions_for: [application])
 
-      assert_raises(ActiveRecord::RecordNotFound) do
-        patch :update, params: { user_id: user, application_id: application, application: { supported_permission_ids: [] } }
+        assert_raises(ActiveRecord::RecordNotFound) do
+          patch :update, params: { user_id: user, application_id: application, application: { supported_permission_ids: [] } }
+        end
       end
-    end
 
-    should "update non-signin permissions, retaining the signin permission, then redirect to the applications path" do
-      application = create(:application)
-      old_permission = create(:supported_permission, application:)
-      new_permission = create(:supported_permission, application:)
+      should "raise an exception if the application is API-only" do
+        sign_in create(:admin_user)
 
-      user = create(
-        :user,
-        with_signin_permissions_for: [application],
-        with_permissions: { application => [old_permission.name] },
-      )
+        application = create(:application, api_only: true)
+        user = create(:user, with_signin_permissions_for: [application])
 
-      current_user = create(:admin_user)
-      sign_in current_user
-
-      stub_policy(
-        current_user,
-        { application:, user: },
-        policy_class: Users::ApplicationPolicy,
-        edit_permissions?: true,
-      )
-
-      patch :update, params: { user_id: user, application_id: application, application: { supported_permission_ids: [new_permission.id] } }
-
-      assert_redirected_to user_applications_path(user)
-      assert_same_elements [new_permission, application.signin_permission], user.supported_permissions
+        assert_raises(ActiveRecord::RecordNotFound) do
+          patch :update, params: { user_id: user, application_id: application, application: { supported_permission_ids: [] } }
+        end
+      end
     end
 
     should "when updating permissions for app A, prevent additionally adding or removing permissions for app B" do
@@ -505,32 +606,6 @@ class Users::PermissionsControllerTest < ActionController::TestCase
       ], user.supported_permissions
     end
 
-    should "assign the application id to the application_id flash" do
-      application = create(:application)
-      old_permission = create(:supported_permission, application:)
-      new_permission = create(:supported_permission, application:)
-
-      user = create(
-        :user,
-        with_signin_permissions_for: [application],
-        with_permissions: { application => [old_permission.name] },
-      )
-
-      current_user = create(:admin_user)
-      sign_in current_user
-
-      stub_policy(
-        current_user,
-        { application:, user: },
-        policy_class: Users::ApplicationPolicy,
-        edit_permissions?: true,
-      )
-
-      patch :update, params: { user_id: user, application_id: application, application: { supported_permission_ids: [new_permission.id] } }
-
-      assert_equal application.id, flash[:application_id]
-    end
-
     context "when the current user is a publishing manager with access to the app" do
       should "prevent adding or removing non-delegatable permissions" do
         application = create(:application)
@@ -572,69 +647,6 @@ class Users::PermissionsControllerTest < ActionController::TestCase
           new_delegatable_permission,
           application.signin_permission,
         ], user.supported_permissions
-      end
-    end
-
-    context "when current_permission_ids and new_permission_id are provided instead of supported_permission_ids" do
-      setup do
-        @application = create(:application)
-        @old_permissions = create_list(:supported_permission, 2, application: @application)
-        @new_permission = create(:supported_permission, application: @application)
-
-        @user = create(
-          :user,
-          with_signin_permissions_for: [@application],
-          with_permissions: { @application => @old_permissions.map(&:name) },
-        )
-
-        @current_user = create(:admin_user)
-        sign_in @current_user
-
-        stub_policy(
-          @current_user,
-          { application: @application, user: @user },
-          policy_class: Users::ApplicationPolicy,
-          edit_permissions?: true,
-        )
-      end
-
-      should "use the relevant params to update permissions" do
-        patch(
-          :update,
-          params: {
-            user_id: @user,
-            application_id: @application,
-            application: {
-              current_permission_ids: @old_permissions.map(&:id),
-              new_permission_id: @new_permission.id,
-            },
-          },
-        )
-
-        assert_redirected_to user_applications_path(@user)
-
-        assert_same_elements [*@old_permissions, @new_permission, @application.signin_permission], @user.supported_permissions
-      end
-
-      context "when the add_more param is 'true'" do
-        should "update permissions then redirect back to the edit page" do
-          patch(
-            :update,
-            params: {
-              user_id: @user,
-              application_id: @application,
-              application: {
-                current_permission_ids: @old_permissions.map(&:id),
-                new_permission_id: @new_permission.id,
-                add_more: "true",
-              },
-            },
-          )
-
-          assert_redirected_to edit_user_application_permissions_path(@user, @application)
-
-          assert_same_elements [*@old_permissions, @new_permission, @application.signin_permission], @user.supported_permissions
-        end
       end
     end
   end

--- a/test/controllers/users/permissions_controller_test.rb
+++ b/test/controllers/users/permissions_controller_test.rb
@@ -108,7 +108,7 @@ class Users::PermissionsControllerTest < ActionController::TestCase
 
   context "#edit" do
     context "when a user can edit another's permissions" do
-      should "display checkboxes for the grantable permissions" do
+      should "render a page with checkboxes for the grantable permissions and a hidden field for the signin permission so that it is not removed" do
         application = create(:application)
         old_grantable_permission = create(:supported_permission, application:)
         new_grantable_permission = create(:supported_permission, application:)
@@ -136,24 +136,6 @@ class Users::PermissionsControllerTest < ActionController::TestCase
         assert_select "input[type='checkbox'][name='application[supported_permission_ids][]'][value='#{new_grantable_permission.id}']"
         assert_select "input[type='checkbox'][name='application[supported_permission_ids][]'][value='#{new_non_grantable_permission.id}']", count: 0
         assert_select "input[type='checkbox'][name='application[supported_permission_ids][]'][value='#{application.signin_permission.id}']", count: 0
-      end
-
-      should "include a hidden field for the signin permission so that it is not removed" do
-        application = create(:application, with_non_delegatable_supported_permissions: %w[permission])
-        user = create(:user, with_signin_permissions_for: [application])
-
-        current_user = create(:admin_user)
-        sign_in current_user
-
-        stub_policy(
-          current_user,
-          { application:, user: },
-          policy_class: Users::ApplicationPolicy,
-          edit_permissions?: true,
-        )
-
-        get :edit, params: { user_id: user, application_id: application }
-
         assert_select "input[type='hidden'][value='#{application.signin_permission.id}']"
       end
 


### PR DESCRIPTION
## Changes in this PR

Makes Account and User Permissions Controller tests in line with the recently-refactored API User Permissions tests in #3121 by:

- Removing unecessary reloading of users
- Grouping similar tests in contexts
- Combining "happy path" rendering tests.

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
