### PR TITLE
Document how API token integrates into eks

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -29,8 +29,12 @@ to access your it:
 * Fill-in a name and email for the API client
 * Once saved, click "Add application token", select "Stuff API" and press
   "Create access token"
-* You should see an access token on the screen, which you must copy as it
-  is the only time it'll be displayed on screen.
+* You should see an access token on the screen. This is the only time it'll be displayed on screen, so make a note of it if you need to.
+
+Once you've created your access token, you'll probably need to:
+
+1. [Synchronise the token with Kubernetes secrets](https://docs.publishing.service.gov.uk/manual/alerts/signon-api-user-token-expires-soon.html#2-update-the-token-in-the-secrets-used-by-the-consuming-application)
+2. Expose the token as an environment variable in govuk-helm-charts ([example](https://github.com/alphagov/govuk-helm-charts/pull/2742))
 
 ## Development.
 


### PR DESCRIPTION
These steps are currently missing from the documentation. I did consider adding them to https://docs.publishing.service.gov.uk/manual/alerts/signon-api-user-token-expires-soon.html itself, but that's more about rotating existing tokens, so this feels the more appropriate place.

Trello: https://trello.com/c/YdGWsy0I/3035-integrate-the-specialist-finder-edit-forms-with-support-api

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
