### PR TITLE
Optimise breadcrumbs component calls

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -67,4 +67,17 @@ module ApplicationHelper
       },
     ]
   end
+
+  def users_breadcrumbs
+    [
+      {
+        title: "Dashboard",
+        url: root_path,
+      },
+      {
+        title: "Users",
+        url: users_path,
+      },
+    ]
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -37,4 +37,17 @@ module ApplicationHelper
     css_classes = ["govuk-tag", classes].compact.join(" ")
     tag.strong(text, class: css_classes)
   end
+
+  def account_breadcrumbs
+    [
+      {
+        title: "Dashboard",
+        url: root_path,
+      },
+      {
+        title: "Settings",
+        url: account_path,
+      },
+    ]
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -50,4 +50,21 @@ module ApplicationHelper
       },
     ]
   end
+
+  def access_breadcrumbs(application)
+    [
+      {
+        title: "Dashboard",
+        url: root_path,
+      },
+      {
+        title: "Applications",
+        url: doorkeeper_applications_path,
+      },
+      {
+        title: application.name,
+        url: edit_doorkeeper_application_path(application),
+      },
+    ]
+  end
 end

--- a/app/views/account/activities/show.html.erb
+++ b/app/views/account/activities/show.html.erb
@@ -1,16 +1,5 @@
 <% content_for :title, "Account access log" %>
 
-<%
-  @breadcrumbs = [
-    {
-      title: "Dashboard",
-      url: root_path,
-    },
-    {
-      title: "Settings",
-      url: account_path,
-    }
-  ]
-%>
+<% @breadcrumbs = account_breadcrumbs %>
 
 <%= render "shared/event_logs_table", logs: @logs %>

--- a/app/views/account/activities/show.html.erb
+++ b/app/views/account/activities/show.html.erb
@@ -1,19 +1,16 @@
 <% content_for :title, "Account access log" %>
 
-<% content_for :breadcrumbs,
-   render("govuk_publishing_components/components/breadcrumbs", {
-     collapse_on_mobile: true,
-     breadcrumbs: [
-       {
-         title: "Dashboard",
-         url: root_path,
-       },
-       {
-         title: "Settings",
-         url: account_path,
-       }
-     ]
-   })
+<%
+  @breadcrumbs = [
+    {
+      title: "Dashboard",
+      url: root_path,
+    },
+    {
+      title: "Settings",
+      url: account_path,
+    }
+  ]
 %>
 
 <%= render "shared/event_logs_table", logs: @logs %>

--- a/app/views/account/applications/index.html.erb
+++ b/app/views/account/applications/index.html.erb
@@ -1,17 +1,6 @@
 <% content_for :title, "GOV.UK apps" %>
 
-<%
-  @breadcrumbs = [
-    {
-      title: "Dashboard",
-      url: root_path,
-    },
-    {
-      title: "Settings",
-      url: account_path,
-    }
-  ]
-%>
+<% @breadcrumbs = account_breadcrumbs %>
 
 <% if flash[:success_alert] %>
   <% content_for(:custom_alerts) do %>

--- a/app/views/account/applications/index.html.erb
+++ b/app/views/account/applications/index.html.erb
@@ -1,19 +1,16 @@
 <% content_for :title, "GOV.UK apps" %>
 
-<% content_for :breadcrumbs,
-   render("govuk_publishing_components/components/breadcrumbs", {
-     collapse_on_mobile: true,
-     breadcrumbs: [
-       {
-         title: "Dashboard",
-         url: root_path,
-       },
-       {
-         title: "Settings",
-         url: account_path,
-       }
-     ]
-   })
+<%
+  @breadcrumbs = [
+    {
+      title: "Dashboard",
+      url: root_path,
+    },
+    {
+      title: "Settings",
+      url: account_path,
+    }
+  ]
 %>
 
 <% if flash[:success_alert] %>

--- a/app/views/account/emails/edit.html.erb
+++ b/app/views/account/emails/edit.html.erb
@@ -1,18 +1,6 @@
 <% content_for :title, "Change your email address" %>
 
