### PR TITLE
[PP-7685] Update Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,12 +8,12 @@ updates:
       time: "07:00"
     allow:
       - dependency-type: "all"
-    open-pull-requests-limit: 20
     ignore:
     - dependency-name: pact
       versions: [ ">=2.0.0" ]
     cooldown:
       default-days: 3
+    open-pull-requests-limit: 25
     groups:
       test:
         patterns:
@@ -39,6 +39,7 @@ updates:
       time: "07:00"
     cooldown:
       default-days: 3
+    open-pull-requests-limit: 25
     groups:
       test:
         patterns:
@@ -58,6 +59,7 @@ updates:
       time: "07:00"
     cooldown:
       default-days: 3
+    open-pull-requests-limit: 25
 
   # Ruby needs to be upgraded manually in multiple places, so cannot
   # be upgraded by Dependabot. That effectively makes the below
@@ -74,3 +76,4 @@ updates:
       - dependency-name: ruby
     cooldown:
       default-days: 7
+    open-pull-requests-limit: 25

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,9 +10,13 @@ updates:
     ignore:
     - dependency-name: pact
       versions: [ ">=2.0.0" ]
+    cooldown:
+      default-days: 3
 
   - package-ecosystem: npm
     directory: /
+    cooldown:
+      default-days: 3
     schedule:
       interval: daily
 
@@ -20,6 +24,8 @@ updates:
     directory: /
     schedule:
       interval: daily
+    cooldown:
+      default-days: 3
 
   # Ruby needs to be upgraded manually in multiple places, so cannot
   # be upgraded by Dependabot. That effectively makes the below
@@ -30,5 +36,7 @@ updates:
     ignore:
       - dependency-name: ruby
     directory: /
+    cooldown:
+      default-days: 7
     schedule:
       interval: weekly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,22 @@ updates:
       versions: [ ">=2.0.0" ]
     cooldown:
       default-days: 3
+    groups:
+      test:
+        patterns:
+        - "capybara*"
+        - "climate_control"
+        - "database_cleaner"
+        - "factory_bot*"
+        - "govuk_test"
+        - "minitest"
+        - "mocha"
+        - "pact*"
+        - "rails-controller-testing"
+        - "shoulda-*"
+        - "simplecov"
+        - "timecop"
+        - "webmock"
 
   - package-ecosystem: npm
     directory: /
@@ -19,6 +35,16 @@ updates:
       default-days: 3
     schedule:
       interval: daily
+    groups:
+      test:
+        patterns:
+          - "jasmine-*"
+          - "selenium-webdriver"
+      lint:
+        patterns:
+          - "standardx"
+          - "stylelint"
+          - "stylelint-*"
 
   - package-ecosystem: github-actions
     directory: /

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,9 @@ updates:
   - package-ecosystem: bundler
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
+      day: tuesday
+      time: "07:00"
     allow:
       - dependency-type: "all"
     open-pull-requests-limit: 20
@@ -31,10 +33,12 @@ updates:
 
   - package-ecosystem: npm
     directory: /
+    schedule:
+      interval: weekly
+      day: tuesday
+      time: "07:00"
     cooldown:
       default-days: 3
-    schedule:
-      interval: daily
     groups:
       test:
         patterns:
@@ -49,7 +53,9 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
+      day: tuesday
+      time: "07:00"
     cooldown:
       default-days: 3
 
@@ -59,10 +65,12 @@ updates:
   # Dockerfile, although this may change in the future. We hope this
   # config will save a dev from trying to upgrade ruby via Dependabot.
   - package-ecosystem: docker
-    ignore:
-      - dependency-name: ruby
     directory: /
-    cooldown:
-      default-days: 7
     schedule:
       interval: weekly
+      day: tuesday
+      time: "07:00"
+    ignore:
+      - dependency-name: ruby
+    cooldown:
+      default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
       day: tuesday
       time: "07:00"
     allow:
-      - dependency-type: "all"
+      - dependency-type: direct
     ignore:
     - dependency-name: pact
       versions: [ ">=2.0.0" ]
@@ -37,6 +37,8 @@ updates:
       interval: weekly
       day: tuesday
       time: "07:00"
+    allow:
+      - dependency-type: direct
     cooldown:
       default-days: 3
     open-pull-requests-limit: 25


### PR DESCRIPTION
This PR refines Dependabot configuration to reduce noise and improve update safety. It introduces cooldown periods to avoid unstable releases, groups related Bundler updates and switches to a weekly Tuesday 7:00 UTC schedule.

It also increases the open PR limit to 25 to support batching, and restricts updates to direct dependencies only for more relevant, manageable changes. 

Security updates remain unaffected and continue to be raised immediately.