### PR TITLE
Bump brace-expansion from 5.0.4 to 5.0.7

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -324,9 +324,9 @@ brace-expansion@^2.0.1:
     balanced-match "^1.0.0"
 
 brace-expansion@^5.0.2:
-  version "5.0.4"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.4.tgz#614daaecd0a688f660bbbc909a8748c3d80d4336"
-  integrity sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==
+  version "5.0.7"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.7.tgz#1b0e46965b479dad65af737b4a02790a05498337"
+  integrity sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==
   dependencies:
     balanced-match "^4.0.2"
 


### PR DESCRIPTION
Dependabot failed to update this indirect/transitive dependency. I did so by manually removing the `brace-expansion@^5.0.2` entry from `yarn.lock` and then running `yarn install`. This is a bit hacky and I wouldn't normally like to manually edit the lockfile, but:
- Signon is running yarn 1 so it doesn't have access to `yarn up --recursive` (as used in https://github.com/alphagov/transition/commit/006badefff3d4dca4a8a21447e851f6642f13b78)
- using `yarn remove jasmine-browser-runner` and `yarn add jasmine-browser-runner` (`jasmine-browser-runner` is the root of the dependency tree) would upgrade all indirect dependencies and I don't want to audit all of them as part of this change
- the final lockfile was generated by a yarn subcommand anyway