### PR TITLE
Bump brace-expansion from 2.0.1 to 2.1.2

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -317,9 +317,9 @@ brace-expansion@^1.1.7:
     concat-map "0.0.1"
 
 brace-expansion@^2.0.1:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.2.tgz#54fc53237a613d854c7bd37463aad17df87214e7"
-  integrity sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.1.2.tgz#0bba2271feb7d458b0d31ad13625aaa4754431e2"
+  integrity sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==
   dependencies:
     balanced-match "^1.0.0"
 


### PR DESCRIPTION
Dependabot failed to update this indirect/transitive dependency. I did so by manually removing the `brace-expansion@^2.0.1` entry from `yarn.lock` and then running `yarn install`. This is a bit hacky and I wouldn't normally like to manually edit the lockfile, but:
- Signon is running yarn 1 so it doesn't have access to `yarn up --recursive` (as used in https://github.com/alphagov/transition/commit/006badefff3d4dca4a8a21447e851f6642f13b78)
- using `yarn remove jasmine-browser-runner` and `yarn add jasmine-browser-runner` (`jasmine-browser-runner` is the root of the dependency tree) would upgrade all indirect dependencies and I don't want to audit all of them as part of this change
- the final lockfile was generated by a yarn subcommand anyway