### PR TITLE
Require ES6 components through layout_for_admin

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -99,6 +99,4 @@
       }
     ]
   } %>
-
-  <%= javascript_include_tag "es6-components", type: "module" %>
 <% end %>

--- a/config/initializers/govuk_publishing_components.rb
+++ b/config/initializers/govuk_publishing_components.rb
@@ -1,0 +1,3 @@
+GovukPublishingComponents.configure do |config|
+  config.use_es6_components = true
+end


### PR DESCRIPTION
 The `layout_for_admin` helper allows to easily separate regular and ES6-compatible JS. But for the ES6 file to be included in the HTML it outputs it needs to be enabled via `use_es6_components = true` (see this [link](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/install-and-use.md)).