### PR TITLE
Fix Sass mixed declarations deprecations

### DIFF
--- a/app/assets/stylesheets/_user_research_recruitment_banner.scss
+++ b/app/assets/stylesheets/_user_research_recruitment_banner.scss
@@ -17,6 +17,6 @@
 }
 
 .user-research-recruitment-banner__buttons {
-  @include govuk-responsive-padding(6, "bottom");
   align-items: center;
+  @include govuk-responsive-padding(6, "bottom");
 }

--- a/app/assets/stylesheets/components/_accessible-autocomplete.scss
+++ b/app/assets/stylesheets/components/_accessible-autocomplete.scss
@@ -1,15 +1,15 @@
 @import "accessible-autocomplete/dist/accessible-autocomplete.min";
 
 .autocomplete__wrapper * {
+  // The styles for the dropdown arrow set the z-index to -1, which place it
+  // behind the autocomplete. Setting the `z-index` on the wrapper seems to fix
+  // this. See: https://github.com/alphagov/accessible-autocomplete/issues/351#issuecomment-582935867
+  z-index: 0;
   // This ensures the font family of all children is '"GDS Transport", arial,
   // sans-serif'. Without this (and the universal selector above), the font of
   // the input and options will be nonstandard. For me, Arial and Times
   // respectively. See: https://github.com/alphagov/accessible-autocomplete/issues/285
   @include govuk-typography-common;
-  // The styles for the dropdown arrow set the z-index to -1, which place it
-  // behind the autocomplete. Setting the `z-index` on the wrapper seems to fix
-  // this. See: https://github.com/alphagov/accessible-autocomplete/issues/351#issuecomment-582935867
-  z-index: 0;
 }
 
 .autocomplete__input--focused + .autocomplete__dropdown-arrow-down {

--- a/app/assets/stylesheets/components/_contact-details.scss
+++ b/app/assets/stylesheets/components/_contact-details.scss
@@ -1,13 +1,12 @@
 .app-c-contact-details {
+  padding-left: govuk-spacing(3);
+  clear: both;
+  border-left: 1px solid $govuk-border-colour;
+
   @include govuk-font($size: 19);
   @include govuk-text-colour;
-  padding-left: govuk-spacing(3);
   // Margin top intended to collapse
   // This adds an additional 10px to the paragraph above
   @include govuk-responsive-margin(6, "top");
   @include govuk-responsive-margin(6, "bottom");
-
-  clear: both;
-
-  border-left: 1px solid $govuk-border-colour;
 }

--- a/app/assets/stylesheets/components/_table.scss
+++ b/app/assets/stylesheets/components/_table.scss
@@ -36,11 +36,11 @@ $table-row-even-background-colour: govuk-colour("light-grey");
     }
 
     .app-table__sort-link {
-      @include govuk-link-style-no-visited-state;
       position: relative;
       padding-right: $sort-link-arrow-size;
       color: $govuk-link-colour;
       text-decoration: none;
+      @include govuk-link-style-no-visited-state;
     }
 
     .app-table__sort-link:focus {


### PR DESCRIPTION
Sass is changing the way it works with "declarations mixed with nested rules". We see the following deprecation warning when running `rails assets:precompile` or in the server logs when loading a page that uses affected Sass rules

```
Deprecation Warning: Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.

More info: https://sass-lang.com/d/mixed-decls
```

The main thing we need to do is move a bunch of `@include`s below other declarations within rules, similar to what was done in govuk_publishing_components here: https://github.com/alphagov/govuk_publishing_components/commit/e65096e49785d37ed097a3247f110ef4c3173ae1

I've visually compared the site before and after updating and recompiling the stylesheets and hard refreshing the page, checking that components/elements using the affected rules look the same, and have included screenshots below

## Screenshots (no changes expected)

### User research recruitment banner

#### Before

<img width="807" alt="Screenshot 2024-09-11 at 15 22 19" src="https://github.com/user-attachments/assets/67c55ed6-262a-4105-a67d-2cf42668d0b9">

#### After

<img width="804" alt="Screenshot 2024-09-11 at 15 21 25" src="https://github.com/user-attachments/assets/1de929c1-11fd-4068-82f6-8f93b24e9331">

### Accessible autocomplete

#### Before

<img width="780" alt="Screenshot 2024-09-11 at 15 25 03" src="https://github.com/user-attachments/assets/f590250c-d71a-48f7-a72e-1ecc4db5f973">

<img width="761" alt="Screenshot 2024-09-11 at 15 26 15" src="https://github.com/user-attachments/assets/4b9cec7c-89e2-4173-a655-3260d7074367">

#### After

<img width="756" alt="Screenshot 2024-09-11 at 15 24 42" src="https://github.com/user-attachments/assets/b41f1e34-eff3-4b41-9763-45dbcbb6eac3">

<img width="770" alt="Screenshot 2024-09-11 at 15 25 15" src="https://github.com/user-attachments/assets/997c85ad-076b-4ba6-bada-818130b05503">

### Contact details

#### Before
<img width="660" alt="Screenshot 2024-09-11 at 15 29 48" src="https://github.com/user-attachments/assets/16984a92-e3c0-4257-89d6-c013462ba401">

#### After

<img width="658" alt="Screenshot 2024-09-11 at 15 32 30" src="https://github.com/user-attachments/assets/1c90084a-89be-4960-b6e4-3fe2e8f01f18">

### Table

This only affects the sort element, and we don't appear have any sortable tables in Signon

#### Before

<img width="1197" alt="Screenshot 2024-09-11 at 15 38 59" src="https://github.com/user-attachments/assets/73d82b3a-4578-4cb5-9f15-a5681c86c772">

#### After

<img width="1186" alt="Screenshot 2024-09-11 at 15 41 18" src="https://github.com/user-attachments/assets/6a5c35fa-148e-4405-b8be-80388f90e433">

---

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
