### PR TITLE
Fix missing assertions warning

### DIFF
--- a/test/integration/applications/access_logs_test.rb
+++ b/test/integration/applications/access_logs_test.rb
@@ -29,8 +29,8 @@ class ApplicationsAccessLogsIntegrationTest < ActionDispatch::IntegrationTest
     context "when there are no matching events" do
       should "see a message stating that there is no activity logged" do
         visit access_logs_doorkeeper_application_path(@application)
-        assert_text "app-name access log"
-        assert_text "No activity logged"
+        assert assert_text "app-name access log"
+        assert assert_text "No activity logged"
       end
     end
 
@@ -43,9 +43,9 @@ class ApplicationsAccessLogsIntegrationTest < ActionDispatch::IntegrationTest
 
       should "see a list of events for the application" do
         visit access_logs_doorkeeper_application_path(@application)
-        assert_text "#{@application.name} access log"
-        assert_text "Successful user application authorization for #{@application.name} for #{@superadmin.name}"
-        assert_text "Successful user application authorization for #{@application.name} for #{@user.name}"
+        assert assert_text "#{@application.name} access log"
+        assert assert_text "Successful user application authorization for #{@application.name} for #{@superadmin.name}"
+        assert assert_text "Successful user application authorization for #{@application.name} for #{@user.name}"
       end
     end
   end

--- a/test/integration/applications/monthly_access_stats_test.rb
+++ b/test/integration/applications/monthly_access_stats_test.rb
@@ -29,8 +29,8 @@ class ApplicationsMonthlyAccessStatsIntegrationTest < ActionDispatch::Integratio
     context "when there are no matching events" do
       should "see a message stating that there is no activity logged" do
         visit monthly_access_stats_doorkeeper_application_path(@application)
-        assert_text "Monthly access counts to app-name"
-        assert_text "No activity logged"
+        assert assert_text "Monthly access counts to app-name"
+        assert assert_text "No activity logged"
       end
     end
 
@@ -46,14 +46,14 @@ class ApplicationsMonthlyAccessStatsIntegrationTest < ActionDispatch::Integratio
 
       should "see a list of events for the application" do
         visit monthly_access_stats_doorkeeper_application_path(@application)
-        assert_text "Monthly access counts to #{@application.name}"
+        assert assert_text "Monthly access counts to #{@application.name}"
 
-        assert_text "Month Total authorization count Unique users authorization count Access logs"
+        assert assert_text "Month Total authorization count Unique users authorization count Access logs"
         # Test data has two months - these should be sorted in descending order
         # 2020-02 has two events for two different users, so we should get 2 2
-        assert_text "2020-02 2 2 2020-02 access logs"
+        assert assert_text "2020-02 2 2 2020-02 access logs"
         # 2020-01 has three events for two different users, so we should get 3 2
-        assert_text "2020-01 3 2 2020-01 access logs"
+        assert assert_text "2020-01 3 2 2020-01 access logs"
       end
     end
   end

--- a/test/integration/sign_in_test.rb
+++ b/test/integration/sign_in_test.rb
@@ -276,7 +276,7 @@ class SignInTest < ActionDispatch::IntegrationTest
       signin_with(email: "email@example.com", password: "some password with various $ymb0l$", second_step: false)
       click_link "Sign out"
 
-      assert_text "Sign in to GOV.UK"
+      assert assert_text "Sign in to GOV.UK"
     end
 
     should "not be able to access restricted paths before completing 2SV" do
@@ -312,7 +312,7 @@ class SignInTest < ActionDispatch::IntegrationTest
 
   should "not display a link to resend unlock instructions" do
     visit root_path
-    assert_no_selector "a", text: "Didn't receive unlock instructions?"
+    assert assert_no_selector "a", text: "Didn't receive unlock instructions?"
   end
 
   should "not be able to access the 2SV login page before logging in" do

--- a/test/integration/two_step_verification_test.rb
+++ b/test/integration/two_step_verification_test.rb
@@ -60,7 +60,7 @@ class TwoStepVerificationTest < ActionDispatch::IntegrationTest
 
         click_link "Sign out"
 
-        signin_with(@user)
+        assert signin_with(@user)
       end
     end
 
@@ -162,7 +162,7 @@ class TwoStepVerificationTest < ActionDispatch::IntegrationTest
 
         click_link "Sign out"
 
-        signin_with(@user)
+        assert signin_with(@user)
       end
     end
   end

