### PR TITLE
(783) Configute Pact tests provider for Signon

### DIFF
--- a/.github/workflows/pact-verify.yml
+++ b/.github/workflows/pact-verify.yml
@@ -1,0 +1,83 @@
+# Pact verify workflow
+#
+# This workflow asserts that Pact contract tests are valid against this
+# codebase. It is trigged when changes are made to this project and it
+# is explicitly called by GDS API Adapters when changes are made there.
+
+name: Run Pact tests
+
+on:
+  workflow_call:
+    inputs:
+      # The commit / tag of this repo to test against
+      ref:
+        required: false
+        type: string
+        default: main
+      # A GitHub Action artifact which contains the pact definition files
+      # Publishing API calls this action to test new pacts against this
+      # workflow
+      pact_artifact:
+        required: false
+        type: string
+      # When using an artifact this is the file path to the pact that is verified
+      # against
+      pact_artifact_file_to_verify:
+        required: false
+        type: string
+        default: gds_api_adapters-signon_api.json
+      # Which version of the pacts to use from the Pact Broker service
+      # This option will be ignored if pact_artifact is set
+      pact_consumer_version:
+        required: false
+        type: string
+        default: branch-main
+
+jobs:
+  pact_verify:
+    name: Verify pact tests
+    runs-on: ubuntu-latest
+    env:
+      RAILS_ENV: test
+    steps:
+      - name: Setup MySQL
+        id: setup-mysql
+        uses: alphagov/govuk-infrastructure/.github/actions/setup-mysql@main
+
+      - name: Setup Redis
+        uses: alphagov/govuk-infrastructure/.github/actions/setup-redis@main
+
+      - uses: actions/checkout@v4
+        with:
+          repository: alphagov/signon
+          ref: ${{ inputs.ref }}
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - run: bundle exec rails db:setup
+        env:
+          TEST_DATABASE_URL: ${{ steps.setup-mysql.outputs.db-url }}
+
+      - if: inputs.pact_artifact == ''
+        run: bundle exec rake pact:verify
+        env:
+          RAILS_ENV: test
+          PACT_CONSUMER_VERSION: ${{ inputs.pact_consumer_version }}
+          TEST_DATABASE_URL: ${{ steps.setup-mysql.outputs.db-url }}
+
+      - if: inputs.pact_artifact != ''
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.pact_artifact }}
+          path: tmp/pacts
+
+      - if: inputs.pact_artifact != ''
+        run: ls -la tmp/pacts/
+
+      - if: inputs.pact_artifact != ''
+        run: bundle exec rake pact:verify:at[tmp/pacts/${{ inputs.pact_artifact_file_to_verify }}]
+        env:
+          RAILS_ENV: test
+          TEST_DATABASE_URL: ${{ steps.setup-mysql.outputs.db-url }}

--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,10 @@ group :development do
 end
 
 group :development, :test do
+  gem "database_cleaner"
   gem "govuk_test"
+  gem "pact", require: false
+  gem "pact_broker-client"
   gem "pry-byebug"
   gem "rubocop-govuk"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,6 +80,7 @@ GEM
     ancestry (4.3.3)
       activerecord (>= 5.2.6)
     ast (2.4.2)
+    awesome_print (1.9.2)
     base64 (0.2.0)
     bcrypt (3.1.20)
     benchmark (0.4.0)
@@ -119,9 +120,16 @@ GEM
       bigdecimal
       rexml
     crass (1.0.6)
+    csv (3.3.1)
     dartsass-rails (0.5.1)
       railties (>= 6.0.0)
       sass-embedded (~> 1.63)
+    database_cleaner (2.1.0)
+      database_cleaner-active_record (>= 2, < 3)
+    database_cleaner-active_record (2.2.0)
+      activerecord (>= 5.a)
+      database_cleaner-core (~> 2.0.0)
+    database_cleaner-core (2.0.1)
     date (3.4.1)
     debug_inspector (1.2.0)
     devise (4.9.4)
@@ -138,6 +146,8 @@ GEM
     devise_zxcvbn (1.1.2)
       devise
       zxcvbn-ruby (>= 0.0.2)
+    diff-lcs (1.5.1)
+    dig_rb (1.0.1)
     docile (1.4.1)
     domain_name (0.6.20240107)
     doorkeeper (5.8.1)
@@ -145,6 +155,8 @@ GEM
     drb (2.2.1)
     erubi (1.13.0)
     execjs (2.10.0)
+    expgen (0.1.1)
+      parslet
     factory_bot (6.5.0)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.4.4)
@@ -157,6 +169,7 @@ GEM
     ffi-compiler (1.3.2)
       ffi (>= 1.15.5)
       rake
+    find_a_port (1.0.1)
     gds-api-adapters (98.1.0)
       addressable
       link_header
