### PR TITLE
Add an API endpoint to get author information

### DIFF
--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -1,0 +1,15 @@
+class Api::UsersController < ApplicationController
+  before_action :doorkeeper_authorize!, :check_signon_permissions
+  skip_after_action :verify_authorized
+
+  def index
+    users = User.where(uid: params[:uuids])
+    render json: Api::UserPresenter.present_many(users)
+  end
+
+private
+
+  def check_signon_permissions
+    head :unauthorized unless doorkeeper_token&.application&.signon?
+  end
+end

--- a/app/models/doorkeeper/application.rb
+++ b/app/models/doorkeeper/application.rb
@@ -76,6 +76,10 @@ class Doorkeeper::Application < ActiveRecord::Base # rubocop:disable Rails/Appli
     ].include?(name)
   end
 
+  def signon?
+    name == "Signon API"
+  end
+
   def redirect_uri
     substituted_uri(self[:redirect_uri])
   end

--- a/app/presenters/api/user_presenter.rb
+++ b/app/presenters/api/user_presenter.rb
@@ -1,0 +1,38 @@
+module Api
+  class UserPresenter
+    def self.present_many(users)
+      users.map { |user| present(user) }
+    end
+
+    def self.present(user)
+      new(user).present
+    end
+
+    def present
+      {
+        uid: @user.uid,
+        name: @user.name,
+        email: @user.email,
+        organisation: organisation,
+      }
+    end
+
+  private
+
+    def initialize(user)
+      @user = user
+    end
+
+    def organisation
+      organisation = @user.organisation
+
+      if organisation
+        {
+          content_id: organisation.content_id,
+          name: organisation.name,
+          slug: organisation.slug,
+        }
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -127,4 +127,6 @@ Rails.application.routes.draw do
   root to: "root#index"
 
   put "/user-research-recruitment/update" => "user_research_recruitment#update"
+
+  get "/api/users" => "api/users#index"
 end

--- a/test/controllers/api/users_controller_test.rb
+++ b/test/controllers/api/users_controller_test.rb
@@ -1,0 +1,97 @@
+require "test_helper"
+
+class Api::UsersControllerTest < ActionController::TestCase
+  setup do
+    @application = create(:application, name: "Signon API")
+  end
+
+  context "as admin user" do
+    setup do
+      @admin = create(:admin_user)
+      sign_in @admin
+    end
+
+    should "not be able to access the API endpoint" do
+      get :index
+
+      assert_equal "401", response.code
+    end
+  end
+
+  context "as a user with a valid token" do
+    setup do
+      @user = create(:user)
+      @user.grant_application_signin_permission(@application)
+      @token = create(:access_token, application: @application, resource_owner_id: @user.id)
+
+      @request.env["HTTP_AUTHORIZATION"] = "Bearer #{@token.token}"
+    end
+
+    should "return users with given UUIDs" do
+      user1 = create(:user, uid: SecureRandom.uuid)
+      _user2 = create(:user, uid: SecureRandom.uuid)
+      user3 = create(:user, uid: SecureRandom.uuid)
+
+      get :index, params: {
+        format: :json,
+        uuids: [user1.uid, user3.uid],
+      }
+
+      assert_equal "200", response.code
+
+      body = JSON.parse(response.body).map(&:deep_symbolize_keys)
+
+      assert_equal body.length, 2
+      assert_equal body[0], Api::UserPresenter.present(user1)
+      assert_equal body[1], Api::UserPresenter.present(user3)
+    end
+
+    should "return an empty array when no users are found" do
+      get :index, params: {
+        format: :json,
+        uuids: [SecureRandom.uuid],
+      }
+
+      assert_equal "200", response.code
+
+      body = JSON.parse(response.body).map(&:deep_symbolize_keys)
+
+      assert_equal body.length, 0
+    end
+  end
+
+  context "with an invalid token" do
+    setup do
+      @request.env["HTTP_AUTHORIZATION"] = "Bearer FAKE_BEARER_TOKEN"
+    end
+
+    should "not succeed" do
+      get :index, params: {
+        format: :json,
+        uuids: [SecureRandom.uuid],
+      }
+
+      assert_equal "401", response.code
+    end
+  end
+
+  context "with a valid bearer token for another application" do
+    setup do
+      other_application = create(:application)
+      @user = create(:user)
+      @user.grant_application_signin_permission(@application)
+      @token = create(:access_token, application: other_application, resource_owner_id: @user.id)
+
+      @request.env["HTTP_AUTHORIZATION"] = "Bearer #{@token.token}"
+    end
+
+    should "not succeed" do
+      get :index, params: {
+        format: :json,
+        uuids: [SecureRandom.uuid],
+      }
+
+      assert_equal "401", response.code
+    end
+  end
+end

--- a/test/models/doorkeeper/application_test.rb
+++ b/test/models/doorkeeper/application_test.rb
@@ -497,4 +497,18 @@ class Doorkeeper::ApplicationTest < ActiveSupport::TestCase
       assert_equal [application_named_bar, application_named_foo], applications
     end
   end
+
+  context "#signon?" do
+    should "return true if the name is correct" do
+      application = create(:application, name: "Signon API")
+
+      assert application.signon?
+    end
+
+    should "return false if the name is not correct" do
+      application = create(:application, name: "Something else")
+
+      assert_not application.signon?
+    end
+  end
 end

--- a/test/presenters/api/user_presenter_test.rb
+++ b/test/presenters/api/user_presenter_test.rb
@@ -1,0 +1,46 @@
+require "test_helper"
+
+class Api::UserPresenterTest < ActiveSupport::TestCase
+  context "#present" do
+    setup do
+      @user = build(:user, organisation: build(:organisation))
+    end
+
+    should "return a presented version of the user" do
+      presented_user = Api::UserPresenter.present(@user)
+
+      assert_equal presented_user, {
+        uid: @user.uid,
+        name: @user.name,
+        email: @user.email,
+        organisation: {
+          content_id: @user.organisation.content_id,
+          name: @user.organisation.name,
+          slug: @user.organisation.slug,
+        },
+      }
+    end
+
+    should "return nil for an organisation" do
+      @user.organisation = nil
+
+      presented_user = Api::UserPresenter.present(@user)
+
+      assert_equal presented_user, {
+        uid: @user.uid,
+        name: @user.name,
+        email: @user.email,
+        organisation: nil,
+      }
+    end
+  end
+
+  context "#present_many" do
+    should "present an array of users" do
+      users = build_list(:user, 4)
+      result = Api::UserPresenter.present_many(users)
+
+      assert_equal(result, users.map { |u| Api::UserPresenter.present(u) })
+    end
+  end
+end


### PR DESCRIPTION
Trello card: https://trello.com/c/jVvs4nAP/640-get-author-information-from-signon

In Content Modelling, we have a need to get user information from a central repository. We have an endpoint that returns information about documents that use a given content block, but we only have the UUID of the user who last updated it. To populate the information, we're currently relying on the fact that the Content Block Manager runs in Whitehall to fetch user information. However, if a user isn't present in Whitehall, we have to show the user as "Unknown".

This adds an API endpoint to signon that allows us to get information about users with given UUIDs. This is slightly unknown territory, as Signon is mainly a frontend application. 

To achieve this, we protect our controller with `:doorkeeper_authorize!`, which, on its own will give access to any users with a valid bearer token for ANY application. To add an extra layer of protection, once this is merged, we'll need to add an API key called `Signon API`. We can then check if the application associated with the user's token is the correct one.