### PR TITLE
Skip API authentication in dev environment

### DIFF
--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -1,5 +1,5 @@
 class Api::UsersController < ApplicationController
-  before_action :doorkeeper_authorize!, :check_signon_permissions
+  before_action :authorize_api_access, unless: -> { Rails.env.development? }
   skip_after_action :verify_authorized
 
   def index
@@ -8,6 +8,10 @@ class Api::UsersController < ApplicationController
   end
 
 private
+
+  def authorize_api_access
+    doorkeeper_authorize! && check_signon_permissions
+  end
 
   def check_signon_permissions
     head :unauthorized unless doorkeeper_token&.application&.signon?

--- a/test/controllers/api/users_controller_test.rb
+++ b/test/controllers/api/users_controller_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class Api::UsersControllerTest < ActionController::TestCase
   setup do
-    @application = create(:application, name: "Signon API")
+    @application = create(:application)
   end
 
   context "as admin user" do
@@ -18,9 +18,21 @@ class Api::UsersControllerTest < ActionController::TestCase
     end
   end
 
+  context "in development environment" do
+    setup do
+      Rails.env.stubs(:development?).returns(true)
+    end
+
+    should "be able to access the API endpoint" do
+      get :index
+
+      assert_equal "200", response.code
+    end
+  end
+
   context "as a user with a valid token" do
     setup do
-      @user = create(:user)
+      @user = create(:user, name: "Signon API")
       @user.grant_application_signin_permission(@application)
       @token = create(:access_token, application: @application, resource_owner_id: @user.id)
 


### PR DESCRIPTION
Now we’re using the users API locally in a couple of applications, the apps are falling over when trying to access the endpoint. I looked into seeding an application user, but this is tricky because we can’t guarantee what the token will be very easily. I’ve worked around this by skipping the authentication if we’re in the development environment.

It’s not ideal, but saves a lot of messy config in the Docker containers to get apps that use the Signon API up and running.