### PR TITLE
Fix Rake task for getting non-GDS permissions

### DIFF
--- a/lib/tasks/permissions.rake
+++ b/lib/tasks/permissions.rake
@@ -86,7 +86,7 @@ namespace :permissions do
         user.application_permissions.find_each do |user_application_permission|
           permission_name = user_application_permission.supported_permission.name
           event_log = event_logs.find do |log|
-            return false unless log[:application_id] == user_application_permission.application_id
+            next unless log[:application_id] == user_application_permission.application_id
 
             log[:permission_names].include?(permission_name)
           end


### PR DESCRIPTION
I accidentally used a return instead of a `next` to go to the next iteration in a `find`

---

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
