### PR TITLE
[PP-7619] Update 2FA page wording

### DIFF
--- a/app/helpers/two_step_verification_helper.rb
+++ b/app/helpers/two_step_verification_helper.rb
@@ -47,8 +47,8 @@ private
 
   def two_factor_code_input(**args)
     options = {
-      label: { text: "Code from app" },
-      hint: "Enter 6-digit code",
+      label: { text: "Security code" },
+      hint: "Enter 6-digit code from your authenticator app",
       name: "code",
       type: "text",
       autocomplete: "one-time-code",


### PR DESCRIPTION
We’re updating the wording on the 2FA page to make it clearer and more intuitive for users who may not regularly sign in or remember setting up two-factor authentication. Feedback [^1] shows that the current prompt, “Code from app,” is too vague and can lead to confusion about which app is being referenced, with some users downloading the wrong applications entirely. By changing the wording, we explicitly guide users to the correct source of the code, reducing ambiguity and helping them complete the sign-in process more smoothly.

This change is expected to improve user understanding and decrease the number of unnecessary 2FA reset requests.

The copy was reviewed by an Interactions Designer on the team and PM. If furher changes are needed based on user feedback, we may need to include feedback from the Design Community.

| Before    | After |
| -------- | ------- |
|  <img width="281" height="231" alt="Screenshot 2026-04-20 at 16 50 52" src="https://github.com/user-attachments/assets/4effcb46-181e-413d-b88c-fdaba0431232" /> |   <img width="359" height="240" alt="Screenshot 2026-04-17 at 10 53 51" src="https://github.com/user-attachments/assets/3799a577-7e17-4960-9f57-a9b0da95fe7e" /> |

[^1]: https://govuk.zendesk.com/agent/tickets/6430528
