### PR TITLE
Update google analytics retention

### DIFF
--- a/app/views/root/privacy_notice.html.erb
+++ b/app/views/root/privacy_notice.html.erb
@@ -165,7 +165,7 @@
   visible_counters: true,
   items: [
     "delete access log data after 2 years",
-    "delete Google Analytics data after 26 months",
+    "delete Google Analytics data after 38 months",
   ]
 } %>
 
@@ -316,4 +316,4 @@
 
 <p class="govuk-body">If these changes affect how your personal data is processed, GDS will take reasonable steps to let you know.</p>
 
-<p class="govuk-body-s">Last updated 23 August 2023</p>
+<p class="govuk-body-s">Last updated 8 November 2024</p>


### PR DESCRIPTION
The actual data retention period in GA4 is 38 months:

<img width="1356" alt="image" src="https://github.com/user-attachments/assets/0525d23c-88f0-4f51-b9c6-22498544d969">

Updating the privacy policy to match.

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
