### PR TITLE
Remove whenever gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,6 @@ gem "sentry-sidekiq"
 gem "sprockets-rails"
 gem "terser"
 gem "uuid"
-gem "whenever"
 
 # GDS Gems
 gem "gds-api-adapters"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,7 +110,6 @@ GEM
       capybara (>= 2.4, < 4.0)
       mail
     chartkick (5.1.2)
-    chronic (0.10.2)
     chunky_png (1.4.0)
     climate_control (1.2.0)
     coderay (1.1.3)
@@ -728,8 +727,6 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    whenever (1.0.0)
-      chronic (>= 0.6.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.7.1)
@@ -793,7 +790,6 @@ DEPENDENCIES
   timecop
   uuid
   webmock
-  whenever
 
 BUNDLED WITH
    2.4.10


### PR DESCRIPTION
This was [added][1] when scheduling a Rake task to run every day. The scheduling has since been [removed from the Signon code][2] and added to GOV.UK Helm Charts ([integration/staging][3], [production[4]), but this supporting gem was left in Signon

[1]: https://github.com/alphagov/signon/commit/9f453022ee1d88c29061c17b00d1afb23de22805
[2]: https://github.com/alphagov/signon/commit/663e4da4c0d58f33cf01606407fae905c395b35f
[3]: https://github.com/alphagov/govuk-helm-charts/commit/ee5ee799870895477e30ddb0fe4323caf61a4b20
[4]: https://github.com/alphagov/govuk-helm-charts/commit/c58c426199904d7ba1e4cdb4458fc13114cd5c2f

---

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
