### PR TITLE
Retain Content Tagger 'Tagathon participant'

### DIFF
--- a/lib/tasks/permissions.rake
+++ b/lib/tasks/permissions.rake
@@ -137,7 +137,6 @@ namespace :permissions do
       { application_name: "Content Data", name: "view_email_subs" },
       { application_name: "Content Data", name: "view_siteimprove" },
       { application_name: "Content Tagger", name: "GDS Editor" },
-      { application_name: "Content Tagger", name: "Tagathon participant" },
       { application_name: "Content Tagger", name: "Unreleased feature" },
       { application_name: "Manuals Publisher", name: "gds_editor" },
       { application_name: "Specialist publisher", name: "gds_editor" },

--- a/test/lib/tasks/permissions_test.rb
+++ b/test/lib/tasks/permissions_test.rb
@@ -129,7 +129,7 @@ class PermissionsTest < ActiveSupport::TestCase
       )
       @content_tagger = application_with_revoke_and_retain_list(
         name: "Content Tagger",
-        non_signin_permissions_to_revoke: ["GDS Editor", "Tagathon participant", "Unreleased feature"],
+        non_signin_permissions_to_revoke: ["GDS Editor", "Unreleased feature"],
         retain_non_signin_permission: true,
       )
       @manuals_publisher = application_with_revoke_and_retain_list(name: "Manuals Publisher", non_signin_permissions_to_revoke: %w[gds_editor])


### PR DESCRIPTION
[Trello](https://trello.com/c/aRHyvjGE/1401-update-rake-task-to-leave-content-tagger-tagathon-participant-permission)

We have a Rake task for removing permissions from non-GDS users, which will be run once to rectify permissions having been inappropriately granted before we tightened up the feature that allows delegation of granting permissions

We've decided not to remove the 'Tagathon participant' permission, so this updates the Rake task in preparation for running it

---

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
