### PR TITLE
Add rake tasks for dealing with deleted organisations

### DIFF
--- a/lib/tasks/data_hygiene.rake
+++ b/lib/tasks/data_hygiene.rake
@@ -12,4 +12,15 @@ namespace :data_hygiene do
     organisation.update!(closed: true)
     puts "Marked organisation #{organisation.slug} as closed"
   end
+
+  desc "Move all users from one organisation to another"
+  task :bulk_update_user_organisation, %i[old_content_id new_content_id] => :environment do |_, args|
+    old_organisation = Organisation.find_by(content_id: args[:old_content_id])
+    new_organisation = Organisation.find_by(content_id: args[:new_content_id])
+
+    users = User.where(organisation: old_organisation)
+    users.update_all(organisation_id: new_organisation.id)
+
+    puts "Moved #{users.count} users from #{old_organisation.slug} to #{new_organisation.slug}"
+  end
 end

--- a/lib/tasks/data_hygiene.rake
+++ b/lib/tasks/data_hygiene.rake
@@ -5,4 +5,11 @@ namespace :data_hygiene do
       abort "bulk updating organisations encountered errors"
     end
   end
+
+  desc "Mark an organisation as closed"
+  task :close_organisation, %i[content_id] => :environment do |_, args|
+    organisation = Organisation.find_by(content_id: args[:content_id])
+    organisation.update!(closed: true)
+    puts "Marked organisation #{organisation.slug} as closed"
+  end
 end

--- a/test/lib/tasks/data_hygiene_test.rb
+++ b/test/lib/tasks/data_hygiene_test.rb
@@ -16,4 +16,20 @@ class DataHygieneTaskTest < ActiveSupport::TestCase
       assert organisation.reload.closed?
     end
   end
+
+  context "#bulk_update_user_organisation" do
+    should "update the organisation for matching users" do
+      old_organisation = create(:organisation, slug: "department-of-health-old")
+      new_organisation = create(:organisation, slug: "department-of-health-new")
+      another_organisation = create(:organisation, slug: "department-of-other-stuff")
+
+      user_1 = create(:user, organisation: old_organisation)
+      user_2 = create(:user, organisation: another_organisation)
+
+      Rake::Task["data_hygiene:bulk_update_user_organisation"].invoke(old_organisation.content_id, new_organisation.content_id)
+
+      assert_equal new_organisation, user_1.reload.organisation
+      assert_equal another_organisation, user_2.reload.organisation
+    end
+  end
 end

--- a/test/lib/tasks/data_hygiene_test.rb
+++ b/test/lib/tasks/data_hygiene_test.rb
@@ -1,0 +1,19 @@
+require "test_helper"
+
+class DataHygieneTaskTest < ActiveSupport::TestCase
+  setup do
+    Signon::Application.load_tasks if Rake::Task.tasks.empty?
+
+    $stdout.stubs(:write)
+  end
+
+  context "#close_organisation" do
+    should "mark the organisation as closed" do
+      organisation = create(:organisation, slug: "department-of-health", closed: false)
+
+      Rake::Task["data_hygiene:close_organisation"].invoke(organisation.content_id)
+
+      assert organisation.reload.closed?
+    end
+  end
+end


### PR DESCRIPTION
The `OrganisationFetcher` does not handle the situation of an organisation having been deleted in Whitehall without first being closed.
    
This means a deleted organisation remains marked as open, and can have users assigned to it in Signon.
    
Adding rake tasks to:
1. allow us to manually mark organisations as closed, so the organisation no longer appears as an option to which users can be assigned in the user interface.
2. allow us to move all users from one organisation to another, without needing to add all their email addresses in a CSV file.

[Trello card](https://trello.com/c/WDv2141z)