### PR TITLE
Upgrade govuk_publishing_components to 48.0.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -207,7 +207,7 @@ GEM
     govuk_personalisation (1.1.0)
       plek (>= 1.9.0)
       rails (>= 6, < 9)
-    govuk_publishing_components (47.0.0)
+    govuk_publishing_components (48.0.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/app/views/users/_users_filter.html.erb
+++ b/app/views/users/_users_filter.html.erb
@@ -2,7 +2,7 @@
   <%= form_with url: users_path, method: :get, data: { module: "auto-submit-form", "auto-submit-ignore": "option-select-filter" } do |form| %>
     <div class="app-bottom-separator">
       <%= render "govuk_publishing_components/components/search", {
-        id: "name_or_email_filter",
+        label_id: "name_or_email_filter",
         name: "filter",
         label_text: "Search by name or email",
         label_size: "s",


### PR DESCRIPTION
## What / Why
- Upgrades to `govuk_publishing_components` 48.0.0
- Renames a parameter as a result to prevent a label/id being linked together, lost due to a breaking change in the components gem.
- I have tested locally by copying this search component onto the index page of the app, as I can't access the exact page it's rendered on. It's working as expected.
- The changes in this PR are needed because of this PR:  https://github.com/alphagov/govuk_publishing_components/pull/4540 Specifically, `id` refers to ids on the parent HTML element of the component now, so to preserve the ids being for the labels/inputs in this repo they are now called `label_id`.