### PR TITLE
Link to access and permissions public page

### DIFF
--- a/app/views/supported_permissions/index.html.erb
+++ b/app/views/supported_permissions/index.html.erb
@@ -42,6 +42,14 @@
         'signin' permission is delegated, publishing managers can grant or
         remove access to the given application.
       </p>
+      <p class="govuk-body">
+        You can read more about this in the
+        <a
+          class="govuk-link"
+          href="https://docs.publishing.service.gov.uk/repos/signon/access_and_permissions.html"
+          >access and permissions developer documentation</a
+        >.
+      </p>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
[Trello](https://trello.com/c/rcDUrNIT/1500-add-link-to-definition-of-publishing-manager-in-the-permissions-page-for-each-app-in-signon)

We had a question about the meaning of some of the content on this page, particularly the definition of a publishing manager. We wrote documentation about this in this repo's docs, which it turns out are automatically published on gov.uk in the dev docs. We're therefore linking to this resource for readers who want to know more

The existing paragraphs are largely - if not fully - duplicated from those docs, which doesn't create some extra maintenance burden vs having one source of truth, but it's probably useful to have at least a short explainer here without having to click through to a linked external (if still gov.uk) page

---

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
