### PR TITLE
Fix flaky test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,7 +62,7 @@ group :test do
   gem "minitest"
   gem "mocha", require: false
   gem "rails-controller-testing"
-  gem "shoulda-context", require: false
+  gem "shoulda-context", "~> 3.0.0.rc1", require: false
   gem "simplecov"
   gem "timecop"
   gem "webmock"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -747,7 +747,7 @@ GEM
     sentry-sidekiq (6.5.0)
       sentry-ruby (~> 6.5.0)
       sidekiq (>= 5.0)
-    shoulda-context (2.0.0)
+    shoulda-context (3.0.0.rc1)
     sidekiq (7.3.10)
       base64
       connection_pool (>= 2.3.0, < 3)
@@ -868,7 +868,7 @@ DEPENDENCIES
   rqrcode
   rubocop-govuk
   sentry-sidekiq
-  shoulda-context
+  shoulda-context (~> 3.0.0.rc1)
   simplecov
   sprockets-rails
   terser
@@ -877,4 +877,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   4.0.10
+  4.0.10

--- a/test/integration/email_change_test.rb
+++ b/test/integration/email_change_test.rb
@@ -160,7 +160,7 @@ class EmailChangeTest < ActionDispatch::IntegrationTest
       signin_with(@user)
 
       click_link "Change your email"
-      fill_in "Email", with: "new@email.com"
+      fill_in "Email", with: "new@email.com", wait: 3
       click_button "Change email"
 
       confirmation_token = token_sent_to(@user)


### PR DESCRIPTION
This allows a particular call in a particular test to wait longer for an element to be rendered. Otherwise we occasionally see the following error.

```
EmailChangeTest#test_: by a user themselves should be cancellable. :
Capybara::ElementNotFound: Unable to find field "Email" that is not disabled
    test/integration/email_change_test.rb:163:in 'block (2 levels) in <class:EmailChangeTest>'
    test/integration/email_change_test.rb:164:in 'BasicObject#instance_exec'
    test/integration/email_change_test.rb:164:in 'block in EmailChangeTest#create_test_from_should_hash'
bin/rails test test/integration/email_change_test.rb:156
```

If similar problems occur elsewhere, then Capybara's `default_max_wait_time` (default: 2) could be configured globally.

A gem version also had to be tweaked, as described in the commit message.