### PR TITLE
Display success banner when adding or removing access to an application

### DIFF
--- a/app/controllers/account/signin_permissions_controller.rb
+++ b/app/controllers/account/signin_permissions_controller.rb
@@ -20,8 +20,11 @@ class Account::SigninPermissionsController < ApplicationController
     authorize [:account, application], :remove_signin_permission?
 
     params = { supported_permission_ids: current_user.supported_permissions.map(&:id) - [application.signin_permission.id] }
+
     UserUpdate.new(current_user, params, current_user, user_ip_address).call
 
+    flash[:application_id] = application.id
+    flash[:removing_access] = true
     redirect_to account_applications_path
   end
 

--- a/app/controllers/account/signin_permissions_controller.rb
+++ b/app/controllers/account/signin_permissions_controller.rb
@@ -7,6 +7,8 @@ class Account::SigninPermissionsController < ApplicationController
     params = { supported_permission_ids: current_user.supported_permissions.map(&:id) + [application.signin_permission.id] }
     UserUpdate.new(current_user, params, current_user, user_ip_address).call
 
+    flash[:application_id] = application.id
+    flash[:granting_access] = true
     redirect_to account_applications_path
   end
 

--- a/app/controllers/users/signin_permissions_controller.rb
+++ b/app/controllers/users/signin_permissions_controller.rb
@@ -10,6 +10,8 @@ class Users::SigninPermissionsController < ApplicationController
     params = { supported_permission_ids: @user.supported_permissions.map(&:id) + [application.signin_permission.id] }
     UserUpdate.new(@user, params, current_user, user_ip_address).call
 
+    flash[:application_id] = application.id
+    flash[:granting_access] = true
     redirect_to user_applications_path(@user)
   end
 

--- a/app/controllers/users/signin_permissions_controller.rb
+++ b/app/controllers/users/signin_permissions_controller.rb
@@ -25,6 +25,9 @@ class Users::SigninPermissionsController < ApplicationController
     params = { supported_permission_ids: @user.supported_permissions.map(&:id) - [@application.signin_permission.id] }
     UserUpdate.new(@user, params, current_user, user_ip_address).call
 
+    flash[:application_id] = @application.id
+    flash[:removing_access] = true
+
     redirect_to user_applications_path(@user)
   end
 

--- a/app/helpers/application_access_helper.rb
+++ b/app/helpers/application_access_helper.rb
@@ -1,0 +1,10 @@
+module ApplicationAccessHelper
+  def access_granted_message(application_id, user = current_user)
+    application = Doorkeeper::Application.find_by(id: application_id)
+    return nil unless application
+
+    return "You have been granted access to #{application.name}." if user == current_user
+
+    "#{user.name} has been granted access to #{application.name}."
+  end
+end

--- a/app/helpers/application_access_helper.rb
+++ b/app/helpers/application_access_helper.rb
@@ -7,4 +7,13 @@ module ApplicationAccessHelper
 
     "#{user.name} has been granted access to #{application.name}."
   end
+
+  def access_removed_message(application_id, user = current_user)
+    application = Doorkeeper::Application.find_by(id: application_id)
+    return nil unless application
+
+    return "Your access to #{application.name} has been removed." if user == current_user
+
+    "#{user.name}'s access to #{application.name} has been removed."
+  end
 end

--- a/app/helpers/success_alert_helper.rb
+++ b/app/helpers/success_alert_helper.rb
@@ -1,0 +1,15 @@
+module SuccessAlertHelper
+  def access_and_permissions_granted_params(application_id, granting_access:, user: current_user)
+    if granting_access
+      {
+        message: "Access granted",
+        description: access_granted_message(application_id, user),
+      }
+    else
+      {
+        message: "Permissions updated",
+        description: message_for_success(application_id, user),
+      }
+    end
+  end
+end

--- a/app/helpers/success_alert_helper.rb
+++ b/app/helpers/success_alert_helper.rb
@@ -12,4 +12,11 @@ module SuccessAlertHelper
       }
     end
   end
+
+  def access_removed_params(application_id, user: current_user)
+    {
+      message: "Access removed",
+      description: access_removed_message(application_id, user),
+    }
+  end
 end

--- a/app/views/account/applications/index.html.erb
+++ b/app/views/account/applications/index.html.erb
@@ -17,10 +17,14 @@
 %>
 
 <% if flash[:application_id] %>
