### PR TITLE
Bump govuk_publishing_components to v68.3.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -209,7 +209,7 @@ GEM
     govuk_personalisation (1.2.0)
       plek (>= 1.9.0)
       rails (>= 6, < 9)
-    govuk_publishing_components (67.0.1)
+    govuk_publishing_components (68.3.0)
       chartkick
       govuk_app_config
       govuk_personalisation (>= 0.7.0)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,9 +1,17 @@
 //= require govuk_publishing_components/dependencies
-//= require govuk_publishing_components/lib/cookie-functions
+//= require govuk_publishing_components/lib
+//= require govuk_publishing_components/components/button
+//= require govuk_publishing_components/components/checkboxes
 //= require govuk_publishing_components/components/copy-to-clipboard
+//= require govuk_publishing_components/components/error-summary
+//= require govuk_publishing_components/components/file-upload
+//= require govuk_publishing_components/components/govspeak
 //= require govuk_publishing_components/components/option-select
 //= require govuk_publishing_components/components/password-input
+//= require govuk_publishing_components/components/service-navigation
+//= require govuk_publishing_components/components/skip-link
 //= require govuk_publishing_components/components/table
+//= require govuk_publishing_components/components/tabs
 
 //= require ./domain-config
 //= require_tree ./modules

--- a/app/assets/javascripts/es6-components.js
+++ b/app/assets/javascripts/es6-components.js
@@ -10,6 +10,5 @@
 //= require govuk_publishing_components/components/button
 //= require govuk_publishing_components/components/checkboxes
 //= require govuk_publishing_components/components/error-summary
-//= require govuk_publishing_components/components/layout-header
 //= require govuk_publishing_components/components/skip-link
 //= require govuk_publishing_components/components/tabs

--- a/app/assets/stylesheets/components/_table.scss
+++ b/app/assets/stylesheets/components/_table.scss
@@ -1,9 +1,9 @@
 @import "govuk/components/table/table";
 
 $table-border-width: 1px;
-$table-border-colour: govuk-colour("mid-grey");
+$table-border-colour: govuk-colour("black", $variant: "tint-80");
 $table-header-border-width: 2px;
-$table-header-background-colour: govuk-colour("light-grey");
+$table-header-background-colour: govuk-colour("black", $variant: "tint-95");
 $vertical-row-bottom-border-width: 3px;
 $vertical-on-smallscreen-breakpoint: 940px;
 $sort-link-active-colour: govuk-colour("white");
@@ -11,7 +11,7 @@ $sort-link-arrow-size: 14px;
 $sort-link-arrow-size-small: 8px;
 $sort-link-arrow-spacing: calc($sort-link-arrow-size / 2);
 $table-row-hover-background-colour: rgb(43, 140, 196, .2);
-$table-row-even-background-colour: govuk-colour("light-grey");
+$table-row-even-background-colour: govuk-colour("black", $variant: "tint-95");
 
 /* stylelint-disable */
 .govuk-table__cell:empty,

--- a/config/initializers/dartsass.rb
+++ b/config/initializers/dartsass.rb
@@ -1,1 +1,7 @@
 Rails.application.config.dartsass.build_options << " --quiet-deps"
+
+if Rails.env.development?
+  Rails.application.config.dartsass.builds.merge!(
+    GovukPublishingComponents::Config.component_guide_stylesheet,
+  )
+end

--- a/test/controllers/batch_invitation_permissions_controller_test.rb
+++ b/test/controllers/batch_invitation_permissions_controller_test.rb
@@ -63,7 +63,7 @@ class BatchInvitationPermissionsControllerTest < ActionController::TestCase
       get :new, params: { batch_invitation_id: @batch_invitation.id }
 
       assert_select "form" do
-        assert_select ".gem-c-option-select[data-filter-element]"
+        assert_select ".gem-c-option-select[data-filter-attributes]"
       end
     end
 

--- a/test/controllers/invitations_controller_test.rb
+++ b/test/controllers/invitations_controller_test.rb
@@ -80,7 +80,7 @@ class InvitationsControllerTest < ActionController::TestCase
         get :new
 
         assert_select "form" do
-          assert_select ".gem-c-option-select[data-filter-element]"
+          assert_select ".gem-c-option-select[data-filter-attributes]"
         end
       end
 


### PR DESCRIPTION
The Navigation team asked for this as part of their work to update the govuk_publishing_components gem to v6 of the design system and to ensure all of our software is secure and up to date in terms of features.

- Update govuk_publishing_components to v68.3.0, because it contains govuk-frontend v6 (latest major version of the design system)
- Update calls to govuk-colour() to get rid of deprecation warnings
- Add the component guide's stylesheet to Dart SASS' asset compilation
- Follow require advice from /component-guide (imports would have resulted in 35 distinct lines, so I decided sticking to importing 'all-components' is the more economic solution)

Closes [PP-7947](https://gov-uk.atlassian.net/browse/PP-7947)

[PP-7947]: https://gov-uk.atlassian.net/browse/PP-7947?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