@@ -227,6 +240,10 @@ GEM
     http-cookie (1.0.8)
       domain_name (~> 0.5)
     http-form_data (2.3.0)
+    httparty (0.22.0)
+      csv
+      mini_mime (>= 1.0.0)
+      multi_xml (>= 0.5.2)
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
     io-console (0.8.0)
@@ -300,6 +317,8 @@ GEM
       ruby2_keywords (>= 0.0.5)
     msgpack (1.7.5)
     multi_json (1.15.0)
+    multi_xml (0.7.1)
+      bigdecimal (~> 3.1)
     mysql2 (0.5.6)
     net-imap (0.5.2)
       date
@@ -527,10 +546,45 @@ GEM
       opentelemetry-api (~> 1.0)
     orm_adapter (0.5.0)
     ostruct (0.6.1)
+    pact (1.66.0)
+      jsonpath (~> 1.0)
+      pact-mock_service (~> 3.0, >= 3.3.1)
+      pact-support (~> 1.19, >= 1.19.0)
+      rack-test (>= 0.6.3, < 3.0.0)
+      rainbow (~> 3.1)
+      rspec (~> 3.0)
+      string_pattern (~> 2.0)
+      thor (>= 0.20, < 2.0)
+    pact-mock_service (3.12.3)
+      find_a_port (~> 1.0.1)
+      json
+      pact-support (~> 1.16, >= 1.16.4)
+      rack (>= 3.0, < 4.0)
+      rackup (~> 2.0)
+      rspec (>= 2.14)
+      thor (>= 0.19, < 2.0)
+      webrick (~> 1.8)
+    pact-support (1.21.2)
+      awesome_print (~> 1.9)
+      diff-lcs (~> 1.5)
+      expgen (~> 0.1)
+      jsonpath (~> 1.0)
+      rainbow (~> 3.1.1)
+      string_pattern (~> 2.0)
+    pact_broker-client (1.77.0)
+      base64 (~> 0.2)
+      dig_rb (~> 1.0)
+      httparty (>= 0.21.0, < 1.0.0)
+      ostruct
+      rake (~> 13.0)
+      table_print (~> 1.5)
+      term-ansicolor (~> 1.7)
+      thor (>= 0.20, < 2.0)
     parallel (1.26.3)
     parser (3.3.6.0)
       ast (~> 2.4.1)
       racc
+    parslet (2.0.0)
     plek (5.2.0)
     prometheus_exporter (2.2.0)
       webrick
@@ -626,6 +680,19 @@ GEM
       chunky_png (~> 1.0)
       rqrcode_core (~> 1.0)
     rqrcode_core (1.2.0)
+    rspec (3.13.0)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.2)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.3)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.2)
     rubocop (1.69.2)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
@@ -704,13 +771,22 @@ GEM
       activesupport (>= 6.1)
       sprockets (>= 3.0.0)
     statsd-ruby (1.5.0)
+    string_pattern (2.3.0)
+      regexp_parser (~> 2.5, >= 2.5.0)
     stringio (3.1.2)
+    sync (0.5.0)
     systemu (2.6.5)
+    table_print (1.5.7)
+    term-ansicolor (1.11.2)
+      tins (~> 1.0)
     terser (1.2.4)
       execjs (>= 0.3.0, < 3)
     thor (1.3.2)
     timecop (0.9.10)
     timeout (0.4.3)
+    tins (1.37.1)
+      bigdecimal
+      sync
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (3.1.2)
@@ -753,6 +829,7 @@ DEPENDENCIES
   capybara-email
   climate_control
   dartsass-rails
+  database_cleaner
   devise
   devise-encryptable
   devise_invitable
@@ -773,6 +850,8 @@ DEPENDENCIES
   mocha
   mysql2
   nokogiri
+  pact
+  pact_broker-client
   plek
   pry-byebug
   pundit

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ bundle exec rake
 - [Environment variables]
 - [Mass password reset]
 - [Troubleshooting]
+- [API]
 
 ## Licence
 
@@ -40,3 +41,4 @@ bundle exec rake
 [Environment variables]: docs/environment-variables.md
 [Mass password reset]: docs/mass_password_reset.md
 [Troubleshooting]: docs/troubleshooting.md
+[API]: docs/api.md

--- a/Rakefile
+++ b/Rakefile
@@ -5,5 +5,11 @@ require File.expand_path("config/application", __dir__)
 
 Signon::Application.load_tasks
 
