### PR TITLE
Update hosts for application

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -110,7 +110,7 @@ Rails.application.configure do
 
   # Enable DNS rebinding protection and other `Host` header attacks.
   config.hosts = [
-    /signon\..*gov.uk?/,
+    /signon\..*\.gov.uk$/,
   ]
 
   # Skip DNS rebinding protection for the default health check endpoint.


### PR DESCRIPTION
The previous regex permitted `app-name.dodgygov.uk`. Updating to disallow this and only permit `*.gov.uk`.

[Trello card](https://trello.com/c/frqFN7D8)