### PR TITLE
Bump brace-expansion from 1.1.15 to 1.1.16

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -309,9 +309,9 @@ body-parser@^2.2.1:
     type-is "^2.0.1"
 
 brace-expansion@^1.1.7:
-  version "1.1.15"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.15.tgz#a6d90d54067236e5f42570a3b7378d594d9b7738"
-  integrity sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==
+  version "1.1.16"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.16.tgz#723d3a30c0558c225abc9fc479a73e14e26c3c2f"
+  integrity sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"


### PR DESCRIPTION
Dependabot failed to update this indirect/transitive dependency. I did so by manually removing the `brace-expansion@^1.1.7` entry from `yarn.lock` and then running `yarn install`. This is a bit hacky and I wouldn't normally like to manually edit the lockfile, but:
- Signon is running yarn 1 so it doesn't have access to `yarn up --recursive` (as used in https://github.com/alphagov/transition/commit/006badefff3d4dca4a8a21447e851f6642f13b78)
- using `yarn remove jasmine-browser-runner` and `yarn add jasmine-browser-runner` (`jasmine-browser-runner` is the root of the dependency tree) would upgrade all indirect dependencies and I don't want to audit all of them as part of this change
- the final lockfile was generated by a yarn subcommand anyway