+begin
+  require "pact/tasks"
+rescue LoadError
+  # Pact isn't available in all environments
+end
+
 Rake::Task[:default].clear_prerequisites
 task default: %i[lint jasmine test]

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,39 @@
+# API
+
+There is a lightweight API endpoint for signon, which returns information about users with
+given UUIDs.
+
+## Accessing
+
+To access the API, you must have an API-only Application set up in Signon called "Signon API".
+This can be set up like so:
+
+```shell
+rake applications:create name="Signon API" description="API endpoints for user management in Signon" \
+  home_uri="https://signon.integration.publishing.service.gov.uk" \
+  redirect_uri="https://signon.integration.publishing.service.gov.uk" \
+  api_only="true"
+```
+
+You can then create an API user in the Signon UI, grant them access to the Signon API, and 
+access with the Bearer token like so:
+
+```shell
+curl --location --globoff 'https://SIGNON_DOMAIN/api/users?uuids[]=c514c7e0-a049-013d-c537-3209197caa3b' \
+--header 'Authorization: Bearer YOUR_BEARER_TOKEN'
+```
+
+## Endpoints
+
+* [`GET /api/users`](#get-apiusers)
+
+### `GET /api/users`
+
+Lists users for the given `uuids`
+
+#### Query string parameters
+
+* `uuids` (required)
+  * An array of UUIDs to query for
+
+

--- a/lib/tasks/applications.rake
+++ b/lib/tasks/applications.rake
@@ -7,6 +7,7 @@ namespace :applications do
       redirect_uri: ENV["redirect_uri"],
       description: ENV["description"],
       home_uri: ENV["home_uri"],
+      api_only: ENV["api_only"].present?,
     )
     # Optionally set up supported permissions
     permissions = (ENV["supported_permissions"] || "").split(",")

--- a/test/service_consumers/pact_helper.rb
+++ b/test/service_consumers/pact_helper.rb
@@ -1,0 +1,64 @@
+ENV["RAILS_ENV"] = "test"
+ENV["PACT_DO_NOT_TRACK"] = "true"
+require "active_support"
+require "webmock"
+require "pact/provider/rspec"
+require "factory_bot_rails"
+
+module CustomGeneratorArgs
+  def self.generate(_opts = {})
+    "SOME_BEARER_TOKEN"
+  end
+end
+
+WebMock.disable!
+
+Pact.configure do |config|
+  config.reports_dir = "spec/reports/pacts"
+  config.include WebMock::API
+  config.include WebMock::Matchers
+  config.include FactoryBot::Syntax::Methods
+end
+
+def url_encode(str)
+  ERB::Util.url_encode(str)
+end
+
+def stub_access_token_creation!
+  # This stubs Doorkeeper so can ensure the token we generate is predictable, so we can run
+  # the Pact tests with a dummy bearer token
+  Doorkeeper.configure do
+    access_token_generator "CustomGeneratorArgs"
+  end
+end
+
+Pact.service_provider "Signon API" do
+  honours_pact_with "GDS API Adapters" do
+    if ENV["PACT_URI"]
+      pact_uri(ENV["PACT_URI"])
+    else
+      base_url = ENV.fetch("PACT_BROKER_BASE_URL", "https://govuk-pact-broker-6991351eca05.herokuapp.com")
+      url = "#{base_url}/pacts/provider/#{url_encode(name)}/consumer/#{url_encode(consumer_name)}"
+
+      pact_uri "#{url}/versions/#{url_encode(ENV.fetch('PACT_CONSUMER_VERSION', 'master'))}"
+    end
+  end
+end
+
+Pact.provider_states_for "GDS API Adapters" do
+  set_up do
+    DatabaseCleaner.clean_with :truncation
+    stub_access_token_creation!
+    application = create(:application, name: "Signon API")
+    user = create(:api_user, with_permissions: { application => [SupportedPermission::SIGNIN_NAME] })
+    Doorkeeper::AccessToken.create!(resource_owner_id: user.id, application_id: application.id)
+  end
+
+  provider_state "users exist with the UUIDs 9ef9779f-3cba-481a-9a73-00d39e33eb7b, b55873b4-bc83-4efe-bdc9-6b7d381a723e and 64c7d994-17e0-44d9-97b0-87b43a581eb9" do
+    set_up do
+      create(:user, uid: "9ef9779f-3cba-481a-9a73-00d39e33eb7b")
+      create(:user, uid: "b55873b4-bc83-4efe-bdc9-6b7d381a723e")
+      create(:user, uid: "64c7d994-17e0-44d9-97b0-87b43a581eb9")
+    end
+  end
+end


### PR DESCRIPTION
Trello card: https://trello.com/c/ifMWZl9n/783-add-api-adapters-for-signon

This adds the Pact tests provider and the workflow, so we can run Pact tests via `gds-api-adapters` (PR here https://github.com/alphagov/gds-api-adapters/pull/1316).

I've also added some lightweight documentation with details about the endpoint and how to authenticate.