### PR TITLE
Follow-up to PP-7947: Remove redundant JS requires and improve a test helper

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,17 +1,12 @@
 //= require govuk_publishing_components/dependencies
 //= require govuk_publishing_components/lib
-//= require govuk_publishing_components/components/button
-//= require govuk_publishing_components/components/checkboxes
 //= require govuk_publishing_components/components/copy-to-clipboard
-//= require govuk_publishing_components/components/error-summary
 //= require govuk_publishing_components/components/file-upload
 //= require govuk_publishing_components/components/govspeak
 //= require govuk_publishing_components/components/option-select
 //= require govuk_publishing_components/components/password-input
 //= require govuk_publishing_components/components/service-navigation
-//= require govuk_publishing_components/components/skip-link
 //= require govuk_publishing_components/components/table
-//= require govuk_publishing_components/components/tabs
 
 //= require ./domain-config
 //= require_tree ./modules

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,11 +1,8 @@
 //= require govuk_publishing_components/dependencies
 //= require govuk_publishing_components/lib
 //= require govuk_publishing_components/components/copy-to-clipboard
-//= require govuk_publishing_components/components/file-upload
 //= require govuk_publishing_components/components/govspeak
 //= require govuk_publishing_components/components/option-select
-//= require govuk_publishing_components/components/password-input
-//= require govuk_publishing_components/components/service-navigation
 //= require govuk_publishing_components/components/table
 
 //= require ./domain-config

--- a/app/assets/javascripts/es6-components.js
+++ b/app/assets/javascripts/es6-components.js
@@ -10,5 +10,8 @@
 //= require govuk_publishing_components/components/button
 //= require govuk_publishing_components/components/checkboxes
 //= require govuk_publishing_components/components/error-summary
+//= require govuk_publishing_components/components/file-upload
+//= require govuk_publishing_components/components/password-input
+//= require govuk_publishing_components/components/service-navigation
 //= require govuk_publishing_components/components/skip-link
 //= require govuk_publishing_components/components/tabs

--- a/test/support/autocomplete_helper.rb
+++ b/test/support/autocomplete_helper.rb
@@ -8,6 +8,8 @@ class AutocompleteHelper
   end
 
   def select_autocomplete_option(option_string)
+    # Ensure module was actually initialised
+    assert_selector("[data-module='accessible-autocomplete'][data-accessible-autocomplete-module-started]")
     autocomplete_input_element = find(".autocomplete__input")
     autocomplete_input_element.fill_in with: option_string
     autocomplete_option = find(".autocomplete__option")


### PR DESCRIPTION
I made a mistake by blindly following the recommended require statements in the component guide, which has lead to the app requiring five components twice. Turns out ES6 components are required through es6-components.js in a way that hides them from incompatible browsers. Requiring any of the components in that file in application.js completely defeats the purpose of es6-components.js.

In order to harden the `select_autocomplete_option()` test helper, I've added a line that prevents mistaking the `accessible-autocomplete` module failing to initialise for a timing-related error (e.g., `.autocomplete__input` loading too slowly).