### PR TITLE
Use old Chrome in CI tests, with --no-sandbox flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,16 @@ jobs:
         ci_node_total: [4]
         ci_node_index: [0, 1, 2, 3]
     steps:
+      - name: Remove image-bundled Chrome
+        run: sudo apt-get purge google-chrome-stable
+
+      - name: Setup Chrome
+        uses: browser-actions/setup-chrome@v1
+        with:
+          chrome-version: 128
+          install-chromedriver: true
+          install-dependencies: true
+
       - name: Setup MySQL
         id: setup-mysql
         uses: alphagov/govuk-infrastructure/.github/actions/setup-mysql@main

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,6 +14,17 @@ require "mocha/minitest"
 
 GovukTest.configure
 
+Capybara.register_driver :headless_chrome do |app|
+  chrome_options = GovukTest.headless_chrome_selenium_options
+  chrome_options.add_argument("--no-sandbox")
+
+  Capybara::Selenium::Driver.new(
+    app,
+    browser: :chrome,
+    options: chrome_options,
+  )
+end
+
 class ActiveSupport::TestCase
   include FactoryBot::Syntax::Methods
 


### PR DESCRIPTION
Our JS-enabled MiniTest tests are failing fairly consistently on CI. We believe that this started when the most recent Github Actions ubuntu-latest image was released[^1]. Though, we don't 100% understand why. There's some speculation[^2] that the root of the issue has something to do with Chrome/Chromedriver version 134 (which is the version bundled with that new ubuntu-latest).

[^1]: https://github.com/actions/runner-images/pull/11761
[^2]: https://github.com/teamcapybara/capybara/issues/2800

We've largely copied what the Mainstream Publishing team did to get their CI back up-and-running[^3].

[^3]: https://github.com/alphagov/publisher/pull/2596

Summary of changes:
* add --no-sandbox flag to Chromedriver startup (GovukTest will do this for us if we set the `GOVUK_TEST_CHROME_NO_SANDBOX` environment variable, but the theory is that making the change here keeps all these temporary fixes in one place)
* remove the version of Chrome that the actions/runner-images image bundles for us, so that Selenium doesn't try to use it
* install an old version of Chrome and Chromedriver