### PR TITLE
Show parent organisation in table

### DIFF
--- a/app/views/organisations/_organisation_table.html.erb
+++ b/app/views/organisations/_organisation_table.html.erb
@@ -3,6 +3,7 @@
     <%= t.header "Name" %>
     <%= t.header "Organisation Type" %>
     <%= t.header "Slug" %>
+    <%= t.header "Parent Organisation" %>
     <%= t.header "2-step verification mandated?"%>
   <% end %>
 
@@ -12,6 +13,11 @@
         <%= t.cell "#{organisation.name_with_abbreviation(indicate_closed: false)}" %>
         <%= t.cell organisation.organisation_type %>
         <%= t.cell organisation.slug %>
+        <% if organisation.parent %>
+          <%= t.cell organisation.parent.name %>
+        <% else %>
+          <%= t.cell "No parent" %>
+        <% end %>
         <td class="govuk-table__cell">
           <%= organisation.require_2sv %>
           <% if policy(Organisation).edit? %>

--- a/test/controllers/organisations_controller_test.rb
+++ b/test/controllers/organisations_controller_test.rb
@@ -31,6 +31,26 @@ class OrganisationsControllerTest < ActionController::TestCase
       assert_select "#active tr:nth-child(2) td:first-child", text: /Department for Education/
       assert_select "#active tr:last-child td:first-child", text: /Government Digital Service/
     end
+
+    should "include parent organisation when one exists" do
+      parent = create(:organisation, name: "Cabinet Office")
+      create(:organisation, name: "Government Digital Service", parent:)
+
+      get :index
+
+      assert_select "#active tr:last-child td:first-child", text: /Government Digital Service/
+      assert_select "#active tr:last-child td:nth-child(4)", text: /Cabinet Office/
+    end
+
+    should "not include parent organisation when one does not exist" do
+      parent = create(:organisation, name: "Cabinet Office")
+      create(:organisation, name: "Government Digital Service", parent:)
+
+      get :index
+
+      assert_select "#active tr:first-child td:first-child", text: /Cabinet Office/
+      assert_select "#active tr:first-child td:nth-child(4)", text: /No parent/
+    end
   end
 
   context "PUT require 2sv" do


### PR DESCRIPTION
This adds a column to the organisations index table with the name of the parent organisation.

The information is available from a Rails console, but not in the UI, meaning it can be difficult to see the organisation hierarchy without developer input.

Screenshot:
![Screenshot of the Signon organisations index table.  There are five columns: name, type, slug, parent name and 2-step verification mandated.](https://github.com/user-attachments/assets/d4531cc2-f2cf-4494-8053-8b6c6975caa6)

[Trello card](https://trello.com/c/il3oWbfb)