-<%
-  @breadcrumbs = [
-    {
-      title: "Dashboard",
-      url: root_path,
-    },
-    {
-      title: "Settings",
-      url: account_path,
-    }
-  ]
-%>
-
+<% @breadcrumbs = account_breadcrumbs %>
 
 <% if current_user.unconfirmed_email.present? %>
   <%= render "govuk_publishing_components/components/notice", {

--- a/app/views/account/emails/edit.html.erb
+++ b/app/views/account/emails/edit.html.erb
@@ -1,19 +1,16 @@
 <% content_for :title, "Change your email address" %>
 
-<% content_for :breadcrumbs,
-   render("govuk_publishing_components/components/breadcrumbs", {
-     collapse_on_mobile: true,
-     breadcrumbs: [
-       {
-         title: "Dashboard",
-         url: root_path,
-       },
-       {
-         title: "Settings",
-         url: account_path,
-       }
-     ]
-   })
+<%
+  @breadcrumbs = [
+    {
+      title: "Dashboard",
+      url: root_path,
+    },
+    {
+      title: "Settings",
+      url: account_path,
+    }
+  ]
 %>
 
 

--- a/app/views/account/organisations/edit.html.erb
+++ b/app/views/account/organisations/edit.html.erb
@@ -1,19 +1,16 @@
 <% content_for :title, organisation_page_title %>
 
-<% content_for :breadcrumbs,
-   render("govuk_publishing_components/components/breadcrumbs", {
-     collapse_on_mobile: true,
-     breadcrumbs: [
-       {
-         title: "Dashboard",
-         url: root_path,
-       },
-       {
-         title: "Settings",
-         url: account_path,
-       }
-     ]
-   })
+<%
+  @breadcrumbs = [
+    {
+      title: "Dashboard",
+      url: root_path,
+    },
+    {
+      title: "Settings",
+      url: account_path,
+    }
+  ]
 %>
 
 <div class="govuk-grid-row">

--- a/app/views/account/organisations/edit.html.erb
+++ b/app/views/account/organisations/edit.html.erb
@@ -1,17 +1,6 @@
 <% content_for :title, organisation_page_title %>
 
-<%
-  @breadcrumbs = [
-    {
-      title: "Dashboard",
-      url: root_path,
-    },
-    {
-      title: "Settings",
-      url: account_path,
-    }
-  ]
-%>
+<% @breadcrumbs = account_breadcrumbs %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/account/passwords/edit.html.erb
+++ b/app/views/account/passwords/edit.html.erb
@@ -1,19 +1,16 @@
 <% content_for :title, "Change your password" %>
 
-<% content_for :breadcrumbs,
-   render("govuk_publishing_components/components/breadcrumbs", {
-     collapse_on_mobile: true,
-     breadcrumbs: [
-       {
-         title: "Dashboard",
-         url: root_path,
-       },
-       {
-         title: "Settings",
-         url: account_path,
-       }
-     ]
-   })
+<%
+  @breadcrumbs = [
+    {
+      title: "Dashboard",
+      url: root_path,
+    },
+    {
+      title: "Settings",
+      url: account_path,
+    }
+  ]
 %>
 
 <% if current_user.errors.count > 0 %>

--- a/app/views/account/passwords/edit.html.erb
+++ b/app/views/account/passwords/edit.html.erb
@@ -1,17 +1,6 @@
 <% content_for :title, "Change your password" %>
 
-<%
-  @breadcrumbs = [
-    {
-      title: "Dashboard",
-      url: root_path,
-    },
-    {
-      title: "Settings",
-      url: account_path,
-    }
-  ]
-%>
+<% @breadcrumbs = account_breadcrumbs %>
 
 <% if current_user.errors.count > 0 %>
   <% content_for :error_summary do %>

--- a/app/views/account/permissions/edit.html.erb
+++ b/app/views/account/permissions/edit.html.erb
@@ -1,23 +1,20 @@
 <% content_for :title, "Update permissions for #{@application.name}" %>
 
-<% content_for :breadcrumbs,
-   render("govuk_publishing_components/components/breadcrumbs", {
-     collapse_on_mobile: true,
-     breadcrumbs: [
-       {
-         title: "Dashboard",
-         url: root_path,
-       },
-       {
-         title: "GOV.UK apps",
-         url: account_applications_path,
-       },
-       {
-         title: "Settings",
-         url: account_path,
-       }
-     ]
-   })
+<%
+  @breadcrumbs = [
+    {
+      title: "Dashboard",
+      url: root_path,
+    },
+    {
+      title: "GOV.UK apps",
+      url: account_applications_path,
+    },
+    {
+      title: "Settings",
+      url: account_path,
+    }
+  ]
 %>
 
 <% if flash[:new_permission_name] %>

--- a/app/views/account/permissions/show.html.erb
+++ b/app/views/account/permissions/show.html.erb
@@ -1,23 +1,20 @@
 <% content_for :title, "My permissions for #{@application.name}" %>
 
-<% content_for :breadcrumbs,
-   render("govuk_publishing_components/components/breadcrumbs", {
-     collapse_on_mobile: true,
-     breadcrumbs: [
-       {
-         title: "Dashboard",
-         url: root_path,
-       },
-       {
-         title: "GOV.UK apps",
-         url: account_applications_path,
-       },
-       {
-         title: "Settings",
-         url: account_path,
-       }
-     ]
-   })
+<%
+  @breadcrumbs = [
+    {
+      title: "Dashboard",
+      url: root_path,
+    },
+    {
+      title: "GOV.UK apps",
+      url: account_applications_path,
+    },
+    {
+      title: "Settings",
+      url: account_path,
+    }
+  ]
 %>
 
 <%= render "components/table", {

--- a/app/views/account/roles/edit.html.erb
+++ b/app/views/account/roles/edit.html.erb
@@ -1,17 +1,6 @@
 <% content_for :title, role_page_title %>
 
-<%
-  @breadcrumbs = [
-    {
-      title: "Dashboard",
-      url: root_path,
-    },
-    {
-      title: "Settings",
-      url: account_path,
-    }
-  ]
-%>
+<% @breadcrumbs = account_breadcrumbs %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/account/roles/edit.html.erb
+++ b/app/views/account/roles/edit.html.erb
@@ -1,19 +1,16 @@
 <% content_for :title, role_page_title %>
 
-<% content_for :breadcrumbs,
-   render("govuk_publishing_components/components/breadcrumbs", {
-     collapse_on_mobile: true,
-     breadcrumbs: [
-       {
-         title: "Dashboard",
-         url: root_path,
-       },
-       {
-         title: "Settings",
-         url: account_path,
-       }
-     ]
-   })
+<%
+  @breadcrumbs = [
+    {
+      title: "Dashboard",
+      url: root_path,
+    },
+    {
+      title: "Settings",
+      url: account_path,
+    }
+  ]
 %>
 
 <div class="govuk-grid-row">

--- a/app/views/account/signin_permissions/delete.html.erb
+++ b/app/views/account/signin_permissions/delete.html.erb
@@ -1,19 +1,16 @@
 <% content_for :title, "Remove access to #{@application.name}" %>
 
-<% content_for :breadcrumbs,
-   render("govuk_publishing_components/components/breadcrumbs", {
-     collapse_on_mobile: true,
-     breadcrumbs: [
-       {
-         title: "Dashboard",
-         url: root_path,
-       },
-       {
-         title: "GOV.UK apps",
-         url: account_applications_path,
-       }
-     ]
-   })
+<%
+  @breadcrumbs = [
+    {
+      title: "Dashboard",
+      url: root_path,
+    },
+    {
+      title: "GOV.UK apps",
+      url: account_applications_path,
+    }
+  ]
 %>
 
 <p class="govuk-body">Are you sure you want to remove access to <%= @application.name %>?</p>

--- a/app/views/api_users/applications/index.html.erb
+++ b/app/views/api_users/applications/index.html.erb
@@ -1,24 +1,21 @@
 <% content_for :title_caption, "Manage API users" %>
 <% content_for :title, "#{@api_user.name}'s applications" %>
 
-<% content_for :breadcrumbs,
-   render("govuk_publishing_components/components/breadcrumbs", {
-     collapse_on_mobile: true,
-     breadcrumbs: [
-       {
-         title: "Dashboard",
-         url: root_path,
-       },
-       {
-         title: "API users",
-         url: api_users_path,
-       },
-       {
-         title: @api_user.name,
-         url: edit_api_user_path(@api_user),
-       }
-     ]
-   })
+<%
+  @breadcrumbs = [
+    {
+      title: "Dashboard",
+      url: root_path,
+    },
+    {
+      title: "API users",
+      url: api_users_path,
+    },
+    {
+      title: @api_user.name,
+      url: edit_api_user_path(@api_user),
+    }
+  ]
 %>
 
 <% if flash[:application_id] %>

--- a/app/views/api_users/edit.html.erb
+++ b/app/views/api_users/edit.html.erb
@@ -1,20 +1,17 @@
 <% content_for :title_caption, "Manage API users" %>
 <% content_for :title, @api_user.name %>
 
-<% content_for :breadcrumbs,
-   render("govuk_publishing_components/components/breadcrumbs", {
-     collapse_on_mobile: true,
-     breadcrumbs: [
-       {
-         title: "Dashboard",
-         url: root_path,
-       },
-       {
-         title: "API users",
-         url: api_users_path,
-       }
-     ]
-   })
+<%
+  @breadcrumbs = [
+    {
+      title: "Dashboard",
+      url: root_path,
+    },
+    {
+      title: "API users",
+      url: api_users_path,
+    }
+  ]
 %>
 
 <div class="govuk-grid-row">

--- a/app/views/api_users/manage_tokens.html.erb
+++ b/app/views/api_users/manage_tokens.html.erb
@@ -1,24 +1,21 @@
 <% content_for :title_caption, "Manage API users" %>
 <% content_for :title, "Manage tokens for #{@api_user.name}" %>
 
-<% content_for :breadcrumbs,
-   render("govuk_publishing_components/components/breadcrumbs", {
-     collapse_on_mobile: true,
-     breadcrumbs: [
-       {
-         title: "Dashboard",
-         url: root_path,
-       },
-       {
-         title: "API users",
-         url: api_users_path,
-       },
-       {
-         title: @api_user.name,
-         url: edit_api_user_path(@api_user),
-       }
-     ]
-   })
+<%
+  @breadcrumbs = [
+    {
+      title: "Dashboard",
+      url: root_path,
+    },
+    {
+      title: "API users",
+      url: api_users_path,
+    },
+    {
+      title: @api_user.name,
+      url: edit_api_user_path(@api_user),
+    }
+  ]
 %>
 
 <% if authorisation = flash[:authorisation] %>

--- a/app/views/api_users/new.html.erb
+++ b/app/views/api_users/new.html.erb
@@ -1,20 +1,17 @@
 <% content_for :title_caption, "Manage API users" %>
 <% content_for :title, "Create new API user" %>
 
-<% content_for :breadcrumbs,
-   render("govuk_publishing_components/components/breadcrumbs", {
-     collapse_on_mobile: true,
-     breadcrumbs: [
-       {
-         title: "Dashboard",
-         url: root_path,
-       },
-       {
-         title: "API users",
-         url: api_users_path,
-       }
-     ]
-   })
+<%
+  @breadcrumbs = [
+    {
+      title: "Dashboard",
+      url: root_path,
+    },
+    {
+      title: "API users",
+      url: api_users_path,
+    }
+  ]
 %>
 
 <div class="govuk-grid-row">

--- a/app/views/api_users/permissions/edit.html.erb
+++ b/app/views/api_users/permissions/edit.html.erb
@@ -1,28 +1,25 @@
 <% content_for :title_caption, "Manage API users" %>
 <% content_for :title, "Update #{@api_user.name}'s permissions for #{@application.name}" %>
 
-<% content_for :breadcrumbs,
-   render("govuk_publishing_components/components/breadcrumbs", {
-     collapse_on_mobile: true,
-     breadcrumbs: [
-       {
-         title: "Dashboard",
-         url: root_path,
-       },
-       {
-         title: "API users",
-         url: api_users_path,
-       },
-       {
-         title: @api_user.name,
-         url: edit_api_user_path(@api_user),
-       },
-       {
-         title: "Applications",
-         url: api_user_applications_path(@api_user),
-       }
-     ]
-   })
+<%
+  @breadcrumbs = [
+    {
+      title: "Dashboard",
+      url: root_path,
+    },
+    {
+      title: "API users",
+      url: api_users_path,
+    },
+    {
+      title: @api_user.name,
+      url: edit_api_user_path(@api_user),
+    },
+    {
+      title: "Applications",
+      url: api_user_applications_path(@api_user),
+    }
+  ]
 %>
 
 <%= form_tag api_user_application_permissions_path(@api_user, @application), method: :patch do |f| %>

--- a/app/views/authorisations/edit.html.erb
+++ b/app/views/authorisations/edit.html.erb
@@ -1,26 +1,23 @@
 <% content_for :title, "Revoke token giving #{@api_user.name} access to #{@authorisation.application.name}" %>
-<% content_for :breadcrumbs,
-   render("govuk_publishing_components/components/breadcrumbs", {
-     collapse_on_mobile: true,
-     breadcrumbs: [
-       {
-         title: "Dashboard",
-         url: root_path,
-       },
-       {
-         title: "API users",
-         url: api_users_path,
-       },
-       {
-         title: @api_user.name,
-         url: edit_api_user_path(@api_user),
-       },
-       {
-         title: "Manage tokens",
-         url: manage_tokens_api_user_path(@api_user),
-       }
-     ]
-   })
+<%
+  @breadcrumbs = [
+    {
+      title: "Dashboard",
+      url: root_path,
+    },
+    {
+      title: "API users",
+      url: api_users_path,
+    },
+    {
+      title: @api_user.name,
+      url: edit_api_user_path(@api_user),
+    },
+    {
+      title: "Manage tokens",
+      url: manage_tokens_api_user_path(@api_user),
+    }
+  ]
 %>
 
 <div class="govuk-grid-row">

--- a/app/views/authorisations/new.html.erb
+++ b/app/views/authorisations/new.html.erb
@@ -1,28 +1,25 @@
 <% content_for :title_caption, "Manage API users" %>
 <% content_for :title, "Create new access token for #{@api_user.name}" %>
 
-<% content_for :breadcrumbs,
-   render("govuk_publishing_components/components/breadcrumbs", {
-     collapse_on_mobile: true,
-     breadcrumbs: [
-       {
-         title: "Dashboard",
-         url: root_path,
-       },
-       {
-         title: "API users",
-         url: api_users_path,
-       },
-       {
-         title: @api_user.name,
-         url: edit_api_user_path(@api_user),
-       },
-       {
-         title: "Manage tokens",
-         url: manage_tokens_api_user_path(@api_user),
-       }
-     ]
-   })
+<%
+  @breadcrumbs = [
+    {
+      title: "Dashboard",
+      url: root_path,
+    },
+    {
+      title: "API users",
+      url: api_users_path,
+    },
+    {
+      title: @api_user.name,
+      url: edit_api_user_path(@api_user),
+    },
+    {
+      title: "Manage tokens",
+      url: manage_tokens_api_user_path(@api_user),
+    }
+  ]
 %>
 
 <%= form_tag api_user_authorisations_path(@api_user), method: :post do %>

--- a/app/views/batch_invitation_permissions/new.html.erb
+++ b/app/views/batch_invitation_permissions/new.html.erb
@@ -1,16 +1,5 @@
 <% content_for :title, "Manage permissions for new users" %>
-<%
-  @breadcrumbs = [
-    {
-      title: "Dashboard",
-      url: root_path,
-    },
-    {
-      title: "Users",
-      url: users_path,
-    }
-  ]
-%>
+<% @breadcrumbs = users_breadcrumbs %>
 
 <div data-module="clear-selected-permissions">
   <%= render "govuk_publishing_components/components/button", {

--- a/app/views/batch_invitation_permissions/new.html.erb
+++ b/app/views/batch_invitation_permissions/new.html.erb
@@ -1,18 +1,15 @@
 <% content_for :title, "Manage permissions for new users" %>
-<% content_for :breadcrumbs,
-   render("govuk_publishing_components/components/breadcrumbs", {
-     collapse_on_mobile: true,
-     breadcrumbs: [
-       {
-         title: "Dashboard",
-         url: root_path,
-       },
-       {
-         title: "Users",
-         url: users_path,
-       }
-     ]
-   })
+<%
+  @breadcrumbs = [
+    {
+      title: "Dashboard",
+      url: root_path,
+    },
+    {
+      title: "Users",
+      url: users_path,
+    }
+  ]
 %>
 
 <div data-module="clear-selected-permissions">

--- a/app/views/batch_invitations/new.html.erb
+++ b/app/views/batch_invitations/new.html.erb
@@ -1,18 +1,15 @@
 <% content_for :title, "Upload a batch of users" %>
-<% content_for :breadcrumbs,
-   render("govuk_publishing_components/components/breadcrumbs", {
-     collapse_on_mobile: true,
-     breadcrumbs: [
-       {
-         title: "Dashboard",
-         url: root_path,
-       },
-       {
-         title: "Users",
-         url: users_path,
-       }
-     ]
-   })
+<%
+  @breadcrumbs = [
+    {
+      title: "Dashboard",
+      url: root_path,
+    },
+    {
+      title: "Users",
+      url: users_path,
+    }
+  ]
 %>
 
 <div>

--- a/app/views/batch_invitations/new.html.erb
+++ b/app/views/batch_invitations/new.html.erb
@@ -1,16 +1,5 @@
 <% content_for :title, "Upload a batch of users" %>
-<%
-  @breadcrumbs = [
-    {
-      title: "Dashboard",
-      url: root_path,
-    },
-    {
-      title: "Users",
-      url: users_path,
-    }
-  ]
-%>
+<% @breadcrumbs = users_breadcrumbs %>
 
 <div>
   <%= form_for @batch_invitation, multipart: true do |f| %>

--- a/app/views/batch_invitations/show.html.erb
+++ b/app/views/batch_invitations/show.html.erb
@@ -1,22 +1,19 @@
 <% content_for :title, "Creating a batch of users" %>
-<% content_for :breadcrumbs,
-   render("govuk_publishing_components/components/breadcrumbs", {
-     collapse_on_mobile: true,
-     breadcrumbs: [
-       {
-         title: "Dashboard",
-         url: root_path,
-       },
-       {
-         title: "Users",
-         url: users_path,
-       },
-       {
-         title: "Upload a batch of users",
-         url: new_batch_invitation_path,
-       }
-     ]
-   })
+<%
+  @breadcrumbs = [
+    {
+      title: "Dashboard",
+      url: root_path,
+    },
+    {
+      title: "Users",
+      url: users_path,
+    },
+    {
+      title: "Upload a batch of users",
+      url: new_batch_invitation_path,
+    }
+  ]
 %>
 
 <% if @batch_invitation.in_progress? %>

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -1,18 +1,15 @@
 <% content_for :title, "Create new user" %>
-<% content_for :breadcrumbs,
-   render("govuk_publishing_components/components/breadcrumbs", {
-     collapse_on_mobile: true,
-     breadcrumbs: [
-       {
-         title: "Dashboard",
-         url: root_path,
-       },
-       {
-         title: "Users",
-         url: users_path,
-       }
-     ]
-   })
+<%
+  @breadcrumbs = [
+    {
+      title: "Dashboard",
+      url: root_path,
+    },
+    {
+      title: "Users",
+      url: users_path,
+    }
+  ]
 %>
 
 <div class="govuk-grid-row">

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -1,16 +1,5 @@
 <% content_for :title, "Create new user" %>
-<%
-  @breadcrumbs = [
-    {
-      title: "Dashboard",
-      url: root_path,
-    },
-    {
-      title: "Users",
-      url: users_path,
-    }
-  ]
-%>
+<% @breadcrumbs = users_breadcrumbs %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/devise/two_step_verification/show.html.erb
+++ b/app/views/devise/two_step_verification/show.html.erb
@@ -1,17 +1,6 @@
 <% content_for :title, two_step_verification_page_title %>
 
-<%
-  @breadcrumbs = [
-    {
-      title: "Dashboard",
-      url: root_path,
-    },
-    {
-      title: "Settings",
-      url: account_path,
-    }
-  ]
-%>
+<% @breadcrumbs = account_breadcrumbs %>
 
 <% if flash[:invalid_code].present? %>
   <% content_for :error_summary do %>

--- a/app/views/devise/two_step_verification/show.html.erb
+++ b/app/views/devise/two_step_verification/show.html.erb
@@ -1,19 +1,16 @@
 <% content_for :title, two_step_verification_page_title %>
 
-<% content_for :breadcrumbs,
-   render("govuk_publishing_components/components/breadcrumbs", {
-     collapse_on_mobile: true,
-     breadcrumbs: [
-       {
-         title: "Dashboard",
-         url: root_path,
-       },
-       {
-         title: "Settings",
-         url: account_path,
-       }
-     ]
-   })
+<%
+  @breadcrumbs = [
+    {
+      title: "Dashboard",
+      url: root_path,
+    },
+    {
+      title: "Settings",
+      url: account_path,
+    }
+  ]
 %>
 
 <% if flash[:invalid_code].present? %>

--- a/app/views/doorkeeper_applications/access_logs.html.erb
+++ b/app/views/doorkeeper_applications/access_logs.html.erb
@@ -1,23 +1,20 @@
 <% content_for :title, "#{@application.name} access log" %>
 
-<% content_for :breadcrumbs,
-               render("govuk_publishing_components/components/breadcrumbs", {
-                 collapse_on_mobile: true,
-                 breadcrumbs: [
-                   {
-                     title: "Dashboard",
-                     url: root_path,
-                   },
-                   {
-                     title: "Applications",
-                     url: doorkeeper_applications_path,
-                   },
-                   {
-                     title: @application.name,
-                     url: edit_doorkeeper_application_path(@application),
-                   }
-                 ]
-               })
+<%
+  @breadcrumbs = [
+    {
+      title: "Dashboard",
+      url: root_path,
+    },
+    {
+      title: "Applications",
+      url: doorkeeper_applications_path,
+    },
+    {
+      title: @application.name,
+      url: edit_doorkeeper_application_path(@application),
+    }
+  ]
 %>
 
 <form>

--- a/app/views/doorkeeper_applications/access_logs.html.erb
+++ b/app/views/doorkeeper_applications/access_logs.html.erb
@@ -1,21 +1,5 @@
 <% content_for :title, "#{@application.name} access log" %>
-
-<%
-  @breadcrumbs = [
-    {
-      title: "Dashboard",
-      url: root_path,
-    },
-    {
-      title: "Applications",
-      url: doorkeeper_applications_path,
-    },
-    {
-      title: @application.name,
-      url: edit_doorkeeper_application_path(@application),
-    }
-  ]
-%>
+<% @breadcrumbs = access_breadcrumbs(@application) %>
 
 <form>
 <%= render "govuk_publishing_components/components/checkboxes", {

--- a/app/views/doorkeeper_applications/edit.html.erb
+++ b/app/views/doorkeeper_applications/edit.html.erb
@@ -1,18 +1,15 @@
 <% content_for :title, "Edit #{@application.name}" %>
-<% content_for :breadcrumbs,
-   render("govuk_publishing_components/components/breadcrumbs", {
-     collapse_on_mobile: true,
-     breadcrumbs: [
-       {
-         title: "Dashboard",
-         url: root_path,
-       },
-       {
-         title: "Applications",
-         url: doorkeeper_applications_path,
-       }
-     ]
-   })
+<%
+  @breadcrumbs = [
+    {
+      title: "Dashboard",
+      url: root_path,
+    },
+    {
+      title: "Applications",
+      url: doorkeeper_applications_path,
+    }
+  ]
 %>
 
 <%= link_to "Users with access",

--- a/app/views/doorkeeper_applications/monthly_access_stats.html.erb
+++ b/app/views/doorkeeper_applications/monthly_access_stats.html.erb
@@ -1,23 +1,20 @@
 <% content_for :title, "Monthly access counts to #{@application.name}" %>
 
-<% content_for :breadcrumbs,
-               render("govuk_publishing_components/components/breadcrumbs", {
-                 collapse_on_mobile: true,
-                 breadcrumbs: [
-                   {
-                     title: "Dashboard",
-                     url: root_path,
-                   },
-                   {
-                     title: "Applications",
-                     url: doorkeeper_applications_path,
-                   },
-                   {
-                     title: @application.name,
-                     url: edit_doorkeeper_application_path(@application),
-                   }
-                 ]
-               })
+<%
+  @breadcrumbs = [
+    {
+      title: "Dashboard",
+      url: root_path,
+    },
+    {
+      title: "Applications",
+      url: doorkeeper_applications_path,
+    },
+    {
+      title: @application.name,
+      url: edit_doorkeeper_application_path(@application),
+    }
+  ]
 %>
 
 

--- a/app/views/doorkeeper_applications/monthly_access_stats.html.erb
+++ b/app/views/doorkeeper_applications/monthly_access_stats.html.erb
@@ -1,22 +1,5 @@
 <% content_for :title, "Monthly access counts to #{@application.name}" %>
-
-<%
-  @breadcrumbs = [
-    {
-      title: "Dashboard",
-      url: root_path,
-    },
-    {
-      title: "Applications",
-      url: doorkeeper_applications_path,
-    },
-    {
-      title: @application.name,
-      url: edit_doorkeeper_application_path(@application),
-    }
-  ]
-%>
-
+<% @breadcrumbs = access_breadcrumbs(@application) %>
 
 <form class="govuk-form-group">
   <%= render "govuk_publishing_components/components/checkboxes", {

--- a/app/views/doorkeeper_applications/users_with_access.html.erb
+++ b/app/views/doorkeeper_applications/users_with_access.html.erb
@@ -1,22 +1,19 @@
 <% content_for :title, "Users with access to #{@application.name}" %>
-<% content_for :breadcrumbs,
-   render("govuk_publishing_components/components/breadcrumbs", {
-     collapse_on_mobile: true,
-     breadcrumbs: [
-       {
-         title: "Dashboard",
-         url: root_path,
-       },
-       {
-         title: "Applications",
-         url: doorkeeper_applications_path,
-       },
-       {
-         title: @application.name,
-         url: edit_doorkeeper_application_path(@application),
-       }
-     ]
-   })
+<%
+  @breadcrumbs = [
+    {
+      title: "Dashboard",
+      url: root_path,
+    },
+    {
+      title: "Applications",
+      url: doorkeeper_applications_path,
+    },
+    {
+      title: @application.name,
+      url: edit_doorkeeper_application_path(@application),
+    }
+  ]
 %>
 
 <%= render "components/table", {

--- a/app/views/doorkeeper_applications/users_with_access.html.erb
+++ b/app/views/doorkeeper_applications/users_with_access.html.erb
@@ -1,20 +1,5 @@
 <% content_for :title, "Users with access to #{@application.name}" %>
-<%
-  @breadcrumbs = [
-    {
-      title: "Dashboard",
-      url: root_path,
-    },
-    {
-      title: "Applications",
-      url: doorkeeper_applications_path,
-    },
-    {
-      title: @application.name,
-      url: edit_doorkeeper_application_path(@application),
-    }
-  ]
-%>
+<% @breadcrumbs = access_breadcrumbs(@application) %>
 
 <%= render "components/table", {
   head: [

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,8 +21,11 @@
   <div class="govuk-width-container">
     <% if yield(:back_link).present? %>
       <%= render "govuk_publishing_components/components/back_link", href: yield(:back_link) %>
-    <% elsif yield(:breadcrumbs).present? %>
-      <%= yield(:breadcrumbs) %>
+    <% elsif @breadcrumbs.present? %>
+      <%= render "govuk_publishing_components/components/breadcrumbs", {
+        collapse_on_mobile: true,
+        breadcrumbs: @breadcrumbs,
+      } %>
     <% end %>
 
     <main class="govuk-main-wrapper" id="main-content" role="main">

--- a/app/views/organisations/edit.html.erb
+++ b/app/views/organisations/edit.html.erb
@@ -1,18 +1,15 @@
 <% content_for :title, "Require 2-step verification for #{@organisation.name}" %>
-<% content_for :breadcrumbs,
-   render("govuk_publishing_components/components/breadcrumbs", {
-     collapse_on_mobile: true,
-     breadcrumbs: [
-       {
-         title: "Dashboard",
-         url: root_path,
-       },
-       {
-         title: "Organisations",
-         url: organisations_path,
-       }
-     ]
-   })
+<%
+  @breadcrumbs = [
+    {
+      title: "Dashboard",
+      url: root_path,
+    },
+    {
+      title: "Organisations",
+      url: organisations_path,
+    }
+  ]
 %>
 
 <%= form_tag organisation_path(@organisation), method: "put" do %>

--- a/app/views/supported_permissions/confirm_destroy.erb
+++ b/app/views/supported_permissions/confirm_destroy.erb
@@ -1,27 +1,24 @@
 <% content_for :title, "Delete #{@supported_permission.name} permission for #{@application.name}" %>
 
-<% content_for :breadcrumbs,
-   render("govuk_publishing_components/components/breadcrumbs", {
-     collapse_on_mobile: true,
-     breadcrumbs: [
-       {
-         title: "Dashboard",
-         url: root_path,
-       },
-       {
-         title: "Applications",
-         url: doorkeeper_applications_path,
-       },
-       {
-         title: @application.name,
-         url: edit_doorkeeper_application_path(@application),
-       },
-       {
-         title: "Permissions",
-         url: doorkeeper_application_supported_permissions_path(@application),
-       }
-     ]
-   })
+<%
+  @breadcrumbs = [
+    {
+      title: "Dashboard",
+      url: root_path,
+    },
+    {
+      title: "Applications",
+      url: doorkeeper_applications_path,
+    },
+    {
+      title: @application.name,
+      url: edit_doorkeeper_application_path(@application),
+    },
+    {
+      title: "Permissions",
+      url: doorkeeper_application_supported_permissions_path(@application),
+    }
+  ]
 %>
 
 <div class="govuk-grid-row">

--- a/app/views/supported_permissions/edit.html.erb
+++ b/app/views/supported_permissions/edit.html.erb
@@ -1,27 +1,24 @@
 <% content_for :title, "Edit #{@supported_permission.name_was} permission for #{@application.name}" %>
 
-<% content_for :breadcrumbs,
-   render("govuk_publishing_components/components/breadcrumbs", {
-     collapse_on_mobile: true,
-     breadcrumbs: [
-       {
-         title: "Dashboard",
-         url: root_path,
-       },
-       {
-         title: "Applications",
-         url: doorkeeper_applications_path,
-       },
-       {
-         title: @application.name,
-         url: edit_doorkeeper_application_path(@application),
-       },
-       {
-         title: "Permissions",
-         url: doorkeeper_application_supported_permissions_path(@application),
-       }
-     ]
-   })
+<%
+  @breadcrumbs = [
+    {
+      title: "Dashboard",
+      url: root_path,
+    },
+    {
+      title: "Applications",
+      url: doorkeeper_applications_path,
+    },
+    {
+      title: @application.name,
+      url: edit_doorkeeper_application_path(@application),
+    },
+    {
+      title: "Permissions",
+      url: doorkeeper_application_supported_permissions_path(@application),
+    }
+  ]
 %>
 
 <%= render 'form' %>

--- a/app/views/supported_permissions/index.html.erb
+++ b/app/views/supported_permissions/index.html.erb
@@ -1,22 +1,19 @@
 <% content_for :title, "Permissions for #{@application.name}" %>
-<% content_for :breadcrumbs,
-   render("govuk_publishing_components/components/breadcrumbs", {
-     collapse_on_mobile: true,
-     breadcrumbs: [
-       {
-         title: "Dashboard",
-         url: root_path,
-       },
-       {
-         title: "Applications",
-         url: doorkeeper_applications_path,
-       },
-       {
-         title: @application.name,
-         url: edit_doorkeeper_application_path(@application),
-       }
-     ]
-   })
+<%
+  @breadcrumbs = [
+    {
+      title: "Dashboard",
+      url: root_path,
+    },
+    {
+      title: "Applications",
+      url: doorkeeper_applications_path,
+    },
+    {
+      title: @application.name,
+      url: edit_doorkeeper_application_path(@application),
+    }
+  ]
 %>
 
 <div class="govuk-form-group">

--- a/app/views/supported_permissions/index.html.erb
+++ b/app/views/supported_permissions/index.html.erb
@@ -1,20 +1,5 @@
 <% content_for :title, "Permissions for #{@application.name}" %>
-<%
-  @breadcrumbs = [
-    {
-      title: "Dashboard",
-      url: root_path,
-    },
-    {
-      title: "Applications",
-      url: doorkeeper_applications_path,
-    },
-    {
-      title: @application.name,
-      url: edit_doorkeeper_application_path(@application),
-    }
-  ]
-%>
+<% @breadcrumbs = access_breadcrumbs(@application) %>
 
 <div class="govuk-form-group">
   <%= render "govuk_publishing_components/components/button", {

--- a/app/views/supported_permissions/new.html.erb
+++ b/app/views/supported_permissions/new.html.erb
@@ -1,27 +1,24 @@
 <% content_for :title, "Add permission for #{@application.name}" %>
 
-<% content_for :breadcrumbs,
-   render("govuk_publishing_components/components/breadcrumbs", {
-     collapse_on_mobile: true,
-     breadcrumbs: [
-       {
-         title: "Dashboard",
-         url: root_path,
-       },
-       {
-         title: "Applications",
-         url: doorkeeper_applications_path,
-       },
-       {
-         title: @application.name,
-         url: edit_doorkeeper_application_path(@application),
-       },
-       {
-         title: "Permissions",
-         url: doorkeeper_application_supported_permissions_path(@application),
-       }
-     ]
-   })
+<%
+  @breadcrumbs = [
+    {
+      title: "Dashboard",
+      url: root_path,
+    },
+    {
+      title: "Applications",
+      url: doorkeeper_applications_path,
+    },
+    {
+      title: @application.name,
+      url: edit_doorkeeper_application_path(@application),
+    },
+    {
+      title: "Permissions",
+      url: doorkeeper_application_supported_permissions_path(@application),
+    }
+  ]
 %>
 
 <%= render 'form' %>

--- a/app/views/suspensions/edit.html.erb
+++ b/app/views/suspensions/edit.html.erb
@@ -1,24 +1,21 @@
 <% content_for :title_caption, @user.api_user? ? "Manage API users" : "Manage other users" %>
 <% content_for :title, "Suspend or unsuspend #{@user.name}" %>
 
-<% content_for :breadcrumbs,
-   render("govuk_publishing_components/components/breadcrumbs", {
-     collapse_on_mobile: true,
-     breadcrumbs: [
-       {
-         title: "Dashboard",
-         url: root_path,
-       },
-       {
-         title: @user.api_user? ? "API users" : "Users",
-         url: @user.api_user? ? api_users_path : users_path,
-       },
-       {
-         title: @user.name,
-         url: user_path(@user),
-       }
-     ]
-   })
+<%
+  @breadcrumbs = [
+    {
+      title: "Dashboard",
+      url: root_path,
+    },
+    {
+      title: @user.api_user? ? "API users" : "Users",
+      url: @user.api_user? ? api_users_path : users_path,
+    },
+    {
+      title: @user.name,
+      url: user_path(@user),
+    }
+  ]
 %>
 
 <% if @suspension.errors.present? %>

--- a/app/views/two_step_verification_exemptions/edit.html.erb
+++ b/app/views/two_step_verification_exemptions/edit.html.erb
@@ -1,24 +1,21 @@
 <% content_for :title_caption, @user.api_user? ? "Manage API users" : "Manage other users" %>
 <% content_for :title, "Exempt #{@user.name} from 2-step verification".html_safe %>
 
-<% content_for :breadcrumbs,
-   render("govuk_publishing_components/components/breadcrumbs", {
-     collapse_on_mobile: true,
-     breadcrumbs: [
-       {
-         title: "Dashboard",
-         url: root_path,
-       },
-       {
-         title: "Users",
-         url: users_path,
-       },
-       {
-         title: @user.name,
-         url: user_path(@user),
-       }
-     ]
-   })
+<%
+  @breadcrumbs = [
+    {
+      title: "Dashboard",
+      url: root_path,
+    },
+    {
+      title: "Users",
+      url: users_path,
+    },
+    {
+      title: @user.name,
+      url: user_path(@user),
+    }
+  ]
 %>
 
 <% if @exemption.errors.any? %>

--- a/app/views/users/applications/index.html.erb
+++ b/app/views/users/applications/index.html.erb
@@ -1,24 +1,21 @@
 <% content_for :title_caption, "Manage other users" %>
 <% content_for :title, "#{@user.name}'s applications" %>
 
-<% content_for :breadcrumbs,
-   render("govuk_publishing_components/components/breadcrumbs", {
-     collapse_on_mobile: true,
-     breadcrumbs: [
-       {
-         title: "Dashboard",
-         url: root_path,
-       },
-       {
-         title: "Users",
-         url: users_path,
-       },
-       {
-         title: @user.name,
-         url: edit_user_path(@user),
-       }
-     ]
-   })
+<%
+  @breadcrumbs = [
+    {
+      title: "Dashboard",
+      url: root_path,
+    },
+    {
+      title: "Users",
+      url: users_path,
+    },
+    {
+      title: @user.name,
+      url: edit_user_path(@user),
+    }
+  ]
 %>
 
 <% if flash[:success_alert] %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,20 +1,17 @@
 <% content_for :title_caption, "Manage other users" %>
 <% content_for :title, @user.name %>
 
-<% content_for :breadcrumbs,
-   render("govuk_publishing_components/components/breadcrumbs", {
-     collapse_on_mobile: true,
-     breadcrumbs: [
-       {
-         title: "Dashboard",
-         url: root_path,
-       },
-       {
-         title: "Users",
-         url: users_path,
-       }
-     ]
-   })
+<%
+  @breadcrumbs = [
+    {
+      title: "Dashboard",
+      url: root_path,
+    },
+    {
+      title: "Users",
+      url: users_path,
+    }
+  ]
 %>
 
 <div class="govuk-grid-row">

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,18 +1,6 @@
 <% content_for :title_caption, "Manage other users" %>
 <% content_for :title, @user.name %>
-
-<%
-  @breadcrumbs = [
-    {
-      title: "Dashboard",
-      url: root_path,
-    },
-    {
-      title: "Users",
-      url: users_path,
-    }
-  ]
-%>
+<% @breadcrumbs = users_breadcrumbs %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/users/emails/edit.html.erb
+++ b/app/views/users/emails/edit.html.erb
@@ -1,24 +1,21 @@
 <% content_for :title_caption, @user.api_user? ? "Manage API users" : "Manage other users" %>
 <% content_for :title, "Change email for #{@user.name}" %>
 
-<% content_for :breadcrumbs,
-   render("govuk_publishing_components/components/breadcrumbs", {
-     collapse_on_mobile: true,
-     breadcrumbs: [
-       {
-         title: "Dashboard",
-         url: root_path,
-       },
-       {
-         title: @user.api_user? ? "API users" : "Users",
-         url: @user.api_user? ? api_users_path : users_path,
-       },
-       {
-         title: @user.name,
-         url: return_path,
-       }
-     ]
-   })
+<%
+  @breadcrumbs = [
+    {
+      title: "Dashboard",
+      url: root_path,
+    },
+    {
+      title: @user.api_user? ? "API users" : "Users",
+      url: @user.api_user? ? api_users_path : users_path,
+    },
+    {
+      title: @user.name,
+      url: return_path,
+    }
+  ]
 %>
 
 <% if @user.web_user? %>

--- a/app/views/users/event_logs.html.erb
+++ b/app/views/users/event_logs.html.erb
@@ -1,24 +1,21 @@
 <% content_for :title_caption, @user.api_user? ? "Manage API users" : "Manage other users" %>
 <% content_for :title, "Account access log for #{@user.name}" %>
 
-<% content_for :breadcrumbs,
-   render("govuk_publishing_components/components/breadcrumbs", {
-     collapse_on_mobile: true,
-     breadcrumbs: [
-       {
-         title: "Dashboard",
-         url: root_path,
-       },
-       {
-         title: @user.api_user? ? "API users" : "Users",
-         url: @user.api_user? ? api_users_path : users_path,
-       },
-       {
-         title: @user.name,
-         url: edit_user_path_by_user_type(@user)
-       }
-     ]
-   })
+<%
+  @breadcrumbs = [
+    {
+      title: "Dashboard",
+      url: root_path,
+    },
+    {
+      title: @user.api_user? ? "API users" : "Users",
+      url: @user.api_user? ? api_users_path : users_path,
+    },
+    {
+      title: @user.name,
+      url: edit_user_path_by_user_type(@user)
+    }
+  ]
 %>
 
 <%= render "shared/event_logs_table", logs: @logs %>

--- a/app/views/users/invitation_resends/edit.html.erb
+++ b/app/views/users/invitation_resends/edit.html.erb
@@ -1,24 +1,21 @@
 <% content_for :title_caption, "Manage other users" %>
 <% content_for :title, "Resend invitation email for #{@user.name}" %>
 
-<% content_for :breadcrumbs,
-   render("govuk_publishing_components/components/breadcrumbs", {
-     collapse_on_mobile: true,
-     breadcrumbs: [
-       {
-         title: "Dashboard",
-         url: root_path,
-       },
-       {
-         title: "Users",
-         url: users_path,
-       },
-       {
-         title: @user.name,
-         url: edit_user_path(@user),
-       }
-     ]
-   })
+<%
+  @breadcrumbs = [
+    {
+      title: "Dashboard",
+      url: root_path,
+    },
+    {
+      title: "Users",
+      url: users_path,
+    },
+    {
+      title: @user.name,
+      url: edit_user_path(@user),
+    }
+  ]
 %>
 
 <div class="govuk-grid-row">

--- a/app/views/users/names/edit.html.erb
+++ b/app/views/users/names/edit.html.erb
@@ -1,24 +1,21 @@
 <% content_for :title_caption, @user.api_user? ? "Manage API users" : "Manage other users" %>
 <% content_for :title, "Change name for #{@user.name_was}" %>
 
-<% content_for :breadcrumbs,
-   render("govuk_publishing_components/components/breadcrumbs", {
-     collapse_on_mobile: true,
-     breadcrumbs: [
-       {
-         title: "Dashboard",
-         url: root_path,
-       },
-       {
-         title: @user.api_user? ? "API users" : "Users",
-         url: @user.api_user? ? api_users_path : users_path,
-       },
-       {
-         title: @user.name_was,
-         url: return_path,
-       }
-     ]
-   })
+<%
+  @breadcrumbs = [
+    {
+      title: "Dashboard",
+      url: root_path,
+    },
+    {
+      title: @user.api_user? ? "API users" : "Users",
+      url: @user.api_user? ? api_users_path : users_path,
+    },
+    {
+      title: @user.name_was,
+      url: return_path,
+    }
+  ]
 %>
 
 <% if @user.errors.count > 0 %>

--- a/app/views/users/organisations/edit.html.erb
+++ b/app/views/users/organisations/edit.html.erb
@@ -1,24 +1,21 @@
 <% content_for :title_caption, "Manage other users" %>
 <% content_for :title, "Change organisation for #{@user.name}" %>
 
-<% content_for :breadcrumbs,
-   render("govuk_publishing_components/components/breadcrumbs", {
-     collapse_on_mobile: true,
-     breadcrumbs: [
-       {
-         title: "Dashboard",
-         url: root_path,
-       },
-       {
-         title: "Users",
-         url: users_path,
-       },
-       {
-         title: @user.name,
-         url: edit_user_path(@user),
-       }
-     ]
-   })
+<%
+  @breadcrumbs = [
+    {
+      title: "Dashboard",
+      url: root_path,
+    },
+    {
+      title: "Users",
+      url: users_path,
+    },
+    {
+      title: @user.name,
+      url: edit_user_path(@user),
+    }
+  ]
 %>
 
 <% if @user.errors.count > 0 %>

--- a/app/views/users/permissions/edit.html.erb
+++ b/app/views/users/permissions/edit.html.erb
@@ -1,28 +1,25 @@
 <% content_for :title_caption, "Manage other users" %>
 <% content_for :title, "Update #{@user.name}'s permissions for #{@application.name}" %>
 
-<% content_for :breadcrumbs,
-   render("govuk_publishing_components/components/breadcrumbs", {
-     collapse_on_mobile: true,
-     breadcrumbs: [
-       {
-         title: "Dashboard",
-         url: root_path,
-       },
-       {
-         title: "Users",
-         url: users_path,
-       },
-       {
-         title: @user.name,
-         url: edit_user_path(@user),
-       },
-       {
-         title: "Applications",
-         url: user_applications_path(@user),
-       }
-     ]
-   })
+<%
+  @breadcrumbs = [
+    {
+      title: "Dashboard",
+      url: root_path,
+    },
+    {
+      title: "Users",
+      url: users_path,
+    },
+    {
+      title: @user.name,
+      url: edit_user_path(@user),
+    },
+    {
+      title: "Applications",
+      url: user_applications_path(@user),
+    }
+  ]
 %>
 
 <% if flash[:new_permission_name] %>

--- a/app/views/users/permissions/show.html.erb
+++ b/app/views/users/permissions/show.html.erb
@@ -1,28 +1,25 @@
 <% content_for :title_caption, "Manage other users" %>
 <% content_for :title, "#{@user.name}'s permissions for #{@application.name}" %>
 
-<% content_for :breadcrumbs,
-   render("govuk_publishing_components/components/breadcrumbs", {
-     collapse_on_mobile: true,
-     breadcrumbs: [
-       {
-         title: "Dashboard",
-         url: root_path,
-       },
-       {
-         title: "Users",
-         url: users_path,
-       },
-       {
-         title: @user.name,
-         url: edit_user_path(@user),
-       },
-       {
-         title: "#{@user.name}'s applications",
-         url: user_applications_path(@user),
-       }
-     ]
-   })
+<%
+  @breadcrumbs = [
+    {
+      title: "Dashboard",
+      url: root_path,
+    },
+    {
+      title: "Users",
+      url: users_path,
+    },
+    {
+      title: @user.name,
+      url: edit_user_path(@user),
+    },
+    {
+      title: "#{@user.name}'s applications",
+      url: user_applications_path(@user),
+    }
+  ]
 %>
 
 <%= render "components/table", {

--- a/app/views/users/roles/edit.html.erb
+++ b/app/views/users/roles/edit.html.erb
@@ -1,24 +1,21 @@
 <% content_for :title_caption, "Manage other users" %>
 <% content_for :title, "Change role for #{@user.name}" %>
 
-<% content_for :breadcrumbs,
-   render("govuk_publishing_components/components/breadcrumbs", {
-     collapse_on_mobile: true,
-     breadcrumbs: [
-       {
-         title: "Dashboard",
-         url: root_path,
-       },
-       {
-         title: "Users",
-         url: users_path,
-       },
-       {
-         title: @user.name,
-         url: edit_user_path(@user),
-       }
-     ]
-   })
+<%
+  @breadcrumbs = [
+    {
+      title: "Dashboard",
+      url: root_path,
+    },
+    {
+      title: "Users",
+      url: users_path,
+    },
+    {
+      title: @user.name,
+      url: edit_user_path(@user),
+    }
+  ]
 %>
 
 <% if @user.errors.count > 0 %>

--- a/app/views/users/signin_permissions/delete.html.erb
+++ b/app/views/users/signin_permissions/delete.html.erb
@@ -1,28 +1,25 @@
 <% content_for :title_caption, "Manage other users" %>
 <% content_for :title, "Remove #{@user.name}'s access to #{@application.name}" %>
 
-<% content_for :breadcrumbs,
-   render("govuk_publishing_components/components/breadcrumbs", {
-     collapse_on_mobile: true,
-     breadcrumbs: [
-       {
-         title: "Dashboard",
-         url: root_path,
-       },
-       {
-         title: "Users",
-         url: users_path,
-       },
-       {
-         title: @user.name,
-         url: edit_user_path(@user),
-       },
-       {
-         title: "Applications",
-         url: user_applications_path(@user),
-       }
-     ]
-   })
+<%
+  @breadcrumbs = [
+    {
+      title: "Dashboard",
+      url: root_path,
+    },
+    {
+      title: "Users",
+      url: users_path,
+    },
+    {
+      title: @user.name,
+      url: edit_user_path(@user),
+    },
+    {
+      title: "Applications",
+      url: user_applications_path(@user),
+    }
+  ]
 %>
 
 <p class="govuk-body">Are you sure you want to remove <%= @user.name %>'s access to <%= @application.name %>?</p>

--- a/app/views/users/two_step_verification_mandations/edit.html.erb
+++ b/app/views/users/two_step_verification_mandations/edit.html.erb
@@ -1,24 +1,21 @@
 <% content_for :title_caption, "Manage other users" %>
 <% content_for :title, "Turn on 2-step verification for #{@user.name}" %>
 
-<% content_for :breadcrumbs,
-   render("govuk_publishing_components/components/breadcrumbs", {
-     collapse_on_mobile: true,
-     breadcrumbs: [
-       {
-         title: "Dashboard",
-         url: root_path,
-       },
-       {
-         title: "Users",
-         url: users_path,
-       },
-       {
-         title: @user.name,
-         url: edit_user_path(@user),
-       }
-     ]
-   })
+<%
+  @breadcrumbs = [
+    {
+      title: "Dashboard",
+      url: root_path,
+    },
+    {
+      title: "Users",
+      url: users_path,
+    },
+    {
+      title: @user.name,
+      url: edit_user_path(@user),
+    }
+  ]
 %>
 
 <% if @user.errors.count > 0 %>

--- a/app/views/users/two_step_verification_resets/edit.html.erb
+++ b/app/views/users/two_step_verification_resets/edit.html.erb
@@ -1,24 +1,21 @@
 <% content_for :title_caption, "Manage other users" %>
 <% content_for :title, "Reset 2-step verification for #{@user.name}" %>
 
-<% content_for :breadcrumbs,
-   render("govuk_publishing_components/components/breadcrumbs", {
-     collapse_on_mobile: true,
-     breadcrumbs: [
-       {
-         title: "Dashboard",
-         url: root_path,
-       },
-       {
-         title: "Users",
-         url: users_path,
-       },
-       {
-         title: @user.name,
-         url: edit_user_path(@user),
-       }
-     ]
-   })
+<%
+  @breadcrumbs = [
+    {
+      title: "Dashboard",
+      url: root_path,
+    },
+    {
+      title: "Users",
+      url: users_path,
+    },
+    {
+      title: @user.name,
+      url: edit_user_path(@user),
+    }
+  ]
 %>
 
 <div class="govuk-grid-row">

--- a/app/views/users/unlockings/edit.html.erb
+++ b/app/views/users/unlockings/edit.html.erb
@@ -1,24 +1,21 @@
 <% content_for :title_caption, "Manage other users" %>
 <% content_for :title, "Unlock account for #{@user.name}" %>
 
-<% content_for :breadcrumbs,
-   render("govuk_publishing_components/components/breadcrumbs", {
-     collapse_on_mobile: true,
-     breadcrumbs: [
-       {
-         title: "Dashboard",
-         url: root_path,
-       },
-       {
-         title: "Users",
-         url: users_path,
-       },
-       {
-         title: @user.name,
-         url: edit_user_path(@user),
-       }
-     ]
-   })
+<%
+  @breadcrumbs = [
+    {
+      title: "Dashboard",
+      url: root_path,
+    },
+    {
+      title: "Users",
+      url: users_path,
+    },
+    {
+      title: @user.name,
+      url: edit_user_path(@user),
+    }
+  ]
 %>
 
 <div class="govuk-grid-row">

--- a/test/integration/account/account_test.rb
+++ b/test/integration/account/account_test.rb
@@ -27,6 +27,60 @@ class AccountTest < ActionDispatch::IntegrationTest
       assert page.has_link?("Your account access log", href: account_activity_path)
     end
 
+    context "linked pages" do
+      setup do
+        user = FactoryBot.create(:admin_user, otp_secret_key: "2SVenabled")
+
+        visit new_user_session_path
+        signin_with user
+
+        visit account_path
+        assert_current_url account_path
+      end
+
+      should "have the correct breadcrumbs on change your email address" do
+        click_link "Change your email address"
+        assert has_link?("Dashboard", href: "/", class: "govuk-breadcrumbs__link")
+        assert has_link?("Settings", href: "/account", class: "govuk-breadcrumbs__link")
+      end
+
+      should "have the correct breadcrumbs on change your password" do
+        click_link "Change your password"
+        assert has_link?("Dashboard", href: "/", class: "govuk-breadcrumbs__link")
+        assert has_link?("Settings", href: "/account", class: "govuk-breadcrumbs__link")
+      end
+
+      should "have the correct breadcrumbs on manage permissions" do
+        click_link "Manage permissions"
+        assert has_link?("Dashboard", href: "/", class: "govuk-breadcrumbs__link")
+        assert has_link?("Settings", href: "/account", class: "govuk-breadcrumbs__link")
+      end
+
+      should "have the correct breadcrumbs on change your 2-step verification phone" do
+        click_link "Change your 2-step verification phone"
+        assert has_link?("Dashboard", href: "/", class: "govuk-breadcrumbs__link")
+        assert has_link?("Settings", href: "/account", class: "govuk-breadcrumbs__link")
+      end
+
+      should "have the correct breadcrumbs on view your role" do
+        click_link "View your role"
+        assert has_link?("Dashboard", href: "/", class: "govuk-breadcrumbs__link")
+        assert has_link?("Settings", href: "/account", class: "govuk-breadcrumbs__link")
+      end
+
+      should "have the correct breadcrumbs on change your organisation" do
+        click_link "Change your organisation"
+        assert has_link?("Dashboard", href: "/", class: "govuk-breadcrumbs__link")
+        assert has_link?("Settings", href: "/account", class: "govuk-breadcrumbs__link")
+      end
+
+      should "have the correct breadcrumbs on your account access log" do
+        click_link "Your account access log"
+        assert has_link?("Dashboard", href: "/", class: "govuk-breadcrumbs__link")
+        assert has_link?("Settings", href: "/account", class: "govuk-breadcrumbs__link")
+      end
+    end
+
     should "link to Change email/password, Change 2SV, role & org for normal users" do
       user = FactoryBot.create(:user, otp_secret_key: "2SVenabled")
 

--- a/test/integration/applications/access_logs_test.rb
+++ b/test/integration/applications/access_logs_test.rb
@@ -24,6 +24,8 @@ class ApplicationsAccessLogsIntegrationTest < ActionDispatch::IntegrationTest
     should "have permission to view account access log" do
       visit access_logs_doorkeeper_application_path(@application)
       assert_equal page.title, "app-name access log - GOV.UK Signon"
+      assert has_link?("Dashboard", href: "/", class: "govuk-breadcrumbs__link")
+      assert has_link?("Applications", href: "/doorkeeper_applications", class: "govuk-breadcrumbs__link")
     end
 
     context "when there are no matching events" do

--- a/test/integration/applications/monthly_access_stats_test.rb
+++ b/test/integration/applications/monthly_access_stats_test.rb
@@ -24,6 +24,8 @@ class ApplicationsMonthlyAccessStatsIntegrationTest < ActionDispatch::Integratio
     should "have permission to view account access log" do
       visit monthly_access_stats_doorkeeper_application_path(@application)
       assert_equal page.title, "Monthly access counts to app-name - GOV.UK Signon"
+      assert has_link?("Dashboard", href: "/", class: "govuk-breadcrumbs__link")
+      assert has_link?("Applications", href: "/doorkeeper_applications", class: "govuk-breadcrumbs__link")
     end
 
     context "when there are no matching events" do

--- a/test/integration/users/account_access_logs_test.rb
+++ b/test/integration/users/account_access_logs_test.rb
@@ -121,5 +121,7 @@ class Users::AccountAccessLogsIntegrationTest < ActionDispatch::IntegrationTest
     assert assert_text "Event"
     assert assert_text "account locked"
     assert_selector "a", text: user.name
+    assert has_link?("Dashboard", href: "/", class: "govuk-breadcrumbs__link")
+    assert has_link?("Users", href: "/users", class: "govuk-breadcrumbs__link")
   end
 end


### PR DESCRIPTION
This application is owned by the Content APIs team. Please let us know in [#govuk-content-apis](https://gds.slack.com/archives/C03D792LYJG) when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Reduce the number of calls to the breadcrumb component by calling it once in the layout and passing that instance the various breadcrumbs from each view, rather than having an instance of the breadcrumb component per view.

## Why
There are 46 views where the breadcrumb component is called, and they're all exactly the same apart from the actual breadcrumbs that get passed to the component.

## Visual changes
None.