### PR TITLE
Update team name in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.
+This application is owned by the Content APIs team. Please let us know in [#govuk-content-apis](https://gds.slack.com/archives/C03D792LYJG) when you raise any PRs.
 
 ⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
 


### PR DESCRIPTION
The team name has changed, so updating the PR template to reflect this.