### PR TITLE
Update 2SV guidance link

### DIFF
--- a/app/views/devise/two_step_verification_session/new.html.erb
+++ b/app/views/devise/two_step_verification_session/new.html.erb
@@ -16,5 +16,5 @@
 <%= render "govuk_publishing_components/components/details", {
   title: "If you’re having problems"
 } do %>
-  <p>If you’re having problems with 2-step verification, see <a href="https://www.gov.uk/guidance/how-to-publish-on-gov-uk/introduction-and-access-to-whitehall-publisher#issues-with-2-step-verification-2sv" class="govuk-link">the troubleshooting guidance</a>.</p>
+  <p>If you’re having problems with 2-step verification, see <a href="https://guidance.publishing.service.gov.uk/accounts-support/manage-accounts-training/manage-accounts/#issues-with-2-step-verification" class="govuk-link">the troubleshooting guidance</a>.</p>
 <% end %>


### PR DESCRIPTION
The current URL redirects to
https://guidance.publishing.service.gov.uk/accounts-support/manage-accounts-training/#issues-with-2-step-verification-2sv, which isn't specifically about 2SV. Users have to find the right section

The new URL links to that section directly

This change was requested by the Content Operations team