### PR TITLE
Bump govuk_publishing_components to v68.3.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -209,7 +209,7 @@ GEM
     govuk_personalisation (1.2.0)
       plek (>= 1.9.0)
       rails (>= 6, < 9)
-    govuk_publishing_components (67.0.1)
+    govuk_publishing_components (68.3.0)
       chartkick
       govuk_app_config
       govuk_personalisation (>= 0.7.0)

--- a/app/assets/javascripts/es6-components.js
+++ b/app/assets/javascripts/es6-components.js
@@ -10,6 +10,5 @@
 //= require govuk_publishing_components/components/button
 //= require govuk_publishing_components/components/checkboxes
 //= require govuk_publishing_components/components/error-summary
-//= require govuk_publishing_components/components/layout-header
 //= require govuk_publishing_components/components/skip-link
 //= require govuk_publishing_components/components/tabs

--- a/app/assets/stylesheets/components/_table.scss
+++ b/app/assets/stylesheets/components/_table.scss
@@ -1,9 +1,9 @@
 @import "govuk/components/table/table";
 
 $table-border-width: 1px;
-$table-border-colour: govuk-colour("mid-grey");
+$table-border-colour: govuk-colour("black", $variant: "tint-80");
 $table-header-border-width: 2px;
-$table-header-background-colour: govuk-colour("light-grey");
+$table-header-background-colour: govuk-colour("black", $variant: "tint-95");
 $vertical-row-bottom-border-width: 3px;
 $vertical-on-smallscreen-breakpoint: 940px;
 $sort-link-active-colour: govuk-colour("white");
@@ -11,7 +11,7 @@ $sort-link-arrow-size: 14px;
 $sort-link-arrow-size-small: 8px;
 $sort-link-arrow-spacing: calc($sort-link-arrow-size / 2);
 $table-row-hover-background-colour: rgb(43, 140, 196, .2);
-$table-row-even-background-colour: govuk-colour("light-grey");
+$table-row-even-background-colour: govuk-colour("black", $variant: "tint-95");
 
 /* stylelint-disable */
 .govuk-table__cell:empty,


### PR DESCRIPTION
- Update govuk_publishing_components to v68.3.0, because it contains govuk-frontend v6 (latest major version of the design system)
- Update calls to govuk-colour() to get rid of deprecation warnings

**Why a draft PR?**

I haven't optimised the `import` and `require` statements yet, because I couldn't get the component guide to work in signon. It would just end up displaying the following error message:

LoadError in GovukPublishingComponents::ComponentGuideController#index
cannot load such file -- sassc
```ruby
          Kernel.warn message, uplevel: ::Gem::BUNDLED_GEMS.uplevel
        end
        kernel_class.send(:no_warning_require, name)
      end
      if kernel_class == ::Kernel
        kernel_class.send(:private, :require)
```
Rails.root: /govuk/signon

`/root/.rbenv/versions/4.0.6/lib/ruby/4.0.0/bundled_gems.rb:60:in 'Kernel.require'` (first line of the stack trace)

Apparently, the error is happening during the `send` call.