--- a/test/integration/users/account_access_logs_test.rb
+++ b/test/integration/users/account_access_logs_test.rb
@@ -24,7 +24,7 @@ class Users::AccountAccessLogsIntegrationTest < ActionDispatch::IntegrationTest
     visit edit_user_path(@user)
     click_on "View account access log"
 
-    assert_account_access_log_page_content(@user)
+    assert assert_account_access_log_page_content(@user)
   end
 
   test "superadmins have permission to view account access log" do
@@ -36,7 +36,7 @@ class Users::AccountAccessLogsIntegrationTest < ActionDispatch::IntegrationTest
     visit edit_user_path(@user)
     click_on "View account access log"
 
-    assert_account_access_log_page_content(@user)
+    assert assert_account_access_log_page_content(@user)
   end
 
   test "super organisation admins have permission to view access logs of users belonging to their organisation" do
@@ -49,7 +49,7 @@ class Users::AccountAccessLogsIntegrationTest < ActionDispatch::IntegrationTest
     visit edit_user_path(user)
     click_on "View account access log"
 
-    assert_account_access_log_page_content(user)
+    assert assert_account_access_log_page_content(user)
   end
 
   test "super organisation admins have permission to view access logs of users belonging to child organisations" do
@@ -63,7 +63,7 @@ class Users::AccountAccessLogsIntegrationTest < ActionDispatch::IntegrationTest
     visit edit_user_path(user)
     click_on "View account access log"
 
-    assert_account_access_log_page_content(user)
+    assert assert_account_access_log_page_content(user)
   end
 
   test "super organisation admins don't have permission to view access logs of users belonging to another organisation" do
@@ -86,7 +86,7 @@ class Users::AccountAccessLogsIntegrationTest < ActionDispatch::IntegrationTest
     visit edit_user_path(user)
     click_on "View account access log"
 
-    assert_account_access_log_page_content(user)
+    assert assert_account_access_log_page_content(user)
   end
 
   test "organisation admins don't have permission to view access logs of users belonging to another organisation" do
@@ -109,17 +109,17 @@ class Users::AccountAccessLogsIntegrationTest < ActionDispatch::IntegrationTest
 
     visit event_logs_user_path(@user)
 
-    assert_text "Successful login"
+    assert assert_text "Successful login"
 
     first("a[rel=next]").click
 
-    assert_text "Successful login"
+    assert assert_text "Successful login"
   end
 
   def assert_account_access_log_page_content(user)
-    assert_text "Time"
-    assert_text "Event"
-    assert_text "account locked"
+    assert assert_text "Time"
+    assert assert_text "Event"
+    assert assert_text "account locked"
     assert_selector "a", text: user.name
   end
 end

--- a/test/models/batch_invitation_test.rb
+++ b/test/models/batch_invitation_test.rb
@@ -23,7 +23,7 @@ class BatchInvitationTest < ActiveSupport::TestCase
   should "allow multiple supported permissions of the same to be added" do
     @bi.grant_permission(@app.signin_permission)
     @bi.grant_permission(@app.signin_permission)
-    @bi.save!
+    assert @bi.save!
   end
 
   context "#has_permissions?" do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -613,7 +613,7 @@ class UserTest < ActiveSupport::TestCase
         user.grant_permission(supported_permission)
         user.save!
 
-        user.has_permission?(supported_permission)
+        assert user.has_permission?(supported_permission)
       end
     end
   end

--- a/test/policies/batch_invitation_policy_test.rb
+++ b/test/policies/batch_invitation_policy_test.rb
@@ -19,7 +19,7 @@ class BatchInvitationPolicyTest < ActiveSupport::TestCase
     end
 
     should "forbid for normal users" do
-      forbid?(create(:user), BatchInvitation.new, :new)
+      assert forbid?(create(:user), BatchInvitation.new, :new)
     end
   end
 end

--- a/test/support/user_helpers.rb
+++ b/test/support/user_helpers.rb
@@ -19,6 +19,8 @@ module UserHelpers
         click_button "Sign in"
       end
     end
+
+    true
   end
 
   def signout


### PR DESCRIPTION
We were getting a lot of noise about tests missing assertions because of using custom assertion methods (or just relying on tests not raising errors rather than explicitly asserting anything). This adds `assert` in multiple places to fix this, and in one case adds a default return of `true` in a method we need to assert on

E.g.

```
Test is missing assertions: `test_: setting a 2SV code signed in with an existing 2SV setup should require the code again on next login. ` /govuk/signon/test/integration/two_step_verification_test.rb:57
```

---

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
