### PR TITLE
Fix high severity security alert

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "stylelint-config-gds": "^1.1.1"
   },
   "resolutions": {
+    "express": "^4.20.0",
     "selenium-webdriver": "4.17.0",
     "stylelint/strip-ansi": "6.0.1",
     "stylelint/string-width": "4.2.3"


### PR DESCRIPTION
Should fix https://github.com/alphagov/signon/security/dependabot/85

We have a high severity security alert on Signon. jasmine-browser-runner 2.5.0 depends on express 4.19.2 which depends on path-to-regexp 0.1.7. express 4.20.0 fixes the issue, so this tells Yarn to use that version or above

Technically it looks like jasmine-browser-runner should already allow patch and minor bumps in its dependencies (using `^`), but Dependabot couldn't upgrade express/path-to-regexp

jasmine-browser runner isn't updated particularly regularly - usually every few months, and patch versions are rare - so it's plausible that they won't release a patch for this any time soon

While this is only a dev dependency - and therefore shouldn't be particularly high risk to ignore - the upgrade will at least resolve the alert, reducing the noise to signal ratio in our dependapanda alerts

We should remove this resolution after upgrading to a future version of jasmine-browser-runner that upgrades its express dependency

---

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