+  <% alert_params = if flash[:removing_access]
+                      access_removed_params(flash[:application_id])
+                    else
+                      access_and_permissions_granted_params(flash[:application_id], granting_access: flash[:granting_access])
+                    end
+  %>
   <% content_for(:custom_alerts) do %>
-    <%= render "govuk_publishing_components/components/success_alert",
-      access_and_permissions_granted_params(flash[:application_id], granting_access: flash[:granting_access])
-    %>
+    <%= render "govuk_publishing_components/components/success_alert", alert_params %>
   <% end %>
 <% end %>
 

--- a/app/views/account/applications/index.html.erb
+++ b/app/views/account/applications/index.html.erb
@@ -18,10 +18,9 @@
 
 <% if flash[:application_id] %>
   <% content_for(:custom_alerts) do %>
-    <%= render "govuk_publishing_components/components/success_alert", {
-        message: "Permissions updated",
-        description: message_for_success(flash[:application_id]),
-    } %>
+    <%= render "govuk_publishing_components/components/success_alert",
+      access_and_permissions_granted_params(flash[:application_id], granting_access: flash[:granting_access])
+    %>
   <% end %>
 <% end %>
 

--- a/app/views/users/applications/index.html.erb
+++ b/app/views/users/applications/index.html.erb
@@ -23,11 +23,9 @@
 
 <% if flash[:application_id] %>
   <% content_for(:custom_alerts) do %>
