### PR TITLE
Fix delegated column rename migration

### DIFF
--- a/db/migrate/20241001140623_rename_supported_permission_delegatable_column.rb
+++ b/db/migrate/20241001140623_rename_supported_permission_delegatable_column.rb
@@ -1,5 +1,5 @@
 class RenameSupportedPermissionDelegatableColumn < ActiveRecord::Migration[7.2]
   def change
-    rename_column :supported_permissions, :delegated, :delegated
+    rename_column :supported_permissions, :delegatable, :delegated
   end
 end


### PR DESCRIPTION
[Trello](https://trello.com/c/XTbuNRCz/1385-revise-delegated-permissions-terminology-in-codebase)

Looks like a mistake creeped into #3205 and we missed it. The migration failed on Argo, so amending the existing migration should work since it's not yet been applied

---

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
