### PR TITLE
[PP-7756] Resolve email address XSS vulnerability

### DIFF
--- a/app/helpers/event_log_helper.rb
+++ b/app/helpers/event_log_helper.rb
@@ -31,7 +31,7 @@ module EventLogHelper
   end
 
   def formatted_trailing_message(log)
-    log.trailing_message
+    sanitize(log.trailing_message)
   end
 
   def formatted_ip_address(log)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -51,6 +51,7 @@ class User < ApplicationRecord
 
   validates :name, presence: true
   validates :email, reject_non_governmental_email_addresses: true
+  validates :unconfirmed_email, format: { with: Devise.email_regexp }, allow_nil: true, reject_non_governmental_email_addresses: true
   validates :reason_for_suspension, presence: true, if: proc { |u| u.suspended? }
   validates :role, inclusion: { in: Roles.all }
   validate :user_can_be_exempted_from_2sv

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -45,12 +45,12 @@ Devise.setup do |config|
   # Configure which authentication keys should be case-insensitive.
   # These keys will be downcased upon creating or modifying a user and when used
   # to authenticate or find a user. Default is :email.
-  config.case_insensitive_keys = [:email]
+  config.case_insensitive_keys = %i[email unconfirmed_email]
 
   # Configure which authentication keys should have whitespace stripped.
   # These keys will have whitespace before and after removed upon creating or
   # modifying a user and when used to authenticate or find a user. Default is :email.
-  config.strip_whitespace_keys = [:email]
+  config.strip_whitespace_keys = %i[email unconfirmed_email]
 
   # Tell if authentication through request.params is enabled. True by default.
   # It can be set to an array that will enable params authentication only for the

--- a/test/integration/email_change_test.rb
+++ b/test/integration/email_change_test.rb
@@ -133,11 +133,11 @@ class EmailChangeTest < ActionDispatch::IntegrationTest
         signin_with(@user)
 
         click_link "Change your email"
-        fill_in "Email", with: "new@email.com"
+        fill_in "Email", with: "new'email@email.com"
         click_button "Change email"
         confirmation_url = ActionMailer::Base
           .deliveries
-          .detect { |mail| mail.to.include?("new@email.com") }
+          .detect { |mail| mail.to.include?("new'email@email.com") }
           .body
           .match(%r{\((https?://\S+)\)})[1]
 
@@ -146,8 +146,9 @@ class EmailChangeTest < ActionDispatch::IntegrationTest
         signout
         signin_with(create(:admin_user))
         visit event_logs_user_path(@user)
-        assert_response_contains "Email change initiated by #{@user.name} from original@email.com to new@email.com"
+        assert_response_contains "Email change initiated by #{@user.name} from original@email.com to new'email@email.com"
         assert_response_contains "Email change confirmed"
+        assert page.html.include?("new&#39;email@email.com")
       end
     end
 

--- a/test/integration/email_change_test.rb
+++ b/test/integration/email_change_test.rb
@@ -45,6 +45,17 @@ class EmailChangeTest < ActionDispatch::IntegrationTest
         assert_response_contains("Email can't be blank")
         assert_nil last_email
       end
+
+      should "show an error and not trigger a notification if the email is invalid" do
+        user = create(:user)
+
+        visit new_user_session_path
+        signin_with(@admin)
+        admin_changes_email_address(user:, new_email: "test@notvalid")
+
+        assert_response_contains("Email is invalid")
+        assert_nil last_email
+      end
     end
 
     context "for a user who hasn't accepted their invite yet" do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -363,6 +363,7 @@ class UserTest < ActiveSupport::TestCase
         "foo@example.com,",
         "foo@example_domain.com",
         "foo@no-dot-domain",
+        "not_an_email",
       ].each do |email|
         user.email = email
 
@@ -383,6 +384,45 @@ class UserTest < ActiveSupport::TestCase
 
       assert_not user.valid?
       assert_equal ["can't contain non-ASCII characters"], user.errors[:email]
+    end
+  end
+
+  context "unconfirmed email validation" do
+    should "accept valid emails" do
+      user = build(:user)
+      [
+        "foo@example.com",
+        "foo_bar@example.COM",
+        "foo@example-domain.com",
+        "user-foo+bar@really.long.domain.co.uk",
+      ].each do |email|
+        user.unconfirmed_email = email
+
+        assert user.valid?, "Expected user to be valid with unconfirmed email: '#{email}'"
+      end
+    end
+
+    should "not allow user to be updated with a known non-government email address" do
+      user = create(:user, email: "alexia.statham@department.gov.uk")
+
+      user.unconfirmed_email = "alexia.statham@yahoo.co.uk"
+
+      assert_not user.valid?
+    end
+
+    should "reject emails with invalid domain parts" do
+      user = build(:user)
+      [
+        "foo@example.com,",
+        "foo@example_domain.com",
+        "foo@no-dot-domain",
+        "not_an_email",
+      ].each do |email|
+        user.unconfirmed_email = email
+
+        assert_not user.valid?, "Expected user to be invalid with unconfirmed email: '#{email}'"
+        assert_equal ["is invalid"], user.errors[:unconfirmed_email]
+      end
     end
   end
 


### PR DESCRIPTION
When a user changes their email address, we store the new email in the `unconfirmed_email` field until they have verified the new email.

However this field does not have the same validations as the `email` field.

This has user impact, because it means that users could enter an invalid email address, but only find out once they attempt to verify it. This wastes their time, as they have to wait for an email and click the link, only to find the email is invalid.

However, perhaps more importantly, it creates a XSS vulnerability, where a compromised user account could attempt to change their email address to something like ascript. This would then execute in the browser of anyone who views that
user's account access log.

By restricting the value to only valid email addresses, we minimise the risk of this occurring. This PR has sanitises the value when rendered from the event log, in the case any malicious entries slip past the validation.