### PR TITLE
Remove hacky override for Contacts Admin

### DIFF
--- a/script/make_oauth_work_in_dev
+++ b/script/make_oauth_work_in_dev
@@ -2,20 +2,11 @@
 require_relative "../config/environment"
 
 def application_repo_name(application)
-  case application.name
-  when /Contacts/i
-    "contacts-admin"
-  else
-    application.name.downcase.gsub(/\s/, "-")
-  end
-end
-
-def env_var_directory_name(application)
   application.name.downcase.gsub(/\s/, "-")
 end
 
 def env_var_path_for_app(application)
-  "/etc/govuk/#{env_var_directory_name(application)}/env.d"
+  "/etc/govuk/#{application_repo_name(application)}/env.d"
 end
 
 def config_path_for_app(application)


### PR DESCRIPTION
Unsure if this script is still used, but in any case there's no longer any need to account for Contacts Admin as it is being retired.

Trello: https://trello.com/c/MiBvG4Xs/3767-retire-contacts-admin

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