-    <%= render "govuk_publishing_components/components/success_alert", {
-        message: "Permissions updated",
-        description: message_for_success(flash[:application_id], @user),
-    } %>
-  <% end %>
+    <%= render "govuk_publishing_components/components/success_alert",
+      access_and_permissions_granted_params(flash[:application_id], granting_access: flash[:granting_access], user: @user)
+    %>  <% end %>
 <% end %>
 
 <%= render "components/table", {

--- a/app/views/users/applications/index.html.erb
+++ b/app/views/users/applications/index.html.erb
@@ -22,10 +22,15 @@
 %>
 
 <% if flash[:application_id] %>
+  <% alert_params = if flash[:removing_access]
+                      access_removed_params(flash[:application_id], user: @user)
+                    else
+                      access_and_permissions_granted_params(flash[:application_id], granting_access: flash[:granting_access], user: @user)
+                    end
+  %>
   <% content_for(:custom_alerts) do %>
-    <%= render "govuk_publishing_components/components/success_alert",
-      access_and_permissions_granted_params(flash[:application_id], granting_access: flash[:granting_access], user: @user)
-    %>  <% end %>
+    <%= render "govuk_publishing_components/components/success_alert", alert_params %>
+  <% end %>
 <% end %>
 
 <%= render "components/table", {

--- a/test/helpers/application_access_helper_test.rb
+++ b/test/helpers/application_access_helper_test.rb
@@ -26,4 +26,25 @@ class ApplicationAccessHelperTest < ActionView::TestCase
       end
     end
   end
+
+  context "#access_removed_message" do
+    context "when the user is removing their own access" do
+      should "return a message informing them that they have access to an application" do
+        assert_equal "Your access to Whitehall has been removed.", access_removed_message(@application)
+      end
+    end
+
+    context "when the user is removing another's access" do
+      should "return a message informing them that the other user have access to an application" do
+        user = create(:user, name: "Gerald")
+        assert_equal "Gerald's access to Whitehall has been removed.", access_removed_message(@application, user)
+      end
+    end
+
+    context "when the application does not exist" do
+      should "return nil" do
+        assert_nil access_removed_message(:made_up_id)
+      end
+    end
+  end
 end

--- a/test/helpers/application_access_helper_test.rb
+++ b/test/helpers/application_access_helper_test.rb
@@ -1,0 +1,29 @@
+require "test_helper"
+
+class ApplicationAccessHelperTest < ActionView::TestCase
+  setup do
+    @application = create(:application, name: "Whitehall")
+    stubs(:current_user).returns(create(:user))
+  end
+
+  context "#access_granted_message" do
+    context "when the user is granting themself access" do
+      should "return a message informing them that they have access to an application" do
+        assert_equal "You have been granted access to Whitehall.", access_granted_message(@application)
+      end
+    end
+
+    context "when the user is granting another access" do
+      should "return a message informing them that the other user have access to an application" do
+        user = create(:user, name: "Gerald")
+        assert_equal "Gerald has been granted access to Whitehall.", access_granted_message(@application, user)
+      end
+    end
+
+    context "when the application does not exist" do
+      should "return nil" do
+        assert_nil access_granted_message(:made_up_id)
+      end
+    end
+  end
+end

--- a/test/helpers/success_alert_helper_test.rb
+++ b/test/helpers/success_alert_helper_test.rb
@@ -25,4 +25,20 @@ class SuccessAlertHelperTest < ActionView::TestCase
       end
     end
   end
+
+  context "#access_removed_params" do
+    setup do
+      @application = create(:application)
+      stubs(:current_user).returns(create(:user))
+    end
+
+    context "when removing access" do
+      should "return success alert params with the `access_removed_message` text" do
+        stubs(:access_removed_message).returns("You've got no access")
+
+        expected = { message: "Access removed", description: "You've got no access" }
+        assert_equal expected, access_removed_params(@application.id)
+      end
+    end
+  end
 end

--- a/test/helpers/success_alert_helper_test.rb
+++ b/test/helpers/success_alert_helper_test.rb
@@ -1,0 +1,28 @@
+require "test_helper"
+
+class SuccessAlertHelperTest < ActionView::TestCase
+  context "#access_and_permissions_granted_params" do
+    setup do
+      @application = create(:application)
+      stubs(:current_user).returns(create(:user))
+    end
+
+    context "when granting access" do
+      should "return success alert params with the `access_granted_message` text" do
+        stubs(:access_granted_message).returns("Granted access")
+
+        expected = { message: "Access granted", description: "Granted access" }
+        assert_equal expected, access_and_permissions_granted_params(@application.id, granting_access: true)
+      end
+    end
+
+    context "when updating permissions" do
+      should "return success alert params with the `message_for_success` text" do
+        stubs(:message_for_success).returns("Added permissions")
+
+        expected = { message: "Permissions updated", description: "Added permissions" }
+        assert_equal expected, access_and_permissions_granted_params(@application.id, granting_access: false)
+      end
+    end
+  end
+end

--- a/test/support/granting_access_helpers.rb
+++ b/test/support/granting_access_helpers.rb
@@ -29,6 +29,9 @@ private
 
     assert app_with_access_table.has_content?(application.name)
     assert grantee.has_access_to?(application)
+    success_banner_caption = grantee_is_self ? "You have been granted access to #{application.name}." : "#{grantee.name} has been granted access to #{application.name}."
+    assert_flash_content("Access granted")
+    assert_flash_content(success_banner_caption)
   end
 
   def refute_grant_access(application)

--- a/test/support/removing_access_helpers.rb
+++ b/test/support/removing_access_helpers.rb
@@ -30,6 +30,9 @@ private
 
     assert apps_without_access_table.has_content?(application.name)
     assert_not grantee.has_access_to?(application)
+    success_banner_caption = grantee_is_self ? "Your access to #{application.name} has been removed." : "#{grantee.name}'s access to #{application.name} has been removed."
+    assert_flash_content("Access removed")
+    assert_flash_content(success_banner_caption)
   end
 
   def refute_remove_access(application)


### PR DESCRIPTION
[Trello card](https://trello.com/c/TrHzYz6u/1352-add-a-success-banner-when-granting-or-removing-app-access)

## Changes in this PR

We previously displayed a success alert banner when one's own or another user's permissions were updated, but didn't show anything when granting access or removing it. We now display the same banner with different messaging when a user's access is granted or removed.

This was a little more involved than I'd expected due to the challenge in differentiating cleanly between a user having all their permissions removed and seeing one message (i.e. they just have the "Signin" permission) and a user being granted access to an app (i.e. also just having the "Signin" permission) and seeing another message in the banner. Because of this, I've had to make use of some additional flash variables and flags to method arguments.

The API Users journey didn't need updating here, as we already show flash messages when an API token is created or revoked, as well as when permissions are updated.

## Screenshots

### Granting own access

<img width="1269" alt="image" src="https://github.com/user-attachments/assets/ee784f38-a748-4a33-b3c4-b4aa3cd78e7b">


### Removing own access

![image](https://github.com/user-attachments/assets/75ad4000-6e23-4f6a-bd0b-d537f58afbf7)

### Granting another user access

![image](https://github.com/user-attachments/assets/0e988058-aa88-4249-9008-3f654313a364)


### Removing another user's access

![image](https://github.com/user-attachments/assets/ae6b085f-956c-4a99-b83c-4872a0bfd0f5)


This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
