### PR TITLE
Fix URI substitution bug

### DIFF
--- a/app/models/doorkeeper/application.rb
+++ b/app/models/doorkeeper/application.rb
@@ -96,7 +96,7 @@ private
     uri_pattern = Rails.configuration.oauth_apps_uri_sub_pattern
     uri_sub = Rails.configuration.oauth_apps_uri_sub_replacement
 
-    if uri_pattern.present? && uri_sub.present?
+    if uri_pattern.present? && uri_sub.present? && !uri.include?(uri_sub)
       uri.sub(uri_pattern, uri_sub)
     else
       uri

--- a/test/models/doorkeeper/application_test.rb
+++ b/test/models/doorkeeper/application_test.rb
@@ -48,6 +48,15 @@ class Doorkeeper::ApplicationTest < ActiveSupport::TestCase
 
       assert_equal "https://app.keep.me/callback", application.redirect_uri
     end
+
+    should "return application original redirect uri if it includes replacement pattern" do
+      Rails.application.config.stubs(oauth_apps_uri_sub_pattern: "replace.me")
+      Rails.application.config.stubs(oauth_apps_uri_sub_replacement: "addition.replace.me")
+
+      application = create(:application, redirect_uri: "https://app.replace.me/callback")
+
+      assert_equal "https://app.addition.replace.me/callback", application.redirect_uri
+    end
   end
 
   context "#home_uri" do
@@ -60,7 +69,7 @@ class Doorkeeper::ApplicationTest < ActiveSupport::TestCase
     context "when URI substitution is enabled" do
       setup do
         Rails.application.config.stubs(oauth_apps_uri_sub_pattern: "replace.me")
-        Rails.application.config.stubs(oauth_apps_uri_sub_replacement: "new.domain")
+        Rails.application.config.stubs(oauth_apps_uri_sub_replacement: "addition.replace.me")
       end
 
       should "return nil if application home uri is nil" do
@@ -72,7 +81,13 @@ class Doorkeeper::ApplicationTest < ActiveSupport::TestCase
       should "return application substituted home uri if match" do
         application = create(:application, home_uri: "https://app.replace.me/")
 
-        assert_equal "https://app.new.domain/", application.home_uri
+        assert_equal "https://app.addition.replace.me/", application.home_uri
+      end
+
+      should "return application original home uri if it includes replacement pattern" do
+        application = create(:application, home_uri: "https://app.addition.replace.me/")
+
+        assert_equal "https://app.addition.replace.me/", application.home_uri
       end
 
       should "return application original home uri if not matched" do


### PR DESCRIPTION
Fixes a bug where the URI sub would repeat even if the original URI matched the pattern. Sometimes resulting in
staging.staging.publishing.service.gov.uk etc

